### PR TITLE
Countryside stewardship grants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
         document_type: "cma_case",
         title: "CMA Cases",
       },
+      "countryside-stewardship-grants" => {
+        document_type: "countryside_stewardship_grant",
+        title: "Countryside Stewardship Grants",
+      },
       "international-development-funds" => {
         document_type: "international_development_fund",
         title: "International Development Funds",

--- a/app/controllers/countryside_stewardship_grants_controller.rb
+++ b/app/controllers/countryside_stewardship_grants_controller.rb
@@ -1,0 +1,2 @@
+class CountrysideStewardshipGrantsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/countryside_stewardship_grant_artefact_formatter.rb
+++ b/app/exporters/formatters/countryside_stewardship_grant_artefact_formatter.rb
@@ -1,0 +1,23 @@
+require "formatters/abstract_artefact_formatter"
+
+class CountrysideStewardshipGrantArtefactFormatter < AbstractArtefactFormatter
+
+  def state
+    state_mapping.fetch(entity.publication_state)
+  end
+
+  def kind
+    "countryside_stewardship_grants"
+  end
+
+  def rendering_app
+    "specialist-frontend"
+  end
+
+  def organisation_slugs
+    %w(
+      natural-england
+      department-for-environment-food-rural-affairs
+    )
+  end
+end

--- a/app/exporters/formatters/countryside_stewardship_grant_indexable_formatter.rb
+++ b/app/exporters/formatters/countryside_stewardship_grant_indexable_formatter.rb
@@ -1,0 +1,19 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class CountrysideStewardshipGrantIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+  def type
+    "countryside_stewardship_grant"
+  end
+
+  private
+  def extra_attributes
+    {}
+  end
+
+  def organisation_slugs
+    %w(
+      natural-england
+      department-for-environment-food-rural-affairs
+    )
+  end
+end

--- a/app/exporters/formatters/countryside_stewardship_grant_publication_alert_formatter.rb
+++ b/app/exporters/formatters/countryside_stewardship_grant_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class CountrysideStewardshipGrantPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "Countryside Stewardship Grants"
+  end
+
+  private
+  def document_noun
+    "grant"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -51,6 +51,8 @@ private
       "marine-accident-investigation-branch"
     when "raib_report"
       "rail-accident-investigation-branch"
+    when "countryside_stewardship_grant"
+      "department-for-environment-food-rural-affairs"
     end
   end
 end

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -32,6 +32,7 @@ private
     {
       "aaib_report" => AaibReportObserversRegistry,
       "cma_case" => CmaCaseObserversRegistry,
+      "countryside_stewardship_grant" => CountrysideStewardshipGrantObserversRegistry,
       "drug_safety_update" => DrugSafetyUpdateObserversRegistry,
       "international_development_fund" => InternationalDevelopmentFundObserversRegistry,
       "maib_report" => MaibReportObserversRegistry,

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -9,6 +9,8 @@ require "formatters/aaib_report_artefact_formatter"
 require "formatters/aaib_report_indexable_formatter"
 require "formatters/cma_case_artefact_formatter"
 require "formatters/cma_case_indexable_formatter"
+require "formatters/countryside_stewardship_grant_artefact_formatter"
+require "formatters/countryside_stewardship_grant_indexable_formatter"
 require "formatters/drug_safety_update_artefact_formatter"
 require "formatters/drug_safety_update_indexable_formatter"
 require "formatters/international_development_fund_artefact_formatter"
@@ -98,6 +100,11 @@ SpecialistPublisherWiring = DependencyContainer.new do
   define_factory(:aaib_report_builder) {
     SpecialistDocumentBuilder.new("aaib_report",
       get(:validatable_document_factories).aaib_report_factory)
+  }
+
+  define_factory(:countryside_stewardship_grant_builder) {
+    SpecialistDocumentBuilder.new("countryside_stewardship_grant",
+    get(:validatable_document_factories).countryside_stewardship_grant_factory)
   }
 
   define_factory(:drug_safety_update_builder) {
@@ -262,6 +269,14 @@ SpecialistPublisherWiring = DependencyContainer.new do
     }
   }
 
+  define_factory(:countryside_stewardship_grant_panopticon_registerer) {
+    ->(document) {
+      get(:panopticon_registerer).call(
+        CountrysideStewardshipGrantArtefactFormatter.new(document)
+      )
+    }
+  }
+
   define_factory(:drug_safety_update_panopticon_registerer) {
     ->(document) {
       get(:panopticon_registerer).call(
@@ -348,6 +363,26 @@ SpecialistPublisherWiring = DependencyContainer.new do
     ->(document) {
       RummagerIndexer.new.delete(
         CmaCaseIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
+  }
+
+  define_factory(:countryside_stewardship_grant_rummager_indexer) {
+    ->(document) {
+      RummagerIndexer.new.add(
+        CountrysideStewardshipGrantIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
+  }
+
+  define_factory(:countryside_stewardship_grant_rummager_deleter) {
+    ->(document) {
+      RummagerIndexer.new.delete(
+        CountrysideStewardshipGrantIndexableFormatter.new(
           MarkdownAttachmentProcessor.new(document)
         )
       )
@@ -484,6 +519,18 @@ SpecialistPublisherWiring = DependencyContainer.new do
     }
   }
 
+  define_instance(:countryside_stewardship_grant_content_api_exporter) {
+    ->(doc) {
+      SpecialistDocumentDatabaseExporter.new(
+        RenderedSpecialistDocument,
+        get(:specialist_document_renderer),
+        get(:countryside_stewardship_grant_finder_schema),
+        doc,
+        PublicationLog,
+      ).call
+    }
+  }
+
   define_instance(:maib_report_content_api_exporter) {
     ->(doc) {
       SpecialistDocumentDatabaseExporter.new(
@@ -560,6 +607,11 @@ SpecialistPublisherWiring = DependencyContainer.new do
   define_singleton(:cma_case_finder_schema) {
     require "finder_schema"
     FinderSchema.new(Rails.root.join("finders/schemas/cma-cases.json"))
+  }
+
+  define_singleton(:countryside_stewardship_grant_finder_schema) {
+    require "finder_schema"
+    FinderSchema.new(Rails.root.join("finders/schemas/countryside-stewardship-grants.json"))
   }
 
   define_singleton(:drug_safety_update_finder_schema) {

--- a/app/models/countryside_stewardship_grant.rb
+++ b/app/models/countryside_stewardship_grant.rb
@@ -1,0 +1,5 @@
+require "document_metadata_decorator"
+
+class CountrysideStewardshipGrant < DocumentMetadataDecorator
+  set_extra_field_names []
+end

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -1,6 +1,7 @@
 require "validators/aaib_report_validator"
 require "validators/change_note_validator"
 require "validators/cma_case_validator"
+require "validators/countryside_stewardship_grant_validator"
 require "validators/drug_safety_update_validator"
 require "validators/international_development_fund_validator"
 require "validators/maib_report_validator"
@@ -46,6 +47,21 @@ class DocumentFactoryRegistry
           CmaCase.new(
             SpecialistDocument.new(
               SlugGenerator.new(prefix: "cma-cases"),
+              *args,
+            ),
+          )
+        )
+      )
+    }
+  end
+
+  def countryside_stewardship_grant_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        CountrysideStewardshipGrantValidator.new(
+          CountrysideStewardshipGrant.new(
+            SpecialistDocument.new(
+              SlugGenerator.new(prefix: "countryside-stewardship-grants"),
               *args,
             ),
           )

--- a/app/models/validators/countryside_stewardship_grant_validator.rb
+++ b/app/models/validators/countryside_stewardship_grant_validator.rb
@@ -1,0 +1,12 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class CountrysideStewardshipGrantValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+end

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -1,0 +1,33 @@
+require "email_alert_exporter"
+require "formatters/countryside_stewardship_grant_publication_alert_formatter"
+
+class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+  private
+  def panopticon_exporter
+    SpecialistPublisherWiring.get(:countryside_stewardship_grant_panopticon_registerer)
+  end
+
+  def content_api_exporter
+    SpecialistPublisherWiring.get(:countryside_stewardship_grant_content_api_exporter)
+  end
+
+  def rummager_exporter
+    SpecialistPublisherWiring.get(:countryside_stewardship_grant_rummager_indexer)
+  end
+
+  def rummager_withdrawer
+    SpecialistPublisherWiring.get(:countryside_stewardship_grant_rummager_deleter)
+  end
+
+  def content_api_withdrawer
+    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
+  end
+
+  def publication_alert_formatter(document)
+    CountrysideStewardshipGrantPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/countryside_stewardship_grant_view_adapter.rb
+++ b/app/view_adapters/countryside_stewardship_grant_view_adapter.rb
@@ -1,0 +1,24 @@
+class CountrysideStewardshipGrantViewAdapter < DocumentViewAdapter
+  attributes = [
+    :title,
+    :summary,
+    :body,
+  ]
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "CountrysideStewardshipGrant")
+  end
+
+  private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:countryside_stewardship_grant_finder_schema)
+  end
+
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -9,6 +9,7 @@ class ViewAdapterRegistry
     {
       "aaib_report" => AaibReportViewAdapter,
       "cma_case" => CmaCaseViewAdapter,
+      "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
       "drug_safety_update" => DrugSafetyUpdateViewAdapter,
       "international_development_fund" => InternationalDevelopmentFundViewAdapter,
       "maib_report" => MaibReportViewAdapter,

--- a/app/views/countryside_stewardship_grants/_form.html.erb
+++ b/app/views/countryside_stewardship_grants/_form.html.erb
@@ -1,0 +1,22 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+  <%= render partial: "shared/form_errors", locals: { object: document } %>
+
+  <%= f.text_field :title %>
+  <%= f.text_area :summary, class: 'short-textarea' %>
+  <%= f.text_area :body %>
+
+  <div class="preview_button"></div>
+  <div class="preview_container" style="display: none;"></div>
+
+  <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+  <div class="actions">
+    <button name="save" class="btn btn-success">Save as draft</button>
+  </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "countryside_stewardship_grant" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ SpecialistPublisher::Application.routes.draw do
   document_types = %w(
     aaib_reports
     cma_cases
+    countryside_stewardship_grants
     drug_safety_updates
     international_development_funds
     maib_reports

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -1,0 +1,31 @@
+Feature: Creating and editing an Countryside Stewardship Grant
+As a DEFRA Editor
+I want to create countryside stewardship grants pages in Specialist publisher
+So that I can add them to the Countryside Stewardship Grants finder
+
+Background:
+Given I am logged in as a "DEFRA" editor
+
+Scenario: Create a new Countryside Stewardship Grant
+  When I create a Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant has been created
+
+Scenario: Cannot create a Countryside Stewardship Grant with invalid fields
+  When I create a Countryside Stewardship Grant with invalid fields
+  Then I should see error messages about missing fields
+  And I should see an error message about a "Body" field containing javascript
+  And the Countryside Stewardship Grant should not have been created
+
+Scenario: Cannot edit an Countryside Stewardship Grant without entering required fields
+  Given a draft Countryside Stewardship Grant exists
+  When I edit an Countryside Stewardship Grant and remove required fields
+  Then the Countryside Stewardship Grant should not have been updated
+
+Scenario: Can view a list of all Countryside Stewardship Grants in the publisher
+  Given two Countryside Stewardship Grants exist
+  Then the Countryside Stewardship Grants should be in the publisher CSG index in the correct order
+
+Scenario: Edit a draft Countryside Stewardship Grant
+  Given a draft Countryside Stewardship Grant exists
+  When I edit a Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should have been updated

--- a/features/publishing-a-countryside-stewardship-grant.feature
+++ b/features/publishing-a-countryside-stewardship-grant.feature
@@ -1,0 +1,60 @@
+Feature: Publishing a Countryside Stewardship Grant
+As a DEFRA Editor
+I want to create countryside stewardship fund pages in draft
+So that I can prepare the info for publication
+
+Background:
+Given I am logged in as a "DEFRA" editor
+
+Scenario: can create a new Countryside Stewardship Grant in draft
+  When I create a Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should be in draft
+
+Scenario: can publish a draft Countryside Stewardship Grant
+  Given a draft Countryside Stewardship Grant exists
+  When I publish the Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should be published
+
+Scenario: can create a new Countryside Stewardship Grant and publish immediately
+  When I publish a new Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should be published
+  And the publish should have been logged 1 times
+
+Scenario: immediately republish a published Countryside Stewardship Grant
+  When I publish a new Countryside Stewardship Grant
+  When I am on the Countryside Stewardship Grant edit page
+  And I edit the document and republish
+  Then the amended document should be published
+  And previous editions should be archived
+
+Scenario: Sends an email alert on first publish
+  Given a draft Countryside Stewardship Grant exists
+  When I publish the Countryside Stewardship Grant
+  Then a publication notification should have been sent
+
+Scenario: Cannot edit a published Countryside Stewardship Grant without a change note
+  Given a published Countryside Stewardship Grant exists
+  When I am on the Countryside Stewardship Grant edit page
+  And I edit the document without a change note
+  Then I see an error requesting that I provide a change note
+
+Scenario: Sends an email alert on a major update and updates logs
+  Given a published Countryside Stewardship Grant exists
+  Then a publication notification should have been sent
+  And the publish should have been logged 1 time
+  When I am on the Countryside Stewardship Grant edit page
+  And I edit the document with a change note
+  And I publish the Countryside Stewardship Grant
+  Then a publication notification should have been sent
+  And the publish should have been logged 2 times
+
+Scenario: Minor updates do not send emails or update logs
+  When I publish a new Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should be published
+  And the publish should have been logged 1 time
+  And a publication notification should have been sent
+  When I am on the Countryside Stewardship Grant edit page
+  And I edit the document and indicate the change is minor
+  When I publish the Countryside Stewardship Grant
+  Then an email alert should not be sent
+  And the publish should still have been logged 1 time

--- a/features/step_definitions/csg_steps.rb
+++ b/features/step_definitions/csg_steps.rb
@@ -1,0 +1,131 @@
+When(/^I create a Countryside Stewardship Grant$/) do
+  @document_title = "Example Countryside Stewardship Grant"
+  @slug = "countryside-stewardship-grants/example-countryside-stewardship-grant"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_countryside_stewardship_grant(@document_fields)
+end
+
+Then(/^the Countryside Stewardship Grant has been created$/) do
+  check_countryside_stewardship_grant_exists_with(@document_fields)
+end
+
+When(/^I create a Countryside Stewardship Grant with invalid fields$/) do
+  @document_fields = {
+    body: "<script>alert('Oh noes!)</script>",
+  }
+  create_countryside_stewardship_grant(@document_fields)
+end
+
+Then(/^the Countryside Stewardship Grant should not have been created$/) do
+  check_document_does_not_exist_with(@document_fields)
+end
+
+Given(/^a draft Countryside Stewardship Grant exists$/) do
+  @document_title = "Example Countryside Stewardship Grant"
+  @slug = "countryside-stewardship-grants/example-countryside-stewardship-grant"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_countryside_stewardship_grant(@document_fields)
+end
+
+When(/^I edit an Countryside Stewardship Grant and remove required fields$/) do
+  edit_countryside_stewardship_grant(@document_title, summary: "")
+end
+
+Then(/^the Countryside Stewardship Grant should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
+Given(/^two Countryside Stewardship Grants exist$/) do
+  @document_fields = {
+    title: "Countryside Stewardship Grant 1",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+  create_countryside_stewardship_grant(@document_fields)
+
+  @document_fields = {
+    title: "Countryside Stewardship Grant 2",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+  create_countryside_stewardship_grant(@document_fields)
+end
+
+Then(/^the Countryside Stewardship Grants should be in the publisher CSG index in the correct order$/) do
+  visit countryside_stewardship_grants_path
+
+  check_for_documents("Countryside Stewardship Grant 2", "Countryside Stewardship Grant 1")
+end
+
+When(/^I edit a Countryside Stewardship Grant$/) do
+  @new_title = "Edited Example Countryside Stewardship Grant"
+  edit_countryside_stewardship_grant(@document_title, title: @new_title)
+end
+
+Then(/^the Countryside Stewardship Grant should have been updated$/) do
+  check_for_new_countryside_stewardship_grant_title(@new_title)
+end
+
+Then(/^the Countryside Stewardship Grant should be in draft$/) do
+  expect(page).to have_content("Publication state draft")
+end
+
+When(/^I publish the Countryside Stewardship Grant$/) do
+  go_to_show_page_for_countryside_stewardship_grant(@document_title)
+  publish_document
+end
+
+Then(/^the Countryside Stewardship Grant should be published$/) do
+  check_document_is_published(@slug, @document_fields)
+end
+
+When(/^I publish a new Countryside Stewardship Grant$/) do
+  @document_title = "Example Countryside Stewardship Grant"
+  @slug = "countryside-stewardship-grants/example-countryside-stewardship-grant"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_countryside_stewardship_grant(@document_fields, publish: true)
+end
+
+When(/^I edit the Countryside Stewardship Grant and republish$/) do
+  @amended_document_attributes = {summary: "New summary", title: "My title"}
+  edit_countryside_stewardship_grant(@document_title, @amended_document_attributes, publish: true)
+end
+
+Given(/^a published Countryside Stewardship Grant exists$/) do
+  @document_title = "Example Countryside Stewardship Grant"
+  @slug = "countryside-stewardship-grants/example-countryside-stewardship-grant"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_countryside_stewardship_grant(@document_fields, publish: true)
+end
+
+When(/^I withdraw a Countryside Stewardship Grant$/) do
+  withdraw_countryside_stewardship_grant(@document_fields.fetch(:title))
+end
+
+Then(/^the Countryside Stewardship Grant should be withdrawn$/) do
+  check_document_is_withdrawn(@slug, @document_fields.fetch(:title))
+end
+
+When(/^I am on the Countryside Stewardship Grant edit page$/) do
+  go_to_edit_page_for_countryside_stewardship_grant(@document_fields.fetch(:title))
+end

--- a/features/support/csg_helpers.rb
+++ b/features/support/csg_helpers.rb
@@ -1,0 +1,72 @@
+module CsgHelpers
+  def create_countryside_stewardship_grant(*args)
+    create_document(:countryside_stewardship_grant, *args)
+  end
+
+  def go_to_show_page_for_countryside_stewardship_grant(*args)
+    go_to_show_page_for_document(:countryside_stewardship_grant, *args)
+  end
+
+  def check_countryside_stewardship_grant_exists_with(*args)
+    check_document_exists_with(:countryside_stewardship_grant, *args)
+  end
+
+  def go_to_countryside_stewardship_grant_index
+    visit_path_if_elsewhere(countryside_stewardship_grants_path)
+  end
+
+  def go_to_edit_page_for_countryside_stewardship_grant(*args)
+    go_to_edit_page_for_document(:countryside_stewardship_grant, *args)
+  end
+
+  def edit_countryside_stewardship_grant(title, *args)
+    go_to_edit_page_for_countryside_stewardship_grant(title)
+    edit_document(title, *args)
+  end
+
+  def check_for_new_countryside_stewardship_grant_title(*args)
+    check_for_new_document_title(:countryside_stewardship_grant, *args)
+  end
+
+  def withdraw_countryside_stewardship_grant(*args)
+    withdraw_document(:countryside_stewardship_grant, *args)
+  end
+
+  def check_header_metadata_depth_is_limited(slug, depth: 1)
+    published_document = RenderedSpecialistDocument.find_by_slug(slug)
+
+    headers = published_document.details.fetch("headers")
+
+    expect(find_header_depths(headers).max).to eq(depth)
+  end
+
+  def document_body_with_deeply_nested_headers
+    %{
+
+      ## Header
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      ### Level 2
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      #### Level 3
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      ##### Level 4
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+    }
+  end
+
+  def find_header_depths(headers, current_depth = 0)
+    if headers.empty?
+      current_depth
+    else
+      headers.flat_map { |h| find_header_depths(h.fetch("headers"), current_depth + 1) }
+    end
+  end
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -63,6 +63,7 @@ module DocumentHelpers
       "drug-device-alerts" => "medical_safety_alert",
       "maib-reports" => "maib_report",
       "raib-reports" => "raib_report",
+      "countryside-stewardship-grants" => "countryside_stewardship_grant",
     }
 
     slug_prefix = slug.split("/").first

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -98,6 +98,7 @@ require "organisations_api_helpers"
 require "email_alert_api_helpers"
 require "form_helpers"
 require "cma_case_helpers"
+require "csg_helpers"
 require "aaib_report_helpers"
 require "dsu_helpers"
 require "idf_helpers"
@@ -120,6 +121,7 @@ World(EmailAlertAPIHelpers)
 World(FormHelpers)
 World(AaibReportHelpers)
 World(CmaCaseHelpers)
+World(CsgHelpers)
 World(DsuHelpers)
 World(IdfHelpers)
 World(DocumentHelpers)

--- a/features/withdrawing-a-countryside-stewardship-grant.feature
+++ b/features/withdrawing-a-countryside-stewardship-grant.feature
@@ -1,0 +1,12 @@
+Feature: Withdrawing a Countryside Stewardship Grant
+As a DEFRA editor
+I want to withdraw a Countryside Stewardship Grant
+So that it is not accessible to the public
+
+Background:
+Given I am logged in as a "DEFRA" editor
+And a published Countryside Stewardship Grant exists
+
+Scenario: Withdraw a Countryside Stewardship Grant
+  When I withdraw a Countryside Stewardship Grant
+  Then the Countryside Stewardship Grant should be withdrawn

--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -1,0 +1,7 @@
+{
+  "slug": "countryside-stewardship-grants",
+  "format": "countryside_stewardship_grant",
+  "name": "Countryside Stewardship grants",
+  "beta": true,
+  "organisations": ["d3ce4ba7-bc75-46b4-89d9-38cb3240376d", "de4e9dc6-cca4-43af-a594-682023b84d6c"]
+}

--- a/finders/schemas/countryside-stewardship-grants.json
+++ b/finders/schemas/countryside-stewardship-grants.json
@@ -1,0 +1,5 @@
+{
+  "slug": "countryside-stewardship-grants",
+  "document_noun": "grant",
+  "facets": []
+}

--- a/spec/exporters/formatters/countryside_stewardship_grant_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/countryside_stewardship_grant_indexable_formatter_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "spec/exporters/formatters/abstract_indexable_formatter_spec"
+require "spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec"
+require "formatters/countryside_stewardship_grant_indexable_formatter"
+
+RSpec.describe CountrysideStewardshipGrantIndexableFormatter do
+  let(:document) {
+    double(
+    :countryside_stewardship_grant,
+    body: double,
+    slug: double,
+    summary: double,
+    title: double,
+    updated_at: double,
+    minor_update?: false,
+    )
+  }
+
+  subject(:formatter) { CountrysideStewardshipGrantIndexableFormatter.new(document) }
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of countryside_stewardship_grant" do
+    expect(formatter.type).to eq("countryside_stewardship_grant")
+  end
+end

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "countryside_stewardship_grant"
+
+RSpec.describe CountrysideStewardshipGrant do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(CountrysideStewardshipGrant.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -17,6 +17,10 @@ FactoryGirl.define do
     organisation_slug "air-accidents-investigation-branch"
   end
 
+  factory :defra_editor, parent: :editor do
+    organisation_slug "department-for-environment-food-rural-affairs"
+  end
+
   factory :dfid_editor, parent: :editor do
     organisation_slug "department-for-international-development"
   end


### PR DESCRIPTION
This PR contains the work necessary to enable creation of DEFRA/Natural England Countryside Stewardship Grants from Specialist Publisher. The facets are still undecided so they will be added at a later date. One thing to note is this scheme is owned by DEFRA and Natural England so this will require some refactoring of the permission checker, but this will also happen at a later date. [Ticket](https://trello.com/c/gZoWid5B/523-finder-countryside-stewardship-grants).