### PR TITLE
Clean up finder publishing

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -3,9 +3,9 @@ require_relative "../app/presenters/finder_content_item_presenter"
 require_relative "../app/presenters/finder_signup_content_item_presenter"
 
 class PublishingApiFinderPublisher
-  def initialize(finders, log = true)
+  def initialize(finders, logger: Logger.new(STDOUT))
     @finders = finders
-    @log = log
+    @logger = logger
   end
 
   def call
@@ -16,16 +16,16 @@ class PublishingApiFinderPublisher
         if preview_domain_or_not_production?
           publish(finder)
         else
-          puts "didn't publish #{finder[:metadata]["name"]} because it is preview_only" if @log
+          logger.info("didn't publish #{finder[:metadata]["name"]} because it is preview_only")
         end
       else
-        puts "didn't publish #{finder[:metadata]["name"]} because it doesn't have a content_id" if @log
+        logger.info("didn't publish #{finder[:metadata]["name"]} because it doesn't have a content_id")
       end
     end
   end
 
 private
-  attr_reader :finders
+  attr_reader :finders, :logger
 
   def publish(finder)
     export_finder(finder)
@@ -49,7 +49,7 @@ private
 
     attrs = finder.exportable_attributes
 
-    puts "publishing '#{attrs["title"]}' finder" if @log
+    logger.info("publishing '#{attrs["title"]}' finder")
 
     publishing_api.put_content_item(finder.base_path, attrs)
   end
@@ -62,7 +62,7 @@ private
 
     attrs = finder_signup.exportable_attributes
 
-    puts "publishing '#{attrs["title"]}' finder signup page" if @log
+    logger.info("publishing '#{attrs["title"]}' finder signup page")
 
     publishing_api.put_content_item(finder_signup.base_path, attrs)
   end

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -7,7 +7,7 @@ class RummagerFinderPublisher
   end
 
   def call
-    @metadatas.each do |metadata|
+    metadatas.each do |metadata|
       if metadata[:file].has_key?("content_id")
         export_finder(metadata)
       else
@@ -19,7 +19,8 @@ class RummagerFinderPublisher
     end
   end
 
-  private
+private
+  attr_reader :metadatas
 
   def export_finder(metadata)
     presenter = FinderRummagerPresenter.new(metadata[:file], metadata[:timestamp])

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -2,8 +2,9 @@ require "gds_api/rummager"
 require_relative "../app/presenters/finder_rummager_presenter"
 
 class RummagerFinderPublisher
-  def initialize(metadatas)
+  def initialize(metadatas, logger: Logger.new(STDOUT))
     @metadatas = metadatas
+    @logger = logger
   end
 
   def call
@@ -14,13 +15,13 @@ class RummagerFinderPublisher
         # Even though rummager doesn't use the content_id we only want to push
         # to rummager if this is live in content-store, so this needs to
         # replicate the logic in PublishingApiFinderPublisher.
-        puts "didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id"
+        logger.info("didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id")
       end
     end
   end
 
 private
-  attr_reader :metadatas
+  attr_reader :metadatas, :logger
 
   def export_finder(metadata)
     presenter = FinderRummagerPresenter.new(metadata[:file], metadata[:timestamp])

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -45,6 +45,8 @@ describe PublishingApiFinderPublisher do
 
     let(:publishing_api) { double("publishing-api") }
 
+    let(:test_logger) { Logger.new(nil) }
+
     before do
       allow(GdsApi::PublishingApi).to receive(:new)
         .with(Plek.new.find("publishing-api"))
@@ -67,7 +69,7 @@ describe PublishingApiFinderPublisher do
       expect(publishing_api).to receive(:put_content_item)
         .with("/second-finder", be_valid_against_schema("finder"))
 
-      PublishingApiFinderPublisher.new(finders, false).call
+      PublishingApiFinderPublisher.new(finders, logger: test_logger).call
     end
 
     it "doesn't publish a Finder without a content id" do
@@ -82,7 +84,7 @@ describe PublishingApiFinderPublisher do
       expect(publishing_api).to receive(:put_content_item)
         .with("/finder-with-content-id", anything)
 
-      PublishingApiFinderPublisher.new(finders, false).call
+      PublishingApiFinderPublisher.new(finders, logger: test_logger).call
     end
 
     it "can publish a Finder with a phase" do
@@ -93,7 +95,7 @@ describe PublishingApiFinderPublisher do
       expect(publishing_api).to receive(:put_content_item)
         .with("/finder-with-phase", be_valid_against_schema("finder"))
 
-      PublishingApiFinderPublisher.new(finders, false).call
+      PublishingApiFinderPublisher.new(finders, logger: test_logger).call
     end
 
     context 'with preview_only false metadata and RAILS_ENV is "production"' do
@@ -108,7 +110,7 @@ describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:put_content_item)
           .with("/finder-with-preview-only-true", anything)
 
-        PublishingApiFinderPublisher.new(finders, false).call
+        PublishingApiFinderPublisher.new(finders, logger: test_logger).call
       end
     end
 
@@ -124,7 +126,7 @@ describe PublishingApiFinderPublisher do
           expect(publishing_api).to receive(:put_content_item)
             .with("/finder-with-preview-only-true", anything)
 
-          PublishingApiFinderPublisher.new(finders, false).call
+          PublishingApiFinderPublisher.new(finders, logger: test_logger).call
         end
       end
 
@@ -139,7 +141,7 @@ describe PublishingApiFinderPublisher do
             expect(publishing_api).not_to receive(:put_content_item)
               .with("/finder-with-preview-only-true", anything)
 
-            PublishingApiFinderPublisher.new(finders, false).call
+            PublishingApiFinderPublisher.new(finders, logger: test_logger).call
           end
         end
 
@@ -149,7 +151,7 @@ describe PublishingApiFinderPublisher do
             expect(publishing_api).to receive(:put_content_item)
               .with("/finder-with-preview-only-true", anything)
 
-            PublishingApiFinderPublisher.new(finders, false).call
+            PublishingApiFinderPublisher.new(finders, logger: test_logger).call
           end
         end
 

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 require "rummager_finder_publisher"
 
 describe RummagerFinderPublisher do
+  let(:rummager) { double }
+
   describe ".call" do
     it "uses GdsApi::Rummager to publish the Finders" do
       metadata = [
@@ -38,7 +40,6 @@ describe RummagerFinderPublisher do
         }
       ]
 
-      rummager = double("rummager")
       expect(GdsApi::Rummager).to receive(:new)
         .with(Plek.new.find("rummager"))
         .and_return(rummager)
@@ -95,7 +96,6 @@ describe RummagerFinderPublisher do
         },
       ]
 
-      rummager = double("rummager")
       expect(GdsApi::Rummager).to receive(:new)
         .with(Plek.new.find("rummager"))
         .and_return(rummager)

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -4,6 +4,8 @@ require "rummager_finder_publisher"
 describe RummagerFinderPublisher do
   let(:rummager) { double }
 
+  let(:test_logger) { Logger.new(nil) }
+
   describe ".call" do
     it "uses GdsApi::Rummager to publish the Finders" do
       metadata = [
@@ -69,7 +71,7 @@ describe RummagerFinderPublisher do
           ],
         })
 
-      RummagerFinderPublisher.new(metadata).call
+      RummagerFinderPublisher.new(metadata, logger: test_logger).call
     end
 
     it "doesn't publish a Finder without a content id" do
@@ -106,7 +108,7 @@ describe RummagerFinderPublisher do
       expect(rummager).to receive(:add_document)
         .with(anything, "/finder-with-content-id", anything)
 
-      RummagerFinderPublisher.new(metadata).call
+      RummagerFinderPublisher.new(metadata, logger: test_logger).call
     end
   end
 end


### PR DESCRIPTION
Mostly swapping `puts` for `Logger`.

I'm hoping @tommyp'll review this and correct me if I've overlooked anything relying on the output of either of these scripts