### PR TITLE
Specify filter mechanism in metadata

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -45,10 +45,11 @@ private
       document_noun: schema.fetch("document_noun"),
       document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
-      format_name: metadata.fetch("format_name"),
+      filter: metadata.fetch("filter", {}),
+      format_name: metadata.fetch("format_name", nil),
       signup_link: metadata.fetch("signup_link", nil),
       show_summaries: metadata.fetch("show_summaries", false),
-      facets: schema.fetch("facets"),
+      facets: schema.fetch("facets", []),
     }
   end
 

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -6,6 +6,9 @@
   "name": "Air Accidents Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.aaib.gov.uk/home/index.cfm'>AAIB website</a> is the main source for AAIB reports",
+  "filter": {
+    "filter_document_type": "aaib_report"
+  },
   "signup_content_id": "1ad5918c-19ff-4431-b20b-1bab890cd84b",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "show_summaries": true,

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -4,6 +4,9 @@
   "format": "cma_case",
   "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases",
+  "filter": {
+    "filter_document_type": "cma_case"
+  },
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
   "signup_enabled": true,

--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -3,5 +3,8 @@
   "format": "countryside_stewardship_grant",
   "name": "Countryside Stewardship grants",
   "beta": true,
+  "filter": {
+    "filter_document_type": "countryside_stewardship_grant"
+  },
   "organisations": ["d3ce4ba7-bc75-46b4-89d9-38cb3240376d", "de4e9dc6-cca4-43af-a594-682023b84d6c", "8bf5624b-dec2-44fa-9b6c-daed166333a5"]
 }

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -4,6 +4,9 @@
   "format": "drug_safety_update",
   "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",
+  "filter": {
+    "filter_document_type": "drug_safety_update"
+  },
   "show_summaries": true,
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -4,6 +4,9 @@
   "format": "international_development_fund",
   "format_name": "International development funding",
   "name": "International development funding",
+  "filter": {
+    "filter_document_type": "international_development_fund"
+  },
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "signup_enabled": true,

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -6,6 +6,9 @@
   "name": "Marine Accident Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.maib.gov.uk/home/index.cfm'>MAIB website</a> is the main source for MAIB reports",
+  "filter": {
+    "filter_document_type": "maib_report"
+  },
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -4,6 +4,9 @@
   "format": "medical_safety_alert",
   "format_name": "Medical safety alert",
   "name": "Alerts and recalls for drugs and medical devices",
+  "filter": {
+    "filter_document_type": "medical_safety_alert"
+  },
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_title": "Drug alerts and medical device alerts",

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -6,6 +6,9 @@
   "name": "Rail Accident Investigation Branch reports",
   "beta": true,
   "beta_message": "Until early 2015, the <a href='http://www.raib.gov.uk/home/index.cfm'>RAIB website</a> is the main source for RAIB reports",
+  "filter": {
+    "filter_document_type": "raib_report"
+  },
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],


### PR DESCRIPTION
Now that we have Finders which may not Filter by one document type, it makes sense to move this into the metadata for each Finder. This is the format for all the existing Finders.