### PR TITLE
Update CMA case facet prepositions

### DIFF
--- a/finders/schemas/cma-cases.json
+++ b/finders/schemas/cma-cases.json
@@ -114,7 +114,6 @@
       "name": "Opened",
       "short_name": "Opened",
       "type": "date",
-      "preposition": "opened",
       "display_as_result_metadata": true,
       "filterable": false
     },
@@ -124,6 +123,7 @@
       "name": "Closed",
       "short_name": "Closed",
       "type": "date",
+      "preposition": "closed",
       "display_as_result_metadata": true,
       "filterable": true
     }


### PR DESCRIPTION
Filtering was swapped from opened date to closed date in 1ddb9d8, but the prepositions weren't updated at the same time.

The result is that when filtering on date it shows, for example:

> 30 cases after 1 January 2015

To match the previous behaviour, it should show:

> 30 cases closed after 1 January 2015

This change makes that happen.