### PR TITLE
Restore ListManualDocumentsService

### DIFF
--- a/app/services/list_manual_documents_service.rb
+++ b/app/services/list_manual_documents_service.rb
@@ -1,0 +1,25 @@
+class ListManualDocumentsService
+  def initialize(manual_repository, context)
+    @manual_repository = manual_repository
+    @context = context
+  end
+
+  def call
+    [manual, documents]
+  end
+
+private
+  attr_reader :manual_repository, :context
+
+  def documents
+    manual.documents
+  end
+
+  def manual
+    @manual ||= manual_repository.fetch(manual_id)
+  end
+
+  def manual_id
+    context.params.fetch("manual_id")
+  end
+end

--- a/app/services/manual_document_service_registry.rb
+++ b/app/services/manual_document_service_registry.rb
@@ -3,6 +3,7 @@ require "create_manual_document_service"
 require "update_manual_document_service"
 require "show_manual_document_service"
 require "new_manual_document_service"
+require "list_manual_documents_service"
 
 class ManualDocumentServiceRegistry
   def preview(context)
@@ -38,6 +39,13 @@ class ManualDocumentServiceRegistry
 
   def new(context)
     NewManualDocumentService.new(
+      manual_repository(context),
+      context,
+    )
+  end
+
+  def list(context)
+    ListManualDocumentsService.new(
       manual_repository(context),
       context,
     )


### PR DESCRIPTION
This is used by the manual_documents_controller#reorder method and shouldn't have been deleted.

This highlights the need for tests around reordering of sections.