### PR TITLE
Fix gov.uk link in email footer

### DIFF
--- a/app/views/email_alerts/publication_footer.html.erb
+++ b/app/views/email_alerts/publication_footer.html.erb
@@ -10,7 +10,7 @@
 
         <li style="margin: 0 0 10px; padding: 0; list-style: none;">
           Provided by
-          <a href="https://gov.uk" style="color: #005EA5 !important;">GOV.UK</a>
+          <a href="https://www.gov.uk" style="color: #005EA5 !important;">GOV.UK</a>
         </li>
 
         <li style="margin: 0 0 10px; padding: 0; list-style: none;">


### PR DESCRIPTION
Linking to https://gov.uk causes an unnecessary redirect to https://www.gov.uk, so just link directly to that.