### PR TITLE
Make both body and hidden_indexable_content indexable

### DIFF
--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -18,7 +18,7 @@ private
       tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark),
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
-      indexable_content: entity.hidden_indexable_content || entity.body
+      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip
     }
   end
 

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
   let(:document) {
     double(
       :asylum_support_decision,
-      body: double("body"),
+      body: double,
       slug: "/slug",
       summary: double,
       title: double,
@@ -37,8 +37,10 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
 
   context "without hidden_indexable_content" do
     it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+
       allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.body)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
     end
   end
 

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -46,7 +46,11 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
 
   context "with hidden_indexable_content" do
     it "should have hidden_indexable_content as its indexable_content" do
-      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.hidden_indexable_content)
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
     end
   end
 


### PR DESCRIPTION
As recommended by search team members here: https://github.com/ministryofjustice/specialist-publisher/commit/512a73301be1f9909573b847e23222a4bcd126cd#commitcomment-12928833

"There's little harm if there's duplication between `body` and `indexable_content_indexable`, and there's
definite benefit to making sure any text we have available is searchable."