### PR TITLE
Add content ids to manuals

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -32,6 +32,7 @@ private
 
   def exportable_attributes
     {
+      content_id: manual.id,
       format: "manual",
       title: rendered_manual_attributes.fetch(:title),
       description: rendered_manual_attributes.fetch(:summary),

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -22,6 +22,7 @@ private
 
   def exportable_attributes
     {
+      content_id: document.id,
       format: "manual_section",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -26,6 +26,7 @@ describe ManualPublishingAPIExporter do
   let(:manual) {
     double(
       :manual,
+      id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       attributes: manual_attributes,
       documents: documents,
     )
@@ -104,6 +105,7 @@ describe ManualPublishingAPIExporter do
     expect(export_recipent).to have_received(:put_content_item).with(
       "/guidance/my-first-manual",
       hash_including(
+        content_id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         format: "manual",
         title: "My first manual",
         description: "This is my first manual",

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -62,7 +62,6 @@ describe ManualPublishingAPIExporter do
 
   let(:manual_attributes) {
     {
-      id: "12345",
       title: "My first manual",
       summary: "This is my first manual",
       body: "<h1>Some heading</h1>\nmanual body",

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -46,6 +46,7 @@ describe ManualSectionPublishingAPIExporter do
   let(:document) {
     double(
       :document,
+      id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
     )
   }
@@ -70,6 +71,7 @@ describe ManualSectionPublishingAPIExporter do
     expect(export_recipent).to have_received(:put_content_item).with(
       "/guidance/my-first-manual/first-section",
       hash_including(
+        content_id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
         format: "manual_section",
         title: "Document title",
         description: "This is the first section",


### PR DESCRIPTION
In theory, every content item in the publishing-api/content-store should have a content_id so that it can be linked to. In practice, it isn't required, although the format of it is validated when it is sent.

We will need to republish all manuals after this is deployed, which can be done with `bin/republish_manuals`.