### PR TITLE
Feature helpers that dont use the UI

### DIFF
--- a/app/services/create_manual_document_service.rb
+++ b/app/services/create_manual_document_service.rb
@@ -33,6 +33,6 @@ class CreateManualDocumentService
   end
 
   def document_params
-    context.params.fetch(:document)
+    context.params.fetch("document")
   end
 end

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -384,7 +384,7 @@ Given(/^a published manual with at least two sections exists$/) do
     summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
   }
 
-  create_manual(@manual_fields)
+  @manual = create_manual_without_ui(@manual_fields)
 
   @section_titles = []
   @section_slugs = []
@@ -393,18 +393,18 @@ Given(/^a published manual with at least two sections exists$/) do
     section_title = "Section #{section_number}"
     section_slug = [@manual_slug, "section-#{section_number}"].join("/")
     section_fields = {
-      section_title: section_title,
-      section_summary: "Section #{section_number} summary",
-      section_body: "Section #{section_number} body",
+      title: section_title,
+      summary: "Section #{section_number} summary",
+      body: "Section #{section_number} body",
     }
 
-    create_manual_document(@manual_title, section_fields)
+    create_manual_document_without_ui(@manual, section_fields)
 
     @section_titles << section_title
     @section_slugs << section_slug
   end
 
-  publish_manual
+  publish_manual_without_ui(@manual)
 
   # Clear out any remote requests caught by webmock.
   # We don't want the remote calls that were made during the publishing setup
@@ -413,7 +413,7 @@ Given(/^a published manual with at least two sections exists$/) do
 end
 
 When(/^a DevOps specialist withdraws the manual for me$/) do
-  withdraw_manual(@manual_title)
+  withdraw_manual_without_ui(@manual)
 end
 
 Then(/^the manual should be withdrawn$/) do

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -253,18 +253,17 @@ module ManualHelpers
     expect(page).to have_content("Warning: There are duplicate section slugs in this manual")
   end
 
-  def withdraw_manual(manual_title)
-    manual_id = get_id_for_manual(manual_title)
-
-    manual_services = ManualServiceRegistry.new
-    manual_services.withdraw(manual_id).call
+  def stub_manual_withdrawal_observers
+    stub_panopticon
+    stub_rummager
+    stub_publishing_api
   end
 
-  def get_id_for_manual(manual_title)
-    visit manuals_path
-    link = page.find_link(manual_title)
-    # TODO this is pretty gross, consider making it less so
-    link.native.attribute("href").value.match(%r{\A/manuals/(.*?)(\?|\z)})[1]
+  def withdraw_manual_without_ui(manual)
+    stub_manual_withdrawal_observers
+
+    manual_services = ManualServiceRegistry.new
+    manual_services.withdraw(manual.id).call
   end
 
   def check_manual_is_withdrawn(manual_title, manual_slug, section_titles, section_slugs)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -10,6 +10,19 @@ module ManualHelpers
     save_as_draft if save
   end
 
+  def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
+    manual_services = OrganisationalManualServiceRegistry.new(
+      organisation_slug: organisation_slug,
+    )
+    manual = manual_services.create(fields).call
+
+    manual_repository = SpecialistPublisherWiring.
+      get(:repository_registry).
+      manual_repository
+
+    manual_repository.fetch(manual.id)
+  end
+
   def create_manual_document(manual_title, fields)
     go_to_manual_page(manual_title)
     click_on "Add section"
@@ -17,6 +30,20 @@ module ManualHelpers
     fill_in_fields(fields)
 
     save_as_draft
+  end
+
+  def create_manual_document_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
+    manual_document_services = ManualDocumentServiceRegistry.new
+    create_service_context = OpenStruct.new(
+      {
+        current_organisation_slug: organisation_slug,
+        params: {
+          "manual_id" => manual.id,
+          "document" => fields,
+        },
+      }
+    )
+    manual_document_services.create(create_service_context).call
   end
 
   def edit_manual(manual_title, new_fields)
@@ -41,6 +68,20 @@ module ManualHelpers
 
   def publish_manual
     click_on "Publish manual"
+  end
+
+  def stub_manual_publication_observers(organisation_slug)
+    stub_panopticon
+    stub_rummager
+    stub_publishing_api
+    stub_organisation_details(organisation_slug)
+  end
+
+  def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")
+    stub_manual_publication_observers(organisation_slug)
+
+    manual_services = ManualServiceRegistry.new
+    manual_services.publish(manual.id, manual.version_number).call
   end
 
   def check_manual_exists_with(attributes)

--- a/features/withdrawing-a-manual.feature
+++ b/features/withdrawing-a-manual.feature
@@ -4,7 +4,6 @@ Feature: Script to withdraw published manuals
   So that it is not accessible to the public
 
   Scenario:
-    Given I am logged in as a "generic" editor
-    And a published manual with at least two sections exists
+    Given a published manual with at least two sections exists
     When a DevOps specialist withdraws the manual for me
     Then the manual should be withdrawn


### PR DESCRIPTION
Helpers for use in Cucumber features that:

- create a manual,
- create a manual section and
- publish a manual

...without logging in as a user and using the UI.

For better or for worse there are features that test services and/or scripts,
and having to log in and use the UI to satisfy prerequisites like,

  `'Given a published manual exists'`

doesn't seem to fit these features' requirements.

As part of this work, we've moved the Withdrawing a Manual feature to these (methods.

(Paired with @binaryberry - thanks!)