### PR TITLE
Add .atom to Finder routes

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -69,6 +69,10 @@ private
       {
         path: "#{base_path}.json",
         type: "exact",
+      },
+      {
+        path: "#{base_path}.atom",
+        type: "exact",
       }
     ]
   end


### PR DESCRIPTION
As we now have atom feeds for Finders we need to send this as a Route as part of the Content Item. This commit adds it to the `FinderContentItemPresenter`.