### PR TITLE
Added Fund State to finder result metadata

### DIFF
--- a/finders/schemas/esi-funds.json
+++ b/finders/schemas/esi-funds.json
@@ -6,7 +6,7 @@
       "name": "Fund state",
       "type": "text",
       "preposition": "which are",
-      "display_as_result_metadata": false,
+      "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [
         {"label": "Open", "value": "open"},
@@ -71,7 +71,6 @@
     {
       "key": "closing_date",
       "name": "Closing date",
-      "short_name": "Closing",
       "type": "date",
       "display_as_result_metadata": true,
       "filterable": false


### PR DESCRIPTION
...and displaying full label name for closing date, as
ESIF required more obvious distinction between open and closed
cases.

Pivotal ticket: https://www.pivotaltracker.com/story/show/96316390

cc @boffbowsh 

Before:
![screen shot 2015-06-24 at 16 16 28](https://cloud.githubusercontent.com/assets/8225167/8333816/8af3be44-1a8c-11e5-948b-94775bbc8738.png)

After (ignore different formatting): 
![screen shot 2015-06-24 at 16 16 52](https://cloud.githubusercontent.com/assets/8225167/8333835/9680e534-1a8c-11e5-85b4-e89843b2ed08.png)
