### PR TITLE
Allow blank opened dates for CMA cases

### DIFF
--- a/app/models/validators/cma_case_validator.rb
+++ b/app/models/validators/cma_case_validator.rb
@@ -9,7 +9,7 @@ class CmaCaseValidator < SimpleDelegator
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
-  validates :opened_date, presence: true, date: true
+  validates :opened_date, allow_blank: true, date: true
   validates :market_sector, presence: true
   validates :case_type, presence: true
   validates :case_state, presence: true


### PR DESCRIPTION
The CMA have some old cases that they don't know the dates for. Allow blank opened dates to let them edit and publish these documents, and make the checking of opened dates a content responsibility.

Ticket: https://www.pivotaltracker.com/story/show/95717826