### PR TITLE
State the alert type in email alert subject line

### DIFF
--- a/app/exporters/formatters/medical_safety_alert_publication_alert_formatter.rb
+++ b/app/exporters/formatters/medical_safety_alert_publication_alert_formatter.rb
@@ -14,6 +14,16 @@ class MedicalSafetyAlertPublicationAlertFormatter < AbstractDocumentPublicationA
     )
   end
 
+  def subject
+    if document.alert_type == "drugs"
+      "Drug alert: #{document.title}"
+    elsif document.alert_type == "devices"
+      "Medical device alert: #{document.title}"
+    else
+      document.title
+    end
+  end
+
 private
   def document_noun
     "alert"

--- a/spec/exporters/formatters/medical_safety_alert_publication_alert_formatter_spec.rb
+++ b/spec/exporters/formatters/medical_safety_alert_publication_alert_formatter_spec.rb
@@ -1,0 +1,25 @@
+require "fast_spec_helper"
+require "formatters/abstract_document_publication_alert_formatter"
+
+RSpec.describe MedicalSafetyAlertPublicationAlertFormatter do
+  let(:url_maker) {
+    double(:url_maker,
+      published_specialist_document_path: "http://www.example.com"
+    )
+  }
+  let(:document) {
+    double(:document,
+      alert_type: "drugs",
+      title: "Some title",
+    )
+  }
+  subject(:formatter) {
+    MedicalSafetyAlertPublicationAlertFormatter.new(
+      document: document,
+      url_maker: url_maker,
+    )
+  }
+  it "has a subject containing the document title" do
+    expect(formatter.subject).to eq("Drug alert: Some title")
+  end
+end


### PR DESCRIPTION
Currently it is not clear to the user whether an alert is relevant to a
drug or a medical device. This commit adds this to the email subject.