### PR TITLE
Use phase correctly

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -17,7 +17,7 @@ class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
         "email_alert_signup" => email_alert_signup,
       },
       "locale" => "en",
-    }
+    }.merge(phase)
   end
 
   def base_path
@@ -39,7 +39,6 @@ private
 
   def details
     {
-      beta: metadata.fetch("beta", false),
       beta_message: metadata.fetch("beta_message", nil),
       document_noun: schema.fetch("document_noun"),
       filter: metadata.fetch("filter", {}),
@@ -100,5 +99,16 @@ private
 
   def email_alert_signup
     [metadata.fetch("signup_content_id", nil)].compact
+  end
+
+  def phase
+    phase = metadata["phase"]
+    if phase
+      {
+        "phase" => phase
+      }
+    else
+      {}
+    end
   end
 end

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -85,6 +85,17 @@ describe PublishingApiFinderPublisher do
       PublishingApiFinderPublisher.new(finders, false).call
     end
 
+    it "can publish a Finder with a phase" do
+      finders = [
+        make_finder("/finder-with-phase", "phase" => "beta"),
+      ]
+
+      expect(publishing_api).to receive(:put_content_item)
+        .with("/finder-with-phase", be_valid_against_schema("finder"))
+
+      PublishingApiFinderPublisher.new(finders, false).call
+    end
+
     context 'with preview_only false metadata and RAILS_ENV is "production"' do
       it "does publish finder" do
         finders = [

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -19,7 +19,7 @@ describe PublishingApiFinderPublisher do
       }
     end
 
-    def make_metadata base_path, overrides = {}
+    def make_metadata(base_path, overrides = {})
       underscore_name = base_path.sub("/", "")
       name = underscore_name.humanize
       metadata = {


### PR DESCRIPTION
With the changes in https://github.com/alphagov/finder-frontend/pull/230
we now use the `phase` attribute from the top level of the Content Item
hash. This commit modifies the check to merge this if it is present in
the metadata along with adding a test to test this behaviour.