### PR TITLE
Import cma cases with missing bodies

### DIFF
--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -1,6 +1,7 @@
 require "builders/specialist_document_builder"
 require "cma_import/mapper"
 require "cma_import/attachment_attacher"
+require "cma_import/missing_body_generator"
 
 class CmaImport
   def initialize(data_files_dir)
@@ -24,11 +25,18 @@ private
   def import_job_builder
     ->(data) {
       DocumentImport::SingleImport.new(
-        document_creator: attachment_attacher,
+        document_creator: missing_body_generator,
         logger: logger,
         data: data,
       )
     }
+  end
+
+  def missing_body_generator
+    CmaImportMissingBodyGenerator.new(
+      create_document_service: attachment_attacher,
+      document_repository: cma_cases_repository,
+    )
   end
 
   def attachment_attacher

--- a/app/importers/cma_import/mapper.rb
+++ b/app/importers/cma_import/mapper.rb
@@ -40,10 +40,6 @@ private
     )
   end
 
-  def body_defined?(data)
-    data.has_key?("body")
-  end
-
   class Presenter < SimpleDelegator
     def initialize(document, data)
       @data = data

--- a/app/importers/cma_import/missing_body_generator.rb
+++ b/app/importers/cma_import/missing_body_generator.rb
@@ -1,0 +1,53 @@
+class CmaImportMissingBodyGenerator
+  def initialize(create_document_service:, document_repository:)
+    @create_document_service = create_document_service
+    @document_repository = document_repository
+  end
+
+  def call(data)
+    document = create_document_service.call(data)
+
+    if needs_body_generating?(document)
+      generate_body(document)
+
+      document_repository.store(document)
+
+      Presenter.new(document)
+    else
+      document
+    end
+  end
+
+private
+  attr_reader :create_document_service, :document_repository
+
+  def needs_body_generating?(document)
+    document.body.empty? && document.attachments.size == 1
+  end
+
+  def default_body
+    "Full text of the decision"
+  end
+
+  def generate_body(document)
+    attachment = document.attachments.first.snippet
+    document.update(body: "#{default_body} #{attachment}")
+  end
+
+  class Presenter < SimpleDelegator
+    def import_notes
+      super.concat(messages)
+    end
+
+  private
+    def messages
+      [
+        body_missing_message,
+      ]
+    end
+
+    def body_missing_message
+      "missing `body` field replaced with default"
+    end
+  end
+end


### PR DESCRIPTION
Generates a body based on the default body copy "Full text of the decision" and links to the document's attachments.

Suggestions for a better approach than CmaImport#document_creator particularly welcome