### PR TITLE
Add a script that publishes a single asset via asset-manager

### DIFF
--- a/bin/create_asset_on_asset-manager
+++ b/bin/create_asset_on_asset-manager
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+
+filename = ARGV.any? ? ARGV.fetch(0) : nil
+unless filename
+  puts "You need to provide a filename as argument when running this script"
+  abort
+end
+file = File.new(filename)
+
+# Even though the script is not dealing with attachments, we are
+# using this instance of the API client because authentication is
+# correctly setup in the attachment API initializer for each
+# environment from alphagov-deployment
+
+client = Attachable.asset_api_client
+
+# This will always create a new asset and won't update existing ones
+response = client.create_asset({file: file})
+
+if response.code == 201
+  puts "Successfully created and submitted for virus scanning"
+  puts "Asset url: #{response.file_url}"
+  puts "Asset id: #{response.id}"
+else
+  puts "The asset was not created and the response status was: #{response.code}"
+  puts "With response body:"
+  puts response.raw_response_body
+  abort
+end

--- a/config/initializers/attachment_api.rb
+++ b/config/initializers/attachment_api.rb
@@ -1,4 +1,9 @@
+# This file is overwritten on deployment. In order to authenticate in dev
+# environment with asset-manager any random string is required as bearer_token
 require "gds_api/asset_manager"
 require "plek"
 
-Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find("asset-manager"))
+Attachable.asset_api_client = GdsApi::AssetManager.new(
+  Plek.current.find("asset-manager"),
+  bearer_token: "1234567890",
+)


### PR DESCRIPTION
At the moment there is no easy way to publish assets that aren't attachments
via asset-manager. This script will allow us to do so.

Uploading the European Structural and Investment funds logo is exactly the
case that required us to write this script.
EU logo PT ticket: https://www.pivotaltracker.com/story/show/92225774

All the merit to the fantastic @jennyd!

NB: 
We made this changes in this codebase and not inside asset-manager because it would have been weird to have the asset-manager to send request to itself and to have an API token to access itself.
Ideally though, a script that uploads assets via asset-manager shouldn't be tied with any repository. Therefore, we might consider rewring this script inside asset-manager and making it using the internals instead of having it to send requests to itself.
This is a temporary workaround because at the moment we have no way to easily manage assets on GOV.UK