### PR TITLE
Add change notes to alert emails

### DIFF
--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -53,6 +53,7 @@ private
       document_title: document.title,
       document_summary: document.summary,
       document_url: url_maker.published_specialist_document_path(document),
+      document_change_note: document_change_note,
     }
   end
 
@@ -70,6 +71,10 @@ private
 
   def updated_or_published_text
     document.version_number == 1 ? "published" : "updated"
+  end
+
+  def document_change_note
+    document.change_note if document.version_number != 1
   end
 
   def extra_fields

--- a/app/views/email_alerts/medical_safety_alerts/publication.html.erb
+++ b/app/views/email_alerts/medical_safety_alerts/publication.html.erb
@@ -15,6 +15,12 @@
         <%= document_summary %>
       </p>
 
+      <% if document_change_note.present? %>
+        <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+          Update: <%= document_change_note %>
+        </p>
+      <% end %>
+
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
         For further information on this <%= document_noun %>:
       </p>

--- a/app/views/email_alerts/publication.html.erb
+++ b/app/views/email_alerts/publication.html.erb
@@ -15,6 +15,12 @@
         <%= document_summary %>
       </p>
 
+      <% if document_change_note.present? %>
+        <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+          Update: <%= document_change_note %>
+        </p>
+      <% end %>
+
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
         For further information on this <%= updated_or_published %> <%= document_noun %>:
       </p>

--- a/spec/exporters/formatters/abstract_document_publication_alert_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_document_publication_alert_formatter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe AbstractDocumentPublicationAlertFormatter do
       title: "Some title",
       slug: "some-prefix/some-permalink",
       summary: "some summary",
-      version_number: 1,
+      change_note: change_note,
+      version_number: version_number,
       extra_fields: {
         metadata_attribute: metadata_attribute,
         array_metadata_attribute: array_metadata_attribute
@@ -40,29 +41,46 @@ RSpec.describe AbstractDocumentPublicationAlertFormatter do
     )
   }
 
-  it "has a name which corresponds to the topic name" do
-    expect(formatter.name).to eql("Specialist Documents")
+  context "a new document" do
+    let(:change_note) { "First published." }
+    let(:version_number) { 1 }
+
+    it "has a name which corresponds to the topic name" do
+      expect(formatter.name).to eql("Specialist Documents")
+    end
+
+    it "has tags which correspond to the email filter tags for that document type (format)" do
+      expect(formatter.tags[:format]).to eql(["document"])
+      expect(formatter.tags[:metadata_attribute]).to eql([metadata_attribute])
+      expect(formatter.tags[:array_metadata_attribute]).to eql(array_metadata_attribute)
+    end
+
+    it "has a subject containing the document title" do
+      expect(formatter.subject).to eq("Some title")
+    end
+
+    it "has a body containing the document title, url, and summary" do
+      expect(formatter.body).to include("Some title")
+      expect(formatter.body).to include("http://www.example.com")
+      expect(formatter.body).to include("some summary")
+      expect(formatter.body).to include("published")
+    end
+
+    it "doesn't include the change note in the body" do
+      expect(formatter.body).to_not include("First published")
+    end
   end
 
-  it "has tags which correspond to the email filter tags for that document type (format)" do
-    expect(formatter.tags[:format]).to eql(["document"])
-    expect(formatter.tags[:metadata_attribute]).to eql([metadata_attribute])
-    expect(formatter.tags[:array_metadata_attribute]).to eql(array_metadata_attribute)
-  end
+  context "an updated document" do
+    let(:change_note) { "This is the change note" }
+    let(:version_number) { 2 }
 
-  it "has a subject containing the document title" do
-    expect(formatter.subject).to eq("Some title")
-  end
+    it "includes 'updated' in the body" do
+      expect(formatter.body).to include("updated")
+    end
 
-  it "has a body containing the document title, url, and summary" do
-    expect(formatter.body).to include("Some title")
-    expect(formatter.body).to include("http://www.example.com")
-    expect(formatter.body).to include("some summary")
-    expect(formatter.body).to include("published")
-  end
-
-  it "includes 'updated' in the body if its not the first document version" do
-    allow(document).to receive(:version_number).and_return(2)
-    expect(formatter.body).to include("updated")
+    it "includes the change note in the body" do
+      expect(formatter.body).to include("This is the change note")
+    end
   end
 end


### PR DESCRIPTION
When a major change is made to a document, include the change note in the alert email.

Should not effect email alerts for new documents.

Includes MHRA, who have a different email template.