### PR TITLE
Reduce duplication in finders

### DIFF
--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -20,7 +20,7 @@ class FinderSchema
   end
 
   def humanized_facet_value(facet_key, value, &block)
-    if facet_data_for(facet_key).fetch("type", nil) == "multi-select"
+    if facet_data_for(facet_key).fetch("type", nil) == "text"
       Array(value).map do |v|
         value_label_mapping_for(facet_key, v).fetch("label", &block)
       end

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -46,6 +46,7 @@ private
       document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
       signup_link: metadata.fetch("signup_link", nil),
+      show_summaries: metadata.fetch("show_summaries", false),
       facets: schema.fetch("facets"),
     }
   end

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -45,6 +45,7 @@ private
       document_noun: schema.fetch("document_noun"),
       document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
+      format_name: metadata.fetch("format_name"),
       signup_link: metadata.fetch("signup_link", nil),
       show_summaries: metadata.fetch("show_summaries", false),
       facets: schema.fetch("facets"),

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -7,6 +7,7 @@
   "beta_message": "Until early 2015, the <a href='http://www.aaib.gov.uk/home/index.cfm'>AAIB website</a> is the main source for AAIB reports",
   "signup_content_id": "1ad5918c-19ff-4431-b20b-1bab890cd84b",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "show_summaries": true,
   "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"],
   "subscription_list_title_prefix": {
     "singular": "Air Accidents Investigation Branch (AAIB) reports with the following aircraft category: ",

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "slug": "aaib-reports",
   "format": "aaib_report",
+  "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.aaib.gov.uk/home/index.cfm'>AAIB website</a> is the main source for AAIB reports",

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -2,6 +2,7 @@
   "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "slug": "cma-cases",
   "format": "cma_case",
+  "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases",
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -2,6 +2,7 @@
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
   "format": "drug_safety_update",
+  "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",
   "show_summaries": true,
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -3,6 +3,7 @@
   "slug": "drug-safety-update",
   "format": "drug_safety_update",
   "name": "Drug Safety Update",
+  "show_summaries": true,
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -2,6 +2,7 @@
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
   "format": "international_development_fund",
+  "format_name": "International development funding",
   "name": "International development funding",
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -6,6 +6,7 @@
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "signup_enabled": true,
+  "show_summaries": true,
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"],
   "subscription_list_title_prefix": "International development funds"
 }

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "slug": "maib-reports",
   "format": "maib_report",
+  "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.maib.gov.uk/home/index.cfm'>MAIB website</a> is the main source for MAIB reports",

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -8,6 +8,7 @@
   "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "signup_enabled": true,
+  "show_summaries": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
   "email_filter_by": "alert_type",

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -2,6 +2,7 @@
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
   "format": "medical_safety_alert",
+  "format_name": "Medical safety alert",
   "name": "Alerts and recalls for drugs and medical devices",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "slug": "raib-reports",
   "format": "raib_report",
+  "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.raib.gov.uk/home/index.cfm'>RAIB website</a> is the main source for RAIB reports",

--- a/finders/schemas/aaib-reports.json
+++ b/finders/schemas/aaib-reports.json
@@ -37,6 +37,7 @@
     {
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
+      "short_name": "Occurred",
       "type": "date",
       "preposition": "occurred",
       "display_as_result_metadata": true,

--- a/finders/schemas/aaib-reports.json
+++ b/finders/schemas/aaib-reports.json
@@ -5,8 +5,10 @@
     {
       "key": "aircraft_category",
       "name": "Aircraft category",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "in aircraft category",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
         {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
@@ -18,8 +20,10 @@
     {
       "key": "report_type",
       "name": "Report type",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Annual safety report", "value": "annual-safety-report"},
         {"label": "Bulletin - Correspondence investigation", "value": "correspondence-investigation"},
@@ -34,7 +38,9 @@
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
       "type": "date",
-      "preposition": "occurred"
+      "preposition": "occurred",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/finders/schemas/aaib-reports.json
+++ b/finders/schemas/aaib-reports.json
@@ -42,6 +42,27 @@
       "preposition": "occurred",
       "display_as_result_metadata": true,
       "filterable": true
+    },
+    {
+      "key": "aircraft_type",
+      "name": "Aircraft type",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "location",
+      "name": "Location",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "location",
+      "name": "Location",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
     }
   ]
 }

--- a/finders/schemas/cma-cases.json
+++ b/finders/schemas/cma-cases.json
@@ -5,8 +5,10 @@
     {
         "key": "case_type",
         "name": "Case type",
-        "type": "multi-select",
+        "type": "text",
         "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
         "allowed_values": [
           {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"},
           {"label": "Criminal cartels", "value": "criminal-cartels"},
@@ -21,8 +23,10 @@
     {
       "key": "case_state",
       "name": "Case state",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "which are",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Open", "value": "open"},
         {"label": "Closed", "value": "closed"}
@@ -32,8 +36,10 @@
     {
       "key": "market_sector",
       "name": "Market sector",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "about",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Aerospace", "value": "aerospace"},
         {"label": "Agriculture, environment and natural resources", "value": "agriculture-environment-and-natural-resources"},
@@ -70,8 +76,10 @@
     {
       "key": "outcome_type",
       "name": "Outcome",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "with outcome",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "CA98 - no grounds for action", "value": "ca98-no-grounds-for-action-non-infringement"},
         {"label": "CA98 - infringement Chapter I", "value": "ca98-infringement-chapter-i"},
@@ -103,7 +111,17 @@
       "key": "opened_date",
       "name": "Opened",
       "type": "date",
-      "preposition": "opened"
+      "preposition": "opened",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+
+    {
+      "key": "closed_date",
+      "short_name": "Closed",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": false
     }
   ]
 }

--- a/finders/schemas/cma-cases.json
+++ b/finders/schemas/cma-cases.json
@@ -110,11 +110,11 @@
     {
       "key": "opened_date",
       "name": "Opened",
+      "short_name": "Opened",
       "type": "date",
       "preposition": "opened",
       "display_as_result_metadata": true,
-      "filterable": true
-    },
+      "filterable": true    },
 
     {
       "key": "closed_date",

--- a/finders/schemas/drug-safety-updates.json
+++ b/finders/schemas/drug-safety-updates.json
@@ -39,6 +39,7 @@
     {
       "key": "first_published_at",
       "name": "Published",
+      "short_name": "Published",
       "type": "date",
       "preposition": "published",
       "display_as_result_metadata": true,

--- a/finders/schemas/drug-safety-updates.json
+++ b/finders/schemas/drug-safety-updates.json
@@ -5,8 +5,10 @@
     {
       "key": "therapeutic_area",
       "name": "Therapeutic area",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "about",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Anaesthesia and intensive care", "value": "anaesthesia-intensive-care"},
         {"label": "Cancer", "value": "cancer"},
@@ -38,7 +40,9 @@
       "key": "first_published_at",
       "name": "Published",
       "type": "date",
-      "preposition": "published"
+      "preposition": "published",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/finders/schemas/international-development-funds.json
+++ b/finders/schemas/international-development-funds.json
@@ -5,8 +5,10 @@
     {
       "key": "fund_state",
       "name": "Funds",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "which are",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Open", "value": "open"},
         {"label": "Closed", "value": "closed"}
@@ -15,8 +17,10 @@
     {
       "key": "location",
       "name": "Countries",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "for",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {
           "label": "Afghanistan",
@@ -135,8 +139,10 @@
     {
       "key": "development_sector",
       "name": "Sector",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "for",
+      "display_as_result_metadata": false,
+      "filterable": true,
       "allowed_values": [
         {
           "label": "Agriculture",
@@ -203,8 +209,10 @@
     {
       "key": "eligible_entities",
       "name": "Eligible organisations",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "open to",
+      "filterable": true,
+      "display_as_result_metadata": false,
       "allowed_values": [
         {
           "label": "Non-governmental organisations (NGOs)",
@@ -243,8 +251,10 @@
     {
       "key": "value_of_funding",
       "name": "Value of funding",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "with value",
+      "display_as_result_metadata": false,
+      "filterable": false,
       "allowed_values": [
         {"label": "Up to £100,000", "value": "up-to-100000"},
         {"label": "£100,001 to £500,000", "value": "100001-500000"},

--- a/finders/schemas/maib-reports.json
+++ b/finders/schemas/maib-reports.json
@@ -35,6 +35,7 @@
     {
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
+      "short_name": "Occurred",
       "type": "date",
       "preposition": "occurred",
       "display_as_result_metadata": true,

--- a/finders/schemas/maib-reports.json
+++ b/finders/schemas/maib-reports.json
@@ -5,8 +5,10 @@
     {
       "key": "vessel_type",
       "name": "Vessel type",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Merchant vessel 100 gross tons or over", "value": "merchant-vessel-100-gross-tons-or-over"},
         {"label": "Merchant vessel under 100 gross tons", "value": "merchant-vessel-under-100-gross-tons"},
@@ -18,8 +20,10 @@
    {
      "key": "report_type",
      "name": "Report type",
-     "type": "multi-select",
+     "type": "text",
      "preposition": "of type",
+     "display_as_result_metadata": true,
+      "filterable": true,
      "allowed_values": [
        {"label": "Investigation report", "value": "investigation-report"},
        {"label": "Safety bulletin", "value": "safety-bulletin"},
@@ -32,7 +36,9 @@
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
       "type": "date",
-      "preposition": "occurred"
+      "preposition": "occurred",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/finders/schemas/medical-safety-alerts.json
+++ b/finders/schemas/medical-safety-alerts.json
@@ -49,6 +49,7 @@
     {
       "key": "issued_date",
       "name": "Issued",
+      "short_name": "Issued",
       "type": "date",
       "preposition": "issued",
       "display_as_result_metadata": true,

--- a/finders/schemas/medical-safety-alerts.json
+++ b/finders/schemas/medical-safety-alerts.json
@@ -5,8 +5,10 @@
     {
       "key": "alert_type",
       "name": "Alert type",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "for",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Drug alert", "value": "drugs"},
         {"label": "Medical device alert", "value": "devices"}
@@ -15,8 +17,10 @@
     {
       "key": "medical_specialism",
       "name": "Medical specialism",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "about",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Anaesthetics", "value": "anaesthetics" },
         {"label": "Cardiology", "value": "cardiology" },
@@ -46,7 +50,9 @@
       "key": "issued_date",
       "name": "Issued",
       "type": "date",
-      "preposition": "issued"
+      "preposition": "issued",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/finders/schemas/raib-reports.json
+++ b/finders/schemas/raib-reports.json
@@ -5,8 +5,10 @@
     {
       "key": "railway_type",
       "name": "Railway type",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Heavy rail", "value": "heavy-rail"},
         {"label": "Light rail", "value": "light-rail"},
@@ -17,8 +19,10 @@
     {
       "key": "report_type",
       "name": "Report type",
-      "type": "multi-select",
+      "type": "text",
       "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
       "allowed_values": [
         {"label": "Investigation report", "value": "investigation-report"},
         {"label": "Bulletin", "value": "bulletin"},
@@ -30,7 +34,9 @@
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
       "type": "date",
-      "preposition": "occurred"
+      "preposition": "occurred",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/finders/schemas/raib-reports.json
+++ b/finders/schemas/raib-reports.json
@@ -33,6 +33,7 @@
     {
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
+      "short_name": "Occurred",
       "type": "date",
       "preposition": "occurred",
       "display_as_result_metadata": true,

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -10,6 +10,7 @@ describe PublishingApiFinderPublisher do
           file: {
             "slug" => "first-finder",
             "name" => "first finder",
+            "format_name" => "first finder things",
             "content_id" => "some-random-id",
             "format" => "a_report_format",
             "signup_content_id" => "content-id-for-email-signup-page",
@@ -20,6 +21,7 @@ describe PublishingApiFinderPublisher do
           file: {
             "slug" => "second-finder",
             "name" => "second finder",
+            "format_name" => "second finder things",
             "content_id" => "some-other-random-id",
             "format" => "some_case_format",
           },
@@ -69,6 +71,7 @@ describe PublishingApiFinderPublisher do
             "slug" => "finder-without-content-id",
             "name" => "finder without content id",
             "format" => "a_report_format",
+            "format_name" => "a report format",
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
@@ -78,6 +81,7 @@ describe PublishingApiFinderPublisher do
             "name" => "finder with content id",
             "content_id" => "some-random-id",
             "format" => "a_report_format",
+            "format_name" => "a report format",
             "signup_content_id" => "content-id-for-email-signup-page",
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",


### PR DESCRIPTION
This PR contains the following commits, which are necessary to reduce specificity in Finder Frontend:

- **Specify if a value should be returned as metadata** - This commit allows us to define on a per-facet basis if we want that facet returned as document metadata.
- **Add labels for certain facets** - Certain facets,  (such as `date_issued`) don't just use the name of the Filter for the metadata label. This commit defines it for all existing instances of this.
- **Allow summary definition in metadata** - This commits sets the summaries flag for certain formats and send that to the content store as part of the details hash.

The rest of the work in Finder Frontend to use these changes will come later.