### PR TITLE
Use manual-specific renderer for manual sections

### DIFF
--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -106,7 +106,7 @@ private
         manual
       ).call
 
-      document_renderer = SpecialistPublisherWiring.get(:specialist_document_renderer)
+      document_renderer = SpecialistPublisherWiring.get(:manual_document_renderer)
       manual.documents.each do |document|
         ManualSectionPublishingAPIExporter.new(
           publishing_api,


### PR DESCRIPTION
There is a custom renderer for manual sections which wraps footnotes in markup that causes it to be treated as a collapsible section. This functionality was added in 9a9ad154a but it was only added to the content API exporter, never the publishing API exporter.