### PR TITLE
Update RAIB slug for permission checks

### DIFF
--- a/app/exporters/formatters/raib_report_artefact_formatter.rb
+++ b/app/exporters/formatters/raib_report_artefact_formatter.rb
@@ -15,6 +15,6 @@ class RaibReportArtefactFormatter < AbstractArtefactFormatter
   end
 
   def organisation_slugs
-    ["rail-accidents-investigation-branch"]
+    ["rail-accident-investigation-branch"]
   end
 end

--- a/app/exporters/formatters/raib_report_indexable_formatter.rb
+++ b/app/exporters/formatters/raib_report_indexable_formatter.rb
@@ -15,6 +15,6 @@ private
   end
 
   def organisation_slugs
-    ["rail-accidents-investigation-branch"]
+    ["rail-accident-investigation-branch"]
   end
 end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -50,7 +50,7 @@ private
     when "maib_report"
       "marine-accident-investigation-branch"
     when "raib_report"
-      "rail-accidents-investigation-branch"
+      "rail-accident-investigation-branch"
     end
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
   end
 
   factory :raib_editor, parent: :editor do
-    organisation_slug "rail-accidents-investigation-branch"
+    organisation_slug "rail-accident-investigation-branch"
   end
 
   factory :generic_editor, parent: :editor do


### PR DESCRIPTION
RAIB was originally created with an incorrect slug in signon. This has since been updated and RAIB editors can no longer access their documents. This commit updates the slug to match the correct version currently in signon.

We should probably republish all RAIB documents after deploying this because they're all associated with a non-existent org