### PR TITLE
Allow DWP and Defra to contribute to ESI finder

### DIFF
--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -34,27 +34,31 @@ private
   end
 
   def user_organisation_owns_format?(format)
-    user.organisation_slug == owning_organisation_for_format(format)
+    owning_organisations_for_format(format).include?(user.organisation_slug)
   end
 
-  def owning_organisation_for_format(format)
+  def owning_organisations_for_format(format)
     case format
     when "cma_case"
-      "competition-and-markets-authority"
+      ["competition-and-markets-authority"]
     when "aaib_report"
-      "air-accidents-investigation-branch"
+      ["air-accidents-investigation-branch"]
     when "international_development_fund"
-      "department-for-international-development"
+      ["department-for-international-development"]
     when "drug_safety_update", "medical_safety_alert"
-      "medicines-and-healthcare-products-regulatory-agency"
+      ["medicines-and-healthcare-products-regulatory-agency"]
     when "esi_fund"
-      "department-for-communities-and-local-government"
+      %w(
+        department-for-communities-and-local-government
+        department-for-work-pensions
+        department-for-environment-food-rural-affairs
+      )
     when "maib_report"
-      "marine-accident-investigation-branch"
+      ["marine-accident-investigation-branch"]
     when "raib_report"
-      "rail-accident-investigation-branch"
+      ["rail-accident-investigation-branch"]
     when "countryside_stewardship_grant"
-      "department-for-environment-food-rural-affairs"
+      ["department-for-environment-food-rural-affairs"]
     end
   end
 end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+
+describe PermissionChecker do
+  let(:cma_writer)  { FactoryGirl.build(:cma_writer) }
+  let(:dclg_editor) { FactoryGirl.build(:dclg_editor) }
+  let(:gds_editor)  { FactoryGirl.build(:gds_editor) }
+
+  describe "#can_edit?" do
+    context "a user who is not an editor" do
+      subject(:checker) { PermissionChecker.new(cma_writer) }
+
+      context "editing a manual" do
+        it "allows editing" do
+          expect(checker.can_edit?("manual")).to be true
+        end
+      end
+
+      context "editing a non-manual format owned by their organisation" do
+        it "allows editing" do
+          expect(checker.can_edit?("cma_case")).to be true
+        end
+      end
+
+      context "editing a non-manual format not owned by their organisation" do
+        it "prevents editing" do
+          expect(checker.can_edit?("maib_report")).to be false
+        end
+      end
+    end
+
+    context "a GDS editor" do
+      subject(:checker) { PermissionChecker.new(gds_editor) }
+
+      it "allows editing of any format" do
+        expect(checker.can_edit?("tea_and_cake")).to be true
+      end
+    end
+  end
+
+  describe "#can_publish?" do
+    context "a user who is not an editor" do
+      subject(:checker) { PermissionChecker.new(cma_writer) }
+
+      it "prevents publishing" do
+        expect(checker.can_publish?("manual")).to be false
+      end
+    end
+
+    context "an editor" do
+      subject(:checker) { PermissionChecker.new(dclg_editor) }
+
+      context "publishing a manual" do
+        it "allows publishing" do
+          expect(checker.can_publish?("manual")).to be true
+        end
+      end
+
+      context "publishing a non-manual format owned by their organisation" do
+        it "allows publishing" do
+          expect(checker.can_publish?("esi_fund")).to be true
+        end
+      end
+
+      context "publishing a non-manual format not owned by their organisation" do
+        it "prevents publishing" do
+          expect(checker.can_publish?("maib_report")).to be false
+        end
+      end
+    end
+
+    context "a GDS editor" do
+      subject(:checker) { PermissionChecker.new(gds_editor) }
+
+      it "allows publishing of any format" do
+        expect(checker.can_publish?("tea_and_biscuits")).to be true
+      end
+    end
+  end
+
+  describe "#is_gds_editor?" do
+    it "is true for a GDS editor" do
+      checker = PermissionChecker.new(gds_editor)
+      expect(checker.is_gds_editor?).to be true
+    end
+
+    it "is false for a non-GDS editor" do
+      checker = PermissionChecker.new(dclg_editor)
+      expect(checker.is_gds_editor?).to be false
+    end
+  end
+end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,9 +1,10 @@
 require "spec_helper"
 
 describe PermissionChecker do
-  let(:cma_writer)  { FactoryGirl.build(:cma_writer) }
-  let(:dclg_editor) { FactoryGirl.build(:dclg_editor) }
-  let(:gds_editor)  { FactoryGirl.build(:gds_editor) }
+  let(:cma_writer)   { FactoryGirl.build(:cma_writer) }
+  let(:dclg_editor)  { FactoryGirl.build(:dclg_editor) }
+  let(:defra_editor) { FactoryGirl.build(:defra_editor) }
+  let(:gds_editor)   { FactoryGirl.build(:gds_editor) }
 
   describe "#can_edit?" do
     context "a user who is not an editor" do
@@ -86,6 +87,24 @@ describe PermissionChecker do
     it "is false for a non-GDS editor" do
       checker = PermissionChecker.new(dclg_editor)
       expect(checker.is_gds_editor?).to be false
+    end
+  end
+
+  describe "multiple organisations owning a format" do
+    let(:checkers) {
+      [PermissionChecker.new(dclg_editor), PermissionChecker.new(defra_editor)]
+    }
+
+    it "allows members of all owning organisations to edit" do
+      checkers.each do |checker|
+        expect(checker.can_edit?("esi_fund")).to be true
+      end
+    end
+
+    it "allows editors who are members of all owning organisations to publish" do
+      checkers.each do |checker|
+        expect(checker.can_publish?("esi_fund")).to be true
+      end
     end
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -45,6 +45,11 @@ FactoryGirl.define do
     organisation_slug "ministry-of-tea"
   end
 
+  factory :gds_editor, parent: :user do
+    permissions %w(signin gds_editor)
+    organisation_slug "government-digital-service"
+  end
+
   factory :panopticon_mapping do
     resource_type "specialist-document"
     sequence(:resource_id) { |n| "some-uuid-#{n}"}


### PR DESCRIPTION
- add unit tests for `PermissionChecker`
- add DWP and Defra as owning organisations for the ESI finder