### PR TITLE
Add link to monthly newsletter

### DIFF
--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -12,6 +12,9 @@
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "signup_enabled": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
-  "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"],
+  "related": [
+    "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
+    "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
+  ],
   "subscription_list_title_prefix": "Drug Safety Update"
 }


### PR DESCRIPTION
Added a link to the Drug Safety Update newsletter on the Drug Safety Update finder. 

Drug Safety Update newsletter was present in the Content Store so adding the content ID did the trick.

Before:
![screen shot 2015-04-21 at 10 52 01](https://cloud.githubusercontent.com/assets/5038475/7249830/3832eddc-e815-11e4-9e35-a654fc1a31e4.png)

After:
![screen shot 2015-04-21 at 10 48 47](https://cloud.githubusercontent.com/assets/5038475/7249867/7226f308-e815-11e4-883a-f6924729b71b.png)


Pivotal Ticket:
https://www.pivotaltracker.com/story/show/92351970