### PR TITLE
Publish specialist docs to publishing API on republication

### DIFF
--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -27,6 +27,7 @@ class AbstractSpecialistDocumentObserversRegistry
 
   def republication
     [
+      publishing_api_exporter,
       rummager_exporter,
     ]
   end


### PR DESCRIPTION
I think this was overlooked in ff3e2050b6db66b5bacf5281440110dde26a6dcb

This means that the bin/publish_cma_cases script wasn't working, as well as
bin/republish_documents and perhaps bin/republish_manuals.

/cc @danielroseman @mikejustdoit 