### PR TITLE
Correct the MAIB organisation slug

### DIFF
--- a/app/exporters/formatters/maib_report_indexable_formatter.rb
+++ b/app/exporters/formatters/maib_report_indexable_formatter.rb
@@ -15,6 +15,6 @@ private
   end
 
   def organisation_slugs
-    ["marine-accidents-investigation-branch"]
+    ["marine-accident-investigation-branch"]
   end
 end

--- a/lib/document_repository_observer_mapper.rb
+++ b/lib/document_repository_observer_mapper.rb
@@ -38,6 +38,10 @@ private
         repository_registry.for_type("raib_report"),
         RaibReportObserversRegistry.new.republication,
       ),
+      "maib_report" => RepositoryObserversTuple.new(
+        repository_registry.for_type("maib_report"),
+        MaibReportObserversRegistry.new.republication,
+      ),
     }
   end
 


### PR DESCRIPTION
This was added in 2d0a48c4d8b5ae9524ad5b40c25d28d4678ed1c4 and seems to have
just been a typo.

~~I don't think just changing this is enough to fix the existing [bad metadata on search results](https://www.gov.uk/search?q=atlantic) - presumably all of the reports need to be resent to Panopticon/Rummager somehow?~~ 