### PR TITLE
Remove email_alert_signup_enabled

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -42,7 +42,6 @@ private
       beta: metadata.fetch("beta", false),
       beta_message: metadata.fetch("beta_message", nil),
       document_noun: schema.fetch("document_noun"),
-      email_signup_enabled: metadata.fetch("signup_enabled", false),
       filter: metadata.fetch("filter", {}),
       format_name: metadata.fetch("format_name", nil),
       signup_link: metadata.fetch("signup_link", nil),

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -8,7 +8,6 @@
   },
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
-  "signup_enabled": true,
   "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
   "subscription_list_title_prefix": {
     "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -10,7 +10,6 @@
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
-  "signup_enabled": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": [
     "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -8,7 +8,6 @@
   },
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
-  "signup_enabled": true,
   "show_summaries": true,
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"],
   "subscription_list_title_prefix": "International development funds"

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -8,7 +8,6 @@
   },
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
-  "signup_enabled": true,
   "show_summaries": true,
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],
   "subscription_list_title_prefix": {

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -10,7 +10,6 @@
   "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
-  "signup_enabled": true,
   "show_summaries": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -8,7 +8,6 @@
   },
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
-  "signup_enabled": true,
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],
   "subscription_list_title_prefix": {
     "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",


### PR DESCRIPTION
As all current Finders that want to show their email_alert_signup page display the link, we can remove the logic for showing and hiding this and do this based on the presence of the email_alert_signup in the links array. In this PR I've removed the line in each metadata file for this and removed the entry in the details hash of the `FinderContentItemPresenter`.