### PR TITLE
Rename slug to base_path

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -31,7 +31,7 @@ private
   end
 
   def base_path
-    "/#{metadata.fetch("slug", "")}"
+    metadata.fetch("base_path")
   end
 
   def description

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -30,7 +30,7 @@ private
   end
 
   def base_path
-    "/#{metadata.fetch("slug")}/email-signup"
+    "#{metadata.fetch("base_path")}/email-signup"
   end
 
   def description

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -1,6 +1,6 @@
 {
   "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
-  "slug": "aaib-reports",
+  "base_path": "/aaib-reports",
   "format": "aaib_report",
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -1,6 +1,6 @@
 {
   "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
-  "slug": "cma-cases",
+  "base_path": "/cma-cases",
   "format": "cma_case",
   "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases",

--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -1,5 +1,5 @@
 {
-  "slug": "countryside-stewardship-grants",
+  "base_path": "/countryside-stewardship-grants",
   "format": "countryside_stewardship_grant",
   "name": "Countryside Stewardship grants",
   "beta": true,

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -1,6 +1,6 @@
 {
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
-  "slug": "drug-safety-update",
+  "base_path": "/drug-safety-update",
   "format": "drug_safety_update",
   "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -1,6 +1,6 @@
 {
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
-  "slug": "international-development-funding",
+  "base_path": "/international-development-funding",
   "format": "international_development_fund",
   "format_name": "International development funding",
   "name": "International development funding",

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -1,6 +1,6 @@
 {
   "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
-  "slug": "maib-reports",
+  "base_path": "/maib-reports",
   "format": "maib_report",
   "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -1,6 +1,6 @@
 {
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
-  "slug": "drug-device-alerts",
+  "base_path": "/drug-device-alerts",
   "format": "medical_safety_alert",
   "format_name": "Medical safety alert",
   "name": "Alerts and recalls for drugs and medical devices",

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -1,6 +1,6 @@
 {
   "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
-  "slug": "raib-reports",
+  "base_path": "/raib-reports",
   "format": "raib_report",
   "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",

--- a/finders/schemas/aaib-reports.json
+++ b/finders/schemas/aaib-reports.json
@@ -1,5 +1,4 @@
 {
-  "slug": "aaib-reports",
   "document_noun": "report",
   "facets": [
     {

--- a/finders/schemas/cma-cases.json
+++ b/finders/schemas/cma-cases.json
@@ -1,5 +1,4 @@
 {
-  "slug": "cma-cases",
   "document_noun": "case",
   "facets": [
     {

--- a/finders/schemas/countryside-stewardship-grants.json
+++ b/finders/schemas/countryside-stewardship-grants.json
@@ -1,5 +1,4 @@
 {
-  "slug": "countryside-stewardship-grants",
   "document_noun": "grant",
   "facets": [
     {

--- a/finders/schemas/drug-safety-updates.json
+++ b/finders/schemas/drug-safety-updates.json
@@ -1,5 +1,4 @@
 {
-  "slug": "drug-safety-update",
   "document_noun": "update",
   "facets": [
     {

--- a/finders/schemas/international-development-funds.json
+++ b/finders/schemas/international-development-funds.json
@@ -1,5 +1,4 @@
 {
-  "slug": "international-development-funding",
   "document_noun": "fund",
   "facets": [
     {

--- a/finders/schemas/maib-reports.json
+++ b/finders/schemas/maib-reports.json
@@ -1,5 +1,4 @@
 {
-  "slug": "maib-reports",
   "document_noun": "report",
   "facets": [
     {

--- a/finders/schemas/medical-safety-alerts.json
+++ b/finders/schemas/medical-safety-alerts.json
@@ -1,5 +1,4 @@
 {
-  "slug": "drug-device-alerts",
   "document_noun": "alert",
   "facets": [
     {

--- a/finders/schemas/raib-reports.json
+++ b/finders/schemas/raib-reports.json
@@ -1,5 +1,4 @@
 {
-  "slug": "raib-reports",
   "document_noun": "report",
   "facets": [
     {

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -8,7 +8,7 @@ describe PublishingApiFinderPublisher do
       metadata = [
         {
           file: {
-            "slug" => "first-finder",
+            "base_path" => "/first-finder",
             "name" => "first finder",
             "format_name" => "first finder things",
             "content_id" => "some-random-id",
@@ -19,7 +19,7 @@ describe PublishingApiFinderPublisher do
         },
         {
           file: {
-            "slug" => "second-finder",
+            "base_path" => "/second-finder",
             "name" => "second finder",
             "format_name" => "second finder things",
             "content_id" => "some-other-random-id",
@@ -32,7 +32,6 @@ describe PublishingApiFinderPublisher do
       schemae =  [
         {
           file: {
-            "slug" => "first-finder",
             "facets" => ["a facet", "another facet"],
             "document_noun" => "reports",
           },
@@ -40,7 +39,6 @@ describe PublishingApiFinderPublisher do
         },
         {
           file: {
-            "slug" => "second-finder",
             "facets" => ["a facet", "another facet"],
             "document_noun" => "cases",
           },
@@ -68,7 +66,7 @@ describe PublishingApiFinderPublisher do
       metadata = [
         {
           file: {
-            "slug" => "finder-without-content-id",
+            "base_path" => "/finder-without-content-id",
             "name" => "finder without content id",
             "format" => "a_report_format",
             "format_name" => "a report format",
@@ -77,7 +75,7 @@ describe PublishingApiFinderPublisher do
         },
         {
           file: {
-            "slug" => "finder-with-content-id",
+            "base_path" => "/finder-with-content-id",
             "name" => "finder with content id",
             "content_id" => "some-random-id",
             "format" => "a_report_format",
@@ -91,7 +89,6 @@ describe PublishingApiFinderPublisher do
       schemae =  [
         {
           file: {
-            "slug" => "finder-without-content-id",
             "facets" => ["a facet", "another facet"],
             "document_noun" => "reports",
           },
@@ -99,7 +96,6 @@ describe PublishingApiFinderPublisher do
         },
         {
           file: {
-            "slug" => "finder-with-content-id",
             "facets" => ["a facet", "another facet"],
             "document_noun" => "reports",
           },


### PR DESCRIPTION
We don't call them slugs when it comes to the content_items. Also this was duplicated in the schemas and wasn't used.