### PR TITLE
Enable email subscription to MAIB reports

### DIFF
--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -8,6 +8,7 @@
   },
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "signup_enabled": true,
   "show_summaries": true,
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],
   "subscription_list_title_prefix": {


### PR DESCRIPTION
Allow users to subscribe to email alerts for MAIB reports.
Tested on preview, screenshot of the email received at the moment I published a test MAIB report: 

![screen shot 2015-03-26 at 14 20 11](https://cloud.githubusercontent.com/assets/5038475/6848312/56a14a8a-d3c4-11e4-9c04-a7f40a3216b2.png)

Paired on this with @binaryberry !