### PR TITLE
Stop stripping leading slashes from manual sections

### DIFF
--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -15,8 +15,12 @@ private
 
   def extra_attributes
     {
-      manual: manual.slug,
+      manual: manual_slug,
     }
+  end
+
+  def manual_slug
+    with_leading_slash(manual.slug)
   end
 
   def title

--- a/spec/exporters/formatters/manual_section_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/manual_section_indexable_formatter_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+require "spec/exporters/formatters/abstract_indexable_formatter_spec"
+require "formatters/manual_section_indexable_formatter"
+
+RSpec.describe ManualSectionIndexableFormatter do
+
+  let(:section) {
+    double(
+      :manual_section,
+      title: double,
+      summary: double,
+      slug: "",
+      body: double,
+    )
+  }
+  let(:manual) {
+    double(
+      :manual,
+      title: double,
+      organisation_slug: double,
+      slug: "",
+    )
+  }
+
+  subject(:formatter) { ManualSectionIndexableFormatter.new(section, manual) }
+
+  describe "as an indexable formatter" do
+    it_behaves_like "an indexable formatter"
+  end
+
+end


### PR DESCRIPTION
- For consistency with how the HMRC Manuals API deals with manual `id`s,
  `link`s and (soon[1]) `manual` attributes in sections, don't strip leading
  slashes.
- This inconsistency was breaking search within a manual
  (https://trello.com/c/KAR7YtA7/119-searching-within-a-manual-uses-the-wrong-layout).

_NOTE_: As part of deploying this, the `republish_manuals` bin script needs to be run.

[1] - PR to be opened shortly.

(Paired with @mikejustdoit on this.)