### PR TITLE
Enable email subscription on ESIF finder

### DIFF
--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -10,5 +10,11 @@
     "document_type": "european_structural_investment_fund"
   },
   "default_order": "-closing_date",
-  "organisations": []
+  "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",
+  "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
+  "organisations": ["2e7868a8-38f5-4ff6-b62f-9a15d1c22d28", "de4e9dc6-cca4-43af-a594-682023b84d6c", "569a9ee5-c195-4b7f-b9dc-edc17a09113f" ],
+  "subscription_list_title_prefix": {
+    "singular": "European Structural and Investment Fund",
+    "plural": "European Structural and Investment Funds"
+  }
 }


### PR DESCRIPTION
This activates email subscriptions, and links them to the content_id of the three organisations related to  ESIF: 
- Department for Environment, Food and Rural Affairs
- Department for Business, Innovation and Skills
- Department for Communities and Local Government

Deploy will require running rake publishing_api:publish_finders to publish finders to publishing-api.

cc @boffbowsh 

[Story on Trello](https://trello.com/c/V9FVIpDx/24-allow-users-to-subscribe-to-emails-about-european-structural-funding-calls-small)

![screen shot 2015-07-07 at 14 19 25](https://cloud.githubusercontent.com/assets/8225167/8548902/9a49520e-24bf-11e5-8b0b-a846b114846c.png)
