### PR TITLE
Fix script to correctly delete old ESIF document

### DIFF
--- a/bin/fix_rummager_ids_and_links
+++ b/bin/fix_rummager_ids_and_links
@@ -60,7 +60,9 @@ document_types.each.with_index do |type, format_index|
     logger.info("    [% 5d/%d] id=%s slug=%s" % [document_index + 1, count, document.id, document.slug])
     services.republish(document.id).call
 
-    rummager.delete_document(type, document.slug)
+    search_format = type == "esi_fund" ? "european_structural_investment_fund" : type
+
+    rummager.delete_document(search_format, document.slug)
   end
 
   logger.info "Migration of all #{type}s complete."


### PR DESCRIPTION
The script to fix the missing leading slash on the `id` and `link` fields sent to
Rummager used the document type from `SpecialistPublisher.document_types` as the
type when deleting the old documents from Rummager. For ESIF documents the
type name is different in the indexable formatter from that in
`SpecialistPublisher.document_types`, so the old documents were not correctly
deleted from Rummager, leaving them as duplicates after the script had been
run to create the documents with the new id.

This change to the existing script will ensure that the old ESIF documents are
correctly deleted. All other formats have the same type name in both places so
ESIF is a special case here. The indexable formatter for a document type isn't
available directly from the wiring, so this is the simplest change to get the
correct type name in the script.

I've made this change to the existing script rather than writing a new one so
that it's clearer in future that the original script did the wrong thing.

/cc @boffbowsh - I've run the script again in dev and the duplicates have gone.