### PR TITLE
Send finders description to Content Store

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -34,7 +34,7 @@ private
   end
 
   def description
-    ""
+    metadata.fetch("description", "")
   end
 
   def details


### PR DESCRIPTION
Finders have a description and should be sent to Content Store at the moment of
publishing.

Having the description stored in Content Store means that Finder Frontend will
be able to access it and use it (i.e., when generating a Finder's metadata for
search engines).

Part of: https://trello.com/c/zFUIJFaJ/287-add-meta-description-tags-to-finders