### PR TITLE
Send specialist documents to publishing api

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -30,6 +30,10 @@ class SpecialistDocumentPublishingAPIFormatter
     }
   end
 
+  def base_path
+    "/#{specialist_document.attributes[:slug]}"
+  end
+
   private
 
   def rendered_document_attributes
@@ -57,10 +61,6 @@ class SpecialistDocumentPublishingAPIFormatter
         note: log.change_note,
       }
     end
-  end
-
-  def base_path
-    "/#{specialist_document.attributes[:slug]}"
   end
 
   def headers

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -13,15 +13,15 @@ class SpecialistDocumentPublishingAPIFormatter
       format: "specialist_document",
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
-      title: rendered_document_attributes.fetch(:title),
-      description: rendered_document_attributes.fetch(:summary),
+      title: rendered_document.attributes.fetch(:title),
+      description: rendered_document.attributes.fetch(:summary),
       update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,
       details: {
         metadata: metadata,
         change_history: change_history,
-        body: rendered_document_attributes[:body]
+        body: rendered_document.attributes[:body]
       }.merge(headers),
       routes: [
         path: base_path,
@@ -36,12 +36,12 @@ class SpecialistDocumentPublishingAPIFormatter
 
   private
 
-  def rendered_document_attributes
-    @rendered_document_attributes ||= specialist_document_renderer.call(specialist_document).attributes
+  def rendered_document
+    @rendered_document ||= specialist_document_renderer.call(specialist_document)
   end
 
   def metadata
-    rendered_document_attributes[:extra_fields].merge(document_type: specialist_document.document_type)
+    rendered_document.extra_fields.merge(document_type: specialist_document.document_type)
   end
 
   def public_updated_at
@@ -65,7 +65,7 @@ class SpecialistDocumentPublishingAPIFormatter
 
   def headers
     strip_empty_header_lists(
-      headers: rendered_document_attributes[:headers]
+      headers: rendered_document.attributes[:headers]
     )
   end
 

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -97,5 +97,4 @@ class SpecialistDocumentPublishingAPIFormatter
   def organisation_slugs
     PermissionChecker.owning_organisations_for_format(specialist_document.document_type)
   end
-
 end

--- a/app/exporters/specialist_document_publishing_api_exporter.rb
+++ b/app/exporters/specialist_document_publishing_api_exporter.rb
@@ -1,0 +1,13 @@
+class SpecialistDocumentPublishingAPIExporter
+  attr_reader :publishing_api, :document
+
+  def initialize(publishing_api, document)
+    @publishing_api = publishing_api
+    @document = document
+  end
+
+  def call
+    publishing_api.put_content_item(document.base_path, document.call)
+  end
+
+end

--- a/app/exporters/specialist_document_publishing_api_exporter.rb
+++ b/app/exporters/specialist_document_publishing_api_exporter.rb
@@ -1,13 +1,18 @@
 class SpecialistDocumentPublishingAPIExporter
-  attr_reader :publishing_api, :document
+  attr_reader :publishing_api, :document, :draft
 
-  def initialize(publishing_api, document)
+  def initialize(publishing_api, document, draft)
     @publishing_api = publishing_api
     @document = document
+    @draft = draft
   end
 
   def call
-    publishing_api.put_content_item(document.base_path, document.call)
+    if draft
+      publishing_api.put_draft_content_item(document.base_path, document.call)
+    else
+      publishing_api.put_content_item(document.base_path, document.call)
+    end
   end
 
 end

--- a/app/exporters/specialist_document_publishing_api_exporter.rb
+++ b/app/exporters/specialist_document_publishing_api_exporter.rb
@@ -14,5 +14,4 @@ class SpecialistDocumentPublishingAPIExporter
       publishing_api.put_content_item(document.base_path, document.call)
     end
   end
-
 end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -2,6 +2,34 @@ class PermissionChecker
   GDS_EDITOR_PERMISSION = "gds_editor"
   EDITOR_PERMISSION = "editor"
 
+  def self.owning_organisations_for_format(format)
+    case format
+    when "cma_case"
+      ["competition-and-markets-authority"]
+    when "aaib_report"
+      ["air-accidents-investigation-branch"]
+    when "international_development_fund"
+      ["department-for-international-development"]
+    when "drug_safety_update", "medical_safety_alert"
+      ["medicines-and-healthcare-products-regulatory-agency"]
+    when "esi_fund"
+      %w(
+        department-for-communities-and-local-government
+        department-for-work-pensions
+        department-for-environment-food-rural-affairs
+        rural-payments-agency
+      )
+    when "maib_report"
+      ["marine-accident-investigation-branch"]
+    when "raib_report"
+      ["rail-accident-investigation-branch"]
+    when "countryside_stewardship_grant"
+      ["department-for-environment-food-rural-affairs"]
+    when "vehicle_recalls_and_faults_alert"
+      ["driver-and-vehicle-standards-agency"]
+    end
+  end
+
   def initialize(user)
     @user = user
   end
@@ -35,34 +63,7 @@ private
   end
 
   def user_organisation_owns_format?(format)
-    owning_organisations_for_format(format).include?(user.organisation_slug)
+    self.class.owning_organisations_for_format(format).include?(user.organisation_slug)
   end
 
-  def owning_organisations_for_format(format)
-    case format
-    when "cma_case"
-      ["competition-and-markets-authority"]
-    when "aaib_report"
-      ["air-accidents-investigation-branch"]
-    when "international_development_fund"
-      ["department-for-international-development"]
-    when "drug_safety_update", "medical_safety_alert"
-      ["medicines-and-healthcare-products-regulatory-agency"]
-    when "esi_fund"
-      %w(
-        department-for-communities-and-local-government
-        department-for-work-pensions
-        department-for-environment-food-rural-affairs
-        rural-payments-agency
-      )
-    when "maib_report"
-      ["marine-accident-investigation-branch"]
-    when "raib_report"
-      ["rail-accident-investigation-branch"]
-    when "countryside_stewardship_grant"
-      ["department-for-environment-food-rural-affairs"]
-    when "vehicle_recalls_and_faults_alert"
-      ["driver-and-vehicle-standards-agency"]
-    end
-  end
 end

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -8,6 +8,7 @@ require "finder_schema"
 require "footnotes_section_heading_renderer"
 require "formatters/manual_artefact_formatter"
 require "gds_api/email_alert_api"
+require "gds_api/publishing_api"
 require "gds_api/rummager"
 require "gds_api_proxy"
 require "govspeak_to_html_renderer"
@@ -252,6 +253,10 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:email_alert_api) {
     GdsApi::EmailAlertApi.new(Plek.current.find("email-alert-api"))
+  }
+
+  define_singleton(:publishing_api) {
+    GdsApi::PublishingApi.new(Plek.new.find("publishing-api"))
   }
 
   define_singleton(:aaib_report_finder_schema) {

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -1,5 +1,6 @@
 require "url_maker"
 require "rummager_indexer"
+require "formatters/specialist_document_publishing_api_formatter"
 
 class AbstractSpecialistDocumentObserversRegistry
   def creation
@@ -14,6 +15,7 @@ class AbstractSpecialistDocumentObserversRegistry
     [
       publication_logger,
       content_api_exporter,
+      publishing_api_exporter,
       panopticon_exporter,
       rummager_exporter,
       publication_alert_exporter,
@@ -42,6 +44,21 @@ private
       panopticon_registerer.call(
         format_document_as_artefact(document)
       )
+    }
+  end
+
+  def publishing_api_exporter
+    ->(document) {
+      rendered_document = SpecialistDocumentPublishingAPIFormatter.new(
+        document,
+        specialist_document_renderer: SpecialistPublisherWiring.get(:specialist_document_renderer),
+        publication_logs: PublicationLog
+      )
+
+      SpecialistDocumentPublishingAPIExporter.new(
+        publishing_api,
+        rendered_document
+      ).call
     }
   end
 
@@ -126,4 +143,9 @@ private
   def url_maker
     UrlMaker.new
   end
+
+  def publishing_api
+    SpecialistPublisherWiring.get(:publishing_api)
+  end
+
 end

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -5,11 +5,15 @@ require "formatters/specialist_document_publishing_api_formatter"
 
 class AbstractSpecialistDocumentObserversRegistry
   def creation
-    []
+    [
+      publishing_api_exporter,
+    ]
   end
 
   def update
-    []
+    [
+      publishing_api_exporter,
+    ]
   end
 
   def publication
@@ -59,7 +63,8 @@ private
 
       SpecialistDocumentPublishingAPIExporter.new(
         publishing_api,
-        rendered_document
+        rendered_document,
+        document.draft?
       ).call
     }
   end

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -1,5 +1,6 @@
 require "url_maker"
 require "rummager_indexer"
+require "publishing_api_withdrawer"
 require "formatters/specialist_document_publishing_api_formatter"
 
 class AbstractSpecialistDocumentObserversRegistry
@@ -33,6 +34,7 @@ class AbstractSpecialistDocumentObserversRegistry
   def withdrawal
     [
       content_api_withdrawer,
+      publishing_api_withdrawer,
       panopticon_exporter,
       rummager_withdrawer,
     ]
@@ -58,6 +60,15 @@ private
       SpecialistDocumentPublishingAPIExporter.new(
         publishing_api,
         rendered_document
+      ).call
+    }
+  end
+
+  def publishing_api_withdrawer
+    ->(document) {
+      PublishingAPIWithdrawer.new(
+        publishing_api: publishing_api,
+        entity: document,
       ).call
     }
   end

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -163,5 +163,4 @@ private
   def publishing_api
     SpecialistPublisherWiring.get(:publishing_api)
   end
-
 end

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -8,6 +8,7 @@ class DrugSafetyUpdateObserversRegistry < AbstractSpecialistDocumentObserversReg
     [
       publication_logger,
       content_api_exporter,
+      publishing_api_exporter,
       panopticon_exporter,
       rummager_exporter,
     ]

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -1,4 +1,3 @@
-require "gds_api/publishing_api"
 require "gds_api/organisations"
 require "manual_publishing_api_exporter"
 require "manual_section_publishing_api_exporter"
@@ -136,7 +135,7 @@ private
   end
 
   def publishing_api
-    GdsApi::PublishingApi.new(Plek.new.find("publishing-api"))
+    SpecialistPublisherWiring.get(:publishing_api)
   end
 
   def organisations_api

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -9,6 +9,7 @@ Feature: Creating and editing a CMA case
   Scenario: Create a new CMA case
     When I create a CMA case
     Then the CMA case has been created
+    And the document should be sent to content preview
 
   Scenario: Cannot create a CMA case with invalid fields
     When I create a CMA case with invalid fields
@@ -30,6 +31,7 @@ Feature: Creating and editing a CMA case
     Given a draft CMA case exists
     When I edit a CMA case
     Then the CMA case should have been updated
+    And the document should be sent to content preview
 
   Scenario: Change the title of a previously published document
     Given a published CMA case exists
@@ -60,4 +62,3 @@ Feature: Creating and editing a CMA case
     When I start creating a new CMA case with embedded javascript
     And I preview the case
     Then I should see an error message about a "Body" field containing javascript
-

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -9,6 +9,7 @@ Given I am logged in as a "DEFRA" editor
 Scenario: Create a new Countryside Stewardship Grant
   When I create a Countryside Stewardship Grant
   Then the Countryside Stewardship Grant has been created
+  And the document should be sent to content preview
 
 Scenario: Cannot create a Countryside Stewardship Grant with invalid fields
   When I create a Countryside Stewardship Grant with invalid fields
@@ -29,3 +30,4 @@ Scenario: Edit a draft Countryside Stewardship Grant
   Given a draft Countryside Stewardship Grant exists
   When I edit a Countryside Stewardship Grant
   Then the Countryside Stewardship Grant should have been updated
+  And the document should be sent to content preview

--- a/features/creating-and-editing-a-drug-safety-update.feature
+++ b/features/creating-and-editing-a-drug-safety-update.feature
@@ -9,6 +9,7 @@ Feature: Creating and editing a Drug Safety Update
   Scenario: Create a new Drug Safety Update
     When I create a Drug Safety Update
     Then the Drug Safety Update has been created
+    And the document should be sent to content preview
 
   Scenario: Cannot create a Drug Safety Update with invalid fields
     When I create a Drug Safety Update with invalid fields
@@ -29,3 +30,4 @@ Feature: Creating and editing a Drug Safety Update
     Given a draft Drug Safety Update exists
     When I edit a Drug Safety Update
     Then the Drug Safety Update should have been updated
+    And the document should be sent to content preview

--- a/features/creating-and-editing-a-maib-report.feature
+++ b/features/creating-and-editing-a-maib-report.feature
@@ -10,6 +10,7 @@ Feature: Publishing an MAIB Report
     When I create a MAIB report
     Then the MAIB report has been created
     And the MAIB report should be in draft
+    And the document should be sent to content preview
 
   Scenario: Cannot create a MAIB report with invalid fields
     When I create a MAIB report with invalid fields
@@ -31,3 +32,4 @@ Feature: Publishing an MAIB Report
     Given a draft MAIB report exists
     When I edit a MAIB report
     Then the MAIB report should have been updated
+    And the document should be sent to content preview

--- a/features/creating-and-editing-a-medical-safety-alert.feature
+++ b/features/creating-and-editing-a-medical-safety-alert.feature
@@ -9,6 +9,7 @@ Feature: Creating and editing a Medical Safety Alert
   Scenario: Create a new Medical Safety Alert
     When I create a Medical Safety Alert
     Then the Medical Safety Alert has been created
+    And the document should be sent to content preview
 
   Scenario: Cannot create a Medical Safety Alert with invalid fields
     When I create a Medical Safety Alert with invalid fields
@@ -29,3 +30,4 @@ Feature: Creating and editing a Medical Safety Alert
     Given a draft Medical Safety Alert exists
     When I edit a Medical Safety Alert
     Then the Medical Safety Alert should have been updated
+    And the document should be sent to content preview

--- a/features/creating-and-editing-a-raib-report.feature
+++ b/features/creating-and-editing-a-raib-report.feature
@@ -10,6 +10,7 @@ Feature: Publishing a RAIB Report
     When I create a RAIB report
     Then the RAIB report has been created
     And the RAIB report should be in draft
+    And the document should be sent to content preview
 
   Scenario: Cannot create a RAIB report with invalid fields
     When I create a RAIB report with invalid fields
@@ -31,3 +32,4 @@ Feature: Publishing a RAIB Report
     Given a draft RAIB report exists
     When I edit a RAIB report
     Then the RAIB report should have been updated
+    And the document should be sent to content preview

--- a/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
+++ b/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
@@ -9,6 +9,7 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
   Scenario: Creating a new Vehicle Recalls and Faults alert
     When I create a Vehicle Recalls and Faults alert
     Then I should see that Vehicle Recalls and Faults alert
+    And the document should be sent to content preview
 
   Scenario: Providing invalid inputs when creating an alert
     When I try to save a Vehicle Recall alert with invalid HTML and no title
@@ -30,3 +31,4 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
     Given a draft of a Vehicle Recalls and Faults alert exists
     When I change the title of that Vehicle Recalls and Faults alert to "A big vehicle fault"
     Then I should see "A big vehicle fault" as the title fo the Vehicle Recalls and Faults alert
+    And the document should be sent to content preview

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -10,6 +10,7 @@ Feature: Creating and editing an AAIB Report
     When I create a AAIB report
     Then the AAIB report has been created
     And the AAIB report should be in draft
+    And the document should be sent to content preview
 
   Scenario: Cannot create a AAIB report with invalid fields
     When I create a AAIB report with invalid fields
@@ -31,3 +32,4 @@ Feature: Creating and editing an AAIB Report
     Given a draft AAIB report exists
     When I edit a AAIB report
     Then the AAIB report should have been updated
+    And the document should be sent to content preview

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -9,6 +9,7 @@ Given I am logged in as a "DCLG" editor
 Scenario: Create a new ESI Fund
   When I create an ESI Fund
   Then the ESI Fund has been created
+  And the document should be sent to content preview
 
 Scenario: Cannot create an ESI Fund with invalid fields
   When I create an ESI Fund with invalid fields
@@ -30,3 +31,4 @@ Scenario: Edit a draft ESI Fund
   Given a draft ESI Fund exists
   When I edit an ESI Fund
   Then the ESI Fund should have been updated
+  And the document should be sent to content preview

--- a/features/creating-and-editing-an-international-development-fund.feature
+++ b/features/creating-and-editing-an-international-development-fund.feature
@@ -9,6 +9,7 @@ Feature: Creating and editing an International Development Fund
   Scenario: Create a new International Development Fund
     When I create a International Development Fund
     Then the International Development Fund has been created
+    And the document should be sent to content preview
 
   Scenario: Cannot create a International Development Fund with invalid fields
     When I create a International Development Fund with invalid fields
@@ -29,3 +30,4 @@ Feature: Creating and editing an International Development Fund
     Given a draft International Development Fund exists
     When I edit a International Development Fund
     Then the International Development Fund should have been updated
+    And the document should be sent to content preview

--- a/features/publishing-a-cma-case.feature
+++ b/features/publishing-a-cma-case.feature
@@ -65,4 +65,3 @@ Feature: Publishing a CMA case
     When I publish the CMA case
     Then an email alert should not be sent
     And the publish should still have been logged 1 time
-

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -1,23 +1,11 @@
 Given(/^I am logged in as a "(.*?)" editor$/) do |editor_type|
   login_as(:"#{editor_type.downcase}_editor")
-
-  # WARNING: These must be stubbed before the first request takes place
-  stub_panopticon
-  stub_rummager
-  stub_publishing_api
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-  stub_email_alert_api
 end
 
 Given(/^I am logged in as a non\-CMA editor$/) do
   login_as(:generic_editor)
-
-  # WARNING: These must be stubbed before the first request takes place
-  stub_panopticon
-  stub_rummager
-  stub_publishing_api
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-  stub_email_alert_api
 end
 
 Then(/^I do not see an option for editing documents$/) do

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -42,3 +42,7 @@ end
 Then(/^the publish should(?: still)* have been logged (\d+) times?$/) do |expected_count_of_logs|
   check_count_of_logs(expected_count_of_logs)
 end
+
+Then(/^the document should be sent to content preview/) do
+  check_document_published_to_publishing_api(@slug, @document_fields, draft: true)
+end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -1,0 +1,7 @@
+Before do
+  # WARNING: These must be stubbed before the first request takes place
+  stub_panopticon
+  stub_rummager
+  stub_publishing_api
+  stub_email_alert_api
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -54,6 +54,17 @@ module DocumentHelpers
       )
   end
 
+  def check_document_published_to_publishing_api(slug, fields)
+    attributes = {
+      title: fields[:title],
+      description: fields[:summary],
+      format: "specialist_document",
+      publishing_app: "specialist-publisher",
+      rendering_app: "specialist-frontend",
+    }
+    assert_publishing_api_put_item("/#{slug}", attributes)
+  end
+
   def check_added_to_rummager(slug, fields)
     document_type_slug_prefix_map = {
       "cma-cases" => "cma_case",
@@ -133,6 +144,7 @@ module DocumentHelpers
   def check_document_is_published(slug, fields)
     check_document_published_to_content_api(slug, fields)
     check_published_with_panopticon(slug, fields.fetch(:title))
+    check_document_published_to_publishing_api(slug, fields)
     check_added_to_rummager(
       slug,
       fields.except(:body),

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -54,7 +54,7 @@ module DocumentHelpers
       )
   end
 
-  def check_document_published_to_publishing_api(slug, fields)
+  def check_document_published_to_publishing_api(slug, fields, draft: false)
     attributes = {
       title: fields[:title],
       description: fields[:summary],
@@ -62,7 +62,11 @@ module DocumentHelpers
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
     }
-    assert_publishing_api_put_item("/#{slug}", attributes)
+    if draft
+      assert_publishing_api_put_draft_item("/#{slug}", attributes)
+    else
+      assert_publishing_api_put_item("/#{slug}", attributes)
+    end
   end
 
   def check_added_to_rummager(slug, fields)

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -119,6 +119,8 @@ module DocumentHelpers
         state: "archived",
       ))
 
+    assert_publishing_api_put_item("/#{slug}", format: "gone")
+
     expect(page).to have_content("withdrawn")
     expect(RenderedSpecialistDocument.where(title: document_title)).to be_empty
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -107,6 +107,8 @@ require "file_fixture_helpers"
 require "gds_sso_helpers"
 require "access_control_helpers"
 require "search_helpers"
+require "mocks"
+require "api_helpers"
 
 require "aaib_report_helpers"
 require "cma_case_helpers"

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -4,6 +4,7 @@ module PublishingAPIHelpers
   include GdsApi::TestHelpers::PublishingApi
   def stub_publishing_api
     stub_default_publishing_api_put
+    stub_default_publishing_api_put_draft
   end
 
   def reset_remote_requests

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
   }
 
   let(:document) {
-    SpecialistDocument.new(nil, edition.document_id, [edition], nil)
+    AaibReport.new(
+      SpecialistDocument.new(nil, edition.document_id, [edition], nil)
+    )
   }
 
   let(:edition) {

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -169,7 +169,6 @@ END_OF_GOVSPEAK
       it "includes uids of departmental editors and GDS editors" do
         expect(presented["access_limited"]["users"]).to eq([cma_editor.uid, gds_editor.uid])
       end
-
     end
   end
 end

--- a/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
+++ b/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
@@ -36,13 +36,31 @@ describe SpecialistDocumentPublishingAPIExporter do
   subject {
     described_class.new(
       publishing_api,
-      document
+      document,
+      draft
     )
   }
 
-  it "exports to the publishing api" do
-    expect(publishing_api).to receive(:put_content_item).with(document_path, document_data)
-    subject.call
+  context "a published item" do
+
+    let(:draft) { false }
+
+    it "exports to the publishing api" do
+      expect(publishing_api).to receive(:put_content_item).with(document_path, document_data)
+      subject.call
+
+    end
+  end
+
+  context "a draft item" do
+
+    let(:draft) { true }
+
+    it "exports to the publishing api" do
+      expect(publishing_api).to receive(:put_draft_content_item).with(document_path, document_data)
+      subject.call
+
+    end
   end
 
 end

--- a/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
+++ b/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
@@ -1,0 +1,48 @@
+require "fast_spec_helper"
+
+require "specialist_document_publishing_api_exporter"
+
+describe SpecialistDocumentPublishingAPIExporter do
+
+  let(:publishing_api) {
+    double(:publishing_api)
+  }
+
+  let(:document_path) { "/cma-cases/foo" }
+
+  let(:document_data) {
+    {
+      content_id: "4bf43033-6c7a-4911-bc03-867945d9b937",
+      format: "specialist_document",
+      publishing_app: "specialist-publisher",
+      rendering_app: "specialist-frontend",
+      title: "This is a title",
+      description: "This is a description",
+      update_type: "major",
+      locale: "en",
+      public_updated_at: Time.now,
+      details: {}
+    }
+  }
+
+  let(:document) {
+    double(
+      "FormattedSpecialistDocument",
+      call: document_data,
+      base_path: document_path
+    )
+  }
+
+  subject {
+    described_class.new(
+      publishing_api,
+      document
+    )
+  }
+
+  it "exports to the publishing api" do
+    expect(publishing_api).to receive(:put_content_item).with(document_path, document_data)
+    subject.call
+  end
+
+end

--- a/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
+++ b/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
@@ -42,25 +42,20 @@ describe SpecialistDocumentPublishingAPIExporter do
   }
 
   context "a published item" do
-
     let(:draft) { false }
 
     it "exports to the publishing api" do
       expect(publishing_api).to receive(:put_content_item).with(document_path, document_data)
       subject.call
-
     end
   end
 
   context "a draft item" do
-
     let(:draft) { true }
 
     it "exports to the publishing api" do
       expect(publishing_api).to receive(:put_draft_content_item).with(document_path, document_data)
       subject.call
-
     end
   end
-
 end


### PR DESCRIPTION
* Export specialist documents to publishing API on publish.
* Send "gone" item to publishing API when specialist doc is withdrawn.
* Send draft specialist documents to content-preview publishing API on create and update.
* Add access limiting data (all users in owning organisation, plus all GDS Editors) to draft document representation.