### PR TITLE
Add script to publish CMA cases

### DIFF
--- a/bin/publish_cma_cases
+++ b/bin/publish_cma_cases
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+# Publishes draft CMA cases with a public_updated_at timestamp of:
+#  - 9am on the day the case was closed, for a closed case
+#  - 9am on the day the case was opened, for an opened case
+#
+# Takes IDs for the cases to publish via STDIN or a file, eg
+#
+#    $ echo abc-123-def | ./bin/publish_cma_cases
+#    $ ./bin/publish_cma_cases < file_with_ids.txt
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+# Override global panopticon timeout as this is a long operation...
+PANOPTICON_API_CREDENTIALS.merge!(timeout: 30)
+
+repository = SpecialistPublisherWiring.get(:repository_registry).for_type("cma_case")
+
+def public_update_at_timestamp_for_document(document)
+  date_of_relevance = document.closed_date.presence || document.opened_date.presence
+  Date.parse(date_of_relevance) + 9.hours
+end
+
+def publish_document(document_id, public_updated_at:)
+  repo = SpecialistPublisherWiring.get(:repository_registry).for_type("cma_case")
+  builder = SpecialistPublisherWiring.get(:cma_case_builder)
+  observers = CmaCaseObserversRegistry.new.republication
+
+  public_updated_at_setter = Proc.new { |document|
+    document.latest_edition.public_updated_at = public_updated_at
+  }
+
+  service = PublishDocumentService.new(
+    repo,
+    [public_updated_at_setter] + observers,
+    document_id,
+    true,
+  )
+
+  service.call
+end
+
+# Take document IDs from STDIN, one per line
+ARGF.lazy.map(&:chomp).each do |document_id|
+  print "Document #{document_id}... "
+
+  begin
+    document = repository.fetch(document_id)
+    public_updated_at = public_update_at_timestamp_for_document(document)
+
+    if document.published?
+      puts "SKIPPING; document already published"
+    else
+      publish_document(document.id, public_updated_at: public_updated_at)
+      puts "SUCCESS; published with public_updated_at of #{public_updated_at.inspect}"
+    end
+  rescue SpecialistDocumentRepository::NotFoundError => e
+    puts "SKIPPING; could not find document"
+  rescue GdsApi::HTTPErrorResponse => e
+    puts "API_ERROR; #{e.message}"
+  rescue StandardError => e
+    puts "FAILED; #{e.message}"
+  end
+end


### PR DESCRIPTION
The Competition and Markets Authority are importing their historic cases into GOV.UK. To support this, we need to be able to publish the imported cases with a suitable published date, and without triggering email alerts.

Ticket: https://www.pivotaltracker.com/story/show/91952024