### PR TITLE
Enable signup for MHRA Finders

### DIFF
--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -7,6 +7,7 @@
   "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/DrugSafetyUpdate/index.htm'>the MHRA website</a> is the official home of the Drug Safety Update.",
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
+  "signup_enabled": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"],
   "subscription_list_title_prefix": "Drug Safety Update"

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -8,6 +8,7 @@
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
+  "signup_enabled": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
   "email_filter_by": "alert_type",


### PR DESCRIPTION
With email workflow now tested we want to enable signup links for Users visiting MHRA Finders.

[Ticket](https://trello.com/c/IvovAfJI/515-show-link-on-the-mhra-finders-to-the-email-subscription-page).