### PR TITLE
Update Medical Safety Alert email copy

### DIFF
--- a/app/views/email_alerts/medical_safety_alerts/publication.html.erb
+++ b/app/views/email_alerts/medical_safety_alerts/publication.html.erb
@@ -16,7 +16,7 @@
       </p>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
-        For further information on this <%= updated_or_published %> <%= document_noun %>:
+        For further information on this <%= document_noun %>:
       </p>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">


### PR DESCRIPTION
Remove the "updated" or "published" text from Medical Safety Alert emails as it doesn't add any value. Alerts are never updated by MHRA – if they need to make a correction they issue another alert because of the way most of their users track which alerts they have actioned.

Trello ticket: https://trello.com/c/TSVnykCU/510-email-text-published-updated