### PR TITLE
Add link to content preview for draft items.

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -7,5 +7,15 @@
     display: block;
     margin-top: 5px;
     font-weight: normal;
+    padding: 0;
+
+    & li {
+      display: inline;
+      list-style: none;
+
+      & + li:before {
+        content: "– ";
+      }
+    }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,6 +79,10 @@ module ApplicationHelper
     "#{Plek.current.website_root}/government/organisations/#{organisation_slug}"
   end
 
+  def content_preview_url(document)
+    "#{Plek.current.find("draft-origin")}/#{document.slug}"
+  end
+
   def publish_form(slug_unique, publishable, document)
     publish_form_text = publish_text_hash(document)
     if !current_user_can_publish?(document.document_type) || !slug_unique || !publishable

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -3,14 +3,7 @@
   <li class='active'><%= manual.title %></li>
 <% end %>
 
-<h1 class="page-header">
-  <%= manual.title %>
-  <% if manual.state == 'published' %>
-    <span class='document-slug'><%= link_to manual.slug, url_for_public_manual(manual) %></span>
-  <% else %>
-    <span class='document-slug' title='When published this manual will appear here.'><%= manual.slug %></span>
-  <% end %>
-</h1>
+<%= render partial: "shared/title", locals: { document: manual, public_url: url_for_public_manual(manual) } %>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,0 +1,13 @@
+<h1 class="page-header"><%= document.title %>
+  <ul class='document-slug'>
+    <li title='<% if !document.published? %>When published this document will appear at this URL<% end %>'>
+      <%= document.slug %>
+    </li>
+    <% if document.published? %>
+      <li><%= link_to "View on website", public_url %></li>
+    <% end %>
+    <% if document.draft? %>
+      <li><%= link_to "Preview draft", content_preview_url(document) %></li>
+    <% end %>
+  </li>
+</h1>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -3,15 +3,8 @@
   <li class='active'><%= document.title %></li>
 <% end %>
 
-<h1 class="page-header"><%= document.title %>
-<% if document.publication_state == "published" %>
-  <span class='document-slug'>
-    <%= link_to document.slug, published_specialist_document_path(document) %>
-  </span>
-<% else %>
-  <span class='document-slug' title='When published this document will appear at this URL'><%= document.slug %></span>
-<% end %>
-</h1>
+<%= render partial: "shared/title", locals: { document: document, public_url: published_specialist_document_path(document) } %>
+
 <div class="row">
   <div class="col-md-8">
     <h2>Summary</h2>

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -10,6 +10,7 @@ Feature: Creating and editing a CMA case
     When I create a CMA case
     Then the CMA case has been created
     And the document should be sent to content preview
+    And I should see a link to preview the document
 
   Scenario: Cannot create a CMA case with invalid fields
     When I create a CMA case with invalid fields

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -10,6 +10,7 @@ Feature: Creating and editing a manual
     When I create a manual
     Then the manual should exist
     And the manual should have been sent to the draft publishing api
+    And I should see a link to preview the manual
 
   Scenario: Edit a draft manual
     Given a draft manual exists without any documents

--- a/features/publishing-a-cma-case.feature
+++ b/features/publishing-a-cma-case.feature
@@ -19,6 +19,7 @@ Feature: Publishing a CMA case
   Scenario: can create a new CMA case and publish immediately
     When I publish a new CMA case
     Then the CMA case should be published
+    And I should see a link to the live document
 
   Scenario: immediately republish a published case
     When I publish a new CMA case

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -10,6 +10,7 @@ Feature: Publishing a manual
     Given a draft manual exists with some documents
     When I publish the manual
     Then the manual and all its documents are published
+    And I should see a link to the live manual
 
   Scenario: Edit and re-publish a manual
     Given a published manual exists

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -46,3 +46,11 @@ end
 Then(/^the document should be sent to content preview/) do
   check_document_published_to_publishing_api(@slug, @document_fields, draft: true)
 end
+
+Then(/^I should see a link to preview the document$/) do
+  check_content_preview_link(@slug)
+end
+
+Then(/^I should see a link to the live document$/) do
+  check_live_link(@slug)
+end

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -12,6 +12,10 @@ Then(/^the manual should exist$/) do
   check_manual_exists_with(@manual_fields)
 end
 
+Then(/^I should see a link to preview the manual$/) do
+  check_content_preview_link(@manual_slug)
+end
+
 Then(/^the manual should have been sent to the draft publishing api$/) do
   check_manual_is_published_to_publishing_api(@manual_slug, draft: true)
 end
@@ -301,6 +305,10 @@ Then(/^the manual and its new document are published$/) do
     @new_document[:slug],
     @new_document[:fields],
   )
+end
+
+Then(/^I should see a link to the live manual$/) do
+  check_live_link(@manual_slug)
 end
 
 Given(/^a published manual exists$/) do

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -31,7 +31,8 @@ module DocumentHelpers
   def check_for_unchanged_slug(title, expected_slug)
     go_to_show_page_for_cma_case(title)
 
-    expect(page).to have_link(expected_slug)
+    expected_link = "#{Plek.current.website_root}/#{expected_slug}"
+    expect(page).to have_link("View on website", href: expected_link)
   end
 
   def check_document_published_to_publishing_api(slug, fields, draft: false)
@@ -111,6 +112,16 @@ module DocumentHelpers
 
   def check_for_invalid_date_error(date_field)
     page.should have_content("#{date_field} should be formatted YYYY-MM-DD")
+  end
+
+  def check_content_preview_link(slug)
+    preview_url = "#{Plek.current.find("draft-origin")}/#{slug}"
+    expect(page).to have_link("Preview draft", href: preview_url)
+  end
+
+  def check_live_link(slug)
+    live_url = "#{Plek.current.website_root}/#{slug}"
+    expect(page).to have_link("View on website", href: live_url)
   end
 
   def check_document_is_published(slug, fields)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -138,6 +138,16 @@ module ManualHelpers
     expect(page).to have_content("#{field.titlecase} can't be blank")
   end
 
+  def check_content_preview_link(slug)
+    preview_url = "#{Plek.current.find("draft-origin")}/#{slug}"
+    expect(page).to have_link("Preview draft", href: preview_url)
+  end
+
+  def check_live_link(slug)
+    live_url = "#{Plek.current.website_root}/#{slug}"
+    expect(page).to have_link("View on website", href: live_url)
+  end
+
   def go_to_manual_page(manual_title)
     visit manuals_path
     click_link manual_title


### PR DESCRIPTION
**Don't merge until the change has been communicated to departments.**

Modifies the show page for manuals and specialist docs so that the slug
is no longer a link, and add "View on website" and "Preview draft" links
next to it. The former only shows if the item has been published, and
the latter only if there is an unpublished draft.

![image](https://cloud.githubusercontent.com/assets/131395/9107093/9fb7053c-3c1c-11e5-9e07-73247523ec8a.png)
