### PR TITLE
[DO NOT MERGE] Remove EU logo from finder

### DIFF
--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -4,7 +4,6 @@
   "format_name": "ESIF call for proposals",
   "name": "European Structural and Investment Funds (ESIF)",
   "beta": true,
-  "logo_path": "https://assets.digital.cabinet-office.gov.uk/media/5540ab8aed915d15d8000030/esi_funds_eu_logo.gif",
   "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Stuctural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {
     "document_type": "european_structural_investment_fund"


### PR DESCRIPTION
__Should not be deployed until new entrance page is published with logo__

The finder is no longer an “entrance page to content” and doesn’t strictly need a logo. The entrance page will instead be a detailed guide.

https://trello.com/c/on5LaLnh/