### PR TITLE
Raib finder  - remove betabranding and enable email subscriptions

### DIFF
--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -3,8 +3,6 @@
   "base_path": "/raib-reports",
   "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",
-  "beta": true,
-  "beta_message": "Until early 2015, the <a href='http://www.raib.gov.uk/home/index.cfm'>RAIB website</a> is the main source for RAIB reports",
   "filter": {
     "document_type": "raib_report"
   },

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -8,6 +8,7 @@
   },
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "signup_enabled": true,
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],
   "subscription_list_title_prefix": {
     "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",


### PR DESCRIPTION
RAIB reports (https://www.gov.uk/raib-reports) soon won't be beta any more, and will need email subscription to be turned on, in the same way this happened for the MAIB finder. 

So I removed beta branding in the finder, and enabled subscriptions.

Before:
![before raib finder email subscription and beta branding removal](https://cloud.githubusercontent.com/assets/8225167/6940316/8b8332e2-d86d-11e4-9b18-6b87fd37abf1.png)

After:
![after raib finder email subscription and beta branding removal](https://cloud.githubusercontent.com/assets/8225167/6940321/9ac69da2-d86d-11e4-90f4-003679e6f61b.png)