### PR TITLE
Remove beta branding from MAIB finder

### DIFF
--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -3,8 +3,6 @@
   "base_path": "/maib-reports",
   "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",
-  "beta": true,
-  "beta_message": "Until early 2015, the <a href='http://www.maib.gov.uk/home/index.cfm'>MAIB website</a> is the main source for MAIB reports",
   "filter": {
     "document_type": "maib_report"
   },


### PR DESCRIPTION
Marine Accident Investigation Branch are no longer labelled as a BETA site.

Pivotal Tracker ticket: https://www.pivotaltracker.com/story/show/90773912