### PR TITLE
Validate tribunal decision sub_category matches parent category

### DIFF
--- a/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
@@ -4,9 +4,7 @@ class AbstractSpecialistDocumentIndexableFormatter < AbstractIndexableFormatter
 
 private
   def expand_value(key)
-    schema = SpecialistPublisherWiring.get("#{type}_finder_schema".to_sym)
-    value = entity.send(key)
-    schema.humanized_facet_value(key, value)
+    FinderSchema.humanized_facet_name(key, entity, type)
   end
 
   def public_timestamp

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -17,8 +17,8 @@ private
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
       tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark),
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
-      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
-      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
+      tribunal_decision_sub_category: entity.tribunal_decision_sub_category.first,
+      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category).first,
     }
   end
 

--- a/app/exporters/formatters/utaac_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/utaac_decision_indexable_formatter.rb
@@ -14,8 +14,8 @@ private
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
       tribunal_decision_judges: entity.tribunal_decision_judges,
       tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
-      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
-      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category),
+      tribunal_decision_sub_category: entity.tribunal_decision_sub_category.first,
+      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category).first,
     }
   end
 

--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -1,6 +1,13 @@
 require "multi_json"
 
 class FinderSchema
+
+  def self.humanized_facet_name(key, entity, type)
+    schema = SpecialistPublisherWiring.get("#{type}_finder_schema".to_sym)
+    value = entity.send(key)
+    schema.humanized_facet_value(key, value)
+  end
+
   def initialize(schema_path)
     @schema_path = schema_path
   end

--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -8,6 +8,11 @@ class FinderSchema
     schema.humanized_facet_value(key, value)
   end
 
+  def self.options_for(facet_name, type)
+    schema = SpecialistPublisherWiring.get("#{type}_finder_schema".to_sym)
+    schema.options_for(facet_name)
+  end
+
   def initialize(schema_path)
     @schema_path = schema_path
   end

--- a/app/models/validators/asylum_support_decision_validator.rb
+++ b/app/models/validators/asylum_support_decision_validator.rb
@@ -1,6 +1,7 @@
 require "delegate"
 require "validators/date_validator"
 require "validators/safe_html_validator"
+require "validators/tribunal_decision_sub_category_relates_to_parent_validator"
 
 class AsylumSupportDecisionValidator < SimpleDelegator
   include ActiveModel::Validations
@@ -14,6 +15,16 @@ class AsylumSupportDecisionValidator < SimpleDelegator
   validates :tribunal_decision_judges, presence: true
   validates :tribunal_decision_landmark, presence: true
   validates :tribunal_decision_reference_number, presence: true
-  validates :tribunal_decision_sub_category, presence: true
+  validates :tribunal_decision_sub_category, presence: true, tribunal_decision_sub_category_relates_to_parent: true
 
+  def category_prefix_for(category)
+    case category
+    when "section-95-asylum-seekers"
+      "section-95"
+    when "section-4-2-failed-asylum-seekers"
+      "section-4-2"
+    when "section-4-1-neither-an-asylum-seeker-nor-a-failed-asylum-seeker"
+      "section-4-1"
+    end
+  end
 end

--- a/app/models/validators/asylum_support_decision_validator.rb
+++ b/app/models/validators/asylum_support_decision_validator.rb
@@ -15,7 +15,7 @@ class AsylumSupportDecisionValidator < SimpleDelegator
   validates :tribunal_decision_judges, presence: true
   validates :tribunal_decision_landmark, presence: true
   validates :tribunal_decision_reference_number, presence: true
-  validates :tribunal_decision_sub_category, presence: true, tribunal_decision_sub_category_relates_to_parent: true
+  validates :tribunal_decision_sub_category, tribunal_decision_sub_category_relates_to_parent: true
 
   def category_prefix_for(category)
     case category

--- a/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
+++ b/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
@@ -1,0 +1,37 @@
+class TribunalDecisionSubCategoryRelatesToParentValidator < ActiveModel::EachValidator
+
+  def validate_each(validator, attribute, sub_category)
+
+    unless prefixed_by_parent_category? sub_category, validator
+      message = "change to be a sub-category of '#{category_label(validator)}' or change category"
+      validator.errors.add attribute, message
+    end
+  end
+
+  private
+
+  def category_prefix(validator)
+    category = validator.tribunal_decision_category
+    prefix = category
+    if validator.respond_to?(:category_prefix_for)
+      category_prefix = validator.category_prefix_for(category)
+      prefix = category_prefix if category_prefix.present?
+    end
+    prefix
+  end
+
+  def prefixed_by_parent_category?(sub_category, validator)
+    prefix = category_prefix(validator)
+    sub_category[/^#{prefix}/]
+  end
+
+  def category_label(validator)
+    labels = FinderSchema.humanized_facet_name(:tribunal_decision_category, validator, type(validator))
+    labels.first
+  end
+
+  def type(validator)
+    validator.class.name.underscore.sub("_validator", "")
+  end
+
+end

--- a/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
+++ b/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
@@ -3,16 +3,40 @@ class TribunalDecisionSubCategoryRelatesToParentValidator < ActiveModel::EachVal
   def validate_each(validator, attribute, sub_category)
     if sub_category.present?
       validate_sub_category(validator, attribute, sub_category)
+    else
+      validate_sub_category_present_if_parent_has_sub_categories(validator, attribute)
     end
   end
 
   private
 
+  def validate_sub_category_present_if_parent_has_sub_categories(validator, attribute)
+    if validator.tribunal_decision_category.present? && category_has_sub_categories?(validator)
+      validator.errors.add attribute, "must not be blank"
+    end
+  end
+
+  def category_has_sub_categories?(validator)
+    prefix = category_prefix(validator)
+    sub_category_allowed_values(validator).any? do
+      |sub_category| sub_category[/^#{prefix}/]
+    end
+  end
+
+  def sub_category_allowed_values(validator)
+    sub_category_options = FinderSchema.options_for(:tribunal_decision_sub_category, type(validator))
+    sub_category_options.map(&:last)
+  end
+
   def validate_sub_category(validator, attribute, sub_category)
     if sub_category.size > 1
       validator.errors.add attribute, "change to a single sub-category"
     elsif !prefixed_by_parent_category?(sub_category.first, validator)
-      message = "change to be a sub-category of '#{category_label(validator)}' or change category"
+      message = if category_has_sub_categories?(validator)
+                  "change to be a sub-category of '#{category_label(validator)}' or change category"
+                else
+                  "remove sub-category as '#{category_label(validator)}' category has no sub-categories"
+                end
       validator.errors.add attribute, message
     end
   end

--- a/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
+++ b/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
@@ -9,7 +9,9 @@ class TribunalDecisionSubCategoryRelatesToParentValidator < ActiveModel::EachVal
   private
 
   def validate_sub_category(validator, attribute, sub_category)
-    unless prefixed_by_parent_category? sub_category, validator
+    if sub_category.size > 1
+      validator.errors.add attribute, "change to a single sub-category"
+    elsif !prefixed_by_parent_category?(sub_category.first, validator)
       message = "change to be a sub-category of '#{category_label(validator)}' or change category"
       validator.errors.add attribute, message
     end

--- a/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
+++ b/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
@@ -1,7 +1,14 @@
 class TribunalDecisionSubCategoryRelatesToParentValidator < ActiveModel::EachValidator
 
   def validate_each(validator, attribute, sub_category)
+    if sub_category.present?
+      validate_sub_category(validator, attribute, sub_category)
+    end
+  end
 
+  private
+
+  def validate_sub_category(validator, attribute, sub_category)
     unless prefixed_by_parent_category? sub_category, validator
       message = "change to be a sub-category of '#{category_label(validator)}' or change category"
       validator.errors.add attribute, message

--- a/app/models/validators/utaac_decision_validator.rb
+++ b/app/models/validators/utaac_decision_validator.rb
@@ -1,6 +1,7 @@
 require "delegate"
 require "validators/date_validator"
 require "validators/safe_html_validator"
+require "validators/tribunal_decision_sub_category_relates_to_parent_validator"
 
 class UtaacDecisionValidator < SimpleDelegator
   include ActiveModel::Validations
@@ -12,6 +13,6 @@ class UtaacDecisionValidator < SimpleDelegator
   validates :tribunal_decision_category, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_judges, presence: true
-  validates :tribunal_decision_sub_category, presence: true
+  validates :tribunal_decision_sub_category, presence: true, tribunal_decision_sub_category_relates_to_parent: true
 
 end

--- a/app/models/validators/utaac_decision_validator.rb
+++ b/app/models/validators/utaac_decision_validator.rb
@@ -13,6 +13,6 @@ class UtaacDecisionValidator < SimpleDelegator
   validates :tribunal_decision_category, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_judges, presence: true
-  validates :tribunal_decision_sub_category, presence: true, tribunal_decision_sub_category_relates_to_parent: true
+  validates :tribunal_decision_sub_category, tribunal_decision_sub_category_relates_to_parent: true
 
 end

--- a/app/views/asylum_support_decisions/_form.html.erb
+++ b/app/views/asylum_support_decisions/_form.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "shared/form_preview" %>
 
     <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
-    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: 'form-control' } %>
+    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: "select2", multiple: true, data: { placeholder: "Select sub-category when relevant" } } %>
     <%= f.select :tribunal_decision_judges, f.object.facet_options(:tribunal_decision_judges), { label: "Judges" }, { class: 'select2', multiple: true, data: { placeholder: 'Select judges' } } %>
     <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
     <%= f.text_field :tribunal_decision_reference_number, label: "Reference number", placeholder: '', class: 'form-control' %>

--- a/app/views/utaac_decisions/_form.html.erb
+++ b/app/views/utaac_decisions/_form.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "shared/form_preview" %>
 
     <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
-    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: 'form-control' } %>
+    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: "select2", multiple: true, data: { placeholder: "Select sub-category when relevant" } } %>
     <%= f.select :tribunal_decision_judges, f.object.facet_options(:tribunal_decision_judges), { label: "Judges" }, { class: 'select2', multiple: true, data: { placeholder: 'Select judges' } } %>
     <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-08-30', class: 'form-control' %>
     <%= f.text_area :hidden_indexable_content, class: 'form-control' %>

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 require "formatters/aaib_report_indexable_formatter"
+require_relative "tribunal_decision_indexable_formatter_spec"
 
 RSpec.describe AsylumSupportDecisionIndexableFormatter do
+  let(:sub_category) { [double] }
   let(:document) {
     double(
       :asylum_support_decision,
@@ -19,7 +21,7 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
       tribunal_decision_judges: [double],
       tribunal_decision_landmark: double,
       tribunal_decision_reference_number: double,
-      tribunal_decision_sub_category: double,
+      tribunal_decision_sub_category: sub_category,
     )
   }
 
@@ -29,7 +31,8 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
   let(:humanized_facet_value) { double }
   include_context "schema with humanized_facet_value available"
 
-  it_should_behave_like "a specialist document indexable formatter"
+  it_behaves_like "a specialist document indexable formatter"
+  it_behaves_like "a tribunal decision indexable formatter"
 
   it "should have a type of asylum_support_decision" do
     expect(formatter.type).to eq("asylum_support_decision")

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
 
   subject(:formatter) { AsylumSupportDecisionIndexableFormatter.new(document) }
 
-  include_context "schema available"
+  let(:document_type) { formatter.type }
+  let(:humanized_facet_value) { double }
+  include_context "schema with humanized_facet_value available"
 
   it_should_behave_like "a specialist document indexable formatter"
 

--- a/spec/exporters/formatters/tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/tribunal_decision_indexable_formatter_spec.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples_for "a tribunal decision indexable formatter" do
+
+  context "with sub_category" do
+    let(:sub_category) { [double] }
+    it "sends single sub_category for indexing" do
+      attributes = formatter.indexable_attributes
+      expect(attributes[:tribunal_decision_sub_category]).to eq(sub_category.first)
+    end
+  end
+
+  context "without sub_category" do
+    let(:sub_category) { [] }
+    it "sends blank for indexing" do
+      attributes = formatter.indexable_attributes
+      expect(attributes[:tribunal_decision_sub_category]).to eq(nil)
+    end
+  end
+
+end

--- a/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe UtaacDecisionIndexableFormatter do
 
   subject(:formatter) { UtaacDecisionIndexableFormatter.new(document) }
 
-  include_context "schema available"
+  let(:document_type) { formatter.type }
+  let(:humanized_facet_value) { double }
+  include_context "schema with humanized_facet_value available"
 
   it_should_behave_like "a specialist document indexable formatter"
 

--- a/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 require "formatters/aaib_report_indexable_formatter"
+require_relative "tribunal_decision_indexable_formatter_spec"
 
 RSpec.describe UtaacDecisionIndexableFormatter do
+  let(:sub_category) { [double] }
   let(:document) {
     double(
       :utaac_decision,
@@ -17,7 +19,7 @@ RSpec.describe UtaacDecisionIndexableFormatter do
       tribunal_decision_category: double,
       tribunal_decision_decision_date: double,
       tribunal_decision_judges: [double],
-      tribunal_decision_sub_category: double,
+      tribunal_decision_sub_category: sub_category,
     )
   }
 
@@ -27,7 +29,8 @@ RSpec.describe UtaacDecisionIndexableFormatter do
   let(:humanized_facet_value) { double }
   include_context "schema with humanized_facet_value available"
 
-  it_should_behave_like "a specialist document indexable formatter"
+  it_behaves_like "a specialist document indexable formatter"
+  it_behaves_like "a tribunal decision indexable formatter"
 
   it "should have a type of utaac_decision" do
     expect(formatter.type).to eq("utaac_decision")

--- a/spec/models/validators/asylum_support_decision_validator_spec.rb
+++ b/spec/models/validators/asylum_support_decision_validator_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+require "validators/asylum_support_decision_validator"
+require_relative "tribunal_decision_sub_category_relates_to_parent_validator_spec"
+
+RSpec.describe AsylumSupportDecisionValidator do
+
+  let(:entity) {
+    double(
+      :entity,
+      title: double,
+      summary: double,
+      body: "body",
+      tribunal_decision_category: category,
+      tribunal_decision_decision_date: "2015-11-01",
+      tribunal_decision_judges: [double],
+      tribunal_decision_landmark: double,
+      tribunal_decision_reference_number: double,
+      tribunal_decision_sub_category: sub_category,
+    )
+  }
+  let(:document_type) { "asylum_support_decision" }
+
+  subject(:validatable) { AsylumSupportDecisionValidator.new(entity) }
+
+  it_behaves_like "tribunal decision sub_category validator"
+
+  describe "#errors" do
+    before do
+      validatable.valid?
+    end
+
+    context "when sub_category matches alternate prefix for parent category" do
+      let(:category) { "section-95-asylum-seekers" }
+      let(:sub_category) { "section-95-jurisdiction" }
+
+      it "returns an empty error hash" do
+        errors = validatable.errors.messages
+        expect(errors).to eq({})
+      end
+    end
+  end
+end

--- a/spec/models/validators/asylum_support_decision_validator_spec.rb
+++ b/spec/models/validators/asylum_support_decision_validator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AsylumSupportDecisionValidator do
 
     context "when sub_category matches alternate prefix for parent category" do
       let(:category) { "section-95-asylum-seekers" }
-      let(:sub_category) { "section-95-jurisdiction" }
+      let(:sub_category) { ["section-95-jurisdiction"] }
 
       it "returns an empty error hash" do
         errors = validatable.errors.messages

--- a/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
+++ b/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
@@ -8,6 +8,17 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
 
   describe "#errors" do
 
+    context "when sub_category not provided" do
+      let(:category) { "category-name" }
+      let(:sub_category) { "" }
+
+      it "returns an empty error hash" do
+        validatable.valid?
+        errors = validatable.errors.messages
+        expect(errors).to eq({})
+      end
+    end
+
     context "when sub_category does not match category" do
       let(:category) { "category-name" }
       let(:sub_category) { "non-matching-sub-category" }

--- a/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
+++ b/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
@@ -12,10 +12,32 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
       let(:category) { "category-name" }
       let(:sub_category) { [] }
 
-      it "returns an empty error hash" do
-        validatable.valid?
-        errors = validatable.errors.messages
-        expect(errors).to eq({})
+      context "and parent category has no sub-categories" do
+        before do
+          allow(finder_schema).to receive(:options_for).with(:tribunal_decision_sub_category).
+            and_return [["Other category sub-category", "other-category-sub-category"]]
+        end
+
+        it "returns an empty error hash" do
+          validatable.valid?
+          errors = validatable.errors.messages
+          expect(errors).to eq({})
+        end
+      end
+
+      context "and parent category has sub-categories" do
+        before do
+          allow(finder_schema).to receive(:options_for).with(:tribunal_decision_sub_category).
+            and_return [["Category name sub-category", "category-name-sub-category"]]
+        end
+
+        it "returns error for sub_category" do
+          validatable.valid?
+          errors = validatable.errors.messages
+          expect(errors).to eq({
+            tribunal_decision_sub_category: ["must not be blank"]
+          })
+        end
       end
     end
 
@@ -36,12 +58,34 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
       let(:category) { "category-name" }
       let(:sub_category) { ["non-matching-sub-category"] }
 
-      it "returns error for sub_category" do
-        validatable.valid?
-        errors = validatable.errors.messages
-        expect(errors).to eq({
-          tribunal_decision_sub_category: ["change to be a sub-category of '#{category_label}' or change category"]
-        })
+      context "and relevant sub_categories exist" do
+        before do
+          allow(finder_schema).to receive(:options_for).with(:tribunal_decision_sub_category).
+            and_return [["Category name sub-category", "category-name-sub-category"]]
+        end
+
+        it "returns change sub-category error message" do
+          validatable.valid?
+          errors = validatable.errors.messages
+          expect(errors).to eq({
+            tribunal_decision_sub_category: ["change to be a sub-category of '#{category_label}' or change category"]
+          })
+        end
+      end
+
+      context "and no relevant sub_categories exist" do
+        before do
+          allow(finder_schema).to receive(:options_for).with(:tribunal_decision_sub_category).
+            and_return [["Other category sub-category", "other-category-sub-category"]]
+        end
+
+        it "returns remove sub-category error message" do
+          validatable.valid?
+          errors = validatable.errors.messages
+          expect(errors).to eq({
+            tribunal_decision_sub_category: ["remove sub-category as '#{category_label}' category has no sub-categories"]
+          })
+        end
       end
     end
 

--- a/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
+++ b/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
 
     context "when sub_category not provided" do
       let(:category) { "category-name" }
-      let(:sub_category) { "" }
+      let(:sub_category) { [] }
 
       it "returns an empty error hash" do
         validatable.valid?
@@ -19,9 +19,22 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
       end
     end
 
+    context "when sub_category has two values" do
+      let(:category) { "category-name" }
+      let(:sub_category) { %w[category-name-sub-category-1 category-name-sub-category-2] }
+
+      it "returns error for sub_category" do
+        validatable.valid?
+        errors = validatable.errors.messages
+        expect(errors).to eq({
+          tribunal_decision_sub_category: ["change to a single sub-category"]
+        })
+      end
+    end
+
     context "when sub_category does not match category" do
       let(:category) { "category-name" }
-      let(:sub_category) { "non-matching-sub-category" }
+      let(:sub_category) { ["non-matching-sub-category"] }
 
       it "returns error for sub_category" do
         validatable.valid?
@@ -34,7 +47,7 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
 
     context "when sub_category matches category" do
       let(:category) { "category-name" }
-      let(:sub_category) { "category-name-subcategory-name" }
+      let(:sub_category) { ["category-name-subcategory-name"] }
 
       it "returns an empty error hash" do
         validatable.valid?

--- a/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
+++ b/spec/models/validators/tribunal_decision_sub_category_relates_to_parent_validator_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.shared_examples_for "tribunal decision sub_category validator" do
+
+  let(:category_label) { "Category label" }
+  let(:humanized_facet_value) { category_label }
+  include_context "schema with humanized_facet_value available"
+
+  describe "#errors" do
+
+    context "when sub_category does not match category" do
+      let(:category) { "category-name" }
+      let(:sub_category) { "non-matching-sub-category" }
+
+      it "returns error for sub_category" do
+        validatable.valid?
+        errors = validatable.errors.messages
+        expect(errors).to eq({
+          tribunal_decision_sub_category: ["change to be a sub-category of '#{category_label}' or change category"]
+        })
+      end
+    end
+
+    context "when sub_category matches category" do
+      let(:category) { "category-name" }
+      let(:sub_category) { "category-name-subcategory-name" }
+
+      it "returns an empty error hash" do
+        validatable.valid?
+        errors = validatable.errors.messages
+        expect(errors).to eq({})
+      end
+    end
+  end
+end

--- a/spec/models/validators/utaac_decision_validator_spec.rb
+++ b/spec/models/validators/utaac_decision_validator_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+require "validators/utaac_decision_validator"
+require_relative "tribunal_decision_sub_category_relates_to_parent_validator_spec"
+
+RSpec.describe UtaacDecisionValidator do
+
+  let(:entity) {
+    double(
+      :entity,
+      title: double,
+      summary: double,
+      body: "body",
+      tribunal_decision_category: category,
+      tribunal_decision_decision_date: "2015-11-01",
+      tribunal_decision_judges: [double],
+      tribunal_decision_sub_category: sub_category,
+    )
+  }
+  let(:document_type) { "utaac_decision" }
+
+  subject(:validatable) { UtaacDecisionValidator.new(entity) }
+
+  it_behaves_like "tribunal decision sub_category validator"
+
+end

--- a/spec/support/schema_helpers.rb
+++ b/spec/support/schema_helpers.rb
@@ -1,0 +1,8 @@
+RSpec.shared_context "schema with humanized_facet_value available" do
+  before do
+    schema = double
+    symbol = "#{document_type}_finder_schema".to_sym
+    allow(SpecialistPublisherWiring).to receive(:get).with(symbol).and_return schema
+    allow(schema).to receive(:humanized_facet_value).and_return [humanized_facet_value]
+  end
+end

--- a/spec/support/schema_helpers.rb
+++ b/spec/support/schema_helpers.rb
@@ -1,8 +1,9 @@
 RSpec.shared_context "schema with humanized_facet_value available" do
+  let(:finder_schema) { double }
+
   before do
-    schema = double
     symbol = "#{document_type}_finder_schema".to_sym
-    allow(SpecialistPublisherWiring).to receive(:get).with(symbol).and_return schema
-    allow(schema).to receive(:humanized_facet_value).and_return [humanized_facet_value]
+    allow(SpecialistPublisherWiring).to receive(:get).with(symbol).and_return finder_schema
+    allow(finder_schema).to receive(:humanized_facet_value).and_return [humanized_facet_value]
   end
 end

--- a/spec/support/shared/abstract_specialist_document_indexable_formatter.rb
+++ b/spec/support/shared/abstract_specialist_document_indexable_formatter.rb
@@ -1,11 +1,4 @@
-RSpec.shared_context "schema available" do
-  before do
-    schema = double
-    symbol = "#{formatter.type}_finder_schema".to_sym
-    allow(SpecialistPublisherWiring).to receive(:get).with(symbol).and_return schema
-    allow(schema).to receive(:humanized_facet_value).and_return double
-  end
-end
+require "formatters/abstract_specialist_document_indexable_formatter"
 
 RSpec.shared_examples_for "a specialist document indexable formatter" do
   describe "last update" do
@@ -28,3 +21,4 @@ RSpec.shared_examples_for "a specialist document indexable formatter" do
     end
   end
 end
+

--- a/spec/support/shared/abstract_specialist_document_indexable_formatter.rb
+++ b/spec/support/shared/abstract_specialist_document_indexable_formatter.rb
@@ -21,4 +21,3 @@ RSpec.shared_examples_for "a specialist document indexable formatter" do
     end
   end
 end
-


### PR DESCRIPTION
This is a solution to a concern raised from the Finder team that it was possible for bad category/sub-category data to be entered by admin users creating tribunal decision documents.

A provided tribunal decision sub-category must be related to the supplied parent category. Some parent categories will not have any sub-categories related to them. A tribunal decision with a blank sub-category will be valid if the parent category has no sub-categories. Otherwise presence of a related sub-category is required.

Screenshots of the validation errors:
![screen shot 2015-09-24 at 11 43 17](https://cloud.githubusercontent.com/assets/3447/10072240/e6efc184-62b7-11e5-9326-8149cd1719bc.png)
![screen shot 2015-09-24 at 11 43 35](https://cloud.githubusercontent.com/assets/3447/10072238/e6eed8c8-62b7-11e5-9174-8d758593aaf1.png)
![screen shot 2015-09-24 at 11 43 54](https://cloud.githubusercontent.com/assets/3447/10072239/e6ef035c-62b7-11e5-80db-5f9819c2817a.png)
![screen shot 2015-09-24 at 11 42 49](https://cloud.githubusercontent.com/assets/3447/10072237/e6ee5150-62b7-11e5-976d-28c73c66f1f3.png)

Changes:
* Add a `TribunalDecisionSubCategoryValidator` for use by tribunal decision finders.
* Validate UTAAC `tribunal_decision_sub_category` facet value is prefixed by the parent category facet value.
* Validate asylum support `tribunal_decision_sub_category` facet value is prefixed by the alternate parent category facet value prefix.
* Error message explains how to select valid sub-category.
* Allow sub-category to be optional.
* Use type-ahead select UI for tribunal decision sub-categories to allow blank sub-category to be provided.
* Validate that only a single sub-category is entered.
* Validate that a sub-category is provided, if there are sub-categories present for given parent category.

