### PR TITLE
Alphabetically sort attributes in asylum support decision code

### DIFF
--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -8,17 +8,17 @@ class AsylumSupportDecisionIndexableFormatter < AbstractSpecialistDocumentIndexa
 private
   def extra_attributes
     {
-      tribunal_decision_judges: entity.tribunal_decision_judges,
-      tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
+      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip,
       tribunal_decision_category: entity.tribunal_decision_category,
       tribunal_decision_category_name: expand_value(:tribunal_decision_category),
-      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
-      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
+      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
+      tribunal_decision_judges: entity.tribunal_decision_judges,
+      tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
       tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark),
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
-      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
-      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip
+      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
+      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
     }
   end
 

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -2,12 +2,12 @@ require "document_metadata_decorator"
 
 class AsylumSupportDecision < DocumentMetadataDecorator
   set_extra_field_names [
-    :tribunal_decision_judges,
+    :hidden_indexable_content,
     :tribunal_decision_category,
-    :tribunal_decision_sub_category,
+    :tribunal_decision_decision_date,
+    :tribunal_decision_judges,
     :tribunal_decision_landmark,
     :tribunal_decision_reference_number,
-    :tribunal_decision_decision_date,
-    :hidden_indexable_content
+    :tribunal_decision_sub_category
   ]
 end

--- a/app/models/validators/asylum_support_decision_validator.rb
+++ b/app/models/validators/asylum_support_decision_validator.rb
@@ -9,11 +9,11 @@ class AsylumSupportDecisionValidator < SimpleDelegator
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
-  validates :tribunal_decision_judges, presence: true
   validates :tribunal_decision_category, presence: true
-  validates :tribunal_decision_sub_category, presence: true
+  validates :tribunal_decision_decision_date, presence: true
+  validates :tribunal_decision_judges, presence: true
   validates :tribunal_decision_landmark, presence: true
   validates :tribunal_decision_reference_number, presence: true
-  validates :tribunal_decision_decision_date, presence: true
+  validates :tribunal_decision_sub_category, presence: true
 
 end

--- a/app/view_adapters/asylum_support_decision_view_adapter.rb
+++ b/app/view_adapters/asylum_support_decision_view_adapter.rb
@@ -4,13 +4,13 @@ require "validators/safe_html_validator"
 
 class AsylumSupportDecisionViewAdapter < DocumentViewAdapter
   attributes = [
-    :tribunal_decision_judges,
+    :hidden_indexable_content,
     :tribunal_decision_category,
-    :tribunal_decision_sub_category,
+    :tribunal_decision_decision_date,
+    :tribunal_decision_judges,
     :tribunal_decision_landmark,
     :tribunal_decision_reference_number,
-    :tribunal_decision_decision_date,
-    :hidden_indexable_content,
+    :tribunal_decision_sub_category,
   ]
 
   def self.model_name

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
       minor_update?: false,
       public_updated_at: double,
 
-      tribunal_decision_judges: [double],
+      hidden_indexable_content: double,
       tribunal_decision_category: double,
-      tribunal_decision_sub_category: double,
+      tribunal_decision_decision_date: double,
+      tribunal_decision_judges: [double],
       tribunal_decision_landmark: double,
       tribunal_decision_reference_number: double,
-      tribunal_decision_decision_date: double,
-      hidden_indexable_content: double,
+      tribunal_decision_sub_category: double,
     )
   }
 


### PR DESCRIPTION
A one-off cleanup of the code. The attributes will be kept in alphabetically sorted order in future pull requests. This change helps reduce churn when doing code generation.