### PR TITLE
Only publish Finder if it has a content id

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -10,8 +10,12 @@ class PublishingApiFinderPublisher
 
   def call
     metadata.zip(schemae).map { |metadata, schema|
-      export_finder(metadata, schema)
-      export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
+      if metadata[:file].has_key?("content_id")
+        export_finder(metadata, schema)
+        export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
+      else
+        puts "didn't publish #{metadata[:file][:title]} because it doesn't have a content_id"
+      end
     }
   end
 
@@ -27,6 +31,8 @@ private
 
     attrs = finder.exportable_attributes
 
+    puts "publishing '#{attrs["title"]}' finder"
+
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end
 
@@ -37,6 +43,8 @@ private
     )
 
     attrs = finder_signup.exportable_attributes
+
+    puts "publishing '#{attrs["title"]}' finder signup page"
 
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -61,5 +61,61 @@ describe PublishingApiFinderPublisher do
 
       PublishingApiFinderPublisher.new(metadata, schemae).call
     end
+
+    it "doesn't publish a Finder without a content id" do
+      metadata = [
+        {
+          file: {
+            "slug" => "finder-without-content-id",
+            "name" => "finder without content id",
+            "format" => "a_report_format",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+        {
+          file: {
+            "slug" => "finder-with-content-id",
+            "name" => "finder with content id",
+            "content_id" => "some-random-id",
+            "format" => "a_report_format",
+            "signup_content_id" => "content-id-for-email-signup-page",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+      ]
+
+      schemae =  [
+        {
+          file: {
+            "slug" => "finder-without-content-id",
+            "facets" => ["a facet", "another facet"],
+            "document_noun" => "reports",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+        {
+          file: {
+            "slug" => "finder-with-content-id",
+            "facets" => ["a facet", "another facet"],
+            "document_noun" => "reports",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+      ]
+
+      publishing_api = double("publishing-api")
+
+      expect(GdsApi::PublishingApi).to receive(:new)
+        .with(Plek.new.find("publishing-api"))
+        .and_return(publishing_api)
+
+      expect(publishing_api).not_to receive(:put_content_item)
+        .with("/finder-without-content-id", anything)
+
+      expect(publishing_api).to receive(:put_content_item)
+        .with("/finder-with-content-id", anything)
+
+      PublishingApiFinderPublisher.new(metadata, schemae).call
+    end
   end
 end


### PR DESCRIPTION
As we work on some Finders, we may not want them to be public. This commit changes the Finder Publisher to only publish a Finder (and it's matching signup page) if it has a content id for the Finder present in the metadata file.