### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -22,7 +22,6 @@ private
 
   def exportable_attributes
     {
-      base_path: base_path,
       format: "manual_section",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -1,7 +1,6 @@
 class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
   def exportable_attributes
     {
-      "base_path" => base_path,
       "format" => format,
       "content_id" => content_id,
       "title" => title,
@@ -21,6 +20,10 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
     }
   end
 
+  def base_path
+    metadata.fetch("base_path")
+  end
+
 private
   def title
     metadata.fetch("name")
@@ -28,10 +31,6 @@ private
 
   def content_id
     metadata.fetch("content_id")
-  end
-
-  def base_path
-    metadata.fetch("base_path")
   end
 
   def description

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -1,7 +1,6 @@
 class FinderSignupContentItemPresenter < Struct.new(:metadata, :timestamp)
   def exportable_attributes
     {
-      "base_path" => base_path,
       "format" => format,
       "content_id" => content_id,
       "title" => title,
@@ -20,6 +19,10 @@ class FinderSignupContentItemPresenter < Struct.new(:metadata, :timestamp)
     }
   end
 
+  def base_path
+    "#{metadata.fetch("base_path")}/email-signup"
+  end
+
 private
   def title
     metadata.fetch("signup_title", metadata.fetch("name"))
@@ -27,10 +30,6 @@ private
 
   def content_id
     metadata.fetch("signup_content_id")
-  end
-
-  def base_path
-    "#{metadata.fetch("base_path")}/email-signup"
   end
 
   def description

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -114,7 +114,6 @@ module ManualHelpers
 
   def check_manual_is_published_to_publishing_api(slug, attrs)
     assert_publishing_api_put_item("/#{slug}",
-      "base_path" => "/#{slug}",
       "format" => "manual",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "specialist-publisher",
@@ -123,7 +122,6 @@ module ManualHelpers
 
   def check_manual_document_is_published_to_publishing_api(slug, attrs)
     assert_publishing_api_put_item("/#{slug}",
-      "base_path" => "/#{slug}",
       "format" => "manual_section",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "specialist-publisher",

--- a/lib/manual_publishing_api_exporter.rb
+++ b/lib/manual_publishing_api_exporter.rb
@@ -28,7 +28,6 @@ private
 
   def exportable_attributes
     {
-      base_path: base_path,
       format: "manual",
       title: rendered_manual_attributes.fetch(:title),
       description: rendered_manual_attributes.fetch(:summary),

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -33,7 +33,7 @@ private
 
     puts "publishing '#{attrs["title"]}' finder"
 
-    publishing_api.put_content_item(attrs["base_path"], attrs)
+    publishing_api.put_content_item(finder.base_path, attrs)
   end
 
   def export_signup(metadata)
@@ -46,7 +46,7 @@ private
 
     puts "publishing '#{attrs["title"]}' finder signup page"
 
-    publishing_api.put_content_item(attrs["base_path"], attrs)
+    publishing_api.put_content_item(finder_signup.base_path, attrs)
   end
 
   def publishing_api

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -99,7 +99,6 @@ describe ManualPublishingAPIExporter do
     expect(export_recipent).to have_received(:put_content_item).with(
       "/guidance/my-first-manual",
       hash_including(
-        base_path: "/guidance/my-first-manual",
         format: "manual",
         title: "My first manual",
         description: "This is my first manual",

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -65,7 +65,6 @@ describe ManualSectionPublishingAPIExporter do
     expect(export_recipent).to have_received(:put_content_item).with(
       "/guidance/my-first-manual/first-section",
       hash_including(
-        base_path: "/guidance/my-first-manual/first-section",
         format: "manual_section",
         title: "Document title",
         description: "This is the first section",


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

I successfully tested publishing changes to a manual and a finder in development.

For more context: https://github.com/alphagov/content-store/pull/104