### PR TITLE
WIP: Scenario outlines for creating and editing specialist documents

### DIFF
--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -11,10 +11,6 @@ Feature: Creating and editing a CMA case
     When I create another case with the same slug
     Then I see a warning about slug clash at publication
 
-  Scenario: Can view a list of all cases in the publisher
-    Given two CMA cases exist
-    Then the CMA cases should be in the publisher case index in the correct order
-
   Scenario: Change the title of a previously published document
     Given a published CMA case exists
     When I change the CMA case title and re-publish

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -6,13 +6,6 @@ Feature: Creating and editing a CMA case
   Background:
     Given I am logged in as a "CMA" editor
 
-  Scenario: Cannot create a CMA case with invalid fields
-    When I create a CMA case with invalid fields
-    Then I should see error messages about missing fields
-    And I should see an error message about an invalid date field "Opened date"
-    And I should see an error message about a "Body" field containing javascript
-    And the CMA case should not have been created
-
   Scenario: Create a CMA case with a clashing slug
     Given a published CMA case exists
     When I create another case with the same slug

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -6,12 +6,6 @@ Feature: Creating and editing a CMA case
   Background:
     Given I am logged in as a "CMA" editor
 
-  Scenario: Create a new CMA case
-    When I create a CMA case
-    Then the CMA case has been created
-    And the document should be sent to content preview
-    And I should see a link to preview the document
-
   Scenario: Cannot create a CMA case with invalid fields
     When I create a CMA case with invalid fields
     Then I should see error messages about missing fields
@@ -27,12 +21,6 @@ Feature: Creating and editing a CMA case
   Scenario: Can view a list of all cases in the publisher
     Given two CMA cases exist
     Then the CMA cases should be in the publisher case index in the correct order
-
-  Scenario: Edit a draft CMA case
-    Given a draft CMA case exists
-    When I edit a CMA case
-    Then the CMA case should have been updated
-    And the document should be sent to content preview
 
   Scenario: Change the title of a previously published document
     Given a published CMA case exists

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -5,7 +5,3 @@ So that I can add them to the Countryside Stewardship Grants finder
 
 Background:
 Given I am logged in as a "DEFRA" editor
-
-Scenario: Can view a list of all Countryside Stewardship Grants in the publisher
-  Given two Countryside Stewardship Grants exist
-  Then the Countryside Stewardship Grants should be in the publisher CSG index in the correct order

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -6,17 +6,6 @@ So that I can add them to the Countryside Stewardship Grants finder
 Background:
 Given I am logged in as a "DEFRA" editor
 
-Scenario: Cannot create a Countryside Stewardship Grant with invalid fields
-  When I create a Countryside Stewardship Grant with invalid fields
-  Then I should see error messages about missing fields
-  And I should see an error message about a "Body" field containing javascript
-  And the Countryside Stewardship Grant should not have been created
-
-Scenario: Cannot edit an Countryside Stewardship Grant without entering required fields
-  Given a draft Countryside Stewardship Grant exists
-  When I edit an Countryside Stewardship Grant and remove required fields
-  Then the Countryside Stewardship Grant should not have been updated
-
 Scenario: Can view a list of all Countryside Stewardship Grants in the publisher
   Given two Countryside Stewardship Grants exist
   Then the Countryside Stewardship Grants should be in the publisher CSG index in the correct order

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing an Countryside Stewardship Grant
-As a DEFRA Editor
-I want to create countryside stewardship grants pages in Specialist publisher
-So that I can add them to the Countryside Stewardship Grants finder
-
-Background:
-Given I am logged in as a "DEFRA" editor

--- a/features/creating-and-editing-a-countryside-stewardship-grant.feature
+++ b/features/creating-and-editing-a-countryside-stewardship-grant.feature
@@ -6,11 +6,6 @@ So that I can add them to the Countryside Stewardship Grants finder
 Background:
 Given I am logged in as a "DEFRA" editor
 
-Scenario: Create a new Countryside Stewardship Grant
-  When I create a Countryside Stewardship Grant
-  Then the Countryside Stewardship Grant has been created
-  And the document should be sent to content preview
-
 Scenario: Cannot create a Countryside Stewardship Grant with invalid fields
   When I create a Countryside Stewardship Grant with invalid fields
   Then I should see error messages about missing fields
@@ -25,9 +20,3 @@ Scenario: Cannot edit an Countryside Stewardship Grant without entering required
 Scenario: Can view a list of all Countryside Stewardship Grants in the publisher
   Given two Countryside Stewardship Grants exist
   Then the Countryside Stewardship Grants should be in the publisher CSG index in the correct order
-
-Scenario: Edit a draft Countryside Stewardship Grant
-  Given a draft Countryside Stewardship Grant exists
-  When I edit a Countryside Stewardship Grant
-  Then the Countryside Stewardship Grant should have been updated
-  And the document should be sent to content preview

--- a/features/creating-and-editing-a-drug-safety-update.feature
+++ b/features/creating-and-editing-a-drug-safety-update.feature
@@ -5,7 +5,3 @@ Feature: Creating and editing a Drug Safety Update
 
   Background:
     Given I am logged in as a "MHRA" editor
-
-  Scenario: Can view a list of all Drug Safety Updates in the publisher
-    Given two Drug Safety Updates exist
-    Then the Drug Safety Updates should be in the publisher DSU index in the correct order

--- a/features/creating-and-editing-a-drug-safety-update.feature
+++ b/features/creating-and-editing-a-drug-safety-update.feature
@@ -6,11 +6,6 @@ Feature: Creating and editing a Drug Safety Update
   Background:
     Given I am logged in as a "MHRA" editor
 
-  Scenario: Create a new Drug Safety Update
-    When I create a Drug Safety Update
-    Then the Drug Safety Update has been created
-    And the document should be sent to content preview
-
   Scenario: Cannot create a Drug Safety Update with invalid fields
     When I create a Drug Safety Update with invalid fields
     Then I should see error messages about missing fields
@@ -25,9 +20,3 @@ Feature: Creating and editing a Drug Safety Update
   Scenario: Can view a list of all Drug Safety Updates in the publisher
     Given two Drug Safety Updates exist
     Then the Drug Safety Updates should be in the publisher DSU index in the correct order
-
-  Scenario: Edit a draft Drug Safety Update
-    Given a draft Drug Safety Update exists
-    When I edit a Drug Safety Update
-    Then the Drug Safety Update should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-a-drug-safety-update.feature
+++ b/features/creating-and-editing-a-drug-safety-update.feature
@@ -6,17 +6,6 @@ Feature: Creating and editing a Drug Safety Update
   Background:
     Given I am logged in as a "MHRA" editor
 
-  Scenario: Cannot create a Drug Safety Update with invalid fields
-    When I create a Drug Safety Update with invalid fields
-    Then I should see error messages about missing fields
-    And I should see an error message about a "Body" field containing javascript
-    And the Drug Safety Update should not have been created
-
-  Scenario: Cannot edit a Drug Safety Update without entering required fields
-    Given a draft Drug Safety Update exists
-    When I edit a Drug Safety Update and remove required fields
-    Then the Drug Safety Update should not have been updated
-
   Scenario: Can view a list of all Drug Safety Updates in the publisher
     Given two Drug Safety Updates exist
     Then the Drug Safety Updates should be in the publisher DSU index in the correct order

--- a/features/creating-and-editing-a-drug-safety-update.feature
+++ b/features/creating-and-editing-a-drug-safety-update.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing a Drug Safety Update
-  As a MHRA Editor
-  I want to create a drug safety update in Specialist publisher
-  So that I can add them to the Drug Safety Update finder
-
-  Background:
-    Given I am logged in as a "MHRA" editor

--- a/features/creating-and-editing-a-maib-report.feature
+++ b/features/creating-and-editing-a-maib-report.feature
@@ -5,8 +5,3 @@ Feature: Publishing an MAIB Report
 
   Background:
     Given I am logged in as a "MAIB" editor
-
-  Scenario: Can view a list of all MAIB reports in the publisher
-    Given two MAIB reports exist
-    Then the MAIB reports should be in the publisher report index in the correct order
-

--- a/features/creating-and-editing-a-maib-report.feature
+++ b/features/creating-and-editing-a-maib-report.feature
@@ -6,12 +6,6 @@ Feature: Publishing an MAIB Report
   Background:
     Given I am logged in as a "MAIB" editor
 
-  Scenario: Create a new MAIB report
-    When I create a MAIB report
-    Then the MAIB report has been created
-    And the MAIB report should be in draft
-    And the document should be sent to content preview
-
   Scenario: Cannot create a MAIB report with invalid fields
     When I create a MAIB report with invalid fields
     Then I should see error messages about missing fields
@@ -27,9 +21,3 @@ Feature: Publishing an MAIB Report
   Scenario: Can view a list of all MAIB reports in the publisher
     Given two MAIB reports exist
     Then the MAIB reports should be in the publisher report index in the correct order
-
-  Scenario: Edit a draft MAIB report
-    Given a draft MAIB report exists
-    When I edit a MAIB report
-    Then the MAIB report should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-a-maib-report.feature
+++ b/features/creating-and-editing-a-maib-report.feature
@@ -1,7 +1,0 @@
-Feature: Publishing an MAIB Report
-  As an MAIB editor
-  I want to create a new report in draft
-  So that I can prepare the info for publication
-
-  Background:
-    Given I am logged in as a "MAIB" editor

--- a/features/creating-and-editing-a-maib-report.feature
+++ b/features/creating-and-editing-a-maib-report.feature
@@ -6,18 +6,7 @@ Feature: Publishing an MAIB Report
   Background:
     Given I am logged in as a "MAIB" editor
 
-  Scenario: Cannot create a MAIB report with invalid fields
-    When I create a MAIB report with invalid fields
-    Then I should see error messages about missing fields
-    Then I should see an error message about an invalid date field "Date of occurrence"
-    And I should see an error message about a "Body" field containing javascript
-    And the MAIB report should not have been created
-
-  Scenario: Cannot edit an MAIB report without entering required fields
-    Given a draft MAIB report exists
-    When I edit an MAIB report and remove required fields
-    Then the MAIB report should not have been updated
-
   Scenario: Can view a list of all MAIB reports in the publisher
     Given two MAIB reports exist
     Then the MAIB reports should be in the publisher report index in the correct order
+

--- a/features/creating-and-editing-a-medical-safety-alert.feature
+++ b/features/creating-and-editing-a-medical-safety-alert.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing a Medical Safety Alert
-  As a MHRA Editor
-  I want to create a Medical Safety Alert in Specialist publisher
-  So that I can add them to the Drug Device Alert finder
-
-  Background:
-    Given I am logged in as a "MHRA" editor

--- a/features/creating-and-editing-a-medical-safety-alert.feature
+++ b/features/creating-and-editing-a-medical-safety-alert.feature
@@ -6,17 +6,6 @@ Feature: Creating and editing a Medical Safety Alert
   Background:
     Given I am logged in as a "MHRA" editor
 
-  Scenario: Cannot create a Medical Safety Alert with invalid fields
-    When I create a Medical Safety Alert with invalid fields
-    Then I should see error messages about missing fields
-    And I should see an error message about a "Body" field containing javascript
-    And the Medical Safety Alert should not have been created
-
-  Scenario: Cannot edit a Medical Safety Alert without entering required fields
-    Given a draft Medical Safety Alert exists
-    When I edit a Medical Safety Alert and remove required fields
-    Then the Medical Safety Alert should not have been updated
-
   Scenario: Can view a list of all Medical Safety Alert in the publisher
     Given two Medical Safety Alerts exist
     Then the Medical Safety Alerts should be in the publisher MSA index in the correct order

--- a/features/creating-and-editing-a-medical-safety-alert.feature
+++ b/features/creating-and-editing-a-medical-safety-alert.feature
@@ -5,7 +5,3 @@ Feature: Creating and editing a Medical Safety Alert
 
   Background:
     Given I am logged in as a "MHRA" editor
-
-  Scenario: Can view a list of all Medical Safety Alert in the publisher
-    Given two Medical Safety Alerts exist
-    Then the Medical Safety Alerts should be in the publisher MSA index in the correct order

--- a/features/creating-and-editing-a-medical-safety-alert.feature
+++ b/features/creating-and-editing-a-medical-safety-alert.feature
@@ -6,11 +6,6 @@ Feature: Creating and editing a Medical Safety Alert
   Background:
     Given I am logged in as a "MHRA" editor
 
-  Scenario: Create a new Medical Safety Alert
-    When I create a Medical Safety Alert
-    Then the Medical Safety Alert has been created
-    And the document should be sent to content preview
-
   Scenario: Cannot create a Medical Safety Alert with invalid fields
     When I create a Medical Safety Alert with invalid fields
     Then I should see error messages about missing fields
@@ -25,9 +20,3 @@ Feature: Creating and editing a Medical Safety Alert
   Scenario: Can view a list of all Medical Safety Alert in the publisher
     Given two Medical Safety Alerts exist
     Then the Medical Safety Alerts should be in the publisher MSA index in the correct order
-
-  Scenario: Edit a draft Medical Safety Alert
-    Given a draft Medical Safety Alert exists
-    When I edit a Medical Safety Alert
-    Then the Medical Safety Alert should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-a-raib-report.feature
+++ b/features/creating-and-editing-a-raib-report.feature
@@ -5,8 +5,3 @@ Feature: Publishing a RAIB Report
 
   Background:
     Given I am logged in as a "RAIB" editor
-
-  Scenario: Can view a list of all RAIB reports in the publisher
-    Given two RAIB reports exist
-    Then the RAIB reports should be in the publisher report index in the correct order
-

--- a/features/creating-and-editing-a-raib-report.feature
+++ b/features/creating-and-editing-a-raib-report.feature
@@ -6,12 +6,6 @@ Feature: Publishing a RAIB Report
   Background:
     Given I am logged in as a "RAIB" editor
 
-  Scenario: Create a new RAIB report
-    When I create a RAIB report
-    Then the RAIB report has been created
-    And the RAIB report should be in draft
-    And the document should be sent to content preview
-
   Scenario: Cannot create a RAIB report with invalid fields
     When I create a RAIB report with invalid fields
     Then I should see error messages about missing fields
@@ -27,9 +21,3 @@ Feature: Publishing a RAIB Report
   Scenario: Can view a list of all RAIB reports in the publisher
     Given two RAIB reports exist
     Then the RAIB reports should be in the publisher report index in the correct order
-
-  Scenario: Edit a draft RAIB report
-    Given a draft RAIB report exists
-    When I edit a RAIB report
-    Then the RAIB report should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-a-raib-report.feature
+++ b/features/creating-and-editing-a-raib-report.feature
@@ -1,7 +1,0 @@
-Feature: Publishing a RAIB Report
-  As an RAIB editor
-  I want to create a new report in draft
-  So that I can prepare the info for publication
-
-  Background:
-    Given I am logged in as a "RAIB" editor

--- a/features/creating-and-editing-a-raib-report.feature
+++ b/features/creating-and-editing-a-raib-report.feature
@@ -6,18 +6,7 @@ Feature: Publishing a RAIB Report
   Background:
     Given I am logged in as a "RAIB" editor
 
-  Scenario: Cannot create a RAIB report with invalid fields
-    When I create a RAIB report with invalid fields
-    Then I should see error messages about missing fields
-    Then I should see an error message about an invalid date field "Date of occurrence"
-    And I should see an error message about a "Body" field containing javascript
-    And the RAIB report should not have been created
-
-  Scenario: Cannot edit an RAIB report without entering required fields
-    Given a draft RAIB report exists
-    When I edit an RAIB report and remove required fields
-    Then the RAIB report should not have been updated
-
   Scenario: Can view a list of all RAIB reports in the publisher
     Given two RAIB reports exist
     Then the RAIB reports should be in the publisher report index in the correct order
+

--- a/features/creating-and-editing-a-specialist-document.feature
+++ b/features/creating-and-editing-a-specialist-document.feature
@@ -43,3 +43,39 @@ Feature: Creating and editing a specialist document
       | RAIB         | RAIB report                      |
       | DFID         | International Development Fund   |
       | DVSA         | Vehicle Recalls and Faults alert |
+
+  Scenario Outline: Cannot create a <document> with invalid fields
+    Given I am logged in as a "<organisation>" editor
+    When I create a <document> with invalid fields
+    Then I should see error messages about missing fields
+    Then I should see an error message about an invalid date field "<date_name>"
+    And I should see an error message about a "Body" field containing javascript
+    And the <document> should not have been created
+
+    Examples:
+      | organisation | document                         | date_name          |
+      | AAIB         | AAIB report                      | Date of occurrence |
+      | CMA          | CMA case                         | Opened date        |
+      | DEFRA        | Countryside Stewardship Grant    | N/A                |
+      | MHRA         | Drug Safety Update               | N/A                |
+      | DCLG         | ESI Fund                         | N/A                |
+      | MAIB         | MAIB report                      | Date of occurrence |
+      | MHRA         | Medical Safety Alert             | Issued date        |
+      | RAIB         | RAIB report                      | Date of occurrence |
+      | DFID         | International Development Fund   | N/A                |
+      | DVSA         | Vehicle Recalls and Faults alert | Alert issue date   |
+
+  Scenario Outline: Cannot edit an <document> without entering required fields
+    Given I am logged in as a "<organisation>" editor
+    Given a draft <document> exists
+    When I edit an <document> and remove required fields
+    Then the <document> should not have been updated
+
+    Examples:
+      | organisation | document                         |
+      | AAIB         | AAIB report                      |
+      | DEFRA        | Countryside Stewardship Grant    |
+      | DCLG         | ESI Fund                         |
+      | MAIB         | MAIB report                      |
+      | RAIB         | RAIB report                      |
+      | DFID         | International Development Fund   |

--- a/features/creating-and-editing-a-specialist-document.feature
+++ b/features/creating-and-editing-a-specialist-document.feature
@@ -1,0 +1,45 @@
+Feature: Creating and editing a specialist document
+  As an editor
+  I want to create documents in specialist publisher
+  So that I can add them to the specialist document finder
+
+  Scenario Outline: Create a new document
+    Given I am logged in as a "<organisation>" editor
+    When I create a <document>
+    Then the <document> has been created
+    And the <document> should be in draft
+    And the document should be sent to content preview
+    And I should see a link to preview the document
+
+    Examples:
+      | organisation | document                         |
+      | AAIB         | AAIB report                      |
+      | CMA          | CMA case                         |
+      | DEFRA        | Countryside Stewardship Grant    |
+      | MHRA         | Drug Safety Update               |
+      | DCLG         | ESI Fund                         |
+      | MAIB         | MAIB report                      |
+      | MHRA         | Medical Safety Alert             |
+      | RAIB         | RAIB report                      |
+      | DFID         | International Development Fund   |
+      | DVSA         | Vehicle Recalls and Faults alert |
+
+  Scenario Outline: Edit a draft document
+    Given I am logged in as a "<organisation>" editor
+    And a draft <document> exists
+    When I edit a <document>
+    Then the <document> should have been updated
+    And the document should be sent to content preview
+
+    Examples:
+      | organisation | document                         |
+      | AAIB         | AAIB report                      |
+      | CMA          | CMA case                         |
+      | DEFRA        | Countryside Stewardship Grant    |
+      | MHRA         | Drug Safety Update               |
+      | DCLG         | ESI Fund                         |
+      | MAIB         | MAIB report                      |
+      | MHRA         | Medical Safety Alert             |
+      | RAIB         | RAIB report                      |
+      | DFID         | International Development Fund   |
+      | DVSA         | Vehicle Recalls and Faults alert |

--- a/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
+++ b/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
@@ -6,11 +6,6 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
   Background:
     Given I am logged in as a "DVSA" editor
 
-  Scenario: Creating a new Vehicle Recalls and Faults alert
-    When I create a Vehicle Recalls and Faults alert
-    Then I should see that Vehicle Recalls and Faults alert
-    And the document should be sent to content preview
-
   Scenario: Providing invalid inputs when creating an alert
     When I try to save a Vehicle Recall alert with invalid HTML and no title
     Then I should see error messages about missing fields
@@ -26,9 +21,3 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
   Scenario: Viewing a list of all Vehicle Recalls and Faults alerts in the publisher
     Given two Vehicle Recalls and Faults alerts exist
     Then the Vehicle Recalls and Faults alerts should be in the publisher CSG index
-
-  Scenario: Editing a draft Vehicle Recalls and Faults alert
-    Given a draft of a Vehicle Recalls and Faults alert exists
-    When I change the title of that Vehicle Recalls and Faults alert to "A big vehicle fault"
-    Then I should see "A big vehicle fault" as the title fo the Vehicle Recalls and Faults alert
-    And the document should be sent to content preview

--- a/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
+++ b/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
@@ -6,13 +6,6 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
   Background:
     Given I am logged in as a "DVSA" editor
 
-  Scenario: Providing invalid inputs when creating an alert
-    When I try to save a Vehicle Recall alert with invalid HTML and no title
-    Then I should see error messages about missing fields
-    And I should see an error message about invalid HTML in "Body"
-    And I should see an error message about an invalid date field "Alert issue date"
-    And the Vehicle Recall alert is not persisted
-
   Scenario: Providing invalid inputs when editing an alert
     Given a draft Vehicle Recalls and Faults alert exists
     When I edit the Vehicle Recalls and Faults alert and remove summary

--- a/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
+++ b/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
@@ -10,7 +10,3 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
     Given a draft Vehicle Recalls and Faults alert exists
     When I edit the Vehicle Recalls and Faults alert and remove summary
     Then the Vehicle Recalls and Faults alert should show an error for the summary
-
-  Scenario: Viewing a list of all Vehicle Recalls and Faults alerts in the publisher
-    Given two Vehicle Recalls and Faults alerts exist
-    Then the Vehicle Recalls and Faults alerts should be in the publisher CSG index

--- a/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
+++ b/features/creating-and-editing-a-vehicle-recall-and-fault-alert.feature
@@ -19,7 +19,7 @@ Feature: Creating and editing a Vehicle Recalls and Faults alert
     And the Vehicle Recall alert is not persisted
 
   Scenario: Providing invalid inputs when editing an alert
-    Given a draft of a Vehicle Recalls and Faults alert exists
+    Given a draft Vehicle Recalls and Faults alert exists
     When I edit the Vehicle Recalls and Faults alert and remove summary
     Then the Vehicle Recalls and Faults alert should show an error for the summary
 

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -5,8 +5,3 @@ Feature: Creating and editing an AAIB Report
 
   Background:
     Given I am logged in as a "AAIB" editor
-
-  Scenario: Can view a list of all AAIB reports in the publisher
-    Given two AAIB reports exist
-    Then the AAIB reports should be in the publisher report index in the correct order
-

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -6,18 +6,7 @@ Feature: Creating and editing an AAIB Report
   Background:
     Given I am logged in as a "AAIB" editor
 
-  Scenario: Cannot create a AAIB report with invalid fields
-    When I create a AAIB report with invalid fields
-    Then I should see error messages about missing fields
-    Then I should see an error message about an invalid date field "Date of occurrence"
-    And I should see an error message about a "Body" field containing javascript
-    And the AAIB report should not have been created
-
-  Scenario: Cannot edit an AAIB report without entering required fields
-    Given a draft AAIB report exists
-    When I edit an AAIB report and remove required fields
-    Then the AAIB report should not have been updated
-
   Scenario: Can view a list of all AAIB reports in the publisher
     Given two AAIB reports exist
     Then the AAIB reports should be in the publisher report index in the correct order
+

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -6,12 +6,6 @@ Feature: Creating and editing an AAIB Report
   Background:
     Given I am logged in as a "AAIB" editor
 
-  Scenario: Create a new AAIB report
-    When I create a AAIB report
-    Then the AAIB report has been created
-    And the AAIB report should be in draft
-    And the document should be sent to content preview
-
   Scenario: Cannot create a AAIB report with invalid fields
     When I create a AAIB report with invalid fields
     Then I should see error messages about missing fields
@@ -27,9 +21,3 @@ Feature: Creating and editing an AAIB Report
   Scenario: Can view a list of all AAIB reports in the publisher
     Given two AAIB reports exist
     Then the AAIB reports should be in the publisher report index in the correct order
-
-  Scenario: Edit a draft AAIB report
-    Given a draft AAIB report exists
-    When I edit a AAIB report
-    Then the AAIB report should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing an AAIB Report
-  As an AAIB editor
-  I want to create air investigation report pages in Specialist publisher
-  So that I can add them to the AAIB reports finder
-
-  Background:
-    Given I am logged in as a "AAIB" editor

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -5,7 +5,3 @@ So that I can add them to the ESI Funds finder
 
 Background:
 Given I am logged in as a "DCLG" editor
-
-Scenario: Can view a list of all ESI Funds in the publisher
-  Given two ESI Funds exist
-  Then the ESI Funds should be in the publisher CSG index in the correct order

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -6,11 +6,6 @@ So that I can add them to the ESI Funds finder
 Background:
 Given I am logged in as a "DCLG" editor
 
-Scenario: Create a new ESI Fund
-  When I create an ESI Fund
-  Then the ESI Fund has been created
-  And the document should be sent to content preview
-
 Scenario: Cannot create an ESI Fund with invalid fields
   When I create an ESI Fund with invalid fields
   Then I should see error messages about missing fields
@@ -26,9 +21,3 @@ Scenario: Cannot edit an ESI Fund without entering required fields
 Scenario: Can view a list of all ESI Funds in the publisher
   Given two ESI Funds exist
   Then the ESI Funds should be in the publisher CSG index in the correct order
-
-Scenario: Edit a draft ESI Fund
-  Given a draft ESI Fund exists
-  When I edit an ESI Fund
-  Then the ESI Fund should have been updated
-  And the document should be sent to content preview

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing an ESI Fund
-As a DCLG Editor
-I want to create ESI Funds pages in Specialist publisher
-So that I can add them to the ESI Funds finder
-
-Background:
-Given I am logged in as a "DCLG" editor

--- a/features/creating-and-editing-an-esi-fund.feature
+++ b/features/creating-and-editing-an-esi-fund.feature
@@ -6,18 +6,6 @@ So that I can add them to the ESI Funds finder
 Background:
 Given I am logged in as a "DCLG" editor
 
-Scenario: Cannot create an ESI Fund with invalid fields
-  When I create an ESI Fund with invalid fields
-  Then I should see error messages about missing fields
-  And I should see an error message about an invalid date field "Closing date"
-  And I should see an error message about a "Body" field containing javascript
-  And the ESI Fund should not have been created
-
-Scenario: Cannot edit an ESI Fund without entering required fields
-  Given a draft ESI Fund exists
-  When I edit an ESI Fund and remove required fields
-  Then the ESI Fund should not have been updated
-
 Scenario: Can view a list of all ESI Funds in the publisher
   Given two ESI Funds exist
   Then the ESI Funds should be in the publisher CSG index in the correct order

--- a/features/creating-and-editing-an-international-development-fund.feature
+++ b/features/creating-and-editing-an-international-development-fund.feature
@@ -6,11 +6,6 @@ Feature: Creating and editing an International Development Fund
   Background:
     Given I am logged in as a "DFID" editor
 
-  Scenario: Create a new International Development Fund
-    When I create a International Development Fund
-    Then the International Development Fund has been created
-    And the document should be sent to content preview
-
   Scenario: Cannot create a International Development Fund with invalid fields
     When I create a International Development Fund with invalid fields
     Then I should see error messages about missing fields
@@ -25,9 +20,3 @@ Feature: Creating and editing an International Development Fund
   Scenario: Can view a list of all International Development Funds in the publisher
     Given two International Development Funds exist
     Then the International Development Funds should be in the publisher IDF index in the correct order
-
-  Scenario: Edit a draft International Development Fund
-    Given a draft International Development Fund exists
-    When I edit a International Development Fund
-    Then the International Development Fund should have been updated
-    And the document should be sent to content preview

--- a/features/creating-and-editing-an-international-development-fund.feature
+++ b/features/creating-and-editing-an-international-development-fund.feature
@@ -5,7 +5,3 @@ Feature: Creating and editing an International Development Fund
 
   Background:
     Given I am logged in as a "DFID" editor
-
-  Scenario: Can view a list of all International Development Funds in the publisher
-    Given two International Development Funds exist
-    Then the International Development Funds should be in the publisher IDF index in the correct order

--- a/features/creating-and-editing-an-international-development-fund.feature
+++ b/features/creating-and-editing-an-international-development-fund.feature
@@ -6,17 +6,6 @@ Feature: Creating and editing an International Development Fund
   Background:
     Given I am logged in as a "DFID" editor
 
-  Scenario: Cannot create a International Development Fund with invalid fields
-    When I create a International Development Fund with invalid fields
-    Then I should see error messages about missing fields
-    And I should see an error message about a "Body" field containing javascript
-    And the International Development Fund should not have been created
-
-  Scenario: Cannot edit an International Development Fund without entering required fields
-    Given a draft International Development Fund exists
-    When I edit an International Development Fund and remove required fields
-    Then the International Development Fund should not have been updated
-
   Scenario: Can view a list of all International Development Funds in the publisher
     Given two International Development Funds exist
     Then the International Development Funds should be in the publisher IDF index in the correct order

--- a/features/creating-and-editing-an-international-development-fund.feature
+++ b/features/creating-and-editing-an-international-development-fund.feature
@@ -1,7 +1,0 @@
-Feature: Creating and editing an International Development Fund
-  As a DFID Editor
-  I want to create international development fund pages in Specialist publisher
-  So that I can add them to the International Development Funds finder
-
-  Background:
-    Given I am logged in as a "DFID" editor

--- a/features/publishing-a-vehicle-recalls-and-faults-alert.feature
+++ b/features/publishing-a-vehicle-recalls-and-faults-alert.feature
@@ -11,7 +11,7 @@ Feature: Publishing Vehicle Recalls and Faults alerts
     Then the Vehicle Recalls and Faults alert should be in draft
 
   Scenario: Publishing a draft of a Vehicle Recalls and Faults alert
-    Given a draft of a Vehicle Recalls and Faults alert exists
+    Given a draft Vehicle Recalls and Faults alert exists
     When I publish the Vehicle Recalls and Faults alert
     Then the Vehicle Recalls and Faults alert should be published
 
@@ -28,7 +28,7 @@ Feature: Publishing Vehicle Recalls and Faults alerts
     And previous editions should be archived
 
   Scenario: Sending an email alert on first publish
-    Given a draft of a Vehicle Recalls and Faults alert exists
+    Given a draft Vehicle Recalls and Faults alert exists
     When I publish the Vehicle Recalls and Faults alert
     Then a publication notification should have been sent
 

--- a/features/publishing-an-esi-fund.feature
+++ b/features/publishing-an-esi-fund.feature
@@ -7,7 +7,7 @@ Background:
 Given I am logged in as a "DCLG" editor
 
 Scenario: can create a new ESI Fund in draft
-  When I create an ESI Fund
+  When I create a ESI Fund
   Then the ESI Fund should be in draft
 
 Scenario: can publish a draft ESI Fund

--- a/features/step_definitions/aaib_report_steps.rb
+++ b/features/step_definitions/aaib_report_steps.rb
@@ -46,7 +46,7 @@ Given(/^two AAIB reports exist$/) do
   create_aaib_report(@document_fields)
 end
 
-Then(/^the AAIB reports should be in the publisher report index in the correct order$/) do
+Then(/^the AAIB reports should be in the publisher document index in the correct order$/) do
   visit aaib_reports_path
 
   check_for_documents("AAIB Report 2", "AAIB Report 1")

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -72,7 +72,7 @@ Then(/^the CMA case should not have been created$/) do
   check_document_does_not_exist_with(@document_fields)
 end
 
-Then(/^the CMA cases should be in the publisher case index in the correct order$/) do
+Then(/^the CMA cases should be in the publisher document index in the correct order$/) do
   visit cma_cases_path
 
   check_for_documents(*@documents.map(&:title))

--- a/features/step_definitions/csg_steps.rb
+++ b/features/step_definitions/csg_steps.rb
@@ -61,7 +61,7 @@ Given(/^two Countryside Stewardship Grants exist$/) do
   create_countryside_stewardship_grant(@document_fields)
 end
 
-Then(/^the Countryside Stewardship Grants should be in the publisher CSG index in the correct order$/) do
+Then(/^the Countryside Stewardship Grants should be in the publisher document index in the correct order$/) do
   visit countryside_stewardship_grants_path
 
   check_for_documents("Countryside Stewardship Grant 2", "Countryside Stewardship Grant 1")

--- a/features/step_definitions/document_validation_steps.rb
+++ b/features/step_definitions/document_validation_steps.rb
@@ -4,7 +4,7 @@ Then(/^I should see error messages about missing fields$/) do
 end
 
 Then(/^I should see an error message about an invalid date field "(.*)"$/) do |field|
-  check_for_invalid_date_error(field)
+  check_for_invalid_date_error(field) unless field == "N/A"
 end
 
 Then(/^I should see an error message about a "(.*?)" field containing javascript$/) do |field|

--- a/features/step_definitions/drug_safety_update_steps.rb
+++ b/features/step_definitions/drug_safety_update_steps.rb
@@ -76,7 +76,7 @@ Given(/^two Drug Safety Updates exist$/) do
   create_drug_safety_update(@document_fields)
 end
 
-Then(/^the Drug Safety Updates should be in the publisher DSU index in the correct order$/) do
+Then(/^the Drug Safety Updates should be in the publisher document index in the correct order$/) do
   visit drug_safety_updates_path
 
   check_for_documents("Example Drug Safety Update 1", "Example Drug Safety Update 2")

--- a/features/step_definitions/esi_fund_steps.rb
+++ b/features/step_definitions/esi_fund_steps.rb
@@ -1,4 +1,4 @@
-When(/^I create an ESI Fund$/) do
+When(/^I create a ESI Fund$/) do
   @document_title = "Example ESI Fund"
   @slug = "european-structural-investment-funds/example-esi-fund"
   @document_fields = {
@@ -68,7 +68,7 @@ Then(/^the ESI Funds should be in the publisher CSG index in the correct order$/
   check_for_documents("ESI Fund 2", "ESI Fund 1")
 end
 
-When(/^I edit an ESI Fund$/) do
+When(/^I edit a ESI Fund$/) do
   @new_title = "Edited Example ESI Fund"
   edit_esi_fund(@document_title, title: @new_title)
 end

--- a/features/step_definitions/esi_fund_steps.rb
+++ b/features/step_definitions/esi_fund_steps.rb
@@ -62,7 +62,7 @@ Given(/^two ESI Funds exist$/) do
   create_esi_fund(@document_fields)
 end
 
-Then(/^the ESI Funds should be in the publisher CSG index in the correct order$/) do
+Then(/^the ESI Funds should be in the publisher document index in the correct order$/) do
   visit esi_funds_path
 
   check_for_documents("ESI Fund 2", "ESI Fund 1")

--- a/features/step_definitions/esi_fund_steps.rb
+++ b/features/step_definitions/esi_fund_steps.rb
@@ -14,7 +14,7 @@ Then(/^the ESI Fund has been created$/) do
   check_esi_fund_exists_with(@document_fields)
 end
 
-When(/^I create an ESI Fund with invalid fields$/) do
+When(/^I create a ESI Fund with invalid fields$/) do
   @document_fields = {
     body: "<script>alert('Oh noes!)</script>",
     closing_date: "2016/01/01",

--- a/features/step_definitions/international_development_fund_steps.rb
+++ b/features/step_definitions/international_development_fund_steps.rb
@@ -61,7 +61,7 @@ Given(/^two International Development Funds exist$/) do
   create_international_development_fund(@document_fields)
 end
 
-Then(/^the International Development Funds should be in the publisher IDF index in the correct order$/) do
+Then(/^the International Development Funds should be in the publisher document index in the correct order$/) do
   visit international_development_funds_path
 
   check_for_documents("International Development Fund 2", "International Development Fund 1")

--- a/features/step_definitions/maib_report_steps.rb
+++ b/features/step_definitions/maib_report_steps.rb
@@ -66,7 +66,7 @@ Given(/^two MAIB reports exist$/) do
   create_maib_report(@document_fields)
 end
 
-Then(/^the MAIB reports should be in the publisher report index in the correct order$/) do
+Then(/^the MAIB reports should be in the publisher document index in the correct order$/) do
   visit maib_reports_path
 
   check_for_documents("MAIB report 2", "MAIB report 1")

--- a/features/step_definitions/medical_safety_alert_steps.rb
+++ b/features/step_definitions/medical_safety_alert_steps.rb
@@ -52,7 +52,7 @@ Given(/^two Medical Safety Alerts exist$/) do
   create_medical_safety_alert(@document_fields)
 end
 
-Then(/^the Medical Safety Alerts should be in the publisher MSA index in the correct order$/) do
+Then(/^the Medical Safety Alerts should be in the publisher document index in the correct order$/) do
   visit medical_safety_alerts_path
 
   check_for_documents("Example Medical Safety Alert", "Example Medical Safety Alert 2")

--- a/features/step_definitions/medical_safety_alert_steps.rb
+++ b/features/step_definitions/medical_safety_alert_steps.rb
@@ -13,6 +13,7 @@ end
 When(/^I create a Medical Safety Alert with invalid fields$/) do
   @document_fields = {
     body: "<script>alert('Oh noes!)</script>",
+    issued_date: "bad_date"
   }
   create_medical_safety_alert(@document_fields)
 end

--- a/features/step_definitions/raib_report_steps.rb
+++ b/features/step_definitions/raib_report_steps.rb
@@ -66,7 +66,7 @@ Given(/^two RAIB reports exist$/) do
   create_raib_report(@document_fields)
 end
 
-Then(/^the RAIB reports should be in the publisher report index in the correct order$/) do
+Then(/^the RAIB reports should be in the publisher document index in the correct order$/) do
   visit raib_reports_path
 
   check_for_documents("RAIB report 2", "RAIB report 1")

--- a/features/step_definitions/tribunal_decision_steps.rb
+++ b/features/step_definitions/tribunal_decision_steps.rb
@@ -1,0 +1,10 @@
+Given(/^two "(.*?)" exist$/) do |documents|
+  type = tribunal_decision_type(documents)
+  create_tribunal_decision(type, title: "decision 1")
+  create_tribunal_decision(type, title: "decision 2")
+end
+
+Then(/^the "(.*?)" should be in the publisher document index in the correct order$/) do |documents|
+  visit tribunal_decision_path(documents)
+  check_for_documents("decision 2", "decision 1")
+end

--- a/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
+++ b/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
@@ -16,12 +16,25 @@ When(/^I try to save a Vehicle Recall alert with invalid HTML and no title$/) do
   create_vehicle_recalls_and_faults_alert(@invalid_fields)
 end
 
+Then(/^the Vehicle Recalls and Faults alert has been created$/) do
+  check_document_exists_with(:vehicle_recalls_and_faults_alert, @document_fields)
+end
+
 Then(/^the Vehicle Recall alert is not persisted$/) do
   check_document_does_not_exist_with(@document_fields)
 end
 
-Given(/^a draft of a Vehicle Recalls and Faults alert exists$/) do
+Given(/^a draft Vehicle Recalls and Faults alert exists$/) do
   create_a_draft_of_vehicle_fault_alert
+end
+
+When(/^I edit a Vehicle Recalls and Faults alert$/) do
+  @new_title = "Edited Example Vehicle Recall"
+  edit_vehicle_recalls_and_faults_alert(@document_title, title: @new_title)
+end
+
+Then(/^the Vehicle Recalls and Faults alert should have been updated$/) do
+  check_for_new_document_title(:vehicle_recalls_and_faults_alert, @new_title)
 end
 
 When(/^I edit the Vehicle Recalls and Faults alert and remove summary$/) do

--- a/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
+++ b/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
@@ -6,7 +6,7 @@ Then(/^I should see that Vehicle Recalls and Faults alert$/) do
   check_vehicle_recalls_and_faults_alert_exists_with(@document_fields)
 end
 
-When(/^I try to save a Vehicle Recall alert with invalid HTML and no title$/) do
+When(/^I create a Vehicle Recalls and Faults alert with invalid fields$/) do
   @invalid_fields = {
     title: nil,
     summary: nil,
@@ -14,6 +14,10 @@ When(/^I try to save a Vehicle Recall alert with invalid HTML and no title$/) do
     alert_issue_date: "99-99/99"
   }
   create_vehicle_recalls_and_faults_alert(@invalid_fields)
+end
+
+Then(/^the Vehicle Recalls and Faults alert should not have been created$/) do
+  expect(page).to have_content("Summary can't be blank")
 end
 
 Then(/^the Vehicle Recalls and Faults alert has been created$/) do

--- a/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
+++ b/features/step_definitions/vehicle_recalls_and_faults_alert_steps.rb
@@ -61,7 +61,7 @@ Given(/^two Vehicle Recalls and Faults alerts exist$/) do
   end
 end
 
-Then(/^the Vehicle Recalls and Faults alerts should be in the publisher CSG index$/) do
+Then(/^the Vehicle Recalls and Faults alerts should be in the publisher document index in the correct order$/) do
   visit vehicle_recalls_and_faults_alerts_path
 
   check_for_documents("Example fault 0", "Example fault 1")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -118,6 +118,7 @@ require "idf_helpers"
 require "maib_report_helpers"
 require "msa_helpers"
 require "raib_report_helpers"
+require "tribunal_decision_helpers"
 require "vehicle_recalls_and_faults_alert_helpers"
 
 World(RummagerHelpers)
@@ -142,4 +143,5 @@ World(IdfHelpers)
 World(MaibReportHelpers)
 World(MsaHelpers)
 World(RaibReportHelpers)
+World(TribunalDecisionHelpers)
 World(VehicleRecallsAndFaultsAlertHelpers)

--- a/features/support/tribunal_decision_helpers.rb
+++ b/features/support/tribunal_decision_helpers.rb
@@ -1,0 +1,41 @@
+module TribunalDecisionHelpers
+
+  def tribunal_decision_type(value)
+    type = value.singularize.underscore.gsub(' ','_').to_sym
+  end
+
+  def tribunal_decision_path(documents)
+    types = tribunal_decision_type(documents).to_s.pluralize
+    send(:"#{types}_path")
+  end
+
+  def tribunal_decision_fields(type, overrides)
+    fields = {
+      title: "Lorem ipsum",
+      summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+      body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10)
+    }
+    fields.merge!(tribunal_decision_fields_for(type))
+    fields.merge!(overrides)
+    fields
+  end
+
+  def create_tribunal_decision(type, overrides = {})
+    fields = tribunal_decision_fields(type, overrides)
+    create_document(type, fields)
+  end
+
+  def tribunal_decision_fields_for(type)
+    case type
+    when :utaac_decision
+      {
+        "Category" => "Benefits for children",
+        "Sub-category" => "Benefits for children - child benefit",
+        "Judges" => "Angus, R",
+        "Decision date" => "2015-02-02"
+      }
+    else
+      raise "Add fields for #{type} to tribunal_decision_fields_for() in tribunal_decision_helpers.rb"
+    end
+  end
+end

--- a/features/support/tribunal_decision_helpers.rb
+++ b/features/support/tribunal_decision_helpers.rb
@@ -27,6 +27,15 @@ module TribunalDecisionHelpers
 
   def tribunal_decision_fields_for(type)
     case type
+    when :asylum_support_decision
+      {
+        "Category" => "Section 95 (asylum-seekers)",
+        "Sub-category" => "Section 95 - jurisdiction",
+        "Judges" => "Bashir, S",
+        "Decision date" => "2015-02-02",
+        "Landmark" => "Landmark",
+        "Reference number" => "1234"
+      }
     when :utaac_decision
       {
         "Category" => "Benefits for children",

--- a/features/viewing-list-of-specialist-documents.feature
+++ b/features/viewing-list-of-specialist-documents.feature
@@ -11,6 +11,7 @@ Feature: Viewing specialist documents
     Examples:
       | organisation | documents                         |
       | AAIB         | AAIB reports                      |
+      | AST          | "Asylum support decisions"        |
       | CMA          | CMA cases                         |
       | DEFRA        | Countryside Stewardship Grants    |
       | MHRA         | Drug Safety Updates               |

--- a/features/viewing-list-of-specialist-documents.feature
+++ b/features/viewing-list-of-specialist-documents.feature
@@ -20,3 +20,4 @@ Feature: Viewing specialist documents
       | RAIB         | RAIB reports                      |
       | DFID         | International Development Funds   |
       | DVSA         | Vehicle Recalls and Faults alerts |
+      | UTAAC        | "UTAAC decisions"                 |

--- a/features/viewing-list-of-specialist-documents.feature
+++ b/features/viewing-list-of-specialist-documents.feature
@@ -1,0 +1,22 @@
+Feature: Viewing specialist documents
+  As an editor
+  I want to view documents in specialist publisher
+  So that I select a specialist document to work on
+
+  Scenario Outline: Can view a list of all documents in the publisher
+    Given I am logged in as a "<organisation>" editor
+    Given two <documents> exist
+    Then the <documents> should be in the publisher document index in the correct order
+
+    Examples:
+      | organisation | documents                         |
+      | AAIB         | AAIB reports                      |
+      | CMA          | CMA cases                         |
+      | DEFRA        | Countryside Stewardship Grants    |
+      | MHRA         | Drug Safety Updates               |
+      | DCLG         | ESI Funds                         |
+      | MAIB         | MAIB reports                      |
+      | MHRA         | Medical Safety Alerts             |
+      | RAIB         | RAIB reports                      |
+      | DFID         | International Development Funds   |
+      | DVSA         | Vehicle Recalls and Faults alerts |

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -45,6 +45,10 @@ FactoryGirl.define do
     organisation_slug "driver-and-vehicle-standards-agency"
   end
 
+  factory :utaac_editor, parent: :editor do
+    organisation_slug "upper-tribunal-administrative-appeals-chamber"
+  end
+
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end
@@ -73,4 +77,5 @@ FactoryGirl.define do
       }
     end
   end
+
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -45,6 +45,10 @@ FactoryGirl.define do
     organisation_slug "driver-and-vehicle-standards-agency"
   end
 
+  factory :ast_editor, parent: :editor do
+    organisation_slug "first-tier-tribunal-asylum-support"
+  end
+
   factory :utaac_editor, parent: :editor do
     organisation_slug "upper-tribunal-administrative-appeals-chamber"
   end


### PR DESCRIPTION
Let's discuss this on Wed next week. Intention is to make it straight-forward to add new specialist documents, e.g. tribunal decisions, to the features in a consistent manner. Agreed previously we want a single approach to integration testing for all specialist document finders. This seems like a good consolidation.

Changes are:

* Use cucumber scenario outlines to define common steps for [creating and editing specialist documents](https://github.com/alphagov/specialist-publisher/pull/568/files/#diff-6) and [viewing specialist document lists](https://github.com/alphagov/specialist-publisher/pull/568/files/#diff-27).
* Rename some step definitions to match pattern in scenario outline steps.
* Delete the scenarios that are duplicates of the scenario outlines.
* Add scenario examples for viewing specialist document lists for [UTAAC tribunal decisions](https://github.com/ministryofjustice/specialist-publisher/commit/debe5a83fd35846b3cc3d8d89d53c7fd5e20affe) and [Asylum Support tribunal decisions](https://github.com/ministryofjustice/specialist-publisher/commit/fe4a082a4037f8effa85e3a21c404d5f66283a1b).