### PR TITLE
Add "email_filter_by" element to esif metadata

### DIFF
--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -17,6 +17,7 @@
     "singular": "European Structural and Investment Fund",
     "plural": "European Structural and Investment Funds"
   },
+  "email_filter_by": "location",
   "email_signup_choice": [
     {
       "key": "north-east",


### PR DESCRIPTION
Finder-frontend has been throwing errors in Errbit since PR #517 was
merged in specialist-publisher. This should fix it.

I pushed the branch to preview and it the government gateway page is displayed 
properly after the subscription.

cc @tommyp 