### PR TITLE
Catch multiple publishing

### DIFF
--- a/app/services/publish_document_service.rb
+++ b/app/services/publish_document_service.rb
@@ -7,8 +7,10 @@ class PublishDocumentService
   end
 
   def call
-    publish
-    persist
+    if document.latest_edition != document.published_edition
+      publish
+      persist
+    end
 
     document
   end

--- a/spec/services/publish_document_service_spec.rb
+++ b/spec/services/publish_document_service_spec.rb
@@ -3,7 +3,16 @@ require "publish_document_service"
 RSpec.describe PublishDocumentService do
   let(:document_id) { double(:document_id) }
   let(:repository) { double(:repository) }
-  let(:document) { double(:document, minor_update: minor_update, extra_fields: {bulk_published: false}) }
+  let(:latest_edition) { double(:latest_edition) }
+  let(:published_edition) { double(:published_edition) }
+  let(:document) {
+    double(:document,
+      minor_update: minor_update,
+      extra_fields: {bulk_published: false},
+      latest_edition: latest_edition,
+      published_edition: published_edition,
+    )
+  }
   let(:minor_update) { nil }
   let(:listeners) { [] }
 


### PR DESCRIPTION
If a user is trying to publish a document that has already been
published (e.g. they double click publish, or have the same document
open in multiple tabs), then do nothing.