### PR TITLE
Friendly CLI interface for republish_documents

### DIFF
--- a/bin/republish_documents
+++ b/bin/republish_documents
@@ -2,8 +2,31 @@
 
 require File.expand_path("../../config/environment", __FILE__)
 require "specialist_publisher"
+require "logger"
 
-document_types = ARGV.any? ? ARGV : SpecialistPublisher.document_types
+logger = Logger.new(STDOUT)
+logger.formatter = Logger::Formatter.new
+
+def usage
+  $stderr.puts %Q{
+USAGE: #{File.basename(__FILE__)} (all|[format ...])
+
+Available formats:
+
+  #{SpecialistPublisher.document_types.sort.join("\n  ")}
+
+}
+
+  exit(1)
+end
+
+usage unless ARGV.any?
+
+if ARGV == ["all"]
+  document_types = SpecialistPublisher.document_types
+else
+  document_types = ARGV
+end
 
 unsupported_document_types = document_types - SpecialistPublisher.document_types
 if unsupported_document_types.any?

--- a/bin/republish_documents
+++ b/bin/republish_documents
@@ -2,10 +2,6 @@
 
 require File.expand_path("../../config/environment", __FILE__)
 require "specialist_publisher"
-require "logger"
-
-logger = Logger.new(STDOUT)
-logger.formatter = Logger::Formatter.new
 
 def usage
   $stderr.puts %Q{


### PR DESCRIPTION
If invoked with no arguments, print out a help message describing usage.

```
$ bundle exec ./bin/republish_documents             
                                                                                              
USAGE: republish_documents (all|[format ...])                                                 
                                                                                              
Available formats:                                                                            
                                                                                              
  aaib_report                                                                                 
  cma_case                                                                                    
  countryside_stewardship_grant                                                               
  drug_safety_update                                                                          
  esi_fund                                                                                    
  international_development_fund                                                              
  maib_report                                                                                 
  medical_safety_alert                                                                        
  raib_report                                                                                 
  vehicle_recalls_and_faults_alert                                                            
                                                                                              
```