### PR TITLE
Tidy up observer wiring

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -6,23 +6,14 @@ require "document_factory_registry"
 require "document_headers_depth_limiter"
 require "footnotes_section_heading_renderer"
 require "formatters/aaib_report_artefact_formatter"
-require "formatters/aaib_report_indexable_formatter"
 require "formatters/cma_case_artefact_formatter"
-require "formatters/cma_case_indexable_formatter"
 require "formatters/countryside_stewardship_grant_artefact_formatter"
-require "formatters/countryside_stewardship_grant_indexable_formatter"
 require "formatters/drug_safety_update_artefact_formatter"
-require "formatters/drug_safety_update_indexable_formatter"
 require "formatters/esi_fund_artefact_formatter"
-require "formatters/esi_fund_indexable_formatter"
 require "formatters/international_development_fund_artefact_formatter"
-require "formatters/international_development_fund_indexable_formatter"
 require "formatters/maib_report_artefact_formatter"
-require "formatters/maib_report_indexable_formatter"
 require "formatters/medical_safety_alert_artefact_formatter"
-require "formatters/medical_safety_alert_indexable_formatter"
 require "formatters/raib_report_artefact_formatter"
-require "formatters/raib_report_indexable_formatter"
 require "gds_api/email_alert_api"
 require "gds_api/rummager"
 require "gds_api_proxy"
@@ -34,7 +25,6 @@ require "null_finder_schema"
 require "panopticon_registerer"
 require "rendered_specialist_document"
 require "repository_registry"
-require "rummager_indexer"
 require "specialist_document_database_exporter"
 require "specialist_document_header_extractor"
 require "specialist_document_repository"
@@ -340,186 +330,6 @@ SpecialistPublisherWiring = DependencyContainer.new do
 
       get(:panopticon_registerer).call(
         ManualChangeNotesArtefactFormatter.new(manual)
-      )
-    }
-  }
-
-  define_factory(:aaib_report_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        AaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:aaib_report_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        AaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:cma_case_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        CmaCaseIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:cma_case_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        CmaCaseIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:countryside_stewardship_grant_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        CountrysideStewardshipGrantIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:countryside_stewardship_grant_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        CountrysideStewardshipGrantIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:drug_safety_update_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        DrugSafetyUpdateIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:esi_fund_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        EsiFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:esi_fund_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        EsiFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:maib_report_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        MaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:maib_report_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        MaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:medical_safety_alert_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        MedicalSafetyAlertIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:drug_safety_update_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        DrugSafetyUpdateIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:medical_safety_alert_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        MedicalSafetyAlertIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:international_development_fund_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        InternationalDevelopmentFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:international_development_fund_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        InternationalDevelopmentFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:raib_report_rummager_indexer) {
-    ->(document) {
-      RummagerIndexer.new.add(
-        RaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  }
-
-  define_factory(:raib_report_rummager_deleter) {
-    ->(document) {
-      RummagerIndexer.new.delete(
-        RaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
       )
     }
   }

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -334,12 +334,6 @@ SpecialistPublisherWiring = DependencyContainer.new do
     }
   }
 
-  define_factory(:specialist_document_content_api_withdrawer) {
-    ->(document) {
-      RenderedSpecialistDocument.where(slug: document.slug).map(&:destroy)
-    }
-  }
-
   define_instance(:aaib_report_content_api_exporter) {
     ->(doc) {
       SpecialistDocumentDatabaseExporter.new(

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -5,15 +5,6 @@ require "dependency_container"
 require "document_factory_registry"
 require "document_headers_depth_limiter"
 require "footnotes_section_heading_renderer"
-require "formatters/aaib_report_artefact_formatter"
-require "formatters/cma_case_artefact_formatter"
-require "formatters/countryside_stewardship_grant_artefact_formatter"
-require "formatters/drug_safety_update_artefact_formatter"
-require "formatters/esi_fund_artefact_formatter"
-require "formatters/international_development_fund_artefact_formatter"
-require "formatters/maib_report_artefact_formatter"
-require "formatters/medical_safety_alert_artefact_formatter"
-require "formatters/raib_report_artefact_formatter"
 require "gds_api/email_alert_api"
 require "gds_api/rummager"
 require "gds_api_proxy"
@@ -248,78 +239,6 @@ SpecialistPublisherWiring = DependencyContainer.new do
         PANOPTICON_API_CREDENTIALS
       )
     )
-  }
-
-  define_factory(:aaib_report_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        AaibReportArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:cma_case_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        CmaCaseArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:countryside_stewardship_grant_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        CountrysideStewardshipGrantArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:drug_safety_update_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        DrugSafetyUpdateArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:esi_fund_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        EsiFundArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:maib_report_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        MaibReportArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:medical_safety_alert_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        MedicalSafetyAlertArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:international_development_fund_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        InternationalDevelopmentFundArtefactFormatter.new(document)
-      )
-    }
-  }
-
-  define_factory(:raib_report_panopticon_registerer) {
-    ->(document) {
-      get(:panopticon_registerer).call(
-        RaibReportArtefactFormatter.new(document)
-      )
-    }
   }
 
   define_factory(:manual_panopticon_registerer) {

--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/aaib_report_publication_alert_formatter"
 
 class AaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -9,8 +9,8 @@ private
     SpecialistPublisherWiring.get(:aaib_report_content_api_exporter)
   end
 
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:aaib_report_panopticon_registerer)
+  def format_document_as_artefact(document)
+    AaibReportArtefactFormatter.new(document)
   end
 
   def format_document_for_indexing(document)

--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/aaib_report_publication_alert_formatter"
+require "formatters/aaib_report_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class AaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:aaib_report_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        AaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:aaib_report_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        AaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/aaib_report_publication_alert_formatter"
 require "formatters/aaib_report_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class AaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:aaib_report_panopticon_registerer)
   end
 
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        AaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        AaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    AaibReportIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     AaibReportPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -38,6 +38,18 @@ class AbstractSpecialistDocumentObserversRegistry
 
 private
   def panopticon_exporter
+    ->(document) {
+      panopticon_registerer.call(
+        format_document_as_artefact(document)
+      )
+    }
+  end
+
+  def panopticon_registerer
+    SpecialistPublisherWiring.get(:panopticon_registerer)
+  end
+
+  def format_document_as_artefact(document)
     raise NotImplementedError
   end
 

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -1,4 +1,5 @@
 require "url_maker"
+require "rummager_indexer"
 
 class AbstractSpecialistDocumentObserversRegistry
   def creation
@@ -45,10 +46,22 @@ private
   end
 
   def rummager_exporter
-    raise NotImplementedError
+    ->(document) {
+      RummagerIndexer.new.add(
+        format_document_for_indexing(document)
+      )
+    }
   end
 
   def rummager_withdrawer
+    ->(document) {
+      RummagerIndexer.new.delete(
+        format_document_for_indexing(document)
+      )
+    }
+  end
+
+  def format_document_for_indexing(document)
     raise NotImplementedError
   end
 

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -53,7 +53,9 @@ private
   end
 
   def content_api_withdrawer
-    raise NotImplementedError
+    ->(document) {
+      RenderedSpecialistDocument.where(slug: document.slug).map(&:destroy)
+    }
   end
 
   def email_alert_api

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/cma_case_publication_alert_formatter"
+require "formatters/cma_case_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class CmaCaseObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:cma_case_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        CmaCaseIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:cma_case_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        CmaCaseIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     CmaCasePublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -5,8 +5,8 @@ require "markdown_attachment_processor"
 class CmaCaseObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
 private
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:cma_case_panopticon_registerer)
+  def format_document_as_artefact(document)
+    CmaCaseArtefactFormatter.new(document)
   end
 
   def content_api_exporter

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/cma_case_publication_alert_formatter"
 require "formatters/cma_case_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class CmaCaseObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:cma_case_content_api_exporter)
   end
 
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        CmaCaseIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        CmaCaseIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    CmaCaseIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/cma_case_publication_alert_formatter"
 
 class CmaCaseObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -5,8 +5,8 @@ require "markdown_attachment_processor"
 class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
   private
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:countryside_stewardship_grant_panopticon_registerer)
+  def format_document_as_artefact(document)
+    CountrysideStewardshipGrantArtefactFormatter.new(document)
   end
 
   def content_api_exporter

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -34,10 +34,6 @@ class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentO
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     CountrysideStewardshipGrantPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/countryside_stewardship_grant_publication_alert_formatter"
 
 class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/countryside_stewardship_grant_publication_alert_formatter"
+require "formatters/countryside_stewardship_grant_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentO
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:countryside_stewardship_grant_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        CountrysideStewardshipGrantIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:countryside_stewardship_grant_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        CountrysideStewardshipGrantIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/countryside_stewardship_grant_publication_alert_formatter"
 require "formatters/countryside_stewardship_grant_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentO
     SpecialistPublisherWiring.get(:countryside_stewardship_grant_content_api_exporter)
   end
 
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        CountrysideStewardshipGrantIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        CountrysideStewardshipGrantIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    CountrysideStewardshipGrantIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -41,8 +41,4 @@ private
       )
     }
   end
-
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
 end

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -1,6 +1,5 @@
 require "formatters/drug_safety_update_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class DrugSafetyUpdateObserversRegistry < AbstractSpecialistDocumentObserversRegistry
   # Overridden to not send publication alerts -- they're sent manually each month to the list
@@ -22,23 +21,9 @@ private
     SpecialistPublisherWiring.get(:drug_safety_update_panopticon_registerer)
   end
 
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        DrugSafetyUpdateIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        DrugSafetyUpdateIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    DrugSafetyUpdateIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 end

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -1,3 +1,7 @@
+require "formatters/drug_safety_update_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
+
 class DrugSafetyUpdateObserversRegistry < AbstractSpecialistDocumentObserversRegistry
   # Overridden to not send publication alerts -- they're sent manually each month to the list
   def publication
@@ -19,11 +23,23 @@ private
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:drug_safety_update_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        DrugSafetyUpdateIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:drug_safety_update_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        DrugSafetyUpdateIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -1,5 +1,3 @@
-require "email_alert_exporter"
-
 class DrugSafetyUpdateObserversRegistry < AbstractSpecialistDocumentObserversRegistry
   # Overridden to not send publication alerts -- they're sent manually each month to the list
   def publication

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -17,8 +17,8 @@ private
     SpecialistPublisherWiring.get(:drug_safety_update_content_api_exporter)
   end
 
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:drug_safety_update_panopticon_registerer)
+  def format_document_as_artefact(document)
+    DrugSafetyUpdateArtefactFormatter.new(document)
   end
 
   def format_document_for_indexing(document)

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -34,10 +34,6 @@ class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     EsiFundPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -5,8 +5,8 @@ require "markdown_attachment_processor"
 class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
   private
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:esi_fund_panopticon_registerer)
+  def format_document_as_artefact(document)
+    EsiFundArtefactFormatter.new(document)
   end
 
   def content_api_exporter

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/esi_fund_publication_alert_formatter"
 
 class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/esi_fund_publication_alert_formatter"
 require "formatters/esi_fund_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
     SpecialistPublisherWiring.get(:esi_fund_content_api_exporter)
   end
 
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        EsiFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        EsiFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    EsiFundIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/esi_fund_publication_alert_formatter"
+require "formatters/esi_fund_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:esi_fund_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        EsiFundIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:esi_fund_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        EsiFundIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/international_development_fund_publication_alert_formatter"
+require "formatters/international_development_fund_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class InternationalDevelopmentFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:international_development_fund_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        InternationalDevelopmentFundIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:international_development_fund_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        InternationalDevelopmentFundIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     InternationalDevelopmentFundPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/international_development_fund_publication_alert_formatter"
 
 class InternationalDevelopmentFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/international_development_fund_publication_alert_formatter"
 require "formatters/international_development_fund_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class InternationalDevelopmentFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:international_development_fund_content_api_exporter)
   end
 
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        InternationalDevelopmentFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        InternationalDevelopmentFundIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    InternationalDevelopmentFundIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -5,8 +5,8 @@ require "markdown_attachment_processor"
 class InternationalDevelopmentFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
 private
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:international_development_fund_panopticon_registerer)
+  def format_document_as_artefact(document)
+    InternationalDevelopmentFundArtefactFormatter.new(document)
   end
 
   def content_api_exporter

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     MaibReportPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/maib_report_publication_alert_formatter"
 
 class MaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/maib_report_publication_alert_formatter"
 require "formatters/maib_report_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class MaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:maib_report_panopticon_registerer)
   end
 
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        MaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        MaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    MaibReportIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/maib_report_publication_alert_formatter"
+require "formatters/maib_report_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class MaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:maib_report_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        MaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:maib_report_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        MaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -9,8 +9,8 @@ private
     SpecialistPublisherWiring.get(:maib_report_content_api_exporter)
   end
 
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:maib_report_panopticon_registerer)
+  def format_document_as_artefact(document)
+    MaibReportArtefactFormatter.new(document)
   end
 
   def format_document_for_indexing(document)

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     MedicalSafetyAlertPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/medical_safety_alert_publication_alert_formatter"
 
 class MedicalSafetyAlertObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/medical_safety_alert_publication_alert_formatter"
 require "formatters/medical_safety_alert_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class MedicalSafetyAlertObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:medical_safety_alert_content_api_exporter)
   end
 
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        MedicalSafetyAlertIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        MedicalSafetyAlertIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    MedicalSafetyAlertIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/medical_safety_alert_publication_alert_formatter"
+require "formatters/medical_safety_alert_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class MedicalSafetyAlertObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:medical_safety_alert_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        MedicalSafetyAlertIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:medical_safety_alert_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        MedicalSafetyAlertIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -5,8 +5,8 @@ require "markdown_attachment_processor"
 class MedicalSafetyAlertObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
 private
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:medical_safety_alert_panopticon_registerer)
+  def format_document_as_artefact(document)
+    MedicalSafetyAlertArtefactFormatter.new(document)
   end
 
   def content_api_exporter

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -1,4 +1,7 @@
 require "formatters/raib_report_publication_alert_formatter"
+require "formatters/raib_report_indexable_formatter"
+require "markdown_attachment_processor"
+require "rummager_indexer"
 
 class RaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -12,11 +15,23 @@ private
   end
 
   def rummager_withdrawer
-    SpecialistPublisherWiring.get(:raib_report_rummager_deleter)
+    ->(document) {
+      RummagerIndexer.new.delete(
+        RaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def rummager_exporter
-    SpecialistPublisherWiring.get(:raib_report_rummager_indexer)
+    ->(document) {
+      RummagerIndexer.new.add(
+        RaibReportIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(document)
+        )
+      )
+    }
   end
 
   def content_api_withdrawer

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -34,10 +34,6 @@ private
     }
   end
 
-  def content_api_withdrawer
-    SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
-  end
-
   def publication_alert_formatter(document)
     RaibReportPublicationAlertFormatter.new(
       url_maker: url_maker,

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -9,8 +9,8 @@ private
     SpecialistPublisherWiring.get(:raib_report_content_api_exporter)
   end
 
-  def panopticon_exporter
-    SpecialistPublisherWiring.get(:raib_report_panopticon_registerer)
+  def format_document_as_artefact(document)
+    RaibReportArtefactFormatter.new(document)
   end
 
   def format_document_for_indexing(document)

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -1,7 +1,6 @@
 require "formatters/raib_report_publication_alert_formatter"
 require "formatters/raib_report_indexable_formatter"
 require "markdown_attachment_processor"
-require "rummager_indexer"
 
 class RaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry
 
@@ -14,24 +13,10 @@ private
     SpecialistPublisherWiring.get(:raib_report_panopticon_registerer)
   end
 
-  def rummager_withdrawer
-    ->(document) {
-      RummagerIndexer.new.delete(
-        RaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
-  end
-
-  def rummager_exporter
-    ->(document) {
-      RummagerIndexer.new.add(
-        RaibReportIndexableFormatter.new(
-          MarkdownAttachmentProcessor.new(document)
-        )
-      )
-    }
+  def format_document_for_indexing(document)
+    RaibReportIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
   end
 
   def publication_alert_formatter(document)

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -1,4 +1,3 @@
-require "email_alert_exporter"
 require "formatters/raib_report_publication_alert_formatter"
 
 class RaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry


### PR DESCRIPTION
A small set of changes to observer registries and the wiring file that cuts the number of lines in the wiring by a bit over one third.

Best reviewed one commit at a time. Perhaps the best person to review this is @tommyp.