### PR TITLE
Update Access to work label for filter

### DIFF
--- a/finders/schemas/esi-funds.json
+++ b/finders/schemas/esi-funds.json
@@ -21,7 +21,7 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
-        {"label": "Access to work", "value": "access-to-work"},
+        {"label": "Access to employment", "value": "access-to-work"},
         {"label": "Business support", "value": "business-support"},
         {"label": "Climate change", "value": "climate-change"},
         {"label": "Environment", "value": "environment"},


### PR DESCRIPTION
To prevent misleading users from thinking this is related or similar
to a former name of an existing Government programme for disabled
people I have updated the label to read 'Access to employment'

https://www.pivotaltracker.com/story/show/92349076