### PR TITLE
Clean up all Medical Safety Alert titles

### DIFF
--- a/db/migrate/20150116162518_remove_alert_type_from_titles.rb
+++ b/db/migrate/20150116162518_remove_alert_type_from_titles.rb
@@ -1,0 +1,14 @@
+class RemoveAlertTypeFromTitles < Mongoid::Migration
+  def self.up
+    SpecialistDocumentEdition.where(document_type: "medical_safety_alert").order("updated_at ASC").each do |medical_safety_alert|
+      title = medical_safety_alert.title
+      title = title.gsub(/^Medical device alert: /, "").gsub(/^Drug alert: /, "")
+      title[0] = title[0].capitalize
+      medical_safety_alert.set(:title, title)
+    end
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
As we now include the alert type automatically in medical device
alerts, publishers will no longer need to manually add them to the
titles. This means we can also clean up all the existing titles.

Fixes capitalisation as well.