### PR TITLE
Speed up publishing

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,8 +1,8 @@
 class ManualPublishingAPIExporter
 
-  def initialize(export_recipent, organisations_api, manual_renderer, publication_logs, manual)
+  def initialize(export_recipent, organisation, manual_renderer, publication_logs, manual)
     @export_recipent = export_recipent
-    @organisations_api = organisations_api
+    @organisation = organisation
     @manual_renderer = manual_renderer
     @publication_logs = publication_logs
     @manual = manual
@@ -16,7 +16,7 @@ private
 
   attr_reader(
     :export_recipent,
-    :organisations_api,
+    :organisation,
     :manual_renderer,
     :publication_logs,
     :manual
@@ -106,9 +106,5 @@ private
       abbreviation: organisation.details.abbreviation,
       web_url: organisation.web_url,
     }
-  end
-
-  def organisation
-    @organisation ||= organisations_api.organisation(manual.attributes.fetch(:organisation_slug))
   end
 end

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -1,8 +1,8 @@
 class ManualSectionPublishingAPIExporter
 
-  def initialize(export_recipent, organisations_api, document_renderer, manual, document)
+  def initialize(export_recipent, organisation, document_renderer, manual, document)
     @export_recipent = export_recipent
-    @organisations_api = organisations_api
+    @organisation = organisation
     @document_renderer = document_renderer
     @manual = manual
     @document = document
@@ -14,7 +14,7 @@ class ManualSectionPublishingAPIExporter
 
 private
 
-  attr_reader :export_recipent, :document_renderer, :organisations_api, :manual, :document
+  attr_reader :export_recipent, :document_renderer, :organisation, :manual, :document
 
   def base_path
     "/#{rendered_document_attributes.fetch(:slug)}"
@@ -63,9 +63,5 @@ private
       abbreviation: organisation.details.abbreviation,
       web_url: organisation.web_url,
     }
-  end
-
-  def organisation
-    @organisation ||= organisations_api.organisation(manual.attributes.fetch(:organisation_slug))
   end
 end

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -10,6 +10,7 @@ class ManualSectionPublishingAPIExporter
 
   def call
     export_recipent.put_content_item(base_path, exportable_attributes)
+    document.mark_as_exported
   end
 
 private

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -135,6 +135,16 @@ class SpecialistDocument
     end
   end
 
+  def needs_exporting?
+    latest_edition.exported_at.nil?
+  end
+
+  def mark_as_exported
+    edition = latest_edition
+    edition.exported_at = Time.zone.now
+    edition.save
+  end
+
 protected
 
   attr_reader :slug_generator, :edition_factory
@@ -180,7 +190,7 @@ protected
 
   def previous_edition_attributes
     latest_edition.attributes
-      .except("_id")
+      .except(*no_copy_attributes)
       .symbolize_keys
   end
 
@@ -195,6 +205,15 @@ protected
       :updated_at,
       :slug,
       :version_number,
+    ]
+  end
+
+  def no_copy_attributes
+    %w[
+      _id
+      created_at
+      updated_at
+      exported_at
     ]
   end
 end

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -16,6 +16,7 @@ class SpecialistDocumentEdition
   field :change_note, type: String
   field :minor_update, type: Boolean
   field :public_updated_at, type: DateTime
+  field :exported_at, type: DateTime
 
   validates :document_id, presence: true
   validates :document_type, presence: true

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -97,10 +97,12 @@ private
 
   def publishing_api_exporter
     ->(manual) {
+      organisation = organisations_api.organisation(manual.attributes.fetch(:organisation_slug))
+
       manual_renderer = SpecialistPublisherWiring.get(:manual_renderer)
       ManualPublishingAPIExporter.new(
         publishing_api,
-        organisations_api,
+        organisation,
         manual_renderer,
         PublicationLog,
         manual
@@ -110,7 +112,7 @@ private
       manual.documents.each do |document|
         ManualSectionPublishingAPIExporter.new(
           publishing_api,
-          organisations_api,
+          organisation,
           document_renderer,
           manual,
           document

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -43,6 +43,8 @@ private
   def publication_logger
     ->(manual) {
       manual.documents.each do |doc|
+        next unless doc.needs_exporting?
+
         PublicationLog.create!(
           title: doc.title,
           slug: doc.slug,
@@ -110,6 +112,8 @@ private
 
       document_renderer = SpecialistPublisherWiring.get(:manual_document_renderer)
       manual.documents.each do |document|
+        next unless document.needs_exporting?
+
         ManualSectionPublishingAPIExporter.new(
           publishing_api,
           organisation,

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -8,21 +8,20 @@ Feature: Publishing a manual
 
   Scenario: Publish a manual
     Given a draft manual exists
-    And a draft document exists for the manual
     When I publish the manual
-    Then the manual and its documents are published
+    Then the manual and all its documents are published
 
   Scenario: Edit and re-publish a manual
     Given a published manual exists
-    When I edit the manual's documents
+    When I edit one of the manual's documents
     And I publish the manual
-    Then the manual and its documents are published
+    Then the manual and the edited document are published
 
   Scenario: Add a section to a published manual
     Given a published manual exists
     When I add another section to the manual
     And I publish the manual
-    Then the manual and its documents are published
+    Then the manual and its new document are published
 
   Scenario: Add a change note
     Given a published manual exists
@@ -32,7 +31,7 @@ Feature: Publishing a manual
   Scenario: Omit the change note
     Given a published manual exists
     Then I see no visible change note in the manual document edit form
-    When I edit the manual document without a change note
+    When I edit one of the manual's documents without a change note
     Then I see an error requesting that I provide a change note
     When I indicate that the change is minor
     Then the document is updated without a change note

--- a/features/withdrawing-a-manual.feature
+++ b/features/withdrawing-a-manual.feature
@@ -3,7 +3,10 @@ Feature: Script to withdraw published manuals
   I want to withdraw a manual
   So that it is not accessible to the public
 
+  Background:
+    Given I am logged in as a "CMA" editor
+
   Scenario:
-    Given a published manual with at least two sections exists
+    Given a published manual exists
     When a DevOps specialist withdraws the manual for me
     Then the manual should be withdrawn

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -7,7 +7,7 @@ describe ManualPublishingAPIExporter do
   subject {
     ManualPublishingAPIExporter.new(
       export_recipent,
-      organisations_api,
+      organisation,
       manual_renderer,
       publication_logs_collection,
       manual
@@ -15,12 +15,6 @@ describe ManualPublishingAPIExporter do
   }
 
   let(:export_recipent) { double(:export_recipent, put_content_item: nil) }
-  let(:organisations_api) {
-    double(
-      :organisations_api,
-      organisation: organisation,
-    )
-  }
   let(:manual_renderer) { ->(_) { double(:rendered_manual, attributes: manual_attributes) } }
 
   let(:manual) {

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -7,7 +7,7 @@ describe ManualSectionPublishingAPIExporter do
   subject {
     ManualSectionPublishingAPIExporter.new(
       export_recipent,
-      organisations_api,
+      organisation,
       document_renderer,
       manual,
       document
@@ -15,12 +15,6 @@ describe ManualSectionPublishingAPIExporter do
   }
 
   let(:export_recipent) { double(:export_recipent, put_content_item: nil) }
-  let(:organisations_api) {
-    double(
-      :organisations_api,
-      organisation: organisation,
-    )
-  }
   let(:document_renderer) { ->(_) { double(:rendered_document, attributes: rendered_attributes) } }
 
   let(:organisation) {

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -42,6 +42,7 @@ describe ManualSectionPublishingAPIExporter do
       :document,
       id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
+      mark_as_exported: nil,
     )
   }
 
@@ -103,5 +104,11 @@ describe ManualSectionPublishingAPIExporter do
         }
       )
     )
+  end
+
+  it "marks the document as exported" do
+    subject.call
+
+    expect(document).to have_received(:mark_as_exported)
   end
 end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -38,6 +38,8 @@ describe SpecialistDocument do
       extra_fields: extra_fields,
       minor_update: false,
       change_note: "Some changes",
+      :exported_at= => nil,
+      save: nil,
     }
   }
 
@@ -622,6 +624,22 @@ describe SpecialistDocument do
         doc.withdraw!
 
         expect(published_edition_v1).to have_received(:archive)
+      end
+    end
+  end
+
+  describe "#mark_as_exported" do
+    let(:editions) { [published_edition_v1, draft_edition_v2] }
+
+    it "sets the exported_at date on the latest edition" do
+      time = Time.now
+      Timecop.freeze(time) do
+        doc.mark_as_exported
+        expect(draft_edition_v2).to have_received(:exported_at=).with(time).ordered
+        expect(draft_edition_v2).to have_received(:save).ordered
+
+        expect(published_edition_v1).not_to have_received(:exported_at=)
+        expect(published_edition_v1).not_to have_received(:save)
       end
     end
   end


### PR DESCRIPTION
The intent of this PR is to get a big enough speed boost during the normal publishing flow to allow us to send to the draft publishing API and other services on every save instead of only on publish, and therefore allow easy previewing.

### Changes
#### Only call the organisation API once when publishing.

We currently call the organisation API for the
manual and each section, but the organisation slug
used is the one from the manual, thus the response
is guaranteed to always be the same.

#### Avoid sending unchanged manual sections to publishing API.

This avoids a bunch of govspeak rendering and time
waiting on the API to respond.

### Speed gains

The current time taken to publish a manual is around 1.5s per section, give or take.  This leads to documents like the open document format manual taking 32 seconds to publish (measured on the preview environment).

After this change (and after the first time each document is published) the time taken to publish any document is around 3 seconds plus 1 second per changed section.

https://trello.com/c/yP4BSFf3/284-speed-up-publishing-of-manuals