### PR TITLE
GDS editors can add attachments to any Manual

### DIFF
--- a/app/controllers/manual_document_attachments_controller.rb
+++ b/app/controllers/manual_document_attachments_controller.rb
@@ -41,6 +41,18 @@ class ManualDocumentAttachmentsController < ApplicationController
 
 private
   def services
+    if current_user_is_gds_editor?
+      gds_editor_services
+    else
+      organisational_services
+    end
+  end
+
+  def gds_editor_services
+    ManualDocumentAttachmentServiceRegistry.new
+  end
+
+  def organisational_services
     OrganisationalManualDocumentAttachmentServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )

--- a/app/controllers/manual_document_attachments_controller.rb
+++ b/app/controllers/manual_document_attachments_controller.rb
@@ -41,6 +41,8 @@ class ManualDocumentAttachmentsController < ApplicationController
 
 private
   def services
-    ManualDocumentAttachmentServiceRegistry.new
+    OrganisationalManualDocumentAttachmentServiceRegistry.new(
+      organisation_slug: current_organisation_slug,
+    )
   end
 end

--- a/app/services/abstract_manual_document_attachment_service_registry.rb
+++ b/app/services/abstract_manual_document_attachment_service_registry.rb
@@ -1,0 +1,36 @@
+require "create_manual_document_attachment_service"
+require "update_manual_document_attachment_service"
+require "show_manual_document_attachment_service"
+require "new_manual_document_attachment_service"
+
+class AbstractManualDocumentAttachmentServiceRegistry
+  def create(context)
+    CreateManualDocumentAttachmentService.new(
+      repository,
+      context,
+    )
+  end
+
+  def update(context)
+    UpdateManualDocumentAttachmentService.new(
+      repository,
+      context,
+    )
+  end
+
+  def show(context)
+    ShowManualDocumentAttachmentService.new(
+      repository,
+      context,
+    )
+  end
+
+  def new(context)
+    NewManualDocumentAttachmentService.new(
+      repository,
+      # TODO: This be should be created from the document or just be a form object
+      Attachment.method(:new),
+      context,
+    )
+  end
+end

--- a/app/services/manual_document_attachment_service_registry.rb
+++ b/app/services/manual_document_attachment_service_registry.rb
@@ -1,46 +1,7 @@
-require "create_manual_document_attachment_service"
-require "update_manual_document_attachment_service"
-require "show_manual_document_attachment_service"
-require "new_manual_document_attachment_service"
-
-class ManualDocumentAttachmentServiceRegistry
-  def create(context)
-    CreateManualDocumentAttachmentService.new(
-      manual_repository(context),
-      context,
-    )
-  end
-
-  def update(context)
-    UpdateManualDocumentAttachmentService.new(
-      manual_repository(context),
-      context,
-    )
-  end
-
-  def show(context)
-    ShowManualDocumentAttachmentService.new(
-      manual_repository(context),
-      context,
-    )
-  end
-
-  def new(context)
-    NewManualDocumentAttachmentService.new(
-      manual_repository(context),
-      # TODO: This be should be created from the document or just be a form object
-      Attachment.method(:new),
-      context,
-    )
-  end
+class ManualDocumentAttachmentServiceRegistry < AbstractManualDocumentAttachmentServiceRegistry
 
 private
-  def manual_repository_factory
-    SpecialistPublisherWiring.get(:repository_registry).
-      organisation_scoped_manual_repository_factory
-  end
-
-  def manual_repository(context)
-    manual_repository_factory.call(context.current_organisation_slug)
+  def repository
+    SpecialistPublisherWiring.get(:repository_registry).manual_repository
   end
 end

--- a/app/services/organisational_manual_document_attachment_service_registry.rb
+++ b/app/services/organisational_manual_document_attachment_service_registry.rb
@@ -1,0 +1,17 @@
+class OrganisationalManualDocumentAttachmentServiceRegistry < AbstractManualDocumentAttachmentServiceRegistry
+  def initialize(dependencies)
+    @organisation_slug = dependencies.fetch(:organisation_slug)
+  end
+
+private
+  attr_reader :organisation_slug
+
+  def manual_repository_factory
+    SpecialistPublisherWiring.get(:repository_registry)
+      .organisation_scoped_manual_repository_factory
+  end
+
+  def repository
+    manual_repository_factory.call(organisation_slug)
+  end
+end

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -1,14 +1,12 @@
 Feature: Attachments
-  As a CMA editor
+  As an editor
   I want to upload an attachment to a case via the publisher
   So that users can access the supporting documents
 
-  Background:
-    Given I am logged in as a "CMA" editor
-
   @javascript
   Scenario: CMA editor can add attachment to case
-    Given there is an existing draft case
+    Given I am logged in as a "CMA" editor
+    And there is an existing draft case
     When I attach a file and give it a title
     Then I see the attachment on the page with its example markdown embed code
     When I copy+paste the embed code into the body of the case
@@ -18,13 +16,15 @@ Feature: Attachments
     Then the attachments from the previous edition remain
 
   Scenario: CMA editor can replace and attachment
-    Given there is a published case with an attachment
+    Given I am logged in as a "CMA" editor
+    And there is a published case with an attachment
     When I edit the attachment
     Then I see the updated attachment on the document edit page
 
   @regression
   Scenario: CMA editor can add and replace attachment to manual
-    Given a draft manual exists without any documents
+    Given I am logged in as a "CMA" editor
+    And a draft manual exists without any documents
     And a draft document exists for the manual
     When I attach a file and give it a title
     Then I see the attached file

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -30,3 +30,13 @@ Feature: Attachments
     Then I see the attached file
     When I edit the attachment
     Then I see the updated attachment on the document edit page
+
+  @regression
+  Scenario: GDS editor can add attachment to manual from another Org
+    Given a draft manual exists belonging to "ministry-of-tea"
+    And I am logged in as a "GDS" editor
+    And a draft document exists for the manual
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page


### PR DESCRIPTION
When the User comes to add an attachment, if they were a GDS editor editing a non GDS manual then this would come back with a "Manual not found". This commit fixes that by using a new registry which isn't scoped to an organisation for GDS editors.

This approach introduces some duplication. This is intended as it keeps the attachment code similar to the code that deals with manuals. The hope this is that this duplication can be removed more easily at a later date. 

This PR also refactors the background in some feature tests to make them less tied to CMA. 

[Ticket](https://trello.com/c/yo9nTcYO/85-attachments-can-t-be-added-to-manual-sections).