### PR TITLE
Add format name to CSG

### DIFF
--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -1,6 +1,7 @@
 {
   "base_path": "/countryside-stewardship-grants",
   "name": "Countryside Stewardship grants",
+  "format_name": "Countryside Stewardship grant",
   "beta": true,
   "filter": {
     "document_type": "countryside_stewardship_grant"


### PR DESCRIPTION
This is used by specialist frontend to link back to the Finder.