### PR TITLE
Specialist document publishing api formatter

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,0 +1,44 @@
+class SpecialistDocumentPublishingApiFormatter
+  attr_reader :specialist_document, :specialist_document_renderer
+
+  def initialize(specialist_document, specialist_document_renderer: )
+    @specialist_document = specialist_document
+    @specialist_document_renderer = specialist_document_renderer
+  end
+
+  def call
+    {
+      content_id: specialist_document.id,
+      format: "specialist_document",
+      publishing_app: "specialist-publisher",
+      rendering_app: "specialist-frontend",
+      title: rendered_document_attributes.fetch(:title),
+      description: rendered_document_attributes.fetch(:summary),
+      update_type: "major",
+      locale: "en",
+      public_updated_at: public_updated_at,
+      details: {
+        metadata: metadata,
+        change_history: [],
+        body: rendered_document_attributes[:body]
+      }
+    }
+  end
+
+  private
+
+  def rendered_document_attributes
+    @rendered_document_attributes ||= specialist_document_renderer.call(specialist_document).attributes
+  end
+
+  def metadata
+    rendered_document_attributes[:extra_fields].merge(document_type: specialist_document.document_type)
+  end
+
+  def public_updated_at
+    # Editions only get a public_updated_at when they are published, so field
+    # can be blank.
+    specialist_document.public_updated_at || specialist_document.updated_at
+  end
+
+end

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,9 +1,10 @@
 class SpecialistDocumentPublishingApiFormatter
-  attr_reader :specialist_document, :specialist_document_renderer
+  attr_reader :specialist_document, :specialist_document_renderer, :publication_logs
 
-  def initialize(specialist_document, specialist_document_renderer: )
+  def initialize(specialist_document, specialist_document_renderer: , publication_logs: )
     @specialist_document = specialist_document
     @specialist_document_renderer = specialist_document_renderer
+    @publication_logs = publication_logs
   end
 
   def call
@@ -19,7 +20,7 @@ class SpecialistDocumentPublishingApiFormatter
       public_updated_at: public_updated_at,
       details: {
         metadata: metadata,
-        change_history: [],
+        change_history: change_history,
         body: rendered_document_attributes[:body]
       }
     }
@@ -41,4 +42,12 @@ class SpecialistDocumentPublishingApiFormatter
     specialist_document.public_updated_at || specialist_document.updated_at
   end
 
+  def change_history
+    publication_logs.change_notes_for(specialist_document.slug).map do |log|
+      {
+        public_timestamp: log.published_at.iso8601,
+        note: log.change_note,
+      }
+    end
+  end
 end

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,4 +1,4 @@
-class SpecialistDocumentPublishingApiFormatter
+class SpecialistDocumentPublishingAPIFormatter
   attr_reader :specialist_document, :specialist_document_renderer, :publication_logs
 
   def initialize(specialist_document, specialist_document_renderer:, publication_logs:)

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -15,14 +15,18 @@ class SpecialistDocumentPublishingApiFormatter
       rendering_app: "specialist-frontend",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),
-      update_type: "major",
+      update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,
       details: {
         metadata: metadata,
         change_history: change_history,
         body: rendered_document_attributes[:body]
-      }.merge(headers)
+      }.merge(headers),
+      routes: [
+        path: base_path,
+        type: 'exact'
+      ]
     }
   end
 
@@ -42,6 +46,10 @@ class SpecialistDocumentPublishingApiFormatter
     specialist_document.public_updated_at || specialist_document.updated_at
   end
 
+  def update_type
+    specialist_document.minor_update? ? "minor" : "major"
+  end
+
   def change_history
     publication_logs.change_notes_for(specialist_document.slug).map do |log|
       {
@@ -49,6 +57,10 @@ class SpecialistDocumentPublishingApiFormatter
         note: log.change_note,
       }
     end
+  end
+
+  def base_path
+    "/#{specialist_document.attributes[:slug]}"
   end
 
   def headers

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -22,7 +22,7 @@ class SpecialistDocumentPublishingApiFormatter
         metadata: metadata,
         change_history: change_history,
         body: rendered_document_attributes[:body]
-      }
+      }.merge(headers)
     }
   end
 
@@ -48,6 +48,20 @@ class SpecialistDocumentPublishingApiFormatter
         public_timestamp: log.published_at.iso8601,
         note: log.change_note,
       }
+    end
+  end
+
+  def headers
+    strip_empty_header_lists(
+      :headers => rendered_document_attributes[:headers]
+    )
+  end
+
+  def strip_empty_header_lists(header_struct)
+    if header_struct[:headers].any?
+      header_struct.merge(:headers => header_struct[:headers].map {|h| strip_empty_header_lists(h)} )
+    else
+      header_struct.reject { |k, _| k == :headers }
     end
   end
 end

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,7 +1,7 @@
 class SpecialistDocumentPublishingApiFormatter
   attr_reader :specialist_document, :specialist_document_renderer, :publication_logs
 
-  def initialize(specialist_document, specialist_document_renderer: , publication_logs: )
+  def initialize(specialist_document, specialist_document_renderer:, publication_logs:)
     @specialist_document = specialist_document
     @specialist_document_renderer = specialist_document_renderer
     @publication_logs = publication_logs
@@ -25,7 +25,7 @@ class SpecialistDocumentPublishingApiFormatter
       }.merge(headers),
       routes: [
         path: base_path,
-        type: 'exact'
+        type: "exact"
       ]
     }
   end
@@ -65,13 +65,13 @@ class SpecialistDocumentPublishingApiFormatter
 
   def headers
     strip_empty_header_lists(
-      :headers => rendered_document_attributes[:headers]
+      headers: rendered_document_attributes[:headers]
     )
   end
 
   def strip_empty_header_lists(header_struct)
     if header_struct[:headers].any?
-      header_struct.merge(:headers => header_struct[:headers].map {|h| strip_empty_header_lists(h)} )
+      header_struct.merge(headers: header_struct[:headers].map {|h| strip_empty_header_lists(h)})
     else
       header_struct.reject { |k, _| k == :headers }
     end

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -40,7 +40,11 @@ cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 # TODO as schemas are added for them, change this to include more formats
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec spec/lib/publishing_api_finder_publisher_spec.rb spec/manual_publishing_api_exporter_spec.rb spec/manual_section_publishing_api_exporter_spec.rb
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec \
+  spec/lib/publishing_api_finder_publisher_spec.rb \
+  spec/manual_publishing_api_exporter_spec.rb \
+  spec/manual_section_publishing_api_exporter_spec.rb \
+  spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
 
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -11,12 +11,22 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
   }
   let(:formatter) {
     described_class.new(
-        document, specialist_document_renderer: specialist_document_renderer
+      document,
+      specialist_document_renderer: specialist_document_renderer,
+      publication_logs: publication_logs
     )
   }
 
-  let(:document) {
-    SpecialistDocument.new(nil, edition.id, [edition])
+  let(:publication_logs) { class_double("PublicationLog", change_notes_for: [publication_log]) }
+
+  let(:publication_log) {
+    instance_double("PublicationLog",
+      slug: document.slug,
+      title: document.title,
+      version_number: document.version_number,
+      change_note: "My change note",
+      published_at: 1.day.ago
+    )
   }
 
   let(:document) {
@@ -54,5 +64,11 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
       fields = ["case_type", "case_state", "market_sector", "opened_date", "document_type"]
       expect(presented["details"]["metadata"].keys).to eq(fields)
     end
+
+    it "should include the document change history" do
+      expect(publication_logs).to receive(:change_notes_for).with(document.slug)
+      expect(presented['details']['change_history'].size).to eq(1)
+    end
+
   end
 end

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
       end
     end
 
+    context "with a body containing govspeak without headers" do
+      let(:body) { "This is a paragraph" }
+
+      it { should be_valid_against_schema("specialist_document") }
+
+      it "should omit the headers attribute" do
+        expect(presented["details"].keys).not_to include("headers")
+      end
+    end
+
     context "with a body containing multiple govspeak headers" do
       let(:body) {
         <<END_OF_GOVSPEAK

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "formatters/specialist_document_publishing_api_formatter"
+require "support/govuk_content_schema_helpers"
+require "specialist_publisher_wiring"
+require "specialist_document"
+
+
+RSpec.describe SpecialistDocumentPublishingApiFormatter do
+  let(:specialist_document_renderer) {
+    SpecialistPublisherWiring.get(:specialist_document_renderer)
+  }
+  let(:formatter) {
+    described_class.new(
+        document, specialist_document_renderer: specialist_document_renderer
+    )
+  }
+
+  let(:document) {
+    SpecialistDocument.new(nil, edition.id, [edition])
+  }
+
+  let(:document) {
+    SpecialistDocument.new(nil, edition.document_id, [edition], nil)
+  }
+
+  let(:edition) {
+    FactoryGirl.create(
+      :specialist_document_edition,
+      document_id: SecureRandom.uuid,
+      document_type: "cma_case",
+      updated_at: 2.days.ago,
+      body: body,
+      extra_fields: {
+        case_type: "mergers",
+        case_state: "open",
+        market_sector: [
+          "clothing-footwear-and-fashion"
+        ],
+        opened_date: "2015-07-10"
+      },
+    )
+  }
+
+  let(:body) { "" }
+
+  subject(:presented) { formatter.call.as_json }
+
+  context "a CMA Case document" do
+    it "should generate a hash which is valid against the specialist_document schema" do
+      expect(presented).to be_valid_against_schema("specialist_document")
+    end
+
+    it "should include the relevant metadata in the details hash" do
+      fields = ["case_type", "case_state", "market_sector", "opened_date", "document_type"]
+      expect(presented["details"]["metadata"].keys).to eq(fields)
+    end
+  end
+end

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -4,7 +4,6 @@ require "support/govuk_content_schema_helpers"
 require "specialist_publisher_wiring"
 require "specialist_document"
 
-
 RSpec.describe SpecialistDocumentPublishingApiFormatter do
   let(:specialist_document_renderer) {
     SpecialistPublisherWiring.get(:specialist_document_renderer)
@@ -61,13 +60,13 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
     end
 
     it "should include the relevant metadata in the details hash" do
-      fields = ["case_type", "case_state", "market_sector", "opened_date", "document_type"]
+      fields = %w(case_type case_state market_sector opened_date document_type)
       expect(presented["details"]["metadata"].keys).to eq(fields)
     end
 
     it "should include the document change history" do
       expect(publication_logs).to receive(:change_notes_for).with(document.slug)
-      expect(presented['details']['change_history'].size).to eq(1)
+      expect(presented["details"]["change_history"].size).to eq(1)
     end
 
     context "with a body containing some govspeak" do
@@ -76,7 +75,7 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
       it { should be_valid_against_schema("specialist_document") }
 
       it "should convert the body from govspeak to html" do
-        expect(presented['details']['body']).to eq(%{<h2 id="heading-2">Heading 2</h2>\n\n<p>Paragraph</p>\n})
+        expect(presented["details"]["body"]).to eq(%{<h2 id="heading-2">Heading 2</h2>\n\n<p>Paragraph</p>\n})
       end
     end
 
@@ -86,12 +85,13 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
       it { should be_valid_against_schema("specialist_document") }
 
       it "should extract headers" do
-        expect(presented['details']['headers']).to eq([{"text"=>"Heading 2", "level"=>2, "id"=>"heading-2"}])
+        expect(presented["details"]["headers"]).to eq([{"text" => "Heading 2", "level" => 2, "id" => "heading-2"}])
       end
     end
 
     context "with a body containing multiple govspeak headers" do
-      let(:body) { <<END_OF_GOVSPEAK
+      let(:body) {
+        <<END_OF_GOVSPEAK
 ## Heading 2
 
 ### Heading 3a
@@ -106,27 +106,27 @@ END_OF_GOVSPEAK
       it { should be_valid_against_schema("specialist_document") }
 
       it "should extract headers" do
-        expect(presented['details']['headers']).to eq(
+        expect(presented["details"]["headers"]).to eq(
           [
             {
-              "text"=>"Heading 2",
-              "level"=>2,
-              "id"=>"heading-2",
+              "text" => "Heading 2",
+              "level" => 2,
+              "id" => "heading-2",
               "headers" => [
                 {
-                  "text"=>"Heading 3a",
-                  "level"=>3,
-                  "id"=>"heading-3a"
+                  "text" => "Heading 3a",
+                  "level" => 3,
+                  "id" => "heading-3a"
                 },
                 {
-                  "text"=>"Heading 3b",
-                  "level"=>3,
-                  "id"=>"heading-3b"
+                  "text" => "Heading 3b",
+                  "level" => 3,
+                  "id" => "heading-3b"
                 },
                 {
-                  "text"=>"Heading 3c",
-                  "level"=>3,
-                  "id"=>"heading-3c"
+                  "text" => "Heading 3c",
+                  "level" => 3,
+                  "id" => "heading-3c"
                 }
               ]
             }

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -4,10 +4,11 @@ require "support/govuk_content_schema_helpers"
 require "specialist_publisher_wiring"
 require "specialist_document"
 
-RSpec.describe SpecialistDocumentPublishingApiFormatter do
+RSpec.describe SpecialistDocumentPublishingAPIFormatter do
   let(:specialist_document_renderer) {
     SpecialistPublisherWiring.get(:specialist_document_renderer)
   }
+
   let(:formatter) {
     described_class.new(
       document,

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -70,5 +70,69 @@ RSpec.describe SpecialistDocumentPublishingApiFormatter do
       expect(presented['details']['change_history'].size).to eq(1)
     end
 
+    context "with a body containing some govspeak" do
+      let(:body) { "## Heading 2\n\nParagraph" }
+
+      it { should be_valid_against_schema("specialist_document") }
+
+      it "should convert the body from govspeak to html" do
+        expect(presented['details']['body']).to eq(%{<h2 id="heading-2">Heading 2</h2>\n\n<p>Paragraph</p>\n})
+      end
+    end
+
+    context "with a body containing a govspeak header" do
+      let(:body) { "## Heading 2\n\nParagraph" }
+
+      it { should be_valid_against_schema("specialist_document") }
+
+      it "should extract headers" do
+        expect(presented['details']['headers']).to eq([{"text"=>"Heading 2", "level"=>2, "id"=>"heading-2"}])
+      end
+    end
+
+    context "with a body containing multiple govspeak headers" do
+      let(:body) { <<END_OF_GOVSPEAK
+## Heading 2
+
+### Heading 3a
+
+### Heading 3b
+
+### Heading 3c
+
+END_OF_GOVSPEAK
+      }
+
+      it { should be_valid_against_schema("specialist_document") }
+
+      it "should extract headers" do
+        expect(presented['details']['headers']).to eq(
+          [
+            {
+              "text"=>"Heading 2",
+              "level"=>2,
+              "id"=>"heading-2",
+              "headers" => [
+                {
+                  "text"=>"Heading 3a",
+                  "level"=>3,
+                  "id"=>"heading-3a"
+                },
+                {
+                  "text"=>"Heading 3b",
+                  "level"=>3,
+                  "id"=>"heading-3b"
+                },
+                {
+                  "text"=>"Heading 3c",
+                  "level"=>3,
+                  "id"=>"heading-3c"
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
   end
 end

--- a/spec/models/publication_log_spec.rb
+++ b/spec/models/publication_log_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe PublicationLog, hits_db: true do
+
+  describe "validation" do
+    let(:attributes) {
+      {
+        slug: "my-slug",
+        title: "my title",
+        change_note: "First note",
+        version_number: 1
+      }
+    }
+
+    subject(:publication_log) { PublicationLog.new(attributes) }
+
+    context "all fields set" do
+      it { should be_valid }
+    end
+
+    it "should be valid without a title" do
+      publication_log.title = nil
+      expect(publication_log).to be_valid
+    end
+
+    it "should be valid without a change_note" do
+      publication_log.change_note = nil
+      expect(publication_log).to be_valid
+    end
+
+    it "should be invalid without a slug" do
+      publication_log.slug = nil
+      expect(publication_log).not_to be_valid
+    end
+
+    it "should be invalid without a version_number" do
+      publication_log.version_number = nil
+      expect(publication_log).not_to be_valid
+    end
+  end
+
+  describe ".change_notes_for" do
+    context "there are some publication log entries" do
+      let(:slug) { "cma-cases/my-slug" }
+      let(:other_slug) { "something-else/another-one" }
+
+      let!(:change_notes_for_first_doc) {
+        [
+          PublicationLog.create(
+            slug: slug,
+            title: "",
+            change_note: "First note",
+            version_number: 1,
+          ),
+          PublicationLog.create(
+            slug: slug,
+            title: "",
+            change_note: "Second note",
+            version_number: 2,
+          )
+        ]
+      }
+
+      let!(:change_notes_for_second_doc) {
+        [
+          PublicationLog.create(
+            slug: other_slug,
+            title: "",
+            change_note: "Another note",
+            version_number: 1,
+          )
+        ]
+      }
+
+      it "returns all the change notes for the given slug" do
+        expect(PublicationLog.change_notes_for(slug)).to eq(change_notes_for_first_doc)
+      end
+
+      context "multiple publication logs exist for a particular edition version" do
+        before do
+          PublicationLog.create(
+            slug: slug,
+            title: "",
+            change_note: "Duplicate note",
+            version_number: 2,
+          )
+        end
+
+        it "removes duplicates" do
+          expect(PublicationLog.change_notes_for(slug)).to eq(change_notes_for_first_doc)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/publication_log_spec.rb
+++ b/spec/models/publication_log_spec.rb
@@ -91,5 +91,11 @@ describe PublicationLog, hits_db: true do
         end
       end
     end
+
+    context "no publication logs exist for a slug" do
+      it "returns an empty list" do
+        expect(PublicationLog.change_notes_for("cma-cases/my-slug")).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
The formatter takes a specialist document and generates a hash suitable for sending to the publishing API.

## Testing approach

The spec for the formatter takes a slightly different approach than some other specs in specialist publisher. Rather than stubbing out all of its collaborators, it constructs a real mongoid `SpecialistDocumentEdition` and fetches the real collaborators using the `SpecialistPublisherWiring`. This means that we are testing more objects together at the same time. 

Unit level test coverage of each individual object is quite low, so the heavily stubbed approach gives little confidence that the overall system works.

## Why are we only testing one specialist document type (rather than all of them)?

We considered adding tests which would iterate over every document type, construct an example document and present it.

However, this would give a false confidence because there would be no guarantee that our sample documents would match the document types which the editing interface would be capable of producing. We do not have a set of curated fixtures/factories in specialist publisher, and even if we did, there would again be no guarantee that they would match up with what the UI could produce.

So we felt it would be better to leave these out altogether.

Instead when we implement the exporter itself, we should amend the cucumber features for each specialist document type to include a check that a valid JSON document was sent to the publishing API.

## Contract tests

Specialist-publisher already has contract tests, we've just included the formatter spec in the list of specs run in `jenkins-schema.sh`.