### PR TITLE
Script and Service to republish manuals

### DIFF
--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -19,6 +19,14 @@ class ManualObserversRegistry
     ]
   end
 
+  def republication
+    [
+      panopticon_exporter,
+      publishing_api_exporter,
+      rummager_exporter,
+    ]
+  end
+
   def creation
     []
   end

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -8,6 +8,14 @@ class ManualServiceRegistry
     )
   end
 
+  def republish(manual_id)
+    RepublishManualService.new(
+      manual_repository: manual_repository,
+      listeners: observers.republication,
+      manual_id: manual_id,
+    )
+  end
+
   def withdraw(manual_id)
     WithdrawManualService.new(
       manual_repository: manual_repository,

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,0 +1,30 @@
+class RepublishManualService
+  def initialize(manual_repository:, listeners: [], manual_id:)
+    @manual_repository = manual_repository
+    @listeners = listeners
+    @manual_id = manual_id
+  end
+
+  def call
+    if manual.published?
+      notify_listeners
+    end
+
+    manual
+  end
+
+private
+  attr_reader :manual_repository, :listeners, :manual_id
+
+  def notify_listeners
+    listeners.each { |l| l.call(manual) }
+  end
+
+  def manual
+    @manual ||= manual_repository.fetch(manual_id)
+  rescue KeyError => error
+    raise ManualNotFoundError.new(error)
+  end
+
+  class ManualNotFoundError < StandardError; end
+end

--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "manual_service_registry"
+
+repository = SpecialistPublisherWiring.get(:repository_registry).manual_repository
+
+repository.all.each do |manual|
+  ManualServiceRegistry.new.republish(manual.id).call
+end


### PR DESCRIPTION
This enables us to make changes to the format of manuals as sent to the
publishing-api and then republish them so that they are consistent.

Successfully tested in development.

Hat tip to @evilstreak.