### PR TITLE
Update README to describe converting finder schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ $ bundle exec rake
 2. Add missing field definitions in `config/schema/field_definitions.json`.
 3. Add the new document type in `config/schema/indexes/mainstream.json`.
 
-### [govuk_content_models](https://github.com/alphagov/govuk_content_models)
-
-1. Add the new artefact type in `app/models/artefact.rb`.
-2. Bump the gem version.
-3. Update `govuk_content_models` gem version in [panopticon](https://github.com/alphagov/panopticon) and specialist-publisher.
-
 ### Testing your new specialist document format
 
 We have a spec for each model but most of the testing is done in Cucumber tests. Each document format has a feature for creating & editing, publishing and withdrawing. Be sure to add an editor type to `test/factories.rb` for the owning Org of the newformat (if there isn't already a format owned by that Org). The step definitions in each of the tests are pretty similar, so the methods in `features/support/document_format_helpers.rb` call the abstract methods in `features/support/document_helpers.rb`. The features should also cover add attachments, if you follow the same pattern as the other document formats.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ bundle exec rake
 1. Add a controller that inherits `AbstractDocumentsController`
 1. Add the schema to the `finders/schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
 1. Add the metadata about the Finder to `finders/metadata`
+1. [Add an example](https://github.com/alphagov/govuk-content-schemas/tree/master/formats/specialist_document/frontend/examples) of this format to govuk-content-schemas
+1. Use the [finder schema converter](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/converting-finder-schemas.md) to modify the [`details.json`](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document/publisher/details.json) to include the new format
 1. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.
 1. Define the factory with the builder in `app/lib/specialist_publisher_wiring.rb`.
 1. Define the validatable document factory in `app/models/document_factory_registry.rb`

--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ $ bundle exec rake
 ### In this repo
 
 1. Add the document_type to the `document_types` array in `config/routes.rb`
-2. Add a controller that inherits `AbstractDocumentsController`
-3. Add the schema to the `finders/schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
-4. Add the metadata about the Finder to `finders/metadata`
-5. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.
-6. Define the factory with the builder in `app/lib/specialist_publisher_wiring.rb`.
-7. Define the validatable document factory in `app/models/document_factory_registry.rb`
-8. Define a repository in `app/repositories/repository_registry.rb`
-9. Add observers, along with formatters required. In `app/exporters/formatters/`:
-  - `document_type_publication_alert_formatter.rb` 
+1. Add a controller that inherits `AbstractDocumentsController`
+1. Add the schema to the `finders/schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
+1. Add the metadata about the Finder to `finders/metadata`
+1. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.
+1. Define the factory with the builder in `app/lib/specialist_publisher_wiring.rb`.
+1. Define the validatable document factory in `app/models/document_factory_registry.rb`
+1. Define a repository in `app/repositories/repository_registry.rb`
+1. Add observers, along with formatters required. In `app/exporters/formatters/`:
+  - `document_type_publication_alert_formatter.rb`
   - `document_type_artefact_formatter.rb` for Panopticon
   - `document_type_indexable_formatter.rb` for Rummager
   - `document_type_observers_registry.rb` in `app/observers/`
   Add the observer registry to the `observer_registry` hash in `app/lib/specialist_publisher.rb`
-10. Add `app/view_adapters/document_type_view_adapter.rb` along with its entry in `app/view_adapters/view_adapter_registry.rb`. Also add the `_form.html.erb` which has the extra fields for that document_type. Be sure to pass the correct `form_namespace` matching the document_type.
-11. Add the entry to `app/lib/permission_checker.rb` for the owning organisation and an entry in the finders array in `ApplicationController`.
+1. Add `app/view_adapters/document_type_view_adapter.rb` along with its entry in `app/view_adapters/view_adapter_registry.rb`. Also add the `_form.html.erb` which has the extra fields for that document_type. Be sure to pass the correct `form_namespace` matching the document_type.
+1. Add the entry to `app/lib/permission_checker.rb` for the owning organisation and an entry in the finders array in `ApplicationController`.
 
 ### In [rummager](https://github.com/alphagov/rummager/)
 


### PR DESCRIPTION
The process for adding a new specialist document format should also
include updating govuk-content-schemas appropriately to include the new
format.