### PR TITLE
Remove format from Finder content item

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -43,7 +43,6 @@ private
       beta: metadata.fetch("beta", false),
       beta_message: metadata.fetch("beta_message", nil),
       document_noun: schema.fetch("document_noun"),
-      document_type: metadata.fetch("format"),
       email_signup_enabled: metadata.fetch("signup_enabled", false),
       filter: metadata.fetch("filter", {}),
       format_name: metadata.fetch("format_name", nil),

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -1,7 +1,6 @@
 {
   "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "base_path": "/aaib-reports",
-  "format": "aaib_report",
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "beta": true,

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -1,7 +1,6 @@
 {
   "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "base_path": "/cma-cases",
-  "format": "cma_case",
   "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases",
   "filter": {

--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -1,6 +1,5 @@
 {
   "base_path": "/countryside-stewardship-grants",
-  "format": "countryside_stewardship_grant",
   "name": "Countryside Stewardship grants",
   "beta": true,
   "filter": {

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -1,7 +1,6 @@
 {
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "base_path": "/drug-safety-update",
-  "format": "drug_safety_update",
   "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",
   "filter": {

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -1,7 +1,6 @@
 {
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "base_path": "/international-development-funding",
-  "format": "international_development_fund",
   "format_name": "International development funding",
   "name": "International development funding",
   "filter": {

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -1,7 +1,6 @@
 {
   "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "base_path": "/maib-reports",
-  "format": "maib_report",
   "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",
   "beta": true,

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -1,7 +1,6 @@
 {
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "base_path": "/drug-device-alerts",
-  "format": "medical_safety_alert",
   "format_name": "Medical safety alert",
   "name": "Alerts and recalls for drugs and medical devices",
   "filter": {

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -1,7 +1,6 @@
 {
   "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "base_path": "/raib-reports",
-  "format": "raib_report",
   "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",
   "beta": true,


### PR DESCRIPTION
Now that we have the filter mechanism in the content item, we don't need the format to be present.