### PR TITLE
Publish a legacy report to the MHRA finder

### DIFF
--- a/bin/publish_legacy_report_to_mhra_finder
+++ b/bin/publish_legacy_report_to_mhra_finder
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+repository = SpecialistPublisherWiring.get(:repository_registry).for_type(:medical_safety_alert)
+document = repository.fetch("46147971-ed51-4d1a-88f5-f9ae06ef23f1")
+document.update(bulk_published: true)
+document.update(public_updated_at: DateTime.new(2013, 07, 18, 14, 00, 00))
+document.publish!
+repository.store(document)
+
+SpecialistPublisher.document_services("medical_safety_alert").republish("46147971-ed51-4d1a-88f5-f9ae06ef23f1").call
+
+puts "Timestamps updated."


### PR DESCRIPTION
- This was left behind during the import when they transitioned to
  GOV.UK. Hence, set the publish date to be 2013-07-18.
- Do this using a bin script, Specialist Publisher's equivalent to
  data migrations.

Thanks to @evilstreak for helping with this!

Potentially a next TODO item is to make this script generic so it takes three arguments and can be used for any document that needs publishing at a specific date. Won't do this right now though as the important thing is to get this one document published.