### PR TITLE
Add publisher URL to CMA import output

### DIFF
--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -102,8 +102,18 @@ private
     def import_notes
       [
         "id: #{id}",
+        "publisher_url: #{publisher_url}",
         "slug: #{slug}",
       ]
+    end
+
+  private
+    def publisher_url
+      "#{publisher_host}/cma-cases/#{id}"
+    end
+
+    def publisher_host
+      Plek.new.find("specialist-publisher")
     end
   end
 end


### PR DESCRIPTION
So that when we provide the output to the CMA for review they can click straight into the right page in Specialist Publisher.