### PR TITLE
Validate format of closing_date for ESI funds

### DIFF
--- a/app/models/validators/esi_fund_validator.rb
+++ b/app/models/validators/esi_fund_validator.rb
@@ -9,4 +9,5 @@ class EsiFundValidator < SimpleDelegator
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
+  validates :closing_date, allow_blank: true, date: true
 end

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -13,6 +13,7 @@ Scenario: Create a new ESI Fund
 Scenario: Cannot create an ESI Fund with invalid fields
   When I create an ESI Fund with invalid fields
   Then I should see error messages about missing fields
+  And I should see an error message about an invalid date field "Closing date"
   And I should see an error message about a "Body" field containing javascript
   And the ESI Fund should not have been created
 

--- a/features/step_definitions/esi_fund_steps.rb
+++ b/features/step_definitions/esi_fund_steps.rb
@@ -17,6 +17,7 @@ end
 When(/^I create an ESI Fund with invalid fields$/) do
   @document_fields = {
     body: "<script>alert('Oh noes!)</script>",
+    closing_date: "2016/01/01",
   }
   create_esi_fund(@document_fields)
 end


### PR DESCRIPTION
Note: This won't prevent existing documents with bad dates being published. This needs to be communicated to the editors.