### PR TITLE
Fix typo in Finder Publisher

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -14,7 +14,7 @@ class PublishingApiFinderPublisher
         export_finder(metadata, schema)
         export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
       else
-        puts "didn't publish #{metadata[:file][:title]} because it doesn't have a content_id"
+        puts "didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id"
       end
     }
   end


### PR DESCRIPTION
When a Finder metadata doesn't have a content id we want to say that we didn't publish it. This commit fixes it to display the name of the unpublished finder properly.