### PR TITLE
Link to earlier asylum support decisions

### DIFF
--- a/finders/metadata/asylum-support-decisions.json
+++ b/finders/metadata/asylum-support-decisions.json
@@ -39,5 +39,6 @@
       "prechecked": false
     }
   ],
+  "summary": "<p>Find details of <a rel=\"external\" href=\"http://www.asylum-support-tribunal.gov.uk/public/search.aspx\">earlier decisions</a>.</p>",
   "preview_only": true
 }


### PR DESCRIPTION
Use summary html to link from asylum support decisions finder to earlier published asylum support tribunal decisions.