### PR TITLE
Add European Structural and Investment funds to Publisher

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,10 @@ class ApplicationController < ActionController::Base
         document_type: "drug_safety_update",
         title: "Drug Safety Update",
       },
+      "esi-funds" => {
+        document_type: "esi_fund",
+        title: "ESI Funds",
+      },
       "medical-safety-alerts" => {
         document_type: "medical_safety_alert" ,
         title: "Medical Safety Alerts",

--- a/app/controllers/esi_funds_controller.rb
+++ b/app/controllers/esi_funds_controller.rb
@@ -1,0 +1,2 @@
+class EsiFundsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/esi_fund_artefact_formatter.rb
+++ b/app/exporters/formatters/esi_fund_artefact_formatter.rb
@@ -1,0 +1,20 @@
+require "formatters/abstract_artefact_formatter"
+
+class EsiFundArtefactFormatter < AbstractArtefactFormatter
+
+  def state
+    state_mapping.fetch(entity.publication_state)
+  end
+
+  def kind
+    "european_structural_investment_fund"
+  end
+
+  def rendering_app
+    "specialist-frontend"
+  end
+
+  def organisation_slugs
+    []
+  end
+end

--- a/app/exporters/formatters/esi_fund_indexable_formatter.rb
+++ b/app/exporters/formatters/esi_fund_indexable_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class EsiFundIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+
+  def type
+    "european_structural_investment_fund"
+  end
+
+private
+  def organisation_slugs
+    []
+  end
+end

--- a/app/exporters/formatters/esi_fund_publication_alert_formatter.rb
+++ b/app/exporters/formatters/esi_fund_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class EsiFundPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "European Structural and Investment Funds"
+  end
+
+private
+  def document_noun
+    "fund"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -47,6 +47,8 @@ private
       "department-for-international-development"
     when "drug_safety_update", "medical_safety_alert"
       "medicines-and-healthcare-products-regulatory-agency"
+    when "esi_fund"
+      "department-for-communities-and-local-government"
     when "maib_report"
       "marine-accident-investigation-branch"
     when "raib_report"

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -34,6 +34,7 @@ private
       "cma_case" => CmaCaseObserversRegistry,
       "countryside_stewardship_grant" => CountrysideStewardshipGrantObserversRegistry,
       "drug_safety_update" => DrugSafetyUpdateObserversRegistry,
+      "esi_fund" => EsiFundObserversRegistry,
       "international_development_fund" => InternationalDevelopmentFundObserversRegistry,
       "maib_report" => MaibReportObserversRegistry,
       "medical_safety_alert" => MedicalSafetyAlertObserversRegistry,

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -3,6 +3,7 @@ require "validators/change_note_validator"
 require "validators/cma_case_validator"
 require "validators/countryside_stewardship_grant_validator"
 require "validators/drug_safety_update_validator"
+require "validators/esi_fund_validator"
 require "validators/international_development_fund_validator"
 require "validators/maib_report_validator"
 require "validators/manual_document_validator"
@@ -79,6 +80,19 @@ class DocumentFactoryRegistry
               SlugGenerator.new(prefix: "drug-safety-update"),
               *args,
             )
+          )
+        )
+      )
+    }
+  end
+
+  def esi_fund_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        EsiFundValidator.new(
+          SpecialistDocument.new(
+            SlugGenerator.new(prefix: "european-structural-investment-funds"),
+            *args,
           )
         )
       )

--- a/app/models/esi_fund.rb
+++ b/app/models/esi_fund.rb
@@ -1,0 +1,4 @@
+require "document_metadata_decorator"
+
+class EsiFund < DocumentMetadataDecorator
+end

--- a/app/models/validators/esi_fund_validator.rb
+++ b/app/models/validators/esi_fund_validator.rb
@@ -1,0 +1,12 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class EsiFundValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+end

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,0 +1,33 @@
+require "email_alert_exporter"
+require "formatters/esi_fund_publication_alert_formatter"
+
+class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+  private
+  def panopticon_exporter
+    SpecialistPublisherWiring.get(:esi_fund_panopticon_registerer)
+  end
+
+  def content_api_exporter
+    SpecialistPublisherWiring.get(:esi_fund_content_api_exporter)
+  end
+
+  def rummager_exporter
+    SpecialistPublisherWiring.get(:esi_fund_rummager_indexer)
+  end
+
+  def rummager_withdrawer
+    SpecialistPublisherWiring.get(:esi_fund_rummager_deleter)
+  end
+
+  def content_api_withdrawer
+    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
+  end
+
+  def publication_alert_formatter(document)
+    EsiFundPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/esi_fund_view_adapter.rb
+++ b/app/view_adapters/esi_fund_view_adapter.rb
@@ -1,0 +1,24 @@
+class EsiFundViewAdapter < DocumentViewAdapter
+  attributes = [
+    :title,
+    :summary,
+    :body,
+  ]
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "EsiFund")
+  end
+
+private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:esi_fund_schema)
+  end
+
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -11,6 +11,7 @@ class ViewAdapterRegistry
       "cma_case" => CmaCaseViewAdapter,
       "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
       "drug_safety_update" => DrugSafetyUpdateViewAdapter,
+      "esi_fund" => EsiFundViewAdapter,
       "international_development_fund" => InternationalDevelopmentFundViewAdapter,
       "maib_report" => MaibReportViewAdapter,
       "medical_safety_alert" => MedicalSafetyAlertViewAdapter,

--- a/app/views/esi_funds/_form.html.erb
+++ b/app/views/esi_funds/_form.html.erb
@@ -1,0 +1,22 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+  <%= render partial: "shared/form_errors", locals: { object: document } %>
+
+  <%= f.text_field :title %>
+  <%= f.text_area :summary, class: 'short-textarea' %>
+  <%= f.text_area :body %>
+
+  <div class="preview_button"></div>
+  <div class="preview_container" style="display: none;"></div>
+
+  <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+  <div class="actions">
+    <button name="save" class="btn btn-success">Save as draft</button>
+  </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "esi_fund" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ SpecialistPublisher::Application.routes.draw do
     cma_cases
     countryside_stewardship_grants
     drug_safety_updates
+    esi_funds
     international_development_funds
     maib_reports
     medical_safety_alerts

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -1,0 +1,31 @@
+Feature: Creating and editing an ESI Fund
+As a DCLG Editor
+I want to create ESI Funds pages in Specialist publisher
+So that I can add them to the ESI Funds finder
+
+Background:
+Given I am logged in as a "DCLG" editor
+
+Scenario: Create a new ESI Fund
+  When I create an ESI Fund
+  Then the ESI Fund has been created
+
+Scenario: Cannot create an ESI Fund with invalid fields
+  When I create an ESI Fund with invalid fields
+  Then I should see error messages about missing fields
+  And I should see an error message about a "Body" field containing javascript
+  And the ESI Fund should not have been created
+
+Scenario: Cannot edit an ESI Fund without entering required fields
+  Given a draft ESI Fund exists
+  When I edit an ESI Fund and remove required fields
+  Then the ESI Fund should not have been updated
+
+Scenario: Can view a list of all ESI Funds in the publisher
+  Given two ESI Funds exist
+  Then the ESI Funds should be in the publisher CSG index in the correct order
+
+Scenario: Edit a draft ESI Fund
+  Given a draft ESI Fund exists
+  When I edit an ESI Fund
+  Then the ESI Fund should have been updated

--- a/features/publishing-an-esi-fund.feature
+++ b/features/publishing-an-esi-fund.feature
@@ -1,0 +1,60 @@
+Feature: Publishing an ESI Fund
+As a DCLG Editor
+I want to publish European Structural and Investment funds
+So that they are available to the public
+
+Background:
+Given I am logged in as a "DCLG" editor
+
+Scenario: can create a new ESI Fund in draft
+  When I create an ESI Fund
+  Then the ESI Fund should be in draft
+
+Scenario: can publish a draft ESI Fund
+  Given a draft ESI Fund exists
+  When I publish the ESI Fund
+  Then the ESI Fund should be published
+
+Scenario: can create a new ESI Fund and publish immediately
+  When I publish a new ESI Fund
+  Then the ESI Fund should be published
+  And the publish should have been logged 1 times
+
+Scenario: immediately republish a published ESI Fund
+  When I publish a new ESI Fund
+  When I am on the ESI Fund edit page
+  And I edit the document and republish
+  Then the amended document should be published
+  And previous editions should be archived
+
+Scenario: Sends an email alert on first publish
+  Given a draft ESI Fund exists
+  When I publish the ESI Fund
+  Then a publication notification should have been sent
+
+Scenario: Cannot edit a published ESI Fund without a change note
+  Given a published ESI Fund exists
+  When I am on the ESI Fund edit page
+  And I edit the document without a change note
+  Then I see an error requesting that I provide a change note
+
+Scenario: Sends an email alert on a major update and updates logs
+  Given a published ESI Fund exists
+  Then a publication notification should have been sent
+  And the publish should have been logged 1 time
+  When I am on the ESI Fund edit page
+  And I edit the document with a change note
+  And I publish the ESI Fund
+  Then a publication notification should have been sent
+  And the publish should have been logged 2 times
+
+Scenario: Minor updates do not send emails or update logs
+  When I publish a new ESI Fund
+  Then the ESI Fund should be published
+  And the publish should have been logged 1 time
+  And a publication notification should have been sent
+  When I am on the ESI Fund edit page
+  And I edit the document and indicate the change is minor
+  When I publish the ESI Fund
+  Then an email alert should not be sent
+  And the publish should still have been logged 1 time

--- a/features/step_definitions/esi_fund_steps.rb
+++ b/features/step_definitions/esi_fund_steps.rb
@@ -1,0 +1,131 @@
+When(/^I create an ESI Fund$/) do
+  @document_title = "Example ESI Fund"
+  @slug = "european-structural-investment-funds/example-esi-fund"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_esi_fund(@document_fields)
+end
+
+Then(/^the ESI Fund has been created$/) do
+  check_esi_fund_exists_with(@document_fields)
+end
+
+When(/^I create an ESI Fund with invalid fields$/) do
+  @document_fields = {
+    body: "<script>alert('Oh noes!)</script>",
+  }
+  create_esi_fund(@document_fields)
+end
+
+Then(/^the ESI Fund should not have been created$/) do
+  check_document_does_not_exist_with(@document_fields)
+end
+
+Given(/^a draft ESI Fund exists$/) do
+  @document_title = "Example ESI Fund"
+  @slug = "european-structural-investment-funds/example-esi-fund"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_esi_fund(@document_fields)
+end
+
+When(/^I edit an ESI Fund and remove required fields$/) do
+  edit_esi_fund(@document_title, summary: "")
+end
+
+Then(/^the ESI Fund should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
+Given(/^two ESI Funds exist$/) do
+  @document_fields = {
+    title: "ESI Fund 1",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+  create_esi_fund(@document_fields)
+
+  @document_fields = {
+    title: "ESI Fund 2",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+  create_esi_fund(@document_fields)
+end
+
+Then(/^the ESI Funds should be in the publisher CSG index in the correct order$/) do
+  visit esi_funds_path
+
+  check_for_documents("ESI Fund 2", "ESI Fund 1")
+end
+
+When(/^I edit an ESI Fund$/) do
+  @new_title = "Edited Example ESI Fund"
+  edit_esi_fund(@document_title, title: @new_title)
+end
+
+Then(/^the ESI Fund should have been updated$/) do
+  check_for_new_esi_fund_title(@new_title)
+end
+
+Then(/^the ESI Fund should be in draft$/) do
+  expect(page).to have_content("Publication state draft")
+end
+
+When(/^I publish the ESI Fund$/) do
+  go_to_show_page_for_esi_fund(@document_title)
+  publish_document
+end
+
+Then(/^the ESI Fund should be published$/) do
+  check_document_is_published(@slug, @document_fields)
+end
+
+When(/^I publish a new ESI Fund$/) do
+  @document_title = "Example ESI Fund"
+  @slug = "european-structural-investment-funds/example-esi-fund"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_esi_fund(@document_fields, publish: true)
+end
+
+When(/^I edit the ESI Fund and republish$/) do
+  @amended_document_attributes = {summary: "New summary", title: "My title"}
+  edit_esi_fund(@document_title, @amended_document_attributes, publish: true)
+end
+
+Given(/^a published ESI Fund exists$/) do
+  @document_title = "Example ESI Fund"
+  @slug = "european-structural-investment-funds/example-esi-fund"
+  @document_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: document_body_with_deeply_nested_headers,
+  }
+
+  create_esi_fund(@document_fields, publish: true)
+end
+
+When(/^I withdraw an ESI Fund$/) do
+  withdraw_esi_fund(@document_fields.fetch(:title))
+end
+
+Then(/^the ESI Fund should be withdrawn$/) do
+  check_document_is_withdrawn(@slug, @document_fields.fetch(:title))
+end
+
+When(/^I am on the ESI Fund edit page$/) do
+  go_to_edit_page_for_esi_fund(@document_fields.fetch(:title))
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -61,6 +61,7 @@ module DocumentHelpers
       "international-development-funding" => "international_development_fund",
       "drug-safety-update" => "drug_safety_update",
       "drug-device-alerts" => "medical_safety_alert",
+      "european-structural-investment-funds" => "european_structural_investment_fund",
       "maib-reports" => "maib_report",
       "raib-reports" => "raib_report",
       "countryside-stewardship-grants" => "countryside_stewardship_grant",

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -97,21 +97,23 @@ require "publishing_api_helpers"
 require "organisations_api_helpers"
 require "email_alert_api_helpers"
 require "form_helpers"
-require "cma_case_helpers"
-require "csg_helpers"
-require "aaib_report_helpers"
-require "dsu_helpers"
-require "idf_helpers"
 require "document_helpers"
-require "maib_report_helpers"
-require "raib_report_helpers"
 require "manual_helpers"
-require "msa_helpers"
 require "attachment_helpers"
 require "rerendering_helpers"
 require "file_fixture_helpers"
 require "gds_sso_helpers"
 require "access_control_helpers"
+
+require "aaib_report_helpers"
+require "cma_case_helpers"
+require "csg_helpers"
+require "dsu_helpers"
+require "esi_fund_helpers"
+require "idf_helpers"
+require "maib_report_helpers"
+require "msa_helpers"
+require "raib_report_helpers"
 
 World(PanopticonHelpers)
 World(RummagerHelpers)
@@ -119,18 +121,20 @@ World(PublishingAPIHelpers)
 World(OrganisationsAPIHelpers)
 World(EmailAlertAPIHelpers)
 World(FormHelpers)
-World(AaibReportHelpers)
-World(CmaCaseHelpers)
-World(CsgHelpers)
-World(DsuHelpers)
-World(IdfHelpers)
 World(DocumentHelpers)
-World(MaibReportHelpers)
-World(RaibReportHelpers)
 World(ManualHelpers)
-World(MsaHelpers)
 World(AttachmentHelpers)
 World(FileFixtureHelpers)
 World(RerenderingHelpers)
 World(GdsSsoHelpers)
 World(AccessControlHelpers)
+
+World(AaibReportHelpers)
+World(CmaCaseHelpers)
+World(CsgHelpers)
+World(DsuHelpers)
+World(EsiFundHelpers)
+World(IdfHelpers)
+World(MaibReportHelpers)
+World(MsaHelpers)
+World(RaibReportHelpers)

--- a/features/support/esi_fund_helpers.rb
+++ b/features/support/esi_fund_helpers.rb
@@ -1,0 +1,72 @@
+module EsiFundHelpers
+  def create_esi_fund(*args)
+    create_document(:esi_fund, *args)
+  end
+
+  def go_to_show_page_for_esi_fund(*args)
+    go_to_show_page_for_document(:esi_fund, *args)
+  end
+
+  def check_esi_fund_exists_with(*args)
+    check_document_exists_with(:esi_fund, *args)
+  end
+
+  def go_to_esi_fund_index
+    visit_path_if_elsewhere(esi_funds_path)
+  end
+
+  def go_to_edit_page_for_esi_fund(*args)
+    go_to_edit_page_for_document(:esi_fund, *args)
+  end
+
+  def edit_esi_fund(title, *args)
+    go_to_edit_page_for_esi_fund(title)
+    edit_document(title, *args)
+  end
+
+  def check_for_new_esi_fund_title(*args)
+    check_for_new_document_title(:esi_fund, *args)
+  end
+
+  def withdraw_esi_fund(*args)
+    withdraw_document(:esi_fund, *args)
+  end
+
+  def check_header_metadata_depth_is_limited(slug, depth: 1)
+    published_document = RenderedSpecialistDocument.find_by_slug(slug)
+
+    headers = published_document.details.fetch("headers")
+
+    expect(find_header_depths(headers).max).to eq(depth)
+  end
+
+  def document_body_with_deeply_nested_headers
+    %{
+
+      ## Header
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      ### Level 2
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      #### Level 3
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+      ##### Level 4
+
+      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+
+    }
+  end
+
+  def find_header_depths(headers, current_depth = 0)
+    if headers.empty?
+      current_depth
+    else
+      headers.flat_map { |h| find_header_depths(h.fetch("headers"), current_depth + 1) }
+    end
+  end
+end

--- a/features/withdrawing-an-esi-fund.feature
+++ b/features/withdrawing-an-esi-fund.feature
@@ -1,0 +1,12 @@
+Feature: Withdrawing an ESI Fund
+As a DCLG editor
+I want to withdraw an ESI Fund
+So that it is not accessible to the public
+
+Background:
+Given I am logged in as a "DCLG" editor
+And a published ESI Fund exists
+
+Scenario: Withdraw an ESI Fund
+  When I withdraw an ESI Fund
+  Then the ESI Fund should be withdrawn

--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -1,0 +1,9 @@
+{
+  "base_path": "/european-structural-investment-funds",
+  "name": "European Structural and Investment Funds",
+  "beta": true,
+  "filter": {
+    "filter_document_type": "european_structural_investment_fund"
+  },
+  "organisations": []
+}

--- a/finders/schemas/esi-funds.json
+++ b/finders/schemas/esi-funds.json
@@ -1,0 +1,4 @@
+{
+  "document_noun": "fund",
+  "facets": []
+}

--- a/spec/exporters/formatters/esi_fund_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/esi_fund_indexable_formatter_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "spec/exporters/formatters/abstract_indexable_formatter_spec"
+require "spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec"
+require "formatters/esi_fund_indexable_formatter"
+
+RSpec.describe EsiFundIndexableFormatter do
+  let(:document) {
+    double(
+    :esi_fund,
+    body: double,
+    slug: double,
+    summary: double,
+    title: double,
+    updated_at: double,
+    minor_update?: false,
+    )
+  }
+
+  subject(:formatter) { EsiFundIndexableFormatter.new(document) }
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of european_structural_investment_fund" do
+    expect(formatter.type).to eq("european_structural_investment_fund")
+  end
+end

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "esi_fund"
+
+RSpec.describe EsiFund do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(EsiFund.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -17,6 +17,10 @@ FactoryGirl.define do
     organisation_slug "air-accidents-investigation-branch"
   end
 
+  factory :dclg_editor, parent: :editor do
+    organisation_slug "department-for-communities-and-local-government"
+  end
+
   factory :defra_editor, parent: :editor do
     organisation_slug "department-for-environment-food-rural-affairs"
   end


### PR DESCRIPTION
This PR contains the work necessary to enable creation of DCLG/European Structural and Investment funds from Specialist Publisher. 
The facets will be added in a different PR.

Ticket: https://www.pivotaltracker.com/story/show/87188568
Totally inspired by this great PR: https://github.com/alphagov/specialist-publisher/pull/400

