### PR TITLE
Bulk export all specialist documents to publishing API.

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -14,7 +14,7 @@ class SpecialistDocumentPublishingAPIFormatter
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
       title: rendered_document.attributes.fetch(:title),
-      description: rendered_document.attributes.fetch(:summary),
+      description: rendered_document.attributes.fetch(:summary, ""),
       update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,

--- a/db/migrate/20150727150234_export_all_documents_to_publishing_api.rb
+++ b/db/migrate/20150727150234_export_all_documents_to_publishing_api.rb
@@ -3,7 +3,11 @@ require "lib/specialist_document_bulk_exporter"
 class ExportAllDocumentsToPublishingApi < Mongoid::Migration
   def self.up
     SpecialistPublisher.document_types.each do |type|
-      SpecialistDocumentBulkExporter.new(type, formatter: MigrationSpecialistDocumentPublishingAPIFormatter).call
+      SpecialistDocumentBulkExporter.new(
+        type,
+        formatter: MigrationSpecialistDocumentPublishingAPIFormatter,
+        logger: Logger.new(STDOUT)
+      ).call
     end
   end
 

--- a/db/migrate/20150727150234_export_all_documents_to_publishing_api.rb
+++ b/db/migrate/20150727150234_export_all_documents_to_publishing_api.rb
@@ -1,0 +1,27 @@
+require "lib/specialist_document_bulk_exporter"
+
+class ExportAllDocumentsToPublishingApi < Mongoid::Migration
+  def self.up
+    SpecialistPublisher.document_types.each do |type|
+      SpecialistDocumentBulkExporter.new(type, formatter: MigrationSpecialistDocumentPublishingAPIFormatter).call
+    end
+  end
+
+  def self.down
+  end
+end
+
+class MigrationSpecialistDocumentPublishingAPIFormatter < SpecialistDocumentPublishingAPIFormatter
+  def call
+    # To speed up the export, we want to avoid re-registering routes for existing
+    # published documents, so use a custom formatter subclass that overrides the
+    # format field to be "placeholder_specialist_document". Draft documents *do*
+    # need to register routes though, since they will not exist for unpublished
+    # documents.
+    super.merge(update_type: "republish").tap do |data|
+      if specialist_document.published?
+        data[:format] = "placeholder_specialist_document"
+      end
+    end
+  end
+end

--- a/lib/specialist_document_bulk_exporter.rb
+++ b/lib/specialist_document_bulk_exporter.rb
@@ -1,11 +1,13 @@
 class SpecialistDocumentBulkExporter
-  attr_reader :type, :formatter, :exporter
+  attr_reader :type, :formatter, :exporter, :logger
 
   def initialize(type,
                  formatter: SpecialistDocumentPublishingAPIFormatter,
-                 exporter: SpecialistDocumentPublishingAPIExporter)
+                 exporter: SpecialistDocumentPublishingAPIExporter,
+                 logger: Logger.new(nil))
     @formatter = formatter
     @exporter = exporter
+    @logger = logger
     @type = type
   end
 
@@ -14,12 +16,14 @@ class SpecialistDocumentBulkExporter
     export_all_editions("draft")
   end
 
+  private
+
   def export_all_editions(state)
     editions = specialist_document_editions.where(state: state)
-    puts "Exporting #{editions.count} #{state} #{type} documents"
+    logger.info("Exporting #{editions.count} #{state} #{type} documents")
 
     editions.each_with_index do |edition, i|
-      puts i if i % 10 == 0
+      logger.info(i) if i % 10 == 0
       export_edition(edition)
     end
   end

--- a/lib/specialist_document_bulk_exporter.rb
+++ b/lib/specialist_document_bulk_exporter.rb
@@ -1,0 +1,66 @@
+class SpecialistDocumentBulkExporter
+  attr_reader :type, :formatter, :exporter
+
+  def initialize(type,
+                 formatter: SpecialistDocumentPublishingAPIFormatter,
+                 exporter: SpecialistDocumentPublishingAPIExporter)
+    @formatter = formatter
+    @exporter = exporter
+    @type = type
+  end
+
+  def call
+    export_all_editions("published")
+    export_all_editions("draft")
+  end
+
+  def export_all_editions(state)
+    editions = specialist_document_editions.where(state: state)
+    puts "Exporting #{editions.count} #{state} #{type} documents"
+
+    editions.each_with_index do |edition, i|
+      puts i if i % 10 == 0
+      export_edition(edition)
+    end
+  end
+
+  def export_edition(edition)
+    document = factory.call(edition.document_id, [edition])
+
+    rendered_document = formatter.new(
+      document,
+      specialist_document_renderer: renderer,
+      publication_logs: PublicationLog
+    )
+
+    exporter.new(
+      publishing_api,
+      rendered_document,
+      document.draft?
+    ).call
+  end
+
+  def specialist_document_editions
+    SpecialistDocumentEdition.where(document_type: type)
+  end
+
+  def factory
+    entity_factories.public_send("#{type}_factory")
+  end
+
+  def entity_factories
+    SpecialistPublisherWiring.get(:validatable_document_factories)
+  end
+
+  def publishing_api
+    SpecialistPublisherWiring.get(:publishing_api)
+  end
+
+  def renderer
+    SpecialistPublisherWiring.get(:specialist_document_renderer)
+  end
+
+  def services
+    SpecialistPublisher.document_services(type)
+  end
+end

--- a/spec/lib/specialist_document_bulk_exporter_spec.rb
+++ b/spec/lib/specialist_document_bulk_exporter_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+require "lib/specialist_document_bulk_exporter"
+
+describe SpecialistDocumentBulkExporter do
+  let(:exporter) {
+    double("SpecialistDocumentPublishingAPIExporter", new: double(call: {}))
+  }
+
+  subject {
+    described_class.new(
+      "cma_case",
+      exporter: exporter
+    )
+  }
+
+  let!(:edition1) {
+    FactoryGirl.create(
+      :specialist_document_edition,
+      document_id: SecureRandom.uuid,
+      document_type: "cma_case",
+      updated_at: 2.days.ago,
+      title: "Original title",
+      body: "",
+      state: "published",
+    )
+  }
+
+  let!(:edition2) {
+    FactoryGirl.create(
+      :specialist_document_edition,
+      document_id: edition1.document_id,
+      document_type: "cma_case",
+      updated_at: 1.day.ago,
+      body: "",
+      title: "Updated title",
+      state: "draft",
+    )
+  }
+
+  let!(:edition3) {
+    FactoryGirl.create(
+      :specialist_document_edition,
+      document_id: edition1.document_id,
+      document_type: "cma_case",
+      updated_at: 3.days.ago,
+      title: "Unrelated title",
+      body: "",
+      state: "archived",
+    )
+  }
+
+  it "sends the most recent published and draft edition to publishing-api" do
+    subject.call
+    expect(exporter).to have_received(:new).with(anything, anything, false).once
+    expect(exporter).to have_received(:new).with(anything, anything, true).once
+  end
+end


### PR DESCRIPTION
Utility class to send all specialist documents of a specific type to publishing API, and a migration that calls it for all types.

For published editions, the migration uses an overridden format, "placeholder_specialist_document", so that it does not incur the overhead of re-registering existing routes with the router.

This does not affect the data itself, or the front-end representation. The format name can be correct directly in content-store afterwards.