### PR TITLE
Store asylum support facet labels directly in rummager

### DIFF
--- a/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
@@ -2,6 +2,12 @@ require "formatters/abstract_indexable_formatter"
 
 class AbstractSpecialistDocumentIndexableFormatter < AbstractIndexableFormatter
 
+  def expand_value(key)
+    schema = SpecialistPublisherWiring.get("#{type}_finder_schema".to_sym)
+    value = entity.send(key)
+    schema.humanized_facet_value(key, value)
+  end
+
 private
   def public_timestamp
     entity.public_updated_at || entity.updated_at

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -9,9 +9,13 @@ private
   def extra_attributes
     {
       tribunal_decision_judges: entity.tribunal_decision_judges,
+      tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
       tribunal_decision_category: entity.tribunal_decision_category,
+      tribunal_decision_category_name: expand_value(:tribunal_decision_category),
       tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
+      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
+      tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark),
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
       indexable_content: entity.hidden_indexable_content || entity.body

--- a/finders/schemas/asylum-support-decisions.json
+++ b/finders/schemas/asylum-support-decisions.json
@@ -6,7 +6,7 @@
       "name": "Judges",
       "type": "text",
       "preposition": "by judge",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -140,11 +140,18 @@
       ]
     },
     {
+      "key": "tribunal_decision_judges_name",
+      "name": "Judges name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_category",
       "name": "Category",
       "type": "text",
       "preposition": "categorised as",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -162,11 +169,18 @@
       ]
     },
     {
+      "key": "tribunal_decision_category_name",
+      "name": "Category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_sub_category",
       "name": "Sub-category",
       "type": "text",
       "preposition": "sub-categorised as",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -248,11 +262,17 @@
       ]
     },
     {
+      "key": "tribunal_decision_sub_category_name",
+      "name": "Sub-category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "type": "text",
-      "preposition": null,
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false,
       "allowed_values": [
         {
@@ -266,18 +286,25 @@
       ]
     },
     {
+      "key": "tribunal_decision_landmark_name",
+      "name": "Landmark name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_reference_number",
       "name": "Reference number",
       "type": "text",
-      "preposition": null,
       "display_as_result_metadata": true,
       "filterable": false
     },
     {
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
+      "short_name": "Decided",
       "type": "date",
-      "preposition": null,
+      "preposition": "was decided",
       "display_as_result_metadata": true,
       "filterable": true
     }


### PR DESCRIPTION
This approach means we no longer need to set `allowed_values` in the `rummager` schema configuration. In `finder-frontend` metadata labels now come directly from `rummager` as separate `_name` fields.

Tested in the VM.

**Requires this rummager PR be merged**: https://github.com/alphagov/rummager/pull/508