### PR TITLE
Store asylum support facet labels directly in rummager

### DIFF
--- a/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
@@ -3,6 +3,12 @@ require "formatters/abstract_indexable_formatter"
 class AbstractSpecialistDocumentIndexableFormatter < AbstractIndexableFormatter
 
 private
+  def expand_value(key)
+    schema = SpecialistPublisherWiring.get("#{type}_finder_schema".to_sym)
+    value = entity.send(key)
+    schema.humanized_facet_value(key, value)
+  end
+
   def public_timestamp
     entity.public_updated_at || entity.updated_at
   end

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -9,9 +9,13 @@ private
   def extra_attributes
     {
       tribunal_decision_judges: entity.tribunal_decision_judges,
+      tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
       tribunal_decision_category: entity.tribunal_decision_category,
+      tribunal_decision_category_name: expand_value(:tribunal_decision_category),
       tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
+      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
+      tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark),
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
       indexable_content: entity.hidden_indexable_content || entity.body

--- a/finders/schemas/asylum-support-decisions.json
+++ b/finders/schemas/asylum-support-decisions.json
@@ -6,7 +6,7 @@
       "name": "Judges",
       "type": "text",
       "preposition": "by judge",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -140,11 +140,18 @@
       ]
     },
     {
+      "key": "tribunal_decision_judges_name",
+      "name": "Judges name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_category",
       "name": "Category",
       "type": "text",
       "preposition": "categorised as",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -162,11 +169,18 @@
       ]
     },
     {
+      "key": "tribunal_decision_category_name",
+      "name": "Category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_sub_category",
       "name": "Sub-category",
       "type": "text",
       "preposition": "sub-categorised as",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {
@@ -248,11 +262,17 @@
       ]
     },
     {
+      "key": "tribunal_decision_sub_category_name",
+      "name": "Sub-category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "type": "text",
-      "preposition": null,
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false,
       "allowed_values": [
         {
@@ -266,10 +286,16 @@
       ]
     },
     {
+      "key": "tribunal_decision_landmark_name",
+      "name": "Landmark name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
       "key": "tribunal_decision_reference_number",
       "name": "Reference number",
       "type": "text",
-      "preposition": null,
       "display_as_result_metadata": true,
       "filterable": false
     },
@@ -277,7 +303,7 @@
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "type": "date",
-      "preposition": null,
+      "preposition": null, 
       "display_as_result_metadata": true,
       "filterable": true
     }

--- a/finders/schemas/asylum-support-decisions.json
+++ b/finders/schemas/asylum-support-decisions.json
@@ -302,8 +302,9 @@
     {
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
+      "short_name": "Decided",
       "type": "date",
-      "preposition": null, 
+      "preposition": "decided", 
       "display_as_result_metadata": true,
       "filterable": true
     }

--- a/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
@@ -1,5 +1,14 @@
 require "formatters/abstract_specialist_document_indexable_formatter"
 
+RSpec.shared_context "schema available" do
+  before do
+    schema = double
+    symbol = "#{formatter.type}_finder_schema".to_sym
+    allow(SpecialistPublisherWiring).to receive(:get).with(symbol).and_return schema
+    allow(schema).to receive(:humanized_facet_value).and_return double
+  end
+end
+
 RSpec.shared_examples_for "a specialist document indexable formatter" do
   describe "last update" do
     let(:public_updated_at) { double(:public_updated_at) }

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
       minor_update?: false,
       public_updated_at: double,
 
-      tribunal_decision_judges: double,
+      tribunal_decision_judges: [double],
       tribunal_decision_category: double,
       tribunal_decision_sub_category: double,
       tribunal_decision_landmark: double,
@@ -26,6 +26,8 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
   }
 
   subject(:formatter) { AsylumSupportDecisionIndexableFormatter.new(document) }
+
+  include_context "schema available"
 
   it_should_behave_like "a specialist document indexable formatter"
 

--- a/spec/fixtures/sample_schema.json
+++ b/spec/fixtures/sample_schema.json
@@ -8,7 +8,8 @@
       "name": "Case type",
       "type": "text",
       "allowed_values": [
-        {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"}
+        {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"},
+        {"label": "Criminal cartels", "value": "criminal-cartels"}
       ]
     }
   ]

--- a/spec/fixtures/sample_schema.json
+++ b/spec/fixtures/sample_schema.json
@@ -6,7 +6,7 @@
     {
       "key": "case_type",
       "name": "Case type",
-      "type": "single-select",
+      "type": "text",
       "allowed_values": [
         {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"}
       ]

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -14,6 +14,39 @@ describe FinderSchema do
   end
 
   it "gives the options for a given facet" do
-    expect(finder_schema.options_for(:case_type)).to eq([["CA98 and civil cartels", "ca98-and-civil-cartels"]])
+    expect(finder_schema.options_for(:case_type)).to eq([
+      ["CA98 and civil cartels", "ca98-and-civil-cartels"],
+      ["Criminal cartels", "criminal-cartels"]
+    ])
+  end
+
+  describe "#humanized_facet_value" do
+    context "with facet_key in schema" do
+      context "and value in allowed_values config" do
+        it "should return label" do
+          label = finder_schema.humanized_facet_value(:case_type, "ca98-and-civil-cartels")
+          expect(label).to eq(["CA98 and civil cartels"])
+        end
+      end
+
+      context "and values in allowed_values config" do
+        it "should return labels" do
+          labels = finder_schema.humanized_facet_value(:case_type, %w[ca98-and-civil-cartels criminal-cartels])
+          expect(labels).to eq(["CA98 and civil cartels", "Criminal cartels"])
+        end
+      end
+
+      context "and value not in allowed_values config" do
+        it "should raise exception" do
+          expect { finder_schema.humanized_facet_value(:case_type, "bad-value") }.to raise_exception
+        end
+      end
+    end
+
+    context "with facet_key not in schema" do
+      it "should raise exception" do
+        expect { finder_schema.humanized_facet_value(:bad_key, "ca98-and-civil-cartels") }.to raise_exception
+      end
+    end
   end
 end


### PR DESCRIPTION
* No longer set `allowed_values` in the rummager schema configuration.
* In finder-frontend metadata labels now come directly from rummager as separate `_name` fields.
* Tested in the VM.
* Add specs for FinderSchema `humanized_facet_value()` to confirm expected behaviour.
* Minor decision date field config change.

Associated rummager PR is: alphagov/rummager#508