### PR TITLE
Send `public_timestamp` to rummager

### DIFF
--- a/app/exporters/formatters/abstract_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_indexable_formatter.rb
@@ -25,7 +25,7 @@ private
       link: link,
       indexable_content: indexable_content,
       organisations: organisation_slugs,
-      last_update: last_update,
+      public_timestamp: public_timestamp,
     }
   end
 
@@ -53,7 +53,7 @@ private
     entity.body
   end
 
-  def last_update
+  def public_timestamp
     entity.updated_at
   end
 

--- a/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
@@ -3,7 +3,7 @@ require "formatters/abstract_indexable_formatter"
 class AbstractSpecialistDocumentIndexableFormatter < AbstractIndexableFormatter
 
 private
-  def last_update
+  def public_timestamp
     entity.public_updated_at || entity.updated_at
   end
 end

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -35,7 +35,7 @@ private
     entity.body
   end
 
-  def last_update
+  def public_timestamp
     nil
   end
 

--- a/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
@@ -12,12 +12,12 @@ RSpec.shared_examples_for "a specialist document indexable formatter" do
 
     it "returns the document's public_updated_at if available" do
       allow(document).to receive(:public_updated_at).and_return(public_updated_at)
-      expect(formatter.indexable_attributes[:last_update]).to eq(public_updated_at)
+      expect(formatter.indexable_attributes[:public_timestamp]).to eq(public_updated_at)
     end
 
     it "returns the document's updated_at if there is no public_updated_at" do
       allow(document).to receive(:public_updated_at).and_return(nil)
-      expect(formatter.indexable_attributes[:last_update]).to eq(updated_at)
+      expect(formatter.indexable_attributes[:public_timestamp]).to eq(updated_at)
     end
   end
 end


### PR DESCRIPTION
`last_update`  and `public_timestamp` mean the same thing in rummager.

Current behaviour of rummager is that if `public_timestamp` is empty, `last_update` [gets copied into `public_timestamp`](https://github.com/alphagov/rummager/blob/d3637f348612b76ee4de8d2c01048af39ea2a568/lib/indexer/document_preparer.rb#L46).

This commit changes what is sent to rummager so that we populate `public_timestamp` directly and can remove the special field and special code from rummager.

Trello: https://trello.com/c/yY2jFlXl

Previous PR: https://github.com/alphagov/hmrc-manuals-api/pull/106
