### PR TITLE
Fix some historical mangled manual edition states

### DIFF
--- a/db/migrate/20150507155750_change_manual_edition_states_from_archived_to_withdrawn.rb
+++ b/db/migrate/20150507155750_change_manual_edition_states_from_archived_to_withdrawn.rb
@@ -1,0 +1,13 @@
+class ChangeManualEditionStatesFromArchivedToWithdrawn < Mongoid::Migration
+  def self.up
+    ManualRecord.all.each do |manual_record|
+      manual_record.editions.where(state: "archived").each do |edition|
+        edition.update_attribute(:state, "withdrawn")
+      end
+    end
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Apparently, some manuals were unpublished by hand and the edition states were
mistakenly set to "archived" instead of "withdrawn".

SpecialistDocumentEditions use "archived", but manuals use "withdrawn", so
perhaps that was where the confusion came from.

@evilstreak might be able to give a better description and then I can update the commit message.