### PR TITLE
Give AAIB beta phase

### DIFF
--- a/finders/metadata/aaib-reports.json
+++ b/finders/metadata/aaib-reports.json
@@ -4,7 +4,7 @@
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "description": "Find reports of AAIB investigations into air accidents and incidents",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "aaib_report"
   },


### PR DESCRIPTION
Following on from the changes as to how alpha and beta are handled, this
commit updates AAIB Reports Finder with a `phase` of `"beta"`.