### PR TITLE
Fix already initialized constant

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -24,6 +24,7 @@ require "view_adapter_registry"
 
 $LOAD_PATH.unshift(File.expand_path("../..", "app/services"))
 
+# rubocop:disable ConstantName
 SpecialistPublisherWiring ||= DependencyContainer.new do
   define_factory(:manual_builder) {
     ManualBuilder.new(
@@ -298,3 +299,4 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
     FinderSchema.new(Rails.root.join("finders/schemas/raib-reports.json"))
   }
 end
+# rubocop:enable ConstantName

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -24,7 +24,7 @@ require "view_adapter_registry"
 
 $LOAD_PATH.unshift(File.expand_path("../..", "app/services"))
 
-SpecialistPublisherWiring = DependencyContainer.new do
+SpecialistPublisherWiring ||= DependencyContainer.new do
   define_factory(:manual_builder) {
     ManualBuilder.new(
       slug_generator: SlugGenerator.new(prefix: "guidance"),


### PR DESCRIPTION
These commits are very small, but basically...

SpecialistPublisherWiring is a regular constant variable dressed as a class name. The way it was being assigned was causing `already initialized constant` warnings which really added a lot of noise to a script I've written in another PR.

This does involve handling Rubocop inline, which seems a bit ugly and it'd be good to hear some thoughts