### PR TITLE
Add signup links to MHRA

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -45,6 +45,7 @@ private
       document_noun: schema.fetch("document_noun"),
       document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
+      signup_link: metadata.fetch("signup_link", nil),
       facets: schema.fetch("facets"),
     }
   end

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -6,6 +6,7 @@
   "beta": true,
   "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/DrugSafetyUpdate/index.htm'>the MHRA website</a> is the official home of the Drug Safety Update.",
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
+  "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "signup_enabled": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -6,6 +6,7 @@
   "beta": true,
   "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/Safetywarningsalertsandrecalls/index.htm'>the MHRA website</a> is the main source for drug alerts and medical device alerts.",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
+  "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "signup_enabled": true,


### PR DESCRIPTION
For MHRA, we don’t want to go directly to the finder-frontend signup
url, but via whitehall. This commit adds those links.