### PR TITLE
Truncate metadata values to 140 chars in document summary

### DIFF
--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -18,7 +18,7 @@
       <% document.humanized_attributes.each_pair do |label, values| %>
         <dt><%= label.to_s.humanize %></dt>
         <% Array(values).each do |value| %>
-          <dd><%= value %></dd>
+          <dd><%= truncate(value, length: 140) %></dd>
         <% end %>
       <% end %>
       <dt>Publication state</dt>


### PR DESCRIPTION
Long metadata values take up too much space on the summary page if left untruncated. e.g. Tribunal decision's `hidden_indexable_content` field, which is the length of the entire document.