### PR TITLE
Fix incomplete bodies in cma import

### DIFF
--- a/app/importers/cma_import.rb
+++ b/app/importers/cma_import.rb
@@ -2,6 +2,7 @@ require "builders/specialist_document_builder"
 require "cma_import/mapper"
 require "cma_import/attachment_attacher"
 require "cma_import/missing_body_generator"
+require "cma_import/body_fixer"
 
 class CmaImport
   def initialize(data_files_dir)
@@ -34,8 +35,14 @@ private
 
   def missing_body_generator
     CmaImportMissingBodyGenerator.new(
-      create_document_service: attachment_attacher,
+      create_document_service: body_fixer,
       document_repository: cma_cases_repository,
+    )
+  end
+
+  def body_fixer
+    CmaImportBodyFixer.new(
+      create_document_service: attachment_attacher,
     )
   end
 

--- a/app/importers/cma_import/attachment_attacher.rb
+++ b/app/importers/cma_import/attachment_attacher.rb
@@ -58,14 +58,27 @@ private
   end
 
   def find_link_in_document(asset_data, document)
+    url = asset_data.fetch("original_url")
+
     match = document.body.match(
-      %r|\[([^\]]+)\]\(#{asset_data.fetch("original_url")}\)|
+      %r!
+        # markdown link
+        \[([^\]]+)\] # link text
+        \(#{url}\)
+
+        |
+
+        # html link
+        <a\s+href="#{url}">
+          ([^<]+) # link text
+        </a>
+      !x
     )
 
     if match
       OpenStruct.new(
         match: match.to_s,
-        title: match.captures.first,
+        title: match.captures.compact.first,
       )
     end
   end

--- a/app/importers/cma_import/body_fixer.rb
+++ b/app/importers/cma_import/body_fixer.rb
@@ -1,0 +1,137 @@
+# A number of the scraped JSON files contain markup_sections which aren't
+# included in the body. This object:
+#
+# - works out which sections are missing
+# - adds those sections into the body if it can
+# - adds a warning to the import notes if it can't
+class CmaImportBodyFixer
+  def initialize(create_document_service:)
+    @create_document_service = create_document_service
+  end
+
+  def call(data)
+    massager = DataMassager.new(raw_data: data)
+
+    document = create_document_service.call(massager.massaged_data)
+
+    Presenter.new(
+      document: document,
+      massager: massager,
+    )
+  end
+
+private
+  attr_reader :create_document_service
+
+  class DataMassager
+    def initialize(raw_data:)
+      @raw_data = raw_data
+    end
+
+    def massaged_data
+      raw_data.merge("body" => massaged_body)
+    end
+
+    def body_complete?
+      missing_sections.empty?
+    end
+
+    def missing_section_keys
+      missing_sections.keys
+    end
+
+    def fixed_body?
+      only_missing_final_report_and_appendices_section?
+    end
+
+  private
+    attr_reader :raw_data
+
+    def massaged_body
+      if fixed_body?
+        [body, missing_content].join("\n\n")
+      else
+        body
+      end
+    end
+
+    def body
+      raw_data.fetch("body")
+    end
+
+    def normalised_body
+      body.gsub(/\s+/, " ")
+    end
+
+    def markup_sections
+      raw_data.fetch("markup_sections", [])
+    end
+
+    def missing_content
+      missing_sections.values.map { |content|
+        down_level_headings(content)
+      }
+    end
+
+    def missing_sections
+      markup_sections.reject { |_, content|
+        section_appears_in_body?(content)
+      }
+    end
+
+    def section_appears_in_body?(section_content)
+      normalised_content = section_content.gsub(/\s+/, " ")
+      reheaded_content = down_level_headings(normalised_content)
+
+      normalised_body.include?(normalised_content) || normalised_body.include?(reheaded_content)
+    end
+
+    def only_missing_final_report_and_appendices_section?
+      missing_sections.keys == %w(final-report-and-appendices-glossary)
+    end
+
+    # Swap all headings with a heading one level lower. This is done by finding
+    # all lines that start with a `#` and adding another one
+    def down_level_headings(content)
+      content.gsub(/^#/, "##")
+    end
+  end
+
+  class Presenter < SimpleDelegator
+    def initialize(document:, massager:)
+      @massager = massager
+
+      super(document)
+    end
+
+    def import_notes
+      super + messages
+    end
+
+  private
+    attr_reader :massager
+
+    def messages
+      [
+        incomplete_body_message,
+        body_fixed_automatically_message,
+      ].compact
+    end
+
+    def incomplete_body_message
+      unless massager.body_complete?
+        "Body missing some markup sections: #{missing_sections}"
+      end
+    end
+
+    def body_fixed_automatically_message
+      if massager.fixed_body?
+        "Missing body sections added automatically"
+      end
+    end
+
+    def missing_sections
+      massager.missing_section_keys.join(", ")
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/90459058

Some of the data that was scraped as part of the work to import legacy CMA cases has `markup_sections` which aren't included in the `body` field.

In some cases the missing content are the links to many of the supporting attachments. That is the case where we are missing the `final-report-and-appendices-glossary` section and no other sections.

This code checks if that's the case, and appends it to the body. It also adds some import notes for the log output to list the missing sections and whether it was fixed automatically.