### PR TITLE
Associationless manual repository

### DIFF
--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -69,6 +69,25 @@ class RepositoryRegistry
     }
   end
 
+  def associationless_manual_repository
+    associationless_scoped_manual_repository(ManualRecord.all)
+  end
+
+  def associationless_scoped_manual_repository(collection)
+    ManualRepository.new(
+      factory: Manual.method(:new),
+      collection: collection,
+    )
+  end
+
+  def associationless_organisation_scoped_manual_repository_factory
+    ->(organisation_slug) {
+      associationless_scoped_manual_repository(
+        ManualRecord.where(organisation_slug: organisation_slug)
+      )
+    }
+  end
+
 private
   attr_reader :entity_factories
 end

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -5,7 +5,7 @@ class OrganisationalManualServiceRegistry
 
   def list(context)
     ListManualsService.new(
-      manual_repository: manual_repository,
+      manual_repository: associationless_manual_repository,
       context: context,
     )
   end
@@ -75,6 +75,15 @@ private
 
   def manual_repository
     manual_repository_factory.call(organisation_slug)
+  end
+
+  def associationless_manual_repository_factory
+    SpecialistPublisherWiring.get(:repository_registry).
+      associationless_organisation_scoped_manual_repository_factory
+  end
+
+  def associationless_manual_repository
+    associationless_manual_repository_factory.call(organisation_slug)
   end
 
   def observers


### PR DESCRIPTION
In my development VM, attempting to load `http://specialist-publisher.dev.gov.uk/manuals` was timing out. The rails log reported completing loading in ~10-12 seconds, with MongoDB queries making up ~5-6 of those. There are only 29 Manuals in my development database.

Rough benchmarking using this associationless repository brought loading time down to ~0.3 seconds.

This configuration of the ManualRepository isn't suitable for general purpose use, since it doesn't fetch any of a Manual's associated sections, etc, but none of that is needed when only listing Manuals.