### PR TITLE
Add task to publish finders to rummager.

### DIFF
--- a/app/presenters/finder_rummager_presenter.rb
+++ b/app/presenters/finder_rummager_presenter.rb
@@ -1,0 +1,19 @@
+FinderRummagerPresenter = Struct.new(:metadata, :timestamp) do
+  def type
+    "edition"
+  end
+
+  def id
+    metadata.fetch("base_path")
+  end
+
+  def attributes
+    {
+      "title" => metadata.fetch("name"),
+      "description" => metadata.fetch("description", ""),
+      "link" => metadata.fetch("base_path"),
+      "format" => "finder",
+      "public_timestamp" => timestamp,
+    }
+  end
+end

--- a/app/presenters/finder_rummager_presenter.rb
+++ b/app/presenters/finder_rummager_presenter.rb
@@ -14,6 +14,7 @@ FinderRummagerPresenter = Struct.new(:metadata, :timestamp) do
       "link" => metadata.fetch("base_path"),
       "format" => "finder",
       "public_timestamp" => timestamp,
+      "specialist_sectors" => metadata.fetch("topics", []),
     }
   end
 end

--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -3,6 +3,7 @@
   "base_path": "/aaib-reports",
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
+  "description": "Find reports of AAIB investigations into air accidents and incidents",
   "beta": true,
   "filter": {
     "document_type": "aaib_report"

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -3,6 +3,7 @@
   "base_path": "/cma-cases",
   "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases",
+  "description": "Find reports and updates on current and historical CMA investigations",
   "filter": {
     "document_type": "cma_case"
   },

--- a/finders/metadata/cma-cases.json
+++ b/finders/metadata/cma-cases.json
@@ -10,6 +10,13 @@
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
   "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
+  "topics": [
+    "competition/competition-act-cartels",
+    "competition/consumer-protection",
+    "competition/markets",
+    "competition/mergers",
+    "competition/regulatory-appeals-references"
+  ],
   "subscription_list_title_prefix": {
     "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
     "plural": "Competition and Markets Authority (CMA) cases with the following case types: "

--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -3,6 +3,7 @@
   "base_path": "/countryside-stewardship-grants",
   "name": "Countryside Stewardship grants",
   "format_name": "Countryside Stewardship grant",
+  "description": "Find information about Countryside Stewardship options, capital items and supplements",
   "beta": true,
   "filter": {
     "document_type": "countryside_stewardship_grant"

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -3,6 +3,7 @@
   "base_path": "/drug-safety-update",
   "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",
+  "description": "Find drug safety updates issued by MHRA",
   "filter": {
     "document_type": "drug_safety_update"
   },

--- a/finders/metadata/drug-safety-updates.json
+++ b/finders/metadata/drug-safety-updates.json
@@ -16,5 +16,8 @@
     "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
     "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
   ],
+  "topics": [
+    "medicines-medical-devices-blood/vigilance-safety-alerts"
+  ],
   "subscription_list_title_prefix": "Drug Safety Update"
 }

--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -3,6 +3,7 @@
   "base_path": "/european-structural-investment-funds",
   "format_name": "ESIF call for proposals",
   "name": "European Structural and Investment Funds (ESIF)",
+  "description": "Find and apply to run projects backed by ESIF",
   "beta": true,
   "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Stuctural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {

--- a/finders/metadata/international-development-funds.json
+++ b/finders/metadata/international-development-funds.json
@@ -3,6 +3,7 @@
   "base_path": "/international-development-funding",
   "format_name": "International development funding",
   "name": "International development funding",
+  "description": "Find and apply for funds to run international development projects",
   "filter": {
     "document_type": "international_development_fund"
   },

--- a/finders/metadata/maib-reports.json
+++ b/finders/metadata/maib-reports.json
@@ -3,6 +3,7 @@
   "base_path": "/maib-reports",
   "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",
+  "description": "Find reports of MAIB investigations into marine accidents and incidents",
   "filter": {
     "document_type": "maib_report"
   },

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -3,6 +3,7 @@
   "base_path": "/drug-device-alerts",
   "format_name": "Medical safety alert",
   "name": "Alerts and recalls for drugs and medical devices",
+  "description": "Find alerts and recalls issued by MHRA",
   "filter": {
     "document_type": "medical_safety_alert"
   },

--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -14,6 +14,10 @@
   "show_summaries": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
+  "topics": [
+    "medicines-medical-devices-blood/medical-devices-regulation-safety",
+    "medicines-medical-devices-blood/vigilance-safety-alerts"
+  ],
   "email_filter_by": "alert_type",
   "email_signup_choice": [
     {

--- a/finders/metadata/raib-reports.json
+++ b/finders/metadata/raib-reports.json
@@ -3,6 +3,7 @@
   "base_path": "/raib-reports",
   "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",
+  "description": "Find reports of RAIB investigations into rail accidents and incidents",
   "filter": {
     "document_type": "raib_report"
   },

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -1,0 +1,32 @@
+require "gds_api/rummager"
+require_relative "../app/presenters/finder_rummager_presenter"
+
+class RummagerFinderPublisher
+  def initialize(metadatas)
+    @metadatas = metadatas
+  end
+
+  def call
+    @metadatas.each do |metadata|
+      if metadata[:file].has_key?("content_id")
+        export_finder(metadata)
+      else
+        # Even though rummager doesn't use the content_id we only want to push
+        # to rummager if this is live in content-store, so this needs to
+        # replicate the logic in PublishingApiFinderPublisher.
+        puts "didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id"
+      end
+    end
+  end
+
+  private
+
+  def export_finder(metadata)
+    presenter = FinderRummagerPresenter.new(metadata[:file], metadata[:timestamp])
+    rummager.add_document(presenter.type, presenter.id, presenter.attributes)
+  end
+
+  def rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find("rummager"))
+  end
+end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,18 @@
+
+namespace :rummager do
+  desc "Publish all Finders to Rummager"
+  task :publish_finders do
+    require "rummager_finder_publisher"
+
+    require "multi_json"
+
+    metadatas = Dir.glob("finders/metadata/**/*.json").map do |file_path|
+      {
+        file: MultiJson.load(File.read(file_path)),
+        timestamp: File.mtime(file_path)
+      }
+    end
+
+    RummagerFinderPublisher.new(metadatas).call
+  end
+end

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+require "rummager_finder_publisher"
+
+describe RummagerFinderPublisher do
+  describe ".call" do
+    it "uses GdsApi::Rummager to publish the Finders" do
+      metadata = [
+        {
+          file: {
+            "base_path" => "/first-finder",
+            "name" => "first finder",
+            "format_name" => "first finder things",
+            "description" => "first finder description",
+            "content_id" => SecureRandom.uuid,
+            "format" => "a_report_format",
+            "signup_content_id" => SecureRandom.uuid,
+            "logo_path" => "http://example.com/logo.png",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+        {
+          file: {
+            "base_path" => "/second-finder",
+            "name" => "second finder",
+            "format_name" => "second finder things",
+            "content_id" => SecureRandom.uuid,
+            "format" => "some_case_format",
+            "logo_path" => "http://example.com/logo.png",
+          },
+          timestamp: "2015-02-14T11:43:23.000+00:00",
+        }
+      ]
+
+      rummager = double("rummager")
+      expect(GdsApi::Rummager).to receive(:new)
+        .with(Plek.new.find("rummager"))
+        .and_return(rummager)
+
+      expect(rummager).to receive(:add_document)
+        .with("edition", "/first-finder", {
+          "title" => "first finder",
+          "description" => "first finder description",
+          "link" => "/first-finder",
+          "format" => "finder",
+          "public_timestamp" => "2015-01-05T10:45:10.000+00:00",
+        })
+
+      expect(rummager).to receive(:add_document)
+        .with("edition", "/second-finder", {
+          "title" => "second finder",
+          "description" => "",
+          "link" => "/second-finder",
+          "format" => "finder",
+          "public_timestamp" => "2015-02-14T11:43:23.000+00:00",
+        })
+
+      RummagerFinderPublisher.new(metadata).call
+    end
+
+    it "doesn't publish a Finder without a content id" do
+      metadata = [
+        {
+          file: {
+            "base_path" => "/finder-without-content-id",
+            "name" => "finder without content id",
+            "format" => "a_report_format",
+            "format_name" => "a report format",
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+        {
+          file: {
+            "base_path" => "/finder-with-content-id",
+            "name" => "finder with content id",
+            "content_id" => "some-random-id",
+            "format" => "a_report_format",
+            "format_name" => "a report format",
+            "signup_content_id" => SecureRandom.uuid,
+          },
+          timestamp: "2015-01-05T10:45:10.000+00:00",
+        },
+      ]
+
+      rummager = double("rummager")
+      expect(GdsApi::Rummager).to receive(:new)
+        .with(Plek.new.find("rummager"))
+        .and_return(rummager)
+
+      expect(rummager).not_to receive(:add_document)
+        .with(anything, "/finder-without-content-id", anything)
+
+      expect(rummager).to receive(:add_document)
+        .with(anything, "/finder-with-content-id", anything)
+
+      RummagerFinderPublisher.new(metadata).call
+    end
+  end
+end

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -15,6 +15,9 @@ describe RummagerFinderPublisher do
             "format" => "a_report_format",
             "signup_content_id" => SecureRandom.uuid,
             "logo_path" => "http://example.com/logo.png",
+            "topics" => [
+              "business-tax/paye",
+            ],
           },
           timestamp: "2015-01-05T10:45:10.000+00:00",
         },
@@ -26,6 +29,10 @@ describe RummagerFinderPublisher do
             "content_id" => SecureRandom.uuid,
             "format" => "some_case_format",
             "logo_path" => "http://example.com/logo.png",
+            "topics" => [
+              "competition/mergers",
+              "competition/markets",
+            ],
           },
           timestamp: "2015-02-14T11:43:23.000+00:00",
         }
@@ -43,6 +50,9 @@ describe RummagerFinderPublisher do
           "link" => "/first-finder",
           "format" => "finder",
           "public_timestamp" => "2015-01-05T10:45:10.000+00:00",
+          "specialist_sectors" => [
+            "business-tax/paye",
+          ]
         })
 
       expect(rummager).to receive(:add_document)
@@ -52,6 +62,10 @@ describe RummagerFinderPublisher do
           "link" => "/second-finder",
           "format" => "finder",
           "public_timestamp" => "2015-02-14T11:43:23.000+00:00",
+          "specialist_sectors" => [
+            "competition/mergers",
+            "competition/markets",
+          ],
         })
 
       RummagerFinderPublisher.new(metadata).call


### PR DESCRIPTION
At present the finders have been hacked into search by using
recommended-links. This has problems because we can't include their
topic taggings etc.

This therefore adds a task to send the finders to rummager. The finder descriptions have been populated from the data in recommended-links. The finder topics have been populated from the data in contentapi.