### PR TITLE
Script to publish some outstanding MAIB reports

### DIFF
--- a/bin/publish_some_outstanding_maib_reports
+++ b/bin/publish_some_outstanding_maib_reports
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+# IDs of MAIB reports we need to publish
+ids_to_publish = %w(
+  75d81690-c333-4e9b-a9c8-69fedb8d6296
+  6da39644-1bcd-412d-9992-9bbe1b4e0cb9
+  7dd1cdf0-3ed1-4d5c-a00e-90726a32c300
+  8c7ad08a-8284-4bfe-893d-b916924cb9cc
+  8009c9e8-3ca0-407f-89fe-d338046d5618
+  36f1a2d3-f6d5-4597-a8b2-1321688bfb3d
+  8ae30ad4-54ce-4ff4-b3ab-56df9a2eb2bf
+  02e33a64-2441-4073-8a2b-d46417892ece
+  0f0afd0c-79a4-47f3-bc54-0c02199f8d34
+  b71e8e3e-9f41-4a16-8771-7e677e990ef4
+  8b1ac0dd-2419-419b-bc74-f608af4be41b
+  69aea5f4-3c51-4383-980f-d56d7633dfe0
+)
+
+# The first editions of all published MAIB reports
+def published_editions
+  SpecialistDocumentEdition.where(
+    document_type: "maib_report",
+    version_number: 1,
+    :state.ne => "draft",
+  )
+end
+
+def public_updated_at_timestamp_for_edition(edition)
+  # Split the published editions into two groups: those about incidents before
+  # the one in the current edition, and those about incidents after the one in
+  # the current edition.
+  before, after = published_editions.partition { |other|
+    other.extra_fields.fetch("date_of_occurrence") < edition.extra_fields.fetch("date_of_occurrence")
+  }
+
+  # Get the most recent publication timestamp from those editions about
+  # incidents before the one in the current edition. The current edition will
+  # need to be given a publication timestamp after this time.
+  last_public_updated_at_before = before.map(&:public_updated_at).max
+
+  # Get the earliest publication timestamp from those editions about incidents
+  # after the one in the current edition. The current edition will need to be
+  # given a publication timestamp before this time.
+  first_public_updated_at_after = after.map(&:public_updated_at).min
+
+  # Pick a time after `last_public_updated_at_before`
+  public_updated_at = last_public_updated_at_before + 1.second
+
+  # Check that the time is before `first_public_updated_at_after`
+  if public_updated_at < first_public_updated_at_after
+    public_updated_at
+  else
+    nil
+  end
+end
+
+def publish_edition(edition, public_updated_at:)
+  repo = SpecialistPublisherWiring.get(:repository_registry).for_type("maib_report")
+  builder = SpecialistPublisherWiring.get(:maib_report_builder)
+  observers = MaibReportObserversRegistry.new.republication
+
+  public_updated_at_setter = Proc.new { |document|
+    document.latest_edition.public_updated_at = public_updated_at
+  }
+
+  service = PublishDocumentService.new(
+    repo,
+    [public_updated_at_setter] + observers,
+    edition.document_id,
+    true,
+  )
+
+  service.call
+end
+
+ids_to_publish.each do |id|
+  edition = SpecialistDocumentEdition.where(document_id: id).first
+  public_updated_at = public_updated_at_timestamp_for_edition(edition)
+
+  if public_updated_at.nil?
+    puts "Skipping #{edition.document_id} (#{edition.slug}): could not find suitable public_updated_at timestamp"
+  else
+    puts "Publishing #{edition.document_id} (#{edition.slug}) with public_updated_at timestamp #{public_updated_at}"
+    publish_edition(edition, public_updated_at: public_updated_at)
+  end
+end


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/1261204/stories/87502900

We imported historic MAIB reports and published them in bulk on January 23rd 2015. Since then, MAIB have found 12 more reports which should have been imported and have added those reports into the publishing tool. This script publishes those 12 reports.

Specialist Publisher has no support for specifying a "first published date" for content that pre-dates GOV.UK. The [finder for MAIB reports][1], shows the reports in order of time of last update, with the most recent at the top. In order to have the reports appear in the correct order, they were published in chronological order.

In order to publish these new reports into the correct places in that list, this script uses the `date_of_occurrence` and `public_updated_at` values for the already published reports to find a suitable timestamp to use.

Once this script has been run on production it can be removed.

[1]: https://www.gov.uk/maib-reports

---

I've tested this locally with the latest data on preview. It does the right thing:

```
vagrant@development:/var/govuk/specialist-publisher$ ./bin/publish_some_maib_reports
Publishing 75d81690-c333-4e9b-a9c8-69fedb8d6296 (maib-reports/contact-made-by-container-vessel-johanna-with-a-barge-leg-lost-during-towing-operation) with public_updated_at timestamp 2015-01-23T10:22:07+00:00
/var/govuk/specialist-publisher/app/lib/specialist_publisher_wiring.rb:45: warning: already initialized constant SpecialistPublisherWiring
/var/govuk/specialist-publisher/app/lib/specialist_publisher_wiring.rb:45: warning: previous definition of SpecialistPublisherWiring was here
[DEPRECATED] The 'safe' write concern option has been deprecated in favor of 'w'.
Publishing 6da39644-1bcd-412d-9992-9bbe1b4e0cb9 (maib-reports/collision-between-container-vessel-oocl-finland-and-general-cargo-vessel-tyumen-2-with-loss-of-2-lives) with public_updated_at timestamp 2015-01-23T10:21:06+00:00
Publishing 7dd1cdf0-3ed1-4d5c-a00e-90726a32c300 (maib-reports/collision-between-trawler-sant-yann-ii-and-container-vessel-velazquez) with public_updated_at timestamp 2015-01-23T10:11:54+00:00
Publishing 8c7ad08a-8284-4bfe-893d-b916924cb9cc (maib-reports/sinking-of-long-liner-shark) with public_updated_at timestamp 2015-01-23T10:16:01+00:00
Publishing 8009c9e8-3ca0-407f-89fe-d338046d5618 (maib-reports/collision-between-bulk-carrier-alex-d-and-beam-trawler-jacoba) with public_updated_at timestamp 2015-01-23T10:22:08+00:00
Publishing 36f1a2d3-f6d5-4597-a8b2-1321688bfb3d (maib-reports/accident-while-unloading-from-general-cargo-vessel-excalibur-with-loss-of-1-life) with public_updated_at timestamp 2015-01-23T10:22:15+00:00
Publishing 8ae30ad4-54ce-4ff4-b3ab-56df9a2eb2bf (maib-reports/contact-made-by-ro-ro-freight-carrier-gran-canaria-car-and-linkspan) with public_updated_at timestamp 2015-01-23T10:21:47+00:00
Publishing 02e33a64-2441-4073-8a2b-d46417892ece (maib-reports/collision-between-beam-trawler-henrik-senior-and-ro-ro-cargo-vessel-birka-explorer) with public_updated_at timestamp 2015-01-23T10:16:55+00:00
Publishing 0f0afd0c-79a4-47f3-bc54-0c02199f8d34 (maib-reports/fall-from-pilot-ladder-while-boarding-bulk-carrier-cape-kestrel-with-loss-of-1-life) with public_updated_at timestamp 2015-01-23T10:22:52+00:00
Publishing b71e8e3e-9f41-4a16-8771-7e677e990ef4 (maib-reports/collision-between-container-vessel-anl-wangaratta-and-bulk-carrier-fu-xin-shan) with public_updated_at timestamp 2015-01-23T10:17:14+00:00
Publishing 8b1ac0dd-2419-419b-bc74-f608af4be41b (maib-reports/grounding-of-ro-ro-cargo-vessel-ciudad-de-cadiz) with public_updated_at timestamp 2015-01-23T10:23:24+00:00
Publishing 69aea5f4-3c51-4383-980f-d56d7633dfe0 (maib-reports/collision-between-ro-ro-passenger-ferry-stena-britannica-and-tug-fairplay-22-with-loss-of-2-lives) with public_updated_at timestamp 2015-01-23T10:20:16+00:00
```