### PR TITLE
GDS Editors should have permission to access all manuals

### DIFF
--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -94,6 +94,18 @@ class ManualDocumentsController < ApplicationController
 
 private
   def services
+    if current_user_is_gds_editor?
+      gds_editor_services
+    else
+      organisational_services
+    end
+  end
+
+  def gds_editor_services
+    ManualDocumentServiceRegistry.new
+  end
+
+  def organisational_services
     OrganisationalManualDocumentServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -115,6 +115,18 @@ private
   end
 
   def services
+    if current_user_is_gds_editor?
+      gds_editor_services
+    else
+      organisational_services
+    end
+  end
+
+  def gds_editor_services
+    ManualServiceRegistry.new
+  end
+
+  def organisational_services
     OrganisationalManualServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -115,7 +115,7 @@ private
   end
 
   def services
-    @services ||= OrganisationalManualServiceRegistry.new(
+    OrganisationalManualServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )
   end

--- a/app/services/manual_document_service_registry.rb
+++ b/app/services/manual_document_service_registry.rb
@@ -1,9 +1,60 @@
+require "preview_manual_document_service"
+require "create_manual_document_service"
+require "update_manual_document_service"
 require "show_manual_document_service"
+require "new_manual_document_service"
+require "list_manual_documents_service"
+require "reorder_manual_documents_service"
 require "remove_manual_document_service"
 
 class ManualDocumentServiceRegistry
+  def preview(context)
+    PreviewManualDocumentService.new(
+      manual_repository,
+      manual_document_builder,
+      document_renderer,
+      context,
+    )
+  end
+
+  def create(context)
+    CreateManualDocumentService.new(
+      manual_repository: manual_repository,
+      listeners: [],
+      context: context,
+    )
+  end
+
+  def update(context)
+    UpdateManualDocumentService.new(
+      manual_repository,
+      context,
+    )
+  end
+
   def show(context)
     ShowManualDocumentService.new(
+      manual_repository,
+      context,
+    )
+  end
+
+  def new(context)
+    NewManualDocumentService.new(
+      manual_repository,
+      context,
+    )
+  end
+
+  def list(context)
+    ListManualDocumentsService.new(
+      manual_repository,
+      context,
+    )
+  end
+
+  def update_order(context)
+    ReorderManualDocumentsService.new(
       manual_repository,
       context,
     )
@@ -17,6 +68,14 @@ class ManualDocumentServiceRegistry
   end
 
 private
+  def document_renderer
+    SpecialistPublisherWiring.get(:specialist_document_renderer)
+  end
+
+  def manual_document_builder
+    SpecialistPublisherWiring.get(:manual_document_builder)
+  end
+
   def manual_repository
     SpecialistPublisherWiring.get(:repository_registry).manual_repository
   end

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -1,4 +1,57 @@
 class ManualServiceRegistry
+  def list(context)
+    ListManualsService.new(
+      manual_repository: manual_repository,
+      context: context,
+    )
+  end
+
+  def new(context)
+    ->() { manual_builder.call(title: "") }
+  end
+
+  def create(attributes)
+    CreateManualService.new(
+      manual_repository: manual_repository,
+      manual_builder: manual_builder,
+      listeners: observers.creation,
+      attributes: attributes,
+    )
+  end
+
+  def update(manual_id, attributes)
+    UpdateManualService.new(
+      manual_repository: manual_repository,
+      manual_id: manual_id,
+      attributes: attributes,
+    )
+  end
+
+  def show(manual_id)
+    ShowManualService.new(
+      manual_repository: manual_repository,
+      manual_id: manual_id,
+    )
+  end
+
+  def queue_publish(manual_id)
+    QueuePublishManualService.new(
+      PublishManualWorker,
+      manual_repository,
+      manual_id,
+    )
+  end
+
+  def preview(manual_id, attributes)
+    PreviewManualService.new(
+      repository: manual_repository,
+      builder: manual_builder,
+      renderer: manual_renderer,
+      manual_id: manual_id,
+      attributes: attributes,
+    )
+  end
+
   def publish(manual_id, version_number)
     PublishManualService.new(
       manual_repository: manual_repository,
@@ -25,6 +78,14 @@ class ManualServiceRegistry
   end
 
 private
+  def manual_renderer
+    SpecialistPublisherWiring.get(:manual_renderer)
+  end
+
+  def manual_builder
+    SpecialistPublisherWiring.get(:manual_builder)
+  end
+
   def manual_repository
     SpecialistPublisherWiring.get(:repository_registry).manual_repository
   end

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -1,7 +1,7 @@
 class ManualServiceRegistry
   def list(context)
     ListManualsService.new(
-      manual_repository: manual_repository,
+      manual_repository: associationless_manual_repository,
       context: context,
     )
   end
@@ -84,6 +84,11 @@ private
 
   def manual_builder
     SpecialistPublisherWiring.get(:manual_builder)
+  end
+
+  def associationless_manual_repository
+    SpecialistPublisherWiring.get(:repository_registry).
+      associationless_manual_repository
   end
 
   def manual_repository

--- a/app/services/organisational_manual_document_service_registry.rb
+++ b/app/services/organisational_manual_document_service_registry.rb
@@ -4,6 +4,7 @@ require "update_manual_document_service"
 require "show_manual_document_service"
 require "new_manual_document_service"
 require "list_manual_documents_service"
+require "reorder_manual_documents_service"
 
 class OrganisationalManualDocumentServiceRegistry
   def initialize(dependencies)

--- a/features/access_control.feature
+++ b/features/access_control.feature
@@ -3,19 +3,19 @@ Feature: Access control
   I want to have access only to relevant content
   So that I can publish content on gov.uk
 
-  Background:
-    Given I am logged in as a non-CMA editor
-
   Scenario: Non-CMA editor has no access to documents
+    Given I am logged in as a non-CMA editor
     Then I do not see an option for editing documents
 
   Scenario: Non-CMA editor is sent a document URL
+    Given I am logged in as a non-CMA editor
     When I attempt to visit a document edit URL
     Then I am redirected back to the index page
     And I see a message like "You don't have permission to do that"
 
   Scenario: Editors from multiple organisations have created content
     Given there are manuals created by multiple organisations
+    And I am logged in as a non-CMA editor
     When I view my list of manuals
     Then I only see manuals created by my organisation
 

--- a/features/access_control.feature
+++ b/features/access_control.feature
@@ -13,11 +13,17 @@ Feature: Access control
     Then I am redirected back to the index page
     And I see a message like "You don't have permission to do that"
 
-  Scenario: Editors from multiple organisations have created content
+  Scenario: Editor only sees manuals created by their organisation
     Given there are manuals created by multiple organisations
     And I am logged in as a non-CMA editor
     When I view my list of manuals
     Then I only see manuals created by my organisation
+
+  Scenario: GDS Editor sees manuals created by all organisations
+    Given there are manuals created by multiple organisations
+    And I am logged in as a "GDS" editor
+    When I view my list of manuals
+    Then I see manuals created by all organisations
 
   Scenario: Writers
     Given I am logged in as a writer

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -64,6 +64,11 @@ Then(/^I only see manuals created by my organisation$/) do
   check_manual_not_visible(@cma_manual_fields.fetch(:title))
 end
 
+Then(/^I see manuals created by all organisations$/) do
+  check_manual_visible(@tea_manual_fields.fetch(:title))
+  check_manual_visible(@cma_manual_fields.fetch(:title))
+end
+
 Given(/^I am logged in as a writer$/) do
   login_as(:cma_writer)
 end


### PR DESCRIPTION
Access is normally limited to Manuals owned by the current user's organisation. So that GDS Editors can support other departmental content editors, without having to change their own organisation temporarily in Signon, we treat a GDS Editor as a special case with access to all Manuals.

These changes do not allow a GDS Editor to create a Manual on behalf of another organisation, only to access existing Manuals.

The test coverage for this feature is minimal but since it mirrors the existing access control tests for standard Editors, it's presumably sufficient.

It might make more sense to abstract the explicit use of `current_user_is_gds_editor?` here into a new or existing dedicated object/config for permissions logic. Suggestions would be very welcome.

I think the changes made to the various ServiceRegistries here really draw attention to the increasing duplication and need for refactoring. Again, suggestions would be excellent there as well.