### PR TITLE
Send correct format for ESIF documents to email-alert-api

### DIFF
--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -14,7 +14,7 @@ class AbstractDocumentPublicationAlertFormatter
 
   def tags
     arrayified_extra_fields.merge(
-      format: [document.document_type]
+      format: [format]
     )
   end
 
@@ -59,6 +59,10 @@ private
 
   def document_noun
     raise NotImplementedError
+  end
+
+  def format
+    document.document_type
   end
 
   def view_renderer

--- a/app/exporters/formatters/esi_fund_publication_alert_formatter.rb
+++ b/app/exporters/formatters/esi_fund_publication_alert_formatter.rb
@@ -6,6 +6,10 @@ class EsiFundPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatt
     "European Structural and Investment Funds"
   end
 
+  def format
+    "european_structural_investment_fund"
+  end
+
 private
   def document_noun
     "fund"

--- a/spec/exporters/formatters/esi_fund_publication_alert_formatter_spec.rb
+++ b/spec/exporters/formatters/esi_fund_publication_alert_formatter_spec.rb
@@ -1,0 +1,28 @@
+require "fast_spec_helper"
+require "formatters/esi_fund_publication_alert_formatter"
+
+RSpec.describe EsiFundPublicationAlertFormatter do
+  let(:url_maker) {
+    double(:url_maker,
+      published_specialist_document_path: "http://www.example.com"
+    )
+  }
+  let(:document) {
+    double(:document,
+      alert_type: "drugs",
+      title: "Some title",
+      extra_fields: {},
+      document_type: "esi_fund",
+    )
+  }
+  subject(:formatter) {
+    EsiFundPublicationAlertFormatter.new(
+      document: document,
+      url_maker: url_maker,
+    )
+  }
+
+  it "format should be european_structural_investment_fund" do
+    expect(formatter.tags[:format]).to eq(["european_structural_investment_fund"])
+  end
+end


### PR DESCRIPTION
We were sending "esi_fund" to email-alert-api because that's the string used as
the "document_type" internal to specialist-publisher. All of the other
exporters, however, use "european_structural_investment_fund". This means that
email subscriptions are created for the format
"european_structural_investment_fund", but email alerts are triggered for
"esi_fund", therefore, there aren't any matching subscriptions and so emails
weren't sent.

I couldn't see where and how to write a test for this, suggestions welcome.