### PR TITLE
Add script to update publication timestamp

### DIFF
--- a/bin/update_timestamp
+++ b/bin/update_timestamp
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+def usage
+  $stderr.puts %Q{
+USAGE: #{File.basename(__FILE__)} (format ...)(document_id) (date)
+
+1. available formats:
+
+  #{SpecialistPublisher.document_types.sort.join("\n  ")}
+
+2. document_id:
+  To find document_id, login to specialist-publisher in production, go to document page and copy document_id from url.
+
+3. date:
+  Format: yyyy/mm/dd or to specify publishing time: yyyy/mm/dd hh:mm
+  }
+
+  exit(1)
+end
+
+usage unless ARGV.any?
+document_type = ARGV[0]
+document_id = ARGV[1]
+
+begin
+  date = DateTime.parse(ARGV[2])
+rescue ArgumentError
+  puts "date format invalid, format should be: yyyy/mm/dd or to specify publishing time: yyyy/mm/dd hh:mm"
+  usage
+end
+
+unless SpecialistPublisher.document_types.include?(document_type)
+  raise ArgumentError, "please select document type among available formats provided:\n\n  #{SpecialistPublisher.document_types.sort.join("\n  ")}"
+end
+unless document_id.length > 30 && document_id.length < 40
+  raise ArgumentError, "document_id invalid"
+end
+
+repository = SpecialistPublisherWiring.get(:repository_registry).for_type(document_type.to_sym)
+document = repository.fetch(document_id)
+document.update(public_updated_at: date)
+document.publish!
+repository.store(document)
+
+SpecialistPublisher.document_services(document_type).republish(document_id).call
+
+puts "#{document_type} item timestamp updated to #{date}."


### PR DESCRIPTION
RAIB asked to update the publication date of their RAIB reports, because
the date they were originally published precedes the date they were
published on GOV.UK.

I created a bin script that allows to update publication timestamp
of any document by specifying document type and content_id.

The Trello story mentions updating the PublicationLog but that is not 
relevant here, as the PublicationLog is for Manuals only.

cc @benilovj 

Trello story: https://trello.com/c/A8h4UxSj/1-correct-publication-date-on-2-raib-investigation-reports-medium