### PR TITLE
Remove custom AAIB beta banner

### DIFF
--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -4,7 +4,6 @@
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "beta": true,
-  "beta_message": "Until early 2015, the <a href='http://www.aaib.gov.uk/home/index.cfm'>AAIB website</a> is the main source for AAIB reports",
   "filter": {
     "document_type": "aaib_report"
   },


### PR DESCRIPTION
AAIB have now transitioned and GOV.UK is the canonical source for AAIB reports.

We aren’t enabling email sign up yet because of problems with email volume, which is why the beta banner hasn’t been removed altogether.

https://www.pivotaltracker.com/story/show/92517370

# Before
![screen shot 2015-04-15 at 14 58 36](https://cloud.githubusercontent.com/assets/319055/7160294/f937a9c2-e37f-11e4-82f2-68b69034b02b.png)

# After
![screen shot 2015-04-15 at 14 58 53](https://cloud.githubusercontent.com/assets/319055/7160297/fdf9b2ca-e37f-11e4-8b3c-a43ddf5e9fb0.png)
