### PR TITLE
Allow RPA to edit ESIF documents

### DIFF
--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -53,6 +53,7 @@ private
         department-for-communities-and-local-government
         department-for-work-pensions
         department-for-environment-food-rural-affairs
+        rural-payments-agency
       )
     when "maib_report"
       ["marine-accident-investigation-branch"]


### PR DESCRIPTION
The Rural Payments Agency need access to be able to edit European
Structural Investment Funds documents. This adds their org to the
permissions checker.

https://trello.com/c/Fwf4cBz7/23-allow-rural-payments-agency-to-edit-and-publish-content-on-the-european-structural-funding-calls-small