### PR TITLE
Make attachments collapsible

### DIFF
--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -48,23 +48,30 @@
 </div>
 <div class="row">
   <div class=" col-md-8">
-    <h2>Attachments</h2>
     <% if document.attachments.any? %>
-      <table class='table table-bordered table-hover'>
-        <thead>
-          <th>Title</th>
-          <th>Created</th>
-          <th>Last updated</th>
-        </thead>
-        <% document.attachments.each do | attachment | %>
-        <tr>
-          <td><%= attachment.title %></td>
-          <td><%= attachment.created_at.to_s(:govuk_date)%></td>
-          <td><%= attachment.updated_at.to_s(:govuk_date)%></td>
-        </tr>
-        <% end %>
-      </table>
+      <h2 class="collapsable-heading">
+        <a data-toggle="collapse" data-parent="#accordion" href="#document-attachments-container">
+          Attachments (<%= document.attachments.count %>) <small>(click to expand)</small>
+        </a>
+      </h2>
+      <div id="document-attachments-container" class="panel-collapse collapse">
+        <table class='table table-bordered table-hover'>
+          <thead>
+            <th>Title</th>
+            <th>Created</th>
+            <th>Last updated</th>
+          </thead>
+          <% document.attachments.each do | attachment | %>
+          <tr>
+            <td><%= attachment.title %></td>
+            <td><%= attachment.created_at.to_s(:govuk_date)%></td>
+            <td><%= attachment.updated_at.to_s(:govuk_date)%></td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
     <% else %>
+      <h2>Attachments</h2>
       <p class='no-content-message'>This document doesn't have any attachments</p>
     <% end %>
   </div>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -37,11 +37,11 @@
 <div class="row">
   <div class=" col-md-8">
     <h2 class='collapsable-heading' >
-      <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">
+      <a data-toggle="collapse" data-parent="#accordion" href="#document-body-container">
         Body <small>(click to expand)</small>
       </a>
     </h2>
-    <div id="collapseOne" class="panel-collapse collapse">
+    <div id="document-body-container" class="panel-collapse collapse">
       <pre><%= document.body %></pre>
     </div>
   </div>


### PR DESCRIPTION
Some documents have a lot of attachments. An example of an extreme case at the moment is the "Local bus services market investigation" from the CMA, which has **460 attachments**.

Since the attachments are all displayed on the show page and the edit, publish and withdraw buttons are all right at the bottom of the page, that means editors are having to do way more scrolling than is reasonable.

This is probably best reviewed with whitespace ignored: https://github.com/alphagov/specialist-publisher/pull/461/files?w=1

## Screenshots

### Before

![screen shot 2015-03-31 at 13 44 07](https://cloud.githubusercontent.com/assets/74812/6919406/8bf484a2-d7ae-11e4-82d4-89667473f832.png)

### After

![screen shot 2015-03-31 at 13 50 30](https://cloud.githubusercontent.com/assets/74812/6919407/99e61c42-d7ae-11e4-8d2d-f11ecfa94927.png)

### Document without attachments

![screen shot 2015-03-31 at 13 51 42](https://cloud.githubusercontent.com/assets/74812/6919415/a5ab202c-d7ae-11e4-9698-132b48af5052.png)