### PR TITLE
Gracefully handle manuals that can't be found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  rescue_from("ManualRepository::NotFoundError") do
+    redirect_to(manuals_path, flash: { error: "Manual not found" })
+  end
+
   def current_finder
     finders.fetch(request.path.split("/")[1], nil)
   end

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -3,10 +3,18 @@ require "fetchable"
 class ManualRepository
   include Fetchable
 
+  NotFoundError = Module.new
+
   def initialize(dependencies = {})
     @collection = dependencies.fetch(:collection)
     @factory = dependencies.fetch(:factory)
     @association_marshallers = dependencies.fetch(:association_marshallers, [])
+  end
+
+  def fetch(*args, &block)
+    super
+  rescue KeyError => e
+    raise e.extend(NotFoundError)
   end
 
   def store(manual)


### PR DESCRIPTION
Pattern copied from app/repositories/specialist_document_repository.rb and
app/controllers/abstract_documents_controller.rb.

If you navigate to the path for a manual that doesn't exist in the database, you
currently see a generic Rails error page. This happens routinely when a manual
is created in our Preview environment, gets lost when the production => preview
data sync happens and then a user tries to access it the following day. By
raising a more specific error, we can then catch it and handle it gracefully.