### PR TITLE
Remove beta label from MHRA Finders

### DIFF
--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -3,8 +3,6 @@
   "slug": "drug-safety-update",
   "format": "drug_safety_update",
   "name": "Drug Safety Update",
-  "beta": true,
-  "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/DrugSafetyUpdate/index.htm'>the MHRA website</a> is the official home of the Drug Safety Update.",
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -3,8 +3,6 @@
   "slug": "drug-device-alerts",
   "format": "medical_safety_alert",
   "name": "Alerts and recalls for drugs and medical devices",
-  "beta": true,
-  "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/Safetywarningsalertsandrecalls/index.htm'>the MHRA website</a> is the main source for drug alerts and medical device alerts.",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_title": "Drug alerts and medical device alerts",


### PR DESCRIPTION
MHRA are setting up redirects for their content on Tuesday 27th Jan 2015 at 2.30pm (UTC). Before the redirects are live we should make sure that the pages on GOV.UK are no longer showing a beta label with a message suggesting the old MHRA website is still the place to look.

This commit had a false start in #387 and #388, but we're confident it's really happening this time.