### PR TITLE
Order ESI Funds calls in reverse chronological order of closing date

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -49,7 +49,8 @@ private
       show_summaries: metadata.fetch("show_summaries", false),
       summary: metadata.fetch("summary", nil),
       facets: schema.fetch("facets", []),
-    }
+      default_order: metadata.fetch("default_order", nil),
+    }.reject {|_, value| value.nil?}
   end
 
   def format

--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -9,5 +9,6 @@
   "filter": {
     "document_type": "european_structural_investment_fund"
   },
+  "default_order": "-closing_date",
   "organisations": []
 }


### PR DESCRIPTION
- Users had to scroll down past recently updated closed funds in order to see the open cases unless they used the filters. Now the results are in reverse chronological order of closing date, so the open ones are at the top.
- Add the default_order attribute to the list that is sent to finder-frontend, else the default of "-public_timestamp" would always be used even if we set a different one here (https://github.com/alphagov/finder-frontend/blob/master/app/lib/search_query_builder.rb#L73).
- Make sure it's not passed if it's nil, so that GOV.UK Content Schemas don't complain (they always expect a string - https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/finder/publisher/schema.json#L123).

This requires an update to Rummager's `ALLOWED_SORT_FIELDS`, which I'm about to open a PR for.

Paired with @mikejustdoit on this. Thanks also to @evilstreak for his initial help.