### PR TITLE
Show preview link when manual's document is draft

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,14 @@ module ApplicationHelper
 
   end
 
+  def show_preview?(item)
+    if item.respond_to?(:documents)
+      item.draft? || item.documents.any?(&:draft?)
+    else
+      item.draft?
+    end
+  end
+
   def publication_task_state(task)
     zoned_time = time_with_local_zone(task.updated_at)
     formatted_time = nice_time_format(zoned_time)

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -6,7 +6,7 @@
     <% if document.published? %>
       <li><%= link_to "View on website", public_url %></li>
     <% end %>
-    <% if document.draft? %>
+    <% if show_preview?(document) %>
       <li><%= link_to "Preview draft", content_preview_url(document) %></li>
     <% end %>
   </li>

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -120,3 +120,8 @@ Feature: Creating and editing a manual
     When I reorder the documents
     Then the order of the documents in the manual should have been updated
     And the new order should be visible in the preview environment
+
+  Scenario: Editing a manual document
+    Given a published manual exists
+    When I edit one of the manual's documents
+    Then I should see a link to preview the manual


### PR DESCRIPTION
Previously the preview link would only display when the manual itself
was edited; an edit to a document belonging to that manual does not
change the draft status of the manual itself so the preview link would
not be displayed. Changed the logic so that it also checks the child
documents' statuses.