### PR TITLE
Add leading slash to slugs when sending to Rummager

### DIFF
--- a/app/exporters/formatters/abstract_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_indexable_formatter.rb
@@ -42,7 +42,11 @@ private
   end
 
   def link
-    entity.slug
+    with_leading_slash(entity.slug)
+  end
+
+  def with_leading_slash(slug)
+    slug.start_with?("/") ? slug : "/#{slug}"
   end
 
   def indexable_content

--- a/app/exporters/formatters/manual_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_indexable_formatter.rb
@@ -21,6 +21,10 @@ private
   end
 
   def specialist_sectors
-    entity.tags.select { |t| t[:type] == "specialist_sector" }.map { |t| t[:slug] }
+    if entity.tags.present?
+      entity.tags.select { |t| t[:type] == "specialist_sector" }.map { |t| t[:slug] }
+    else
+      []
+    end
   end
 end

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -31,6 +31,10 @@ private
   end
 
   def link
-    section.slug
+    with_leading_slash(section.slug)
+  end
+
+  def with_leading_slash(slug)
+    slug.start_with?("/") ? slug : "/#{slug}"
   end
 end

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -1,6 +1,8 @@
-class ManualSectionIndexableFormatter
+require "formatters/abstract_indexable_formatter"
+
+class ManualSectionIndexableFormatter < AbstractIndexableFormatter
   def initialize(section, manual)
-    @section = section
+    @entity = section
     @manual = manual
   end
 
@@ -8,33 +10,36 @@ class ManualSectionIndexableFormatter
     "manual_section"
   end
 
-  def id
-    link
-  end
+private
+  attr_reader :manual
 
-  def indexable_attributes
+  def extra_attributes
     {
-      title: "#{manual.title}: #{section.title}",
-      description: section.summary,
-      link: link,
-      indexable_content: section.body,
-      organisations: [manual.organisation_slug],
       manual: manual.slug,
     }
   end
 
-private
-  attr_reader :section, :manual
+  def title
+    "#{manual.title}: #{entity.title}"
+  end
 
-  def extra_attributes
-    {}
+  def description
+    entity.summary
   end
 
   def link
-    with_leading_slash(section.slug)
+    with_leading_slash(entity.slug)
   end
 
-  def with_leading_slash(slug)
-    slug.start_with?("/") ? slug : "/#{slug}"
+  def indexable_content
+    entity.body
+  end
+
+  def last_update
+    nil
+  end
+
+  def organisation_slugs
+    [manual.organisation_slug]
   end
 end

--- a/bin/fix_rummager_ids_and_links
+++ b/bin/fix_rummager_ids_and_links
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "logger"
+
+require "manual_service_registry"
+
+require "specialist_publisher"
+require "specialist_publisher_wiring"
+
+# Script to fix id and link fields being sent to Rummager without the leading
+# slash. Because the ids are changing, we need to add the documents to Rummager
+# with their new ids and then delete the old documents.
+#
+# For each manual and specialist document:
+# - republish
+# - delete the old document from rummager (for the slug without leading slash)
+
+logger = Logger.new(STDOUT)
+logger.formatter = Logger::Formatter.new
+
+rummager = SpecialistPublisherWiring.get(:rummager_api)
+
+# Manuals
+
+repository = SpecialistPublisherWiring.get(:repository_registry).manual_repository
+count = repository.all.count
+
+logger.info "Migrating #{count} manuals..."
+
+repository.all.each.with_index do |manual, i|
+  logger.info("[% 2d/%d] id=%s slug=%s" % [i + 1, count, manual.id, manual.slug])
+  ManualServiceRegistry.new.republish(manual.id).call
+
+  rummager.delete_document("manual", manual.slug)
+  # The sections are republished along with the manual, but need cleaning up in
+  # Rummager separately:
+  manual.documents.each do |document|
+    rummager.delete_document("manual_section", document.slug)
+  end
+end
+
+logger.info "Migrating of #{count} manuals complete."
+
+# Specialist documents
+
+document_types = SpecialistPublisher.document_types
+
+logger.info "Migrating all specialist documents..."
+
+document_types.each.with_index do |type, format_index|
+  logger.info("Format % 2d/%d: %s" % [format_index + 1, document_types.size, type])
+
+  repository = SpecialistPublisherWiring.get(:repository_registry).for_type(type)
+  count = repository.all.count
+  logger.info "Migrating #{count} #{type}s..."
+
+  services = SpecialistPublisher.document_services(type)
+  repository.all.each.with_index do |document, document_index|
+    logger.info("    [% 5d/%d] id=%s slug=%s" % [document_index + 1, count, document.id, document.slug])
+    services.republish(document.id).call
+
+    rummager.delete_document(type, document.slug)
+  end
+
+  logger.info "Migration of all #{type}s complete."
+end
+
+logger.info "Migration of all specialist documents complete."

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -74,7 +74,7 @@ module DocumentHelpers
       )
 
     expect(fake_rummager).to have_received(:add_document)
-      .with(document_type, slug, hash_including(rummager_fields))
+      .with(document_type, "/#{slug}", hash_including(rummager_fields))
   end
 
   def check_for_correctly_archived_editions(document_attrs)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -165,10 +165,10 @@ module ManualHelpers
     expect(fake_rummager).to have_received(:add_document)
       .with(
         "manual",
-        slug,
+        "/#{slug}",
         hash_including(
           title: attrs.fetch(:title),
-          link: slug,
+          link: "/#{slug}",
           indexable_content: attrs.fetch(:summary),
         )
       ).at_least(:once)
@@ -204,10 +204,10 @@ module ManualHelpers
     expect(fake_rummager).to have_received(:add_document)
       .with(
         "manual_section",
-        slug,
+        "/#{slug}",
         hash_including(
           title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:section_title)}",
-          link: slug,
+          link: "/#{slug}",
           indexable_content: attrs.fetch(:section_body),
         )
       ).at_least(:once)
@@ -317,14 +317,14 @@ module ManualHelpers
     expect(fake_rummager).to have_received(:delete_document)
       .with(
         "manual",
-        manual_slug,
+        "/#{manual_slug}",
       )
 
     attributes_for_documents.each do |document_attributes|
       expect(fake_rummager).to have_received(:delete_document)
         .with(
           "manual_section",
-          document_attributes[:slug],
+          "/#{document_attributes[:slug]}",
         )
     end
   end

--- a/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples_for "a specialist document indexable formatter" do
 
     before do
       allow(document).to receive(:updated_at).and_return(updated_at)
+      allow(document.slug).to receive(:start_with?).and_return(false)
     end
 
     it "returns the document's public_updated_at if available" do


### PR DESCRIPTION
This adds the leading slash to the slug for the `id` and `link` fields when formatting manuals, manual sections and specialist documents to send to Rummager (finders already use the full `base_path`) and adds a script to migrate the existing documents in Rummager to the new format.

See the commit messages for the full details.

A [temporary workaround](https://github.com/alphagov/rummager/pull/479) for the broken links due to missing leading slashes has recently been deployed in Rummager, but we need to fix the data at source. This issue is fixed for HMRC manuals in a [PR on the API](https://github.com/alphagov/hmrc-manuals-api/pull/94).