### PR TITLE
Persist changes to CMA case document

### DIFF
--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -33,9 +33,9 @@ private
 
   def attachment_attacher
     CmaImportAttachmentAttacher.new(
-      attribute_mapper,
-      cma_cases_repository,
-      data_files_dir,
+      create_document_service: attribute_mapper,
+      document_repository: cma_cases_repository,
+      assets_directory: data_files_dir,
     )
   end
 

--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -32,7 +32,11 @@ private
   end
 
   def attachment_attacher
-    CmaImportAttachmentAttacher.new(attribute_mapper, data_files_dir)
+    CmaImportAttachmentAttacher.new(
+      attribute_mapper,
+      cma_cases_repository,
+      data_files_dir,
+    )
   end
 
   def attribute_mapper

--- a/app/importers/cma_import/attachment_attacher.rb
+++ b/app/importers/cma_import/attachment_attacher.rb
@@ -1,8 +1,9 @@
 class CmaImportAttachmentAttacher
   include ::DocumentImport::AttachmentHelpers
 
-  def initialize(create_document_service, assets_directory)
+  def initialize(create_document_service, repo, assets_directory)
     @create_document_service = create_document_service
+    @repo = repo
     @assets_directory = assets_directory
   end
 
@@ -13,6 +14,8 @@ class CmaImportAttachmentAttacher
       attach_asset_to_document(asset_data, document)
     }
 
+    repo.store(document)
+
     Presenter.new(
       document,
       assets,
@@ -20,7 +23,7 @@ class CmaImportAttachmentAttacher
   end
 
 private
-  attr_reader :create_document_service, :assets_directory
+  attr_reader :create_document_service, :repo, :assets_directory
 
   def attach_asset_to_document(asset_data, document)
     # Get the link markdown for this asset out of the document body

--- a/app/importers/cma_import/attachment_attacher.rb
+++ b/app/importers/cma_import/attachment_attacher.rb
@@ -1,9 +1,9 @@
 class CmaImportAttachmentAttacher
   include ::DocumentImport::AttachmentHelpers
 
-  def initialize(create_document_service, repo, assets_directory)
+  def initialize(create_document_service:, document_repository:, assets_directory:)
     @create_document_service = create_document_service
-    @repo = repo
+    @document_repository = document_repository
     @assets_directory = assets_directory
   end
 
@@ -14,7 +14,7 @@ class CmaImportAttachmentAttacher
       attach_asset_to_document(asset_data, document)
     }
 
-    repo.store(document)
+    document_repository.store(document)
 
     Presenter.new(
       document,
@@ -23,7 +23,7 @@ class CmaImportAttachmentAttacher
   end
 
 private
-  attr_reader :create_document_service, :repo, :assets_directory
+  attr_reader :create_document_service, :document_repository, :assets_directory
 
   def attach_asset_to_document(asset_data, document)
     # Get the link markdown for this asset out of the document body


### PR DESCRIPTION
It looks like we were only persisting the document during its initial creation, and not after editing its `body` or attachments.

The approach I've taken seems equivalent the other document importers. The only difference is that both valid and non-valid CMA cases are persisted, as described in previous commits (https://github.com/alphagov/specialist-publisher/pull/434).

Part of this ticket: https://www.pivotaltracker.com/story/show/87001102