### PR TITLE
Ensure metadata value is a string before truncation

### DIFF
--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -18,7 +18,7 @@
       <% document.humanized_attributes.each_pair do |label, values| %>
         <dt><%= label.to_s.humanize %></dt>
         <% Array(values).each do |value| %>
-          <dd><%= truncate(value, length: 140) %></dd>
+          <dd><%= truncate(value.to_s, length: 140) %></dd>
         <% end %>
       <% end %>
       <dt>Publication state</dt>


### PR DESCRIPTION
Fixes broken features which had numeric metadata values causing exception when truncate() was called.