### PR TITLE
Add logo to finder metadata

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -44,6 +44,7 @@ private
       document_noun: schema.fetch("document_noun"),
       filter: metadata.fetch("filter", {}),
       format_name: metadata.fetch("format_name", nil),
+      logo_path: metadata.fetch("logo_path", nil),
       signup_link: metadata.fetch("signup_link", nil),
       show_summaries: metadata.fetch("show_summaries", false),
       summary: metadata.fetch("summary", nil),

--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -4,6 +4,7 @@
   "format_name": "ESIF call for proposals",
   "name": "European Structural and Investment Funds (ESIF)",
   "beta": true,
+  "logo_path": "european-structural-investment-funds.gif",
   "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Stuctural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {
     "document_type": "european_structural_investment_fund"

--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -4,7 +4,7 @@
   "format_name": "ESIF call for proposals",
   "name": "European Structural and Investment Funds (ESIF)",
   "beta": true,
-  "logo_path": "european-structural-investment-funds.gif",
+  "logo_path": "https://assets.digital.cabinet-office.gov.uk/media/5540ab8aed915d15d8000030/esi_funds_eu_logo.gif",
   "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Stuctural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {
     "document_type": "european_structural_investment_fund"

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -15,6 +15,7 @@ describe PublishingApiFinderPublisher do
             "content_id" => SecureRandom.uuid,
             "format" => "a_report_format",
             "signup_content_id" => SecureRandom.uuid,
+            "logo_path" => "http://example.com/logo.png",
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
@@ -25,6 +26,7 @@ describe PublishingApiFinderPublisher do
             "format_name" => "second finder things",
             "content_id" => SecureRandom.uuid,
             "format" => "some_case_format",
+            "logo_path" => "http://example.com/logo.png",
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         }


### PR DESCRIPTION
European Structural and Investment funds finder must comply with EU legislations and they therefore needs to display the EU logo.

This pull request adds the possibility to specify a `logo_path` in the finders' metadata.

Quote from the legislation: "the Union emblem and the reference to the Union shall be visible, when landing on the website, inside the viewing area of a digital device, without requiring a user to scroll down the page".

ticket:
https://www.pivotaltracker.com/story/show/92225774
linked to:
https://github.com/alphagov/finder-frontend/pull/189
https://github.com/alphagov/govuk-content-schemas/pull/49