### PR TITLE
Import legacy cma cases

### DIFF
--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -1,5 +1,6 @@
 require "builders/specialist_document_builder"
 require "cma_import/mapper"
+require "cma_import/attachment_attacher"
 
 class CmaImport
   def initialize(data_files_dir)
@@ -23,11 +24,15 @@ private
   def import_job_builder
     ->(data) {
       DocumentImport::SingleImport.new(
-        document_creator: attribute_mapper,
+        document_creator: attachment_attacher,
         logger: logger,
         data: data,
       )
     }
+  end
+
+  def attachment_attacher
+    CmaImportAttachmentAttacher.new(attribute_mapper, data_files_dir)
   end
 
   def attribute_mapper

--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -41,12 +41,14 @@ private
 
   def create_cma_case_service
     ->(attributes) {
-      CreateDocumentService.new(
-        cma_case_builder,
-        cma_cases_repository,
-        [],
-        attributes,
-      ).call
+      DocumentPresenter.new(
+        CreateDocumentService.new(
+          cma_case_builder,
+          cma_cases_repository,
+          [],
+          attributes,
+        ).call
+      )
     }
   end
 
@@ -90,5 +92,14 @@ private
     JSON.parse(File.read(filename)).merge ({
       "import_source" => File.basename(filename),
     })
+  end
+
+  class DocumentPresenter < SimpleDelegator
+    def import_notes
+      [
+        "id: #{id}",
+        "slug: #{slug}",
+      ]
+    end
   end
 end

--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -1,0 +1,84 @@
+require "builders/specialist_document_builder"
+
+class CmaImport
+  def initialize(data_files_dir)
+    @data_files_dir = data_files_dir
+  end
+
+  def call
+    importer.call
+  end
+
+private
+  attr_reader :data_files_dir
+
+  def importer
+    DocumentImport::BulkImporter.new(
+      import_job_builder: import_job_builder,
+      data_enum: data_enum,
+    )
+  end
+
+  def import_job_builder
+    ->(data) {
+      DocumentImport::SingleImport.new(
+        document_creator: create_cma_case_service,
+        logger: logger,
+        data: data,
+      )
+    }
+  end
+
+  def create_cma_case_service
+    ->(attributes) {
+      CreateDocumentService.new(
+        cma_case_builder,
+        cma_cases_repository,
+        [],
+        attributes,
+      ).call
+    }
+  end
+
+  def cma_case_builder
+    SpecialistDocumentBuilder.new(
+      "cma_case",
+      cma_case_factory,
+    )
+  end
+
+  def cma_case_factory
+    ->(*args) {
+      NullValidator.new(
+        CmaCase.new(
+          SpecialistDocument.new(
+            SlugGenerator.new(prefix: "cma-cases"),
+            *args,
+          ),
+        )
+      )
+    }
+  end
+
+  def cma_cases_repository
+    SpecialistPublisherWiring.get(:repository_registry).for_type("cma_case")
+  end
+
+  def logger
+    DocumentImport::Logger.new(STDOUT)
+  end
+
+  def data_enum
+    data_files.lazy.map(&method(:parse_json_file))
+  end
+
+  def data_files
+    Dir.glob(File.join(data_files_dir, "*.json")).sort.reverse
+  end
+
+  def parse_json_file(filename)
+    JSON.parse(File.read(filename)).merge ({
+      "import_source" => File.basename(filename),
+    })
+  end
+end

--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -1,4 +1,5 @@
 require "builders/specialist_document_builder"
+require "cma_import/mapper"
 
 class CmaImport
   def initialize(data_files_dir)
@@ -22,11 +23,15 @@ private
   def import_job_builder
     ->(data) {
       DocumentImport::SingleImport.new(
-        document_creator: create_cma_case_service,
+        document_creator: attribute_mapper,
         logger: logger,
         data: data,
       )
     }
+  end
+
+  def attribute_mapper
+    CmaImportAttributeMapper.new(create_cma_case_service)
   end
 
   def create_cma_case_service

--- a/app/importers/cma_import/attachment_attacher.rb
+++ b/app/importers/cma_import/attachment_attacher.rb
@@ -1,0 +1,100 @@
+class CmaImportAttachmentAttacher
+  include ::DocumentImport::AttachmentHelpers
+
+  def initialize(create_document_service, assets_directory)
+    @create_document_service = create_document_service
+    @assets_directory = assets_directory
+  end
+
+  def call(data)
+    document = create_document_service.call(data)
+
+    assets = data.fetch("assets", []).map { |asset_data|
+      attach_asset_to_document(asset_data, document)
+    }
+
+    AssetAttachmentValidator.new(
+      document,
+      assets,
+    )
+  end
+
+private
+  attr_reader :create_document_service, :assets_directory
+
+  def attach_asset_to_document(asset_data, document)
+    # Get the link markdown for this asset out of the document body
+    original_link = find_link_in_document(asset_data, document)
+    filename = File.basename(asset_data.fetch("filename"))
+
+    asset_title = original_link ? original_link.title : filename
+
+    # Turn the asset_data into attributes we can use to build an attachment
+    file_attributes = attachable_file_attributes(
+      assets_directory,
+      asset_data.merge("title" => asset_title),
+    )
+
+    # Make the attachment
+    attachment = document.add_attachment(file_attributes)
+
+    # Update the link in the document body
+    if original_link
+      replace_in_body(
+        document,
+        original_link.match,
+        attachment.snippet,
+      )
+    end
+
+    OpenStruct.new(
+      linked_from_body?: original_link.present?,
+      filename: filename,
+    )
+  end
+
+  def find_link_in_document(asset_data, document)
+    match = document.body.match(
+      %r|\[([^\]]+)\]\(#{asset_data.fetch("original_url")}\)|
+    )
+
+    if match
+      OpenStruct.new(
+        match: match.to_s,
+        title: match.captures.first,
+      )
+    end
+  end
+
+  class AssetAttachmentValidator < SimpleDelegator
+    def initialize(document, assets)
+      @document = document
+      @assets = assets
+
+      super(document)
+    end
+
+    def valid?
+      super && assets_valid?
+    end
+
+    def errors
+      super.merge(
+        assets: assets_errors,
+      )
+    end
+
+  private
+    attr_reader :document, :assets
+
+    def assets_valid?
+      assets.all?(&:linked_from_body?)
+    end
+
+    def assets_errors
+      assets.reject(&:linked_from_body?).map { |asset|
+        "#{asset.filename} not linked from body"
+      }
+    end
+  end
+end

--- a/app/importers/cma_import/mapper.rb
+++ b/app/importers/cma_import/mapper.rb
@@ -60,12 +60,19 @@ private
 
     def messages
       [
+        original_url_message,
         body_missing_message,
       ].compact
     end
 
     def body_missing_message
       "`body` field not defined" unless data.has_key?("body")
+    end
+
+    def original_url_message
+      url = data.fetch("original_url", "unknown")
+
+      "original_url: #{url}"
     end
   end
 end

--- a/app/importers/cma_import/mapper.rb
+++ b/app/importers/cma_import/mapper.rb
@@ -4,8 +4,13 @@ class CmaImportAttributeMapper
   end
 
   def call(data)
-    create_document_service.call(
+    document = create_document_service.call(
       attributes(data)
+    )
+
+    Presenter.new(
+      document,
+      data,
     )
   end
 
@@ -33,5 +38,34 @@ private
       market_sector
       outcome_type
     )
+  end
+
+  def body_defined?(data)
+    data.has_key?("body")
+  end
+
+  class Presenter < SimpleDelegator
+    def initialize(document, data)
+      @data = data
+
+      super(document)
+    end
+
+    def import_notes
+      super.concat(messages)
+    end
+
+  private
+    attr_reader :data
+
+    def messages
+      [
+        body_missing_message,
+      ].compact
+    end
+
+    def body_missing_message
+      "`body` field not defined" unless data.has_key?("body")
+    end
   end
 end

--- a/app/importers/cma_import/mapper.rb
+++ b/app/importers/cma_import/mapper.rb
@@ -16,13 +16,15 @@ private
     data
       .slice(*attribute_keys)
       .symbolize_keys
+      .merge(
+        body: data.fetch("body", ""),
+      )
   end
 
   def attribute_keys
     %w(
       title
       summary
-      body
 
       opened_date
       closed_date

--- a/app/importers/cma_import/mapper.rb
+++ b/app/importers/cma_import/mapper.rb
@@ -1,0 +1,35 @@
+class CmaImportAttributeMapper
+  def initialize(create_document_service)
+    @create_document_service = create_document_service
+  end
+
+  def call(data)
+    create_document_service.call(
+      attributes(data)
+    )
+  end
+
+private
+  attr_reader :create_document_service
+
+  def attributes(data)
+    data
+      .slice(*attribute_keys)
+      .symbolize_keys
+  end
+
+  def attribute_keys
+    %w(
+      title
+      summary
+      body
+
+      opened_date
+      closed_date
+      case_type
+      case_state
+      market_sector
+      outcome_type
+    )
+  end
+end

--- a/app/importers/document_import.rb
+++ b/app/importers/document_import.rb
@@ -24,31 +24,38 @@ module DocumentImport
     end
 
     def success(document, data)
-      @output.puts("SUCCESS: Created #{document.slug} #{format_data(data)}")
+      write("SUCCESS", document.import_notes.join("\t"), data)
     end
 
     def failure(document, data)
-      errors = document.errors.to_h
-
-      @output.puts("FAILURE: #{document.slug} #{errors} #{format_data(data)}")
+      write("FAILURE", document.errors.to_h, data)
     end
 
     def error(message, data)
-      @output.puts("ERROR: #{message} #{format_data(data)}")
+      write("ERROR", message, data)
     end
 
     def warn(message, data)
-      @output.puts("WARNING: #{message} #{format_data(data)}")
+      write("WARNING", message, data)
     end
 
     def skipped(message, data)
-      @output.puts("SKIPPED: #{message} #{format_data(data)}")
+      write("SKIPPED", message, data)
     end
 
   private
+    def write(status, message, data)
+      line = [
+        status,
+        message,
+        format_data(data),
+      ].join("\t")
+
+      @output.puts(line)
+    end
 
     def format_data(data)
-      data.map { |kv| kv.join(": ") }.join(", ")
+      data.map { |kv| kv.join(": ") }.join("\t")
     end
   end
 

--- a/app/importers/document_import.rb
+++ b/app/importers/document_import.rb
@@ -27,8 +27,6 @@ module DocumentImport
       @output.puts("SUCCESS: Created #{document.slug} #{format_data(data)}")
     end
 
-    # Failure.. Unless it's only failing on summary, in which case it's a..
-    # SUCCESS
     def failure(document, data)
       errors = document.errors.to_h
 

--- a/app/importers/document_import.rb
+++ b/app/importers/document_import.rb
@@ -1,5 +1,6 @@
 module DocumentImport
   class HasNewerVersionError < StandardError; end
+  class FileNotFound < StandardError; end
 
   class BulkImporter
     def initialize(dependencies)

--- a/app/importers/document_import/attachment_helpers.rb
+++ b/app/importers/document_import/attachment_helpers.rb
@@ -11,7 +11,14 @@ module DocumentImport
     def attachable_file_attributes(base_path, asset_data)
       original_filename = asset_data.fetch("original_filename", asset_data["filename"])
 
-      file = File.open(File.join(base_path, asset_data["filename"]))
+      path_to_file = File.join(base_path, asset_data["filename"])
+
+      unless File.exist?(path_to_file)
+        raise FileNotFound.new("file #{path_to_file} does not exist")
+      end
+
+      file = File.open(path_to_file)
+
       file.define_singleton_method(:original_filename) { original_filename }
 
       {

--- a/bin/import_cma_cases
+++ b/bin/import_cma_cases
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "cma_import"
+
+data_files_dir = ARGV.fetch(0)
+
+# Override the timeout value for the Panopticon API during a data import.
+PANOPTICON_API_CREDENTIALS.merge!(timeout: 30)
+
+CmaImport.new(data_files_dir).call


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/87001102

This importer runs over JSON files produced by scraping historic CMA cases from the national archives. Code for the scraper is here: https://github.com/rgarner/cma-tna-crawlers

There is probably further work to do here – several hundred of the records to be imported have missing or incomplete bodies, which will need to be addressed either as part of a re-scrape or as part of the import process.

Best reviewed one commit at a time.

Paired with @mikejustdoit for this work.