### PR TITLE
Add raib_report type to republishing script

### DIFF
--- a/lib/document_repository_observer_mapper.rb
+++ b/lib/document_repository_observer_mapper.rb
@@ -34,6 +34,10 @@ private
         repository_registry.for_type("drug_safety_update"),
         DrugSafetyUpdateObserversRegistry.new.republication,
       ),
+      "raib_report" => RepositoryObserversTuple.new(
+        repository_registry.for_type("raib_report"),
+        RaibReportObserversRegistry.new.republication,
+      ),
     }
   end
 


### PR DESCRIPTION
Given this hash lookup is eminently meta-programmable, that would probably be a nicer option than having to add each format whenever we first need to do a republishing. To unblock republishing RAIB reports, however, this is sufficient.