### PR TITLE
Fix body fixer

### DIFF
--- a/app/importers/cma_import/body_fixer.rb
+++ b/app/importers/cma_import/body_fixer.rb
@@ -56,7 +56,7 @@ private
     end
 
     def body
-      raw_data.fetch("body")
+      raw_data.fetch("body", "")
     end
 
     def normalised_body

--- a/app/importers/cma_import/body_fixer.rb
+++ b/app/importers/cma_import/body_fixer.rb
@@ -64,7 +64,7 @@ private
     end
 
     def markup_sections
-      raw_data.fetch("markup_sections", [])
+      raw_data.fetch("markup_sections", {})
     end
 
     def missing_content


### PR DESCRIPTION
Just a couple of small fixes to CmaImport's BodyFixer decorator.

It transpires that this decorator was only originally developed for and tested against a subset of the legacy CMA cases. Without these defaults in place, a few hundred cases outside of that subset complain