### PR TITLE
Refactor finder publishing

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -74,7 +74,7 @@ private
   end
 
   def publishing_app
-    "finder-api"
+    "specialist-publisher"
   end
 
   def rendering_app

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -1,6 +1,28 @@
 require "time"
 
-class FinderContentItemPresenter < Struct.new(:metadata, :schema)
+class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
+  def exportable_attributes
+    {
+      "base_path" => base_path,
+      "format" => format,
+      "content_id" => content_id,
+      "title" => title,
+      "description" => description,
+      "public_updated_at" => public_updated_at,
+      "update_type" => update_type,
+      "publishing_app" => publishing_app,
+      "rendering_app" => rendering_app,
+      "routes" => routes,
+      "details" => details,
+      "links" => {
+        "organisations" => organisations,
+        "topics" => [],
+        "related" => related,
+      },
+    }
+  end
+
+private
   def title
     metadata.fetch("name")
   end
@@ -53,6 +75,10 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema)
     []
   end
 
+  def publishing_app
+    "finder-api"
+  end
+
   def rendering_app
     "finder-frontend"
   end
@@ -63,5 +89,9 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema)
 
   def update_type
     "minor"
+  end
+
+  def public_updated_at
+    timestamp
   end
 end

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -2,15 +2,15 @@ require "time"
 
 class FinderContentItemPresenter < Struct.new(:metadata, :schema)
   def title
-    metadata["name"]
+    metadata.fetch("name")
   end
 
   def content_id
-    metadata["content_id"]
+    metadata.fetch("content_id")
   end
 
   def base_path
-    "/#{metadata["slug"]}"
+    "/#{metadata.fetch("slug", "")}"
   end
 
   def description
@@ -21,10 +21,10 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema)
     {
       beta: metadata.fetch("beta", false),
       beta_message: metadata.fetch("beta_message", nil),
-      document_noun: schema["document_noun"],
-      document_type: metadata["format"],
+      document_noun: schema.fetch("document_noun"),
+      document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
-      facets: schema["facets"],
+      facets: schema.fetch("facets"),
     }
   end
 
@@ -58,7 +58,7 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema)
   end
 
   def organisations
-    metadata["organisations"]
+    metadata.fetch("organisations", [])
   end
 
   def update_type

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -16,6 +16,7 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
         "organisations" => organisations,
         "topics" => [],
         "related" => related,
+        "email_alert_signup" => email_alert_signup,
       },
     }
   end
@@ -91,5 +92,9 @@ private
 
   def public_updated_at
     timestamp
+  end
+
+  def email_alert_signup
+    [metadata.fetch("signup_content_id", nil)].compact
   end
 end

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -1,5 +1,3 @@
-require "time"
-
 class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
   def exportable_attributes
     {

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -70,7 +70,7 @@ private
   end
 
   def publishing_app
-    "finder-api"
+    "specialist-publisher"
   end
 
   def rendering_app

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -1,6 +1,28 @@
 require "time"
 
-class FinderSignupContentItemPresenter < Struct.new(:metadata)
+class FinderSignupContentItemPresenter < Struct.new(:metadata, :timestamp)
+  def exportable_attributes
+    {
+      "base_path" => base_path,
+      "format" => format,
+      "content_id" => content_id,
+      "title" => title,
+      "description" => description,
+      "public_updated_at" => public_updated_at,
+      "update_type" => update_type,
+      "publishing_app" => publishing_app,
+      "rendering_app" => rendering_app,
+      "routes" => routes,
+      "details" => details,
+      "links" => {
+        "organisations" => organisations,
+        "topics" => [],
+        "related" => related,
+      },
+    }
+  end
+
+private
   def title
     metadata.fetch("signup_title", metadata.fetch("name"))
   end
@@ -49,6 +71,10 @@ class FinderSignupContentItemPresenter < Struct.new(:metadata)
     []
   end
 
+  def publishing_app
+    "finder-api"
+  end
+
   def rendering_app
     "finder-frontend"
   end
@@ -59,5 +85,9 @@ class FinderSignupContentItemPresenter < Struct.new(:metadata)
 
   def update_type
     "minor"
+  end
+
+  def public_updated_at
+    timestamp
   end
 end

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -2,19 +2,19 @@ require "time"
 
 class FinderSignupContentItemPresenter < Struct.new(:metadata)
   def title
-    metadata.fetch("signup_title", metadata["name"])
+    metadata.fetch("signup_title", metadata.fetch("name"))
   end
 
   def content_id
-    metadata["signup_content_id"]
+    metadata.fetch("signup_content_id")
   end
 
   def base_path
-    "/#{metadata["slug"]}/email-signup"
+    "/#{metadata.fetch("slug")}/email-signup"
   end
 
   def description
-    metadata["signup_copy"]
+    metadata.fetch("signup_copy", nil)
   end
 
   def format
@@ -22,7 +22,9 @@ class FinderSignupContentItemPresenter < Struct.new(:metadata)
   end
 
   def related
-    [metadata["content_id"]]
+    [
+      metadata.fetch("content_id"),
+    ]
   end
 
   def routes
@@ -52,7 +54,7 @@ class FinderSignupContentItemPresenter < Struct.new(:metadata)
   end
 
   def organisations
-    metadata["organisations"]
+    metadata.fetch("organisations", [])
   end
 
   def update_type

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -1,5 +1,3 @@
-require "time"
-
 class FinderSignupContentItemPresenter < Struct.new(:metadata, :timestamp)
   def exportable_attributes
     {

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -19,7 +19,14 @@ private
   attr_reader :schemae, :metadata
 
   def export_finder(metadata, schema)
-    attrs = exportable_attributes(FinderContentItemPresenter.new(metadata[:file], schema[:file]), metadata[:timestamp])
+    finder = FinderContentItemPresenter.new(
+      metadata[:file],
+      schema[:file],
+      metadata[:timestamp],
+    )
+
+    attrs = finder.exportable_attributes
+
     if metadata.has_key?("signup_content_id")
       attrs["links"].merge!({ "email_alert_signup" => [metadata["signup_content_id"]] })
     end
@@ -27,32 +34,17 @@ private
   end
 
   def export_signup(metadata)
-    attrs = exportable_attributes(FinderSignupContentItemPresenter.new(metadata[:file]), metadata[:timestamp])
+    finder_signup = FinderSignupContentItemPresenter.new(
+      metadata[:file],
+      metadata[:timestamp],
+    )
+
+    attrs = finder_signup.exportable_attributes
+
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end
 
   def publishing_api
     @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find("publishing-api"))
-  end
-
-  def exportable_attributes(item, timestamp)
-    {
-      "base_path" => item.base_path,
-      "format" => item.format,
-      "content_id" => item.content_id,
-      "title" => item.title,
-      "description" => item.description,
-      "public_updated_at" => timestamp,
-      "update_type" => "major",
-      "publishing_app" => "finder-api",
-      "rendering_app" => item.rendering_app,
-      "routes" => item.routes,
-      "details" => item.details,
-      "links" => {
-        "organisations" => item.organisations,
-        "topics" => [],
-        "related" => item.related,
-      },
-    }
   end
 end

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -11,7 +11,7 @@ class PublishingApiFinderPublisher
   def call
     metadata.zip(schemae).map { |metadata, schema|
       export_finder(metadata, schema)
-      export_signup(metadata) if metadata.has_key?("signup_content_id")
+      export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
     }
   end
 
@@ -27,9 +27,6 @@ private
 
     attrs = finder.exportable_attributes
 
-    if metadata.has_key?("signup_content_id")
-      attrs["links"].merge!({ "email_alert_signup" => [metadata["signup_content_id"]] })
-    end
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end
 

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -7,22 +7,40 @@ describe PublishingApiFinderPublisher do
 
       metadata = [
         {
-          file: {"slug" => "first-finder", "name" => "first finder"},
+          file: {
+            "slug" => "first-finder",
+            "name" => "first finder",
+            "content_id" => "some-random-id",
+            "format" => "a_report_format",
+          },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
         {
-          file: {"slug" => "second-finder", "name" => "second finder"},
+          file: {
+            "slug" => "second-finder",
+            "name" => "second finder",
+            "content_id" => "some-other-random-id",
+            "format" => "some_case_format",
+          },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         }
       ]
 
       schemae =  [
         {
-          file: {"slug" => "first-finder", "facets" => ["a facet", "another facet"] },
+          file: {
+            "slug" => "first-finder",
+            "facets" => ["a facet", "another facet"],
+            "document_noun" => "reports",
+          },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
         {
-          file: {"slug" => "second-finder", "facets" => ["a facet", "another facet"] },
+          file: {
+            "slug" => "second-finder",
+            "facets" => ["a facet", "another facet"],
+            "document_noun" => "cases",
+          },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         }
       ]

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -12,6 +12,7 @@ describe PublishingApiFinderPublisher do
             "name" => "first finder",
             "content_id" => "some-random-id",
             "format" => "a_report_format",
+            "signup_content_id" => "content-id-for-email-signup-page",
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
@@ -49,7 +50,14 @@ describe PublishingApiFinderPublisher do
         .with(Plek.new.find("publishing-api"))
         .and_return(publishing_api)
 
-      expect(publishing_api).to receive(:put_content_item).twice
+      expect(publishing_api).to receive(:put_content_item)
+        .with("/first-finder", anything)
+
+      expect(publishing_api).to receive(:put_content_item)
+        .with("/first-finder/email-signup", anything)
+
+      expect(publishing_api).to receive(:put_content_item)
+        .with("/second-finder", anything)
 
       PublishingApiFinderPublisher.new(metadata, schemae).call
     end


### PR DESCRIPTION
Clean up the separation between the `PublishingApiFinderPublisher` and the two presenters it uses to format data.

Also fixes a bug where email signup pages wouldn't be published.

This work was done to prepare for modifying the publisher to also index the pages in Rummager.