### PR TITLE
Filter CMA cases on closed not opened date

### DIFF
--- a/finders/schemas/cma-cases.json
+++ b/finders/schemas/cma-cases.json
@@ -116,7 +116,7 @@
       "type": "date",
       "preposition": "opened",
       "display_as_result_metadata": true,
-      "filterable": true
+      "filterable": false
     },
 
     {
@@ -125,7 +125,7 @@
       "short_name": "Closed",
       "type": "date",
       "display_as_result_metadata": true,
-      "filterable": false
+      "filterable": true
     }
   ]
 }


### PR DESCRIPTION
Generally when a lawyer is investigating historic cases the date of a decision is much more relevant than the date an investigation began.