### PR TITLE
  Add asylum support tribunal decisions finder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ class ApplicationController < ActionController::Base
 
   def finders
     {
+      "asylum-support-decisions" => {
+        document_type: "asylum_support_decision",
+        title: "Asylum Support Decisions",
+      },
       "aaib-reports" => {
         document_type: "aaib_report",
         title: "AAIB Reports",

--- a/app/controllers/asylum_support_decisions_controller.rb
+++ b/app/controllers/asylum_support_decisions_controller.rb
@@ -1,0 +1,2 @@
+class AsylumSupportDecisionsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -1,0 +1,23 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class AsylumSupportDecisionIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+  def type
+    "asylum_support_decision"
+  end
+
+private
+  def extra_attributes
+    {
+      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
+      tribunal_decision_judges: entity.tribunal_decision_judges,
+      tribunal_decision_category: entity.tribunal_decision_category,
+      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
+      tribunal_decision_landmark: entity.tribunal_decision_landmark,
+      tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
+    }
+  end
+
+  def organisation_slugs
+    ["first-tier-tribunal-asylum-support"]
+  end
+end

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -14,6 +14,7 @@ private
       tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
+      indexable_content: entity.hidden_indexable_content || entity.body
     }
   end
 

--- a/app/exporters/formatters/asylum_support_decision_publication_alert_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class AsylumSupportDecisionPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "First-tier Tribunal (Asylum Support) decisions"
+  end
+
+private
+  def document_noun
+    "decision"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -4,6 +4,8 @@ class PermissionChecker
 
   def self.owning_organisations_for_format(format)
     case format
+    when "asylum_support_decision"
+      ["first-tier-tribunal-asylum-support"]
     when "cma_case"
       ["competition-and-markets-authority"]
     when "aaib_report"

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -23,8 +23,8 @@ module SpecialistPublisher
     OBSERVER_MAP.keys
   end
 
+private
   OBSERVER_MAP = {
-    "asylum_support_decision" => AsylumSupportDecisionObserversRegistry,
     "aaib_report" => AaibReportObserversRegistry,
     "asylum_support_decision" => AsylumSupportDecisionObserversRegistry,
     "cma_case" => CmaCaseObserversRegistry,
@@ -37,8 +37,6 @@ module SpecialistPublisher
     "raib_report" => RaibReportObserversRegistry,
     "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertObserversRegistry,
   }.freeze
-
-  private
 
   def view_adapters
     SpecialistPublisherWiring.get(:view_adapter_registry)

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -23,9 +23,10 @@ module SpecialistPublisher
     OBSERVER_MAP.keys
   end
 
-private
   OBSERVER_MAP = {
+    "asylum_support_decision" => AsylumSupportDecisionObserversRegistry,
     "aaib_report" => AaibReportObserversRegistry,
+    "asylum_support_decision" => AsylumSupportDecisionObserversRegistry,
     "cma_case" => CmaCaseObserversRegistry,
     "countryside_stewardship_grant" => CountrysideStewardshipGrantObserversRegistry,
     "drug_safety_update" => DrugSafetyUpdateObserversRegistry,
@@ -36,6 +37,8 @@ private
     "raib_report" => RaibReportObserversRegistry,
     "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertObserversRegistry,
   }.freeze
+
+  private
 
   def view_adapters
     SpecialistPublisherWiring.get(:view_adapter_registry)

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -119,6 +119,11 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
       get(:validatable_document_factories).vehicle_recalls_and_faults_alert_factory)
   }
 
+  define_factory(:asylum_support_decision_builder) {
+    SpecialistDocumentBuilder.new("asylum_support_decision",
+      get(:validatable_document_factories).asylum_support_decision_factory)
+  }
+
   define_instance(:markdown_attachment_renderer) {
     MarkdownAttachmentProcessor.method(:new)
   }
@@ -244,6 +249,10 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:vehicle_recalls_and_faults_alert_finder_schema) {
     FinderSchema.new(Rails.root.join("finders/schemas/vehicle-recalls-and-faults-alert.json"))
+  }
+
+  define_singleton(:asylum_support_decision_finder_schema) {
+    FinderSchema.new(Rails.root.join("finders/schemas/asylum-support-decisions.json"))
   }
 
   define_singleton(:organisations_api) {

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -1,0 +1,12 @@
+require "document_metadata_decorator"
+
+class AsylumSupportDecision < DocumentMetadataDecorator
+  set_extra_field_names [
+    :tribunal_decision_decision_date,
+    :tribunal_decision_judges,
+    :tribunal_decision_category,
+    :tribunal_decision_sub_category,
+    :tribunal_decision_landmark,
+    :tribunal_decision_reference_number
+  ]
+end

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -7,6 +7,7 @@ class AsylumSupportDecision < DocumentMetadataDecorator
     :tribunal_decision_category,
     :tribunal_decision_sub_category,
     :tribunal_decision_landmark,
-    :tribunal_decision_reference_number
+    :tribunal_decision_reference_number,
+    :hidden_indexable_content
   ]
 end

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -12,6 +12,7 @@ require "validators/medical_safety_alert_validator"
 require "validators/null_validator"
 require "validators/raib_report_validator"
 require "validators/vehicle_recalls_and_faults_alert_validator"
+require "validators/asylum_support_decision_validator"
 
 require "builders/manual_document_builder"
 require "manual_with_documents"
@@ -25,6 +26,7 @@ require "cma_case"
 require "drug_safety_update"
 require "medical_safety_alert"
 require "international_development_fund"
+require "asylum_support_decision"
 
 class DocumentFactoryRegistry
   def aaib_report_factory
@@ -171,6 +173,21 @@ class DocumentFactoryRegistry
               SlugGenerator.new(prefix: "vehicle-recalls-faults"),
               *args,
             )
+          )
+        )
+      )
+    }
+  end
+
+  def asylum_support_decision_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        AsylumSupportDecisionValidator.new(
+          AsylumSupportDecision.new(
+            SpecialistDocument.new(
+              SlugGenerator.new(prefix: "asylum-support-decisions"),
+              *args,
+            ),
           )
         )
       )

--- a/app/models/validators/asylum_support_decision_validator.rb
+++ b/app/models/validators/asylum_support_decision_validator.rb
@@ -1,0 +1,19 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class AsylumSupportDecisionValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+  validates :tribunal_decision_decision_date, presence: true
+  validates :tribunal_decision_judges, presence: true
+  validates :tribunal_decision_category, presence: true
+  validates :tribunal_decision_sub_category, presence: true
+  validates :tribunal_decision_landmark, presence: true
+  validates :tribunal_decision_reference_number, presence: true
+
+end

--- a/app/observers/asylum_support_decision_observers_registry.rb
+++ b/app/observers/asylum_support_decision_observers_registry.rb
@@ -1,0 +1,24 @@
+require "formatters/asylum_support_decision_indexable_formatter"
+require "formatters/asylum_support_decision_publication_alert_formatter"
+require "markdown_attachment_processor"
+
+class AsylumSupportDecisionObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+private
+  def finder_schema
+    SpecialistPublisherWiring.get(:asylum_support_decision_finder_schema)
+  end
+
+  def format_document_for_indexing(document)
+    AsylumSupportDecisionIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
+  end
+
+  def publication_alert_formatter(document)
+    AsylumSupportDecisionPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/asylum_support_decision_view_adapter.rb
+++ b/app/view_adapters/asylum_support_decision_view_adapter.rb
@@ -10,6 +10,7 @@ class AsylumSupportDecisionViewAdapter < DocumentViewAdapter
     :tribunal_decision_sub_category,
     :tribunal_decision_landmark,
     :tribunal_decision_reference_number,
+    :hidden_indexable_content,
   ]
 
   def self.model_name

--- a/app/view_adapters/asylum_support_decision_view_adapter.rb
+++ b/app/view_adapters/asylum_support_decision_view_adapter.rb
@@ -1,0 +1,30 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class AsylumSupportDecisionViewAdapter < DocumentViewAdapter
+  attributes = [
+    :tribunal_decision_decision_date,
+    :tribunal_decision_judges,
+    :tribunal_decision_category,
+    :tribunal_decision_sub_category,
+    :tribunal_decision_landmark,
+    :tribunal_decision_reference_number,
+  ]
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "AsylumSupportDecision")
+  end
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:asylum_support_decision_finder_schema)
+  end
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -17,6 +17,7 @@ class ViewAdapterRegistry
       "medical_safety_alert" => MedicalSafetyAlertViewAdapter,
       "raib_report" => RaibReportViewAdapter,
       "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertViewAdapter,
-    }.fetch(type)
+       "asylum_support_decision" => AsylumSupportDecisionViewAdapter,
+   }.fetch(type)
   end
 end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -3,21 +3,22 @@ class ViewAdapterRegistry
     get(document.document_type).new(document)
   end
 
-  private
+private
+  VIEW_ADAPTER_MAP = {
+    "aaib_report" => AaibReportViewAdapter,
+    "asylum_support_decision" => AsylumSupportDecisionViewAdapter,
+    "cma_case" => CmaCaseViewAdapter,
+    "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
+    "drug_safety_update" => DrugSafetyUpdateViewAdapter,
+    "esi_fund" => EsiFundViewAdapter,
+    "international_development_fund" => InternationalDevelopmentFundViewAdapter,
+    "maib_report" => MaibReportViewAdapter,
+    "medical_safety_alert" => MedicalSafetyAlertViewAdapter,
+    "raib_report" => RaibReportViewAdapter,
+    "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertViewAdapter,
+  }.freeze
 
   def get(type)
-    {
-      "aaib_report" => AaibReportViewAdapter,
-      "cma_case" => CmaCaseViewAdapter,
-      "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
-      "drug_safety_update" => DrugSafetyUpdateViewAdapter,
-      "esi_fund" => EsiFundViewAdapter,
-      "international_development_fund" => InternationalDevelopmentFundViewAdapter,
-      "maib_report" => MaibReportViewAdapter,
-      "medical_safety_alert" => MedicalSafetyAlertViewAdapter,
-      "raib_report" => RaibReportViewAdapter,
-      "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertViewAdapter,
-       "asylum_support_decision" => AsylumSupportDecisionViewAdapter,
-   }.fetch(type)
+    VIEW_ADAPTER_MAP.fetch(type)
   end
 end

--- a/app/views/asylum_support_decisions/_form.html.erb
+++ b/app/views/asylum_support_decisions/_form.html.erb
@@ -1,0 +1,24 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+    <%= render partial: "shared/form_errors", locals: { object: document } %>
+    <%= render partial: "shared/form_fields", locals: { f: f } %>
+    <%= render partial: "shared/form_preview" %>
+
+    <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-07-30', class: 'form-control' %>
+    <%= f.select :tribunal_decision_judges, f.object.facet_options(:tribunal_decision_judges), { label: "Judges" }, { class: 'select2', multiple: true, data: { placeholder: 'Select judges' } } %>
+    <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
+    <%= f.text_field :tribunal_decision_sub_category, label: "Sub-category", class: 'form-control' %>
+    <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
+    <%= f.text_field :tribunal_decision_reference_number, label: "Reference number", class: 'form-control' %>
+
+    <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+    <div class="actions">
+      <button name="save" class="btn btn-success">Save as draft</button>
+    </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "asylum_support_decision" } %>

--- a/app/views/asylum_support_decisions/_form.html.erb
+++ b/app/views/asylum_support_decisions/_form.html.erb
@@ -10,6 +10,7 @@
     <%= f.text_field :tribunal_decision_sub_category, label: "Sub-category", class: 'form-control' %>
     <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
     <%= f.text_field :tribunal_decision_reference_number, label: "Reference number", class: 'form-control' %>
+    <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
 
     <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
 

--- a/finders/metadata/asylum_support_decisions.json
+++ b/finders/metadata/asylum_support_decisions.json
@@ -1,0 +1,13 @@
+{
+  "content_id": "581b4bba-e58f-4d07-8e0a-03c8c00165cc",
+  "base_path": "/asylum-support-decisions",
+  "format_name": "First-tier Tribunal (Asylum Support) decision",
+  "name": "First-tier Tribunal (Asylum Support) decisions",
+  "description": "Find decisions by the First-tier Tribunal (Asylum Support)",
+  "beta": true,
+  "filter": {
+    "document_type": "asylum_support_decision"
+  },
+  "show_summaries": true,
+  "organisations": ["7141e343-e7bb-483b-920a-c6a5cf8f758c"]
+}

--- a/finders/metadata/asylum_support_decisions.json
+++ b/finders/metadata/asylum_support_decisions.json
@@ -9,5 +9,8 @@
     "document_type": "asylum_support_decision"
   },
   "show_summaries": true,
-  "organisations": ["7141e343-e7bb-483b-920a-c6a5cf8f758c"]
+  "organisations": [
+    "7141e343-e7bb-483b-920a-c6a5cf8f758c"
+  ],
+  "preview_only": true
 }

--- a/finders/schemas/asylum-support-decisions.json
+++ b/finders/schemas/asylum-support-decisions.json
@@ -1,0 +1,231 @@
+{
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Decision date",
+      "type": "date",
+      "preposition": null,
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "tribunal_decision_judges",
+      "name": "Judges",
+      "type": "text",
+      "preposition": "by judge",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Alan Ponting",
+          "value": "alan-ponting"
+        },
+        {
+          "label": "Alison Lock",
+          "value": "alison-lock"
+        },
+        {
+          "label": "Allan Briddock",
+          "value": "allan-briddock"
+        },
+        {
+          "label": "Anne-Marie Tootell",
+          "value": "anne-marie-tootell"
+        },
+        {
+          "label": "Charlotte Bayati",
+          "value": "charlotte-bayati"
+        },
+        {
+          "label": "Christopher Rayner",
+          "value": "christopher-rayner"
+        },
+        {
+          "label": "David Saunders",
+          "value": "david-saunders"
+        },
+        {
+          "label": "Dr E Prince",
+          "value": "dr-e-prince"
+        },
+        {
+          "label": "Fiona Ripley",
+          "value": "fiona-ripley"
+        },
+        {
+          "label": "Fozia Rizvi",
+          "value": "fozia-rizvi"
+        },
+        {
+          "label": "Gary Garland",
+          "value": "gary-garland"
+        },
+        {
+          "label": "Gill Carter",
+          "value": "gill-carter"
+        },
+        {
+          "label": "Ian Lewis",
+          "value": "ian-lewis"
+        },
+        {
+          "label": "Jessica Wyman",
+          "value": "jessica-wyman"
+        },
+        {
+          "label": "Joanna Swaney",
+          "value": "joanna-swaney"
+        },
+        {
+          "label": "Julie Cornes",
+          "value": "julie-cornes"
+        },
+        {
+          "label": "Laurence Brass",
+          "value": "laurence-brass"
+        },
+        {
+          "label": "Margaret Phelan",
+          "value": "margaret-phelan"
+        },
+        {
+          "label": "Martin Penrose",
+          "value": "martin-penrose"
+        },
+        {
+          "label": "Noor-Ul Khan",
+          "value": "noor-ul-khan"
+        },
+        {
+          "label": "Paulene Gandhi",
+          "value": "paulene-gandhi"
+        },
+        {
+          "label": "Rafaquat Hussain",
+          "value": "rafaquat-hussain"
+        },
+        {
+          "label": "Rebecca Owens",
+          "value": "rebecca-owens"
+        },
+        {
+          "label": "Richard Briden",
+          "value": "richard-briden"
+        },
+        {
+          "label": "Sally Verity Smith",
+          "value": "sally-verity-smith"
+        },
+        {
+          "label": "Salma Bashir",
+          "value": "salma-bashir"
+        },
+        {
+          "label": "Sanjay Lal",
+          "value": "sanjay-lal"
+        },
+        {
+          "label": "Sarah Breach",
+          "value": "sarah-breach"
+        },
+        {
+          "label": "Sehba Storey",
+          "value": "sehba-storey"
+        },
+        {
+          "label": "Sheila Grewal",
+          "value": "sheila-grewal"
+        },
+        {
+          "label": "Susannah Walker",
+          "value": "susannah-walker"
+        },
+        {
+          "label": "Victoria Woollen",
+          "value": "victoria-woollen"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_category",
+      "name": "Category",
+      "type": "text",
+      "preposition": "categorised as",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Asylum Seeker, Definition of",
+          "value": "asylum-seeker-definition-of"
+        },
+        {
+          "label": "Breach of Conditions by:",
+          "value": "breach-of-conditions-by"
+        },
+        {
+          "label": "European Convention of Human Rights",
+          "value": "european-convention-of-human-rights"
+        },
+        {
+          "label": "Financial Assessment",
+          "value": "financial-assessment"
+        },
+        {
+          "label": "Local Authority Support",
+          "value": "local-authority-support"
+        },
+        {
+          "label": "Medical Evidence",
+          "value": "medical-evidence"
+        },
+        {
+          "label": "Practice and Procedure",
+          "value": "practice-and-procedure"
+        },
+        {
+          "label": "Social Security Benefits",
+          "value": "social-security-benefits"
+        },
+        {
+          "label": "Section 4",
+          "value": "section-4"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_sub_category",
+      "name": "Sub-category",
+      "type": "text",
+      "preposition": "sub-categorised as",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_landmark",
+      "name": "Landmark",
+      "type": "text",
+      "preposition": null,
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "allowed_values": [
+        {
+          "label": "Not Landmark",
+          "value": "not-landmark"
+        },
+        {
+          "label": "Landmark",
+          "value": "landmark"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_reference_number",
+      "name": "Reference number",
+      "type": "text",
+      "preposition": null,
+      "display_as_result_metadata": true,
+      "filterable": false
+    }
+  ]
+}

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "spec/exporters/formatters/abstract_indexable_formatter_spec"
+require "spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec"
+require "formatters/aaib_report_indexable_formatter"
+
+RSpec.describe AsylumSupportDecisionIndexableFormatter do
+  let(:document) {
+    double(
+      :asylum_support_decision,
+      body: double,
+      slug: double,
+      summary: double,
+      title: double,
+      updated_at: double,
+      minor_update?: false,
+
+      tribunal_decision_decision_date: double,
+      tribunal_decision_judges: double,
+      tribunal_decision_category: double,
+      tribunal_decision_sub_category: double,
+      tribunal_decision_landmark: double,
+      tribunal_decision_reference_number: double,
+    )
+  }
+
+  subject(:formatter) { AsylumSupportDecisionIndexableFormatter.new(document) }
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of asylum_support_decision" do
+    expect(formatter.type).to eq("asylum_support_decision")
+  end
+end

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
   let(:document) {
     double(
       :asylum_support_decision,
-      body: double,
-      slug: double,
+      body: double("body"),
+      slug: "/slug",
       summary: double,
       title: double,
       updated_at: double,
       minor_update?: false,
+      public_updated_at: double,
 
       tribunal_decision_decision_date: double,
       tribunal_decision_judges: double,
@@ -20,6 +21,7 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
       tribunal_decision_sub_category: double,
       tribunal_decision_landmark: double,
       tribunal_decision_reference_number: double,
+      hidden_indexable_content: double,
     )
   }
 
@@ -30,4 +32,18 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
   it "should have a type of asylum_support_decision" do
     expect(formatter.type).to eq("asylum_support_decision")
   end
+
+  context "without hidden_indexable_content" do
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.body)
+    end
+  end
+
+  context "with hidden_indexable_content" do
+    it "should have hidden_indexable_content as its indexable_content" do
+      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.hidden_indexable_content)
+    end
+  end
+
 end

--- a/spec/models/asylum_support_decision_spec.rb
+++ b/spec/models/asylum_support_decision_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "asylum_support_decision"
+
+RSpec.describe AsylumSupportDecision do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(AsylumSupportDecision.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end


### PR DESCRIPTION
* Add specialist document finder for asylum support tribunal decisions.
* Code was generated via finder generator.
* Use "tribunal_decision" prefix to distinguish document attributes added for tribunal decisions.
* Tested in VM.

**Dependent on rummager PR:** https://github.com/alphagov/rummager/pull/502