### PR TITLE
Have the registry set the org slug attribute

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -99,9 +99,6 @@ private
     params
       .fetch("manual", {})
       .slice(*valid_params)
-      .merge(
-        organisation_slug: current_organisation_slug,
-      )
       .symbolize_keys
   end
 

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -19,7 +19,7 @@ class OrganisationalManualServiceRegistry
       manual_repository: manual_repository,
       manual_builder: manual_builder,
       listeners: observers.creation,
-      attributes: attributes,
+      attributes: organisation_attributes(attributes),
     )
   end
 
@@ -27,7 +27,7 @@ class OrganisationalManualServiceRegistry
     UpdateManualService.new(
       manual_repository: manual_repository,
       manual_id: manual_id,
-      attributes: attributes,
+      attributes: organisation_attributes(attributes),
     )
   end
 
@@ -52,7 +52,7 @@ class OrganisationalManualServiceRegistry
       builder: manual_builder,
       renderer: manual_renderer,
       manual_id: manual_id,
-      attributes: attributes,
+      attributes: organisation_attributes(attributes),
     )
   end
 
@@ -79,4 +79,7 @@ private
     @observers ||= ManualObserversRegistry.new
   end
 
+  def organisation_attributes(attributes)
+    attributes.merge(organisation_slug: organisation_slug)
+  end
 end


### PR DESCRIPTION
The OrganisationalManualServiceRegistry takes an organisation slug and uses it
to build an organisational manual repository.

The registry caches that organisation slug.

The registry's sole user is the ManualsController. Before passing its
user-supplied params to the registry's services, ManualsController merges that
same organisation slug into its params.

This might not be the right place for this, but it is one approach to making it
nicer to use these 'organisational' services outside of the ManualsController
with less repetition of the configuration.