### PR TITLE
Add artefact formatters to observers registries

### DIFF
--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/aaib_report_publication_alert_formatter"
+require "formatters/aaib_report_artefact_formatter"
 require "formatters/aaib_report_indexable_formatter"
+require "formatters/aaib_report_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class AaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/cma_case_publication_alert_formatter"
+require "formatters/cma_case_artefact_formatter"
 require "formatters/cma_case_indexable_formatter"
+require "formatters/cma_case_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class CmaCaseObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/countryside_stewardship_grant_observers_registry.rb
+++ b/app/observers/countryside_stewardship_grant_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/countryside_stewardship_grant_publication_alert_formatter"
+require "formatters/countryside_stewardship_grant_artefact_formatter"
 require "formatters/countryside_stewardship_grant_indexable_formatter"
+require "formatters/countryside_stewardship_grant_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class CountrysideStewardshipGrantObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -1,3 +1,4 @@
+require "formatters/drug_safety_update_artefact_formatter"
 require "formatters/drug_safety_update_indexable_formatter"
 require "markdown_attachment_processor"
 

--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,5 +1,5 @@
-require "formatters/esi_fund_publication_alert_formatter"
 require "formatters/esi_fund_indexable_formatter"
+require "formatters/esi_fund_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class EsiFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/international_development_fund_publication_alert_formatter"
+require "formatters/international_development_fund_artefact_formatter"
 require "formatters/international_development_fund_indexable_formatter"
+require "formatters/international_development_fund_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class InternationalDevelopmentFundObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/maib_report_publication_alert_formatter"
+require "formatters/maib_report_artefact_formatter"
 require "formatters/maib_report_indexable_formatter"
+require "formatters/maib_report_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class MaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/medical_safety_alert_publication_alert_formatter"
+require "formatters/medical_safety_alert_artefact_formatter"
 require "formatters/medical_safety_alert_indexable_formatter"
+require "formatters/medical_safety_alert_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class MedicalSafetyAlertObserversRegistry < AbstractSpecialistDocumentObserversRegistry

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -1,5 +1,6 @@
-require "formatters/raib_report_publication_alert_formatter"
+require "formatters/raib_report_artefact_formatter"
 require "formatters/raib_report_indexable_formatter"
+require "formatters/raib_report_publication_alert_formatter"
 require "markdown_attachment_processor"
 
 class RaibReportObserversRegistry < AbstractSpecialistDocumentObserversRegistry


### PR DESCRIPTION
This commit/pull request adds requires for artefact formatters to enable
publishing in dev environments, this was refactored and works in
tests and works in preview but didn't work locally

I also reordered the requires alphabetically where possible.