### PR TITLE
Fix CSG artefact kind

### DIFF
--- a/app/exporters/formatters/countryside_stewardship_grant_artefact_formatter.rb
+++ b/app/exporters/formatters/countryside_stewardship_grant_artefact_formatter.rb
@@ -7,7 +7,7 @@ class CountrysideStewardshipGrantArtefactFormatter < AbstractArtefactFormatter
   end
 
   def kind
-    "countryside_stewardship_grants"
+    "countryside_stewardship_grant"
   end
 
   def rendering_app


### PR DESCRIPTION
The artefact kind in the formatter didn't match what Panopticon has. This commit makes it singular to match govuk_content_models.