### PR TITLE
Add email address to email footer

### DIFF
--- a/app/views/email_alerts/publication_footer.html.erb
+++ b/app/views/email_alerts/publication_footer.html.erb
@@ -12,6 +12,10 @@
           Provided by
           <a href="https://gov.uk" style="color: #005EA5 !important;">GOV.UK</a>
         </li>
+
+        <li style="margin: 0 0 10px; padding: 0; list-style: none;">
+          This email was sent to [[EMAIL_ADDRESS]]
+        </li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
This enables users who have email forwarding to know which email
address it was sent to.