### PR TITLE
Refactor finder publishing

### DIFF
--- a/lib/publishing_api_finder_loader.rb
+++ b/lib/publishing_api_finder_loader.rb
@@ -1,0 +1,47 @@
+require "multi_json"
+
+class PublishingApiFinderLoader
+  def initialize(folder)
+    @folder = folder
+  end
+
+  def finders
+    matching_finder_filenames.map do |filename|
+      metadata_file = File.join(folder, "metadata", filename)
+      schema_file = File.join(folder, "schemas", filename)
+
+      {
+        metadata: MultiJson.load(File.read(metadata_file)),
+        schema: MultiJson.load(File.read(schema_file)),
+        timestamp: File.mtime(metadata_file)
+      }
+    end
+  end
+
+  def schema_files_missing_metadata
+    schema_files.reject { |filename| metadata_files.include?(filename) }
+  end
+
+  def metadata_files_missing_schema
+    metadata_files.reject { |filename| schema_files.include?(filename) }
+  end
+
+private
+  attr_reader :folder
+
+  def matching_finder_filenames
+    metadata_files.select { |filename| schema_files.include?(filename) }
+  end
+
+  def metadata_files
+    @matadata_files ||= Dir.glob(File.join(folder, "metadata/*.json")).map do|file|
+      File.basename(file)
+    end
+  end
+
+  def schema_files
+    @schema_files ||= Dir.glob(File.join(folder, "schemas/*.json")).map do|file|
+      File.basename(file)
+    end
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,21 +8,23 @@ namespace :publishing_api do
 
     require "multi_json"
 
-    metadata = Dir.glob("finders/metadata/**/*.json").map do |file_path|
+    metadata_files = Dir.glob("finders/metadata/*.json").map { |file| File.basename(file) }
+    schemas_files = Dir.glob("finders/schemas/*.json").map { |file| File.basename(file) }
+
+    matching_files = metadata_files.select { |filename| schemae_files.include?(filename) }
+
+    finders = matching_files.map do |filename|
+      metadata_file = File.join('finders/metadata', filename)
+      schema_file = File.join('finders/schemas', filename)
+
       {
-        file: MultiJson.load(File.read(file_path)),
-        timestamp: File.mtime(file_path)
+        metadata: MultiJson.load(File.read(metadata_file)),
+        schema: MultiJons.load(File.read(schema_file)),
+        timestamp: File.mtime(metadata_file)
       }
     end
 
-    schemae = Dir.glob("finders/schemas/**/*.json").map do |file_path|
-      {
-        file: MultiJson.load(File.read(file_path)),
-        timestamp: File.mtime(file_path)
-      }
-    end
-
-    PublishingApiFinderPublisher.new(metadata, schemae).call
+    PublishingApiFinderPublisher.new(finders).call
   end
 
   task :publish_documents_as_placeholders => :environment do

--- a/spec/lib/publishing_api_finder_loader_spec.rb
+++ b/spec/lib/publishing_api_finder_loader_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+require "publishing_api_finder_loader"
+
+describe PublishingApiFinderLoader do
+  before do
+    expect(Dir).to receive(:glob).with("finders/metadata/*.json").and_return(%w{
+      finders/metadata/matching-finder-1.json
+      finders/metadata/matching-finder-2.json
+      finders/metadata/unmatching-metadata.json
+    })
+    expect(Dir).to receive(:glob).with("finders/schemas/*.json").and_return(%w{
+      finders/schemas/matching-finder-1.json
+      finders/schemas/matching-finder-2.json
+      finders/schemas/unmatching-schema.json
+    })
+  end
+
+  it "returns metadata files missing matching schemas" do
+    loader = PublishingApiFinderLoader.new("finders")
+    expect(loader.metadata_files_missing_schema).to match_array(["unmatching-metadata.json"])
+  end
+
+  it "returns schema files missing matching metadata" do
+    loader = PublishingApiFinderLoader.new("finders")
+    expect(loader.schema_files_missing_metadata).to match_array(["unmatching-schema.json"])
+  end
+
+  it "returns matching finder data objects" do
+    expect(File).to receive(:read).with("finders/metadata/matching-finder-1.json")
+      .and_return('{"name":"finder-metadata-1"}')
+    expect(File).to receive(:read).with("finders/metadata/matching-finder-2.json")
+      .and_return('{"name":"finder-metadata-2"}')
+    expect(File).to receive(:read).with("finders/schemas/matching-finder-1.json")
+      .and_return('{"name":"finder-schema-1"}')
+    expect(File).to receive(:read).with("finders/schemas/matching-finder-2.json")
+      .and_return('{"name":"finder-schema-2"}')
+
+    expect(File).to receive(:mtime).with("finders/metadata/matching-finder-1.json")
+      .and_return("yesterday")
+    expect(File).to receive(:mtime).with("finders/metadata/matching-finder-2.json")
+      .and_return("today")
+
+    loader = PublishingApiFinderLoader.new("finders")
+    expect(loader.finders).to match_array([
+      {
+        metadata: { "name" => "finder-metadata-1" },
+        schema: { "name" => "finder-schema-1" },
+        timestamp: "yesterday"
+      },
+      {
+        metadata: { "name" => "finder-metadata-2" },
+        schema: { "name" => "finder-schema-2" },
+        timestamp: "today"
+      }
+    ])
+  end
+end


### PR DESCRIPTION
To create the finder content items we were previously running a glob
over two different folders and then zip'ing the resultant file arrays
together. This assumed that both sets of files would be read of disk in
the same order.

This changes that so that instead we now read both folders but then only
select the files that exist in both folders. We then load each of those
files by name so that we can be sure that the files are matched together
correctly.

To do this I have refactored the arguments to the publishing publisher
to take a single object which is an array of finders. Each finder
contains both the schema and the metadata to then create the finder
from. Internally I have modified many of the methods to pass the whole
finder object around rather than passing just the metadata or schema as
they are individually needed.

https://trello.com/c/yFKkfBLp/98-specialist-publisher-finder-publishing-can-silently-mix-finder-facets-between-finders