### PR TITLE
Prevent finder publishing when preview_only set and not in preview env

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -3,24 +3,43 @@ require_relative "../app/presenters/finder_content_item_presenter"
 require_relative "../app/presenters/finder_signup_content_item_presenter"
 
 class PublishingApiFinderPublisher
-  def initialize(metadata, schemae)
+  def initialize(metadata, schemae, log = true)
     @metadata = metadata
     @schemae = schemae
+    @log = log
   end
 
   def call
-    metadata.zip(schemae).map { |metadata, schema|
-      if metadata[:file].has_key?("content_id")
-        export_finder(metadata, schema)
-        export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
+    metadata.zip(schemae).map do |metadata, schema|
+      if metadata[:file].has_key?("content_id") && !preview_only?(metadata)
+        publish metadata, schema
+      elsif preview_only?(metadata)
+        if preview_domain_or_not_production?
+          publish metadata, schema
+        else
+          puts "didn't publish #{metadata[:file]["name"]} because it is preview_only" if @log
+        end
       else
-        puts "didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id"
+        puts "didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id" if @log
       end
-    }
+    end
   end
 
 private
   attr_reader :schemae, :metadata
+
+  def publish metadata, schema
+    export_finder(metadata, schema)
+    export_signup(metadata) if metadata[:file].has_key?("signup_content_id")
+  end
+
+  def preview_only? metadata
+    metadata[:file]["preview_only"] == true
+  end
+
+  def preview_domain_or_not_production?
+    ENV.fetch("GOVUK_APP_DOMAIN", "")[/preview/] || !Rails.env.production?
+  end
 
   def export_finder(metadata, schema)
     finder = FinderContentItemPresenter.new(
@@ -31,7 +50,7 @@ private
 
     attrs = finder.exportable_attributes
 
-    puts "publishing '#{attrs["title"]}' finder"
+    puts "publishing '#{attrs["title"]}' finder" if @log
 
     publishing_api.put_content_item(finder.base_path, attrs)
   end
@@ -44,7 +63,7 @@ private
 
     attrs = finder_signup.exportable_attributes
 
-    puts "publishing '#{attrs["title"]}' finder signup page"
+    puts "publishing '#{attrs["title"]}' finder signup page" if @log
 
     publishing_api.put_content_item(finder_signup.base_path, attrs)
   end


### PR DESCRIPTION
This allows for new finders to be merged onto master for use in preview environment, while preventing them going live on gov.uk. This feature flag was agreed with @jennyd.

It will still publish finder if RAILS_ENV is not production. Set preview_only in the document metadata file when needed.

Also refactored spec to make it easier to reuse metadata and schema fixture setup.