### PR TITLE
Require artefact formatter for ESI Fund observers registry

### DIFF
--- a/app/observers/esi_fund_observers_registry.rb
+++ b/app/observers/esi_fund_observers_registry.rb
@@ -1,3 +1,4 @@
+require "formatters/esi_fund_artefact_formatter"
 require "formatters/esi_fund_indexable_formatter"
 require "formatters/esi_fund_publication_alert_formatter"
 require "markdown_attachment_processor"


### PR DESCRIPTION
I've been seeing intermittent 'uninitialized constant' errors in dev
from this being missing.