### PR TITLE
Remove spurious line from ESI fund spec

### DIFF
--- a/spec/exporters/formatters/esi_fund_publication_alert_formatter_spec.rb
+++ b/spec/exporters/formatters/esi_fund_publication_alert_formatter_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe EsiFundPublicationAlertFormatter do
   }
   let(:document) {
     double(:document,
-      alert_type: "drugs",
       title: "Some title",
       extra_fields: {},
       document_type: "esi_fund",


### PR DESCRIPTION
This seems to have been copy-pasta'd from the medical safety alert spec.