### PR TITLE
Remove `rake ci:setup:rspec`

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -38,7 +38,6 @@ git checkout $SCHEMA_GIT_COMMIT
 cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test bundle exec rake ci:setup:rspec
 # TODO as schemas are added for them, change this to include more formats
 RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec spec/lib/publishing_api_finder_publisher_spec.rb
 


### PR DESCRIPTION
This task is provided by the `ci_reporter` gem which
specialist-publisher is not currently set up to use.

It's currently causing the schema builds to fail.