### PR TITLE
Include summaries in MAIB finder search results

### DIFF
--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -10,6 +10,7 @@
   },
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "show_summaries": true,
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],
   "subscription_list_title_prefix": {
     "singular": "Marine Accident Investigation Branch (MAIB) reports with the following vessel type: ",


### PR DESCRIPTION
Some finders already show the summary field
(eg https://www.gov.uk/international-development-funding)

Marine Accident Investigation Branch (MAIB) has completed work on
their summaries and are now ready to have these show in:
https://www.gov.uk/maib-reports

Finder is configured in a JSON file in Specialist Publisher:
https://github.com/alphagov/specialist-publisher/blob/master/finders/metadata/maib-reports.json
simply include '"show_summaries": true,'
The following rake task `bundle exec rake publishing_api:publish_finders`.
is run automatically on deploy to preview, staging and production.
Which publishes changes made to those files

https://www.pivotaltracker.com/story/show/88531162

Before -
![screen shot 2015-02-23 at 14 04 54](https://cloud.githubusercontent.com/assets/1692222/6330141/d5d639c4-bb6d-11e4-8515-4b5bf6c2f6ff.png)

After -
![screen shot 2015-02-23 at 14 03 43](https://cloud.githubusercontent.com/assets/1692222/6330150/e1d8a716-bb6d-11e4-9add-2a33e2ec4976.png)
