### PR TITLE
Fetch tag for manuals when publishing

### DIFF
--- a/app/exporters/formatters/abstract_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_indexable_formatter.rb
@@ -30,7 +30,7 @@ private
   end
 
   def extra_attributes
-    {}
+    raise NotImplementedError
   end
 
   def title

--- a/app/exporters/formatters/manual_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_indexable_formatter.rb
@@ -6,11 +6,21 @@ class ManualIndexableFormatter < AbstractIndexableFormatter
   end
 
 private
+  def extra_attributes
+    {
+      specialist_sectors: specialist_sectors
+    }
+  end
+
   def indexable_content
     entity.summary # Manuals don't have a body
   end
 
   def organisation_slugs
     [entity.organisation_slug]
+  end
+
+  def specialist_sectors
+    entity.tags.select { |t| t[:type] == "specialist_sector" }.map { |t| t[:slug] }
   end
 end

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -26,6 +26,10 @@ class ManualSectionIndexableFormatter
 private
   attr_reader :section, :manual
 
+  def extra_attributes
+    {}
+  end
+
   def link
     section.slug
   end

--- a/app/lib/tag_fetcher.rb
+++ b/app/lib/tag_fetcher.rb
@@ -1,0 +1,29 @@
+require "gds_api/content_api"
+
+class TagFetcher
+
+  def initialize(manual)
+    @manual = manual
+  end
+
+  def tags
+    if artefact
+      artefact.tags
+    else
+      []
+    end
+  end
+
+private
+
+  attr_reader :manual
+
+  def artefact
+    content_api.artefact(manual.slug)
+  end
+
+  def content_api
+    @content_api ||= GdsApi::ContentApi.new(Plek.new.find("contentapi"))
+  end
+
+end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -9,6 +9,7 @@ class Manual
     :state,
     :version_number,
     :updated_at,
+    :tags,
   )
 
   def initialize(attributes)
@@ -34,6 +35,7 @@ class Manual
       state: state,
       version_number: version_number,
       updated_at: updated_at,
+      tags: tags,
     }
   end
 
@@ -44,6 +46,7 @@ class Manual
     @body = attributes.fetch(:body) { body }
     @organisation_slug = attributes.fetch(:organisation_slug) { organisation_slug }
     @state = attributes.fetch(:state) { state }
+    @tags = attributes.fetch(:tags) { tags }
 
     self
   end

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -58,6 +58,7 @@ private
     field :version_number, type: Integer
     field :document_ids, type: Array
     field :removed_document_ids, type: Array
+    field :tags, type: Array
 
     # We don't make use of the relationship but Mongiod can't save the
     # timestamps properly without it.

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -61,6 +61,7 @@ private
       summary: manual.summary,
       body: manual.body,
       state: manual.state,
+      tags: manual.tags
     }
   end
 

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -1,3 +1,5 @@
+require "tag_fetcher"
+
 class PublishManualService
   def initialize(dependencies)
     @manual_id = dependencies.fetch(:manual_id)
@@ -8,6 +10,7 @@ class PublishManualService
 
   def call
     if versions_match?
+      update_manual_with_tags
       publish
       notify_listeners
       persist
@@ -36,6 +39,19 @@ private
 
   def publish
     manual.publish
+  end
+
+  def tags
+    TagFetcher.new(manual).tags.map { |t|
+      {
+        type: t.details.type,
+        slug: t.slug,
+      }
+    }
+  end
+
+  def update_manual_with_tags
+    manual.update({tags: tags})
   end
 
   def persist

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,7 +1,9 @@
 require "gds_api/test_helpers/publishing_api"
+require "gds_api/test_helpers/content_api"
 
 module ManualHelpers
   include GdsApi::TestHelpers::PublishingApi
+  include GdsApi::TestHelpers::ContentApi
 
   def manual_repository
     SpecialistPublisherWiring.get(:repository_registry).manual_repository
@@ -74,6 +76,7 @@ module ManualHelpers
   end
 
   def publish_manual
+    content_api_does_not_have_manual
     click_on "Publish manual"
   end
 
@@ -81,6 +84,10 @@ module ManualHelpers
     stub_rummager
     stub_publishing_api
     stub_organisation_details(organisation_slug)
+  end
+
+  def content_api_does_not_have_manual
+    content_api_does_not_have_an_artefact("guidance/example-manual-title")
   end
 
   def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")

--- a/spec/lib/tag_fetcher_spec.rb
+++ b/spec/lib/tag_fetcher_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "tag_fetcher"
+require "gds_api/test_helpers/content_api"
+require "webmock/rspec"
+
+describe TagFetcher do
+
+  include GdsApi::TestHelpers::ContentApi
+
+  describe "tag fetching" do
+
+    let(:manual) {
+      Manual.new({
+        id: "guidance/style-guide",
+        slug: "guidance/style-guide",
+        title: "Style guide",
+        summary: "A summary",
+        body: "A body",
+        organisation_slug: "cabinet-office",
+        state: "draft",
+      })
+    }
+
+    let(:slug) { "guidance/style-guide" }
+    let(:tag_slug) { "government-digital-guidance/content-publishing" }
+
+    before do
+      WebMock.disable_net_connect!
+
+      artefact = artefact_for_slug(slug).merge(
+        "title" => @title,
+        "format" => "manual",
+        "details" => {
+          "body" => "<p>Body content</p>\n",
+          "summary" => "Summary of document",
+          "updated_at" => "2014-10-24T08:41:18Z",
+          "published_at" => "2014-10-24T08:41:18Z",
+        },
+        "tags" => [
+          {
+            "id" => "https://www.gov.uk/api/tags/specialist_sector/government-digital-guidance%2Fcontent-publishing.json",
+            "slug" => tag_slug,
+            "web_url" => "https://www.gov.uk/topic/government-digital-guidance/content-publishing",
+            "title" => "Content and publishing",
+          }
+        ]
+      )
+
+      content_api_has_an_artefact(
+        slug,
+        artefact
+      )
+    end
+
+    it "fetches tags for given manual" do
+      tags = TagFetcher.new(manual).tags
+
+      expect(tags.map(&:slug)).to eq([tag_slug])
+    end
+
+  end
+
+end

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -93,4 +93,20 @@ describe ManualRecord, hits_db: true do
       expect(ManualRecord.all_by_updated_at.to_a).to eq([later_edition, middle_edition, early_edition])
     end
   end
+
+  describe "#tags" do
+
+    it "can store tags" do
+      tags = [
+        {
+          type: "A tag type",
+          slug: "a-tag-slug",
+        }
+      ]
+
+      record.editions.create!(tags: tags)
+
+      expect(record.latest_edition.tags).to eq(tags)
+    end
+  end
 end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -13,6 +13,7 @@ describe Manual do
       organisation_slug: organisation_slug,
       state: state,
       updated_at: updated_at,
+      tags: []
     )
   }
 
@@ -63,6 +64,7 @@ describe Manual do
         state: state,
         updated_at: updated_at,
         version_number: 0,
+        tags: [],
       )
     end
   end

--- a/spec/repositories/manual_repository_spec.rb
+++ b/spec/repositories/manual_repository_spec.rb
@@ -34,6 +34,7 @@ describe ManualRepository do
       body: "body",
       organisation_slug: "organisation_slug",
       slug: manual_slug,
+      tags: []
     }
   }
 
@@ -48,6 +49,7 @@ describe ManualRepository do
       :"slug=" => nil,
       latest_edition: nil,
       save!: nil,
+      tags: [],
     )
   }
 
@@ -102,7 +104,7 @@ describe ManualRepository do
       repo.store(manual)
 
       expect(edition).to have_received(:attributes=)
-        .with(manual_attributes.slice(:title, :summary, :state, :body))
+        .with(manual_attributes.slice(:title, :summary, :state, :body, :tags))
     end
 
     it "sets the slug" do


### PR DESCRIPTION
In order for Manuals to appear on topic pages we need to fetch the topics in Content API and send those to Rummager when publishing. This PR adds a `TagFetcher` class which gets the tags and modifies the Manual before saving and publishing it.

The last commit has some shoddy stubbing at a random step. This looks a bit weird but I couldn't figure out where to stub this anywhere else that would result in my tests passing.

Paired on this with @KushalP. [Ticket](https://trello.com/c/QtMO88Uj/73-manuals-are-currently-topic-sub-topic-tagged-in-panopticon-so-the-details-of-the-tags-cannot-be-sent-to-rummager-when-the-manual).