### PR TITLE
Don't index preview_only Finders on Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ bundle exec rake
 1. Add the document_type to the `document_types` array in `config/routes.rb`
 1. Add a controller that inherits `AbstractDocumentsController`
 1. Add the schema to the `finders/schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
-1. Add the metadata about the Finder to `finders/metadata`
+1. Add the metadata about the Finder to `finders/metadata`. This can contain `"preview_only": true` to limit the Finder to the preview environment.
 1. [Add an example](https://github.com/alphagov/govuk-content-schemas/tree/master/formats/specialist_document/frontend/examples) of this format to govuk-content-schemas
 1. Use the [finder schema converter](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/converting-finder-schemas.md) to modify the [`details.json`](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document/publisher/details.json) to include the new format
 1. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -10,7 +10,7 @@ class PublishingApiFinderPublisher
 
   def call
     finders.map do |finder|
-      if finder[:metadata].has_key?("content_id") && !preview_only?(finder)
+      if !preview_only?(finder)
         publish(finder)
       elsif preview_only?(finder)
         if preview_domain_or_not_production?
@@ -18,8 +18,6 @@ class PublishingApiFinderPublisher
         else
           logger.info("didn't publish #{finder[:metadata]["name"]} because it is preview_only")
         end
-      else
-        logger.info("didn't publish #{finder[:metadata]["name"]} because it doesn't have a content_id")
       end
     end
   end

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -10,14 +10,10 @@ class PublishingApiFinderPublisher
 
   def call
     finders.map do |finder|
-      if !preview_only?(finder)
+      if should_publish_in_this_environment?(finder)
         publish(finder)
-      elsif preview_only?(finder)
-        if preview_domain_or_not_production?
-          publish(finder)
-        else
-          logger.info("didn't publish #{finder[:metadata]["name"]} because it is preview_only")
-        end
+      else
+        logger.info("Not publishing #{finder[:metadata]["name"]} because it is preview_only")
       end
     end
   end
@@ -28,6 +24,10 @@ private
   def publish(finder)
     export_finder(finder)
     export_signup(finder) if finder[:metadata].has_key?("signup_content_id")
+  end
+
+  def should_publish_in_this_environment?(finder)
+    !preview_only?(finder) || preview_domain_or_not_production?
   end
 
   def preview_only?(finder)

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -9,8 +9,14 @@ class RummagerFinderPublisher
 
   def call
     metadatas.each do |metadata|
-      if metadata[:file].has_key?("content_id")
+      if metadata[:file].has_key?("content_id") && !preview_only?(metadata)
         export_finder(metadata)
+      elsif preview_only?(metadata)
+        if preview_domain_or_not_production?
+          export_finder(metadata)
+        else
+          logger.info("didn't publish #{metadata[:file]["name"]} because it is preview_only")
+        end
       else
         # Even though rummager doesn't use the content_id we only want to push
         # to rummager if this is live in content-store, so this needs to
@@ -21,7 +27,16 @@ class RummagerFinderPublisher
   end
 
 private
+
   attr_reader :metadatas, :logger
+
+  def preview_only?(metadata)
+    metadata[:file]["preview_only"] == true
+  end
+
+  def preview_domain_or_not_production?
+    ENV.fetch("GOVUK_APP_DOMAIN", "")[/preview/] || !Rails.env.production?
+  end
 
   def export_finder(metadata)
     presenter = FinderRummagerPresenter.new(metadata[:file], metadata[:timestamp])

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -9,7 +9,7 @@ class RummagerFinderPublisher
 
   def call
     metadatas.each do |metadata|
-      if metadata[:file].has_key?("content_id") && !preview_only?(metadata)
+      if !preview_only?(metadata)
         export_finder(metadata)
       elsif preview_only?(metadata)
         if preview_domain_or_not_production?
@@ -17,11 +17,6 @@ class RummagerFinderPublisher
         else
           logger.info("didn't publish #{metadata[:file]["name"]} because it is preview_only")
         end
-      else
-        # Even though rummager doesn't use the content_id we only want to push
-        # to rummager if this is live in content-store, so this needs to
-        # replicate the logic in PublishingApiFinderPublisher.
-        logger.info("didn't publish #{metadata[:file]["name"]} because it doesn't have a content_id")
       end
     end
   end

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -9,14 +9,10 @@ class RummagerFinderPublisher
 
   def call
     metadatas.each do |metadata|
-      if !preview_only?(metadata)
+      if should_publish_in_this_environment?(metadata)
         export_finder(metadata)
-      elsif preview_only?(metadata)
-        if preview_domain_or_not_production?
-          export_finder(metadata)
-        else
-          logger.info("didn't publish #{metadata[:file]["name"]} because it is preview_only")
-        end
+      else
+        logger.info("Not publishing #{metadata[:file]["name"]} because it is preview_only")
       end
     end
   end
@@ -24,6 +20,10 @@ class RummagerFinderPublisher
 private
 
   attr_reader :metadatas, :logger
+
+  def should_publish_in_this_environment?(metadata)
+    !preview_only?(metadata) || preview_domain_or_not_production?
+  end
 
   def preview_only?(metadata)
     metadata[:file]["preview_only"] == true

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -72,21 +72,6 @@ describe PublishingApiFinderPublisher do
       PublishingApiFinderPublisher.new(finders, logger: test_logger).call
     end
 
-    it "doesn't publish a Finder without a content id" do
-      finders = [
-        make_finder("/finder-without-content-id", "content_id" => nil),
-        make_finder("/finder-with-content-id")
-      ]
-
-      expect(publishing_api).not_to receive(:put_content_item)
-        .with("/finder-without-content-id", anything)
-
-      expect(publishing_api).to receive(:put_content_item)
-        .with("/finder-with-content-id", anything)
-
-      PublishingApiFinderPublisher.new(finders, logger: test_logger).call
-    end
-
     it "can publish a Finder with a phase" do
       finders = [
         make_finder("/finder-with-phase", "phase" => "beta"),

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -110,5 +110,118 @@ describe RummagerFinderPublisher do
 
       RummagerFinderPublisher.new(metadata, logger: test_logger).call
     end
+
+    context 'with preview_only false metadata and RAILS_ENV is "production"' do
+      let(:metadata) do
+        [
+          {
+            file: {
+              "base_path" => "/finder-with-preview-only-true",
+              "content_id" => SecureRandom.uuid,
+              "name" => "finder with preview only true",
+              "format" => "a_report_format",
+              "format_name" => "a report format",
+              "preview_only" => false,
+            },
+            timestamp: "2015-01-05T10:45:10.000+00:00",
+          },
+        ]
+      end
+
+      it "does publish finder" do
+        rummager = double("rummager")
+
+        production = ActiveSupport::StringInquirer.new("production")
+        allow(Rails).to receive(:env).and_return(production)
+
+        expect(GdsApi::Rummager).to receive(:new)
+          .with(Plek.new.find("rummager"))
+          .and_return(rummager)
+
+        expect(rummager).to receive(:add_document)
+          .with(anything, "/finder-with-preview-only-true", anything)
+
+        RummagerFinderPublisher.new(metadata, logger: test_logger).call
+      end
+    end
+
+    context "with preview_only true metadata" do
+      let(:metadata) do
+        [
+          {
+            file: {
+              "base_path" => "/finder-with-preview-only-true",
+              "name" => "finder with preview only true",
+              "format" => "a_report_format",
+              "format_name" => "a report format",
+              "preview_only" => true,
+            },
+            timestamp: "2015-01-05T10:45:10.000+00:00",
+          },
+        ]
+      end
+
+      context 'and RAILS_ENV is not "production"' do
+        it "publishes finder" do
+          rummager = double("rummager")
+          expect(GdsApi::Rummager).to receive(:new)
+            .with(Plek.new.find("rummager"))
+            .and_return(rummager)
+
+          expect(rummager).to receive(:add_document)
+            .with(anything, "/finder-with-preview-only-true", anything)
+
+          RummagerFinderPublisher.new(metadata, logger: test_logger).call
+        end
+      end
+
+      context 'and RAILS_ENV is "production"' do
+        let(:metadata) do
+          [
+            {
+              file: {
+                "base_path" => "/finder-with-preview-only-true",
+                "content_id" => SecureRandom.uuid,
+                "name" => "finder with preview only true",
+                "format" => "a_report_format",
+                "format_name" => "a report format",
+                "preview_only" => true,
+              },
+              timestamp: "2015-01-05T10:45:10.000+00:00",
+            },
+          ]
+        end
+
+        let(:rummager) { double("rummager") }
+
+        before do
+          production = ActiveSupport::StringInquirer.new("production")
+          allow(Rails).to receive(:env).and_return(production)
+
+          allow(GdsApi::Rummager).to receive(:new)
+            .with(Plek.new.find("rummager"))
+            .and_return(rummager)
+        end
+
+        context 'and GOVUK_APP_DOMAIN does not contain "preview"' do
+          it "does not publish finder" do
+            expect(rummager).not_to receive(:add_document)
+              .with(anything, "/finder-with-preview-only-true", anything)
+
+            RummagerFinderPublisher.new(metadata, logger: test_logger).call
+          end
+        end
+
+        context 'and GOVUK_APP_DOMAIN contains "preview"' do
+          it "publishes finder" do
+            allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN", "").and_return("preview")
+            expect(rummager).to receive(:add_document)
+              .with(anything, "/finder-with-preview-only-true", anything)
+
+            RummagerFinderPublisher.new(metadata, logger: test_logger).call
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -74,43 +74,6 @@ describe RummagerFinderPublisher do
       RummagerFinderPublisher.new(metadata, logger: test_logger).call
     end
 
-    it "doesn't publish a Finder without a content id" do
-      metadata = [
-        {
-          file: {
-            "base_path" => "/finder-without-content-id",
-            "name" => "finder without content id",
-            "format" => "a_report_format",
-            "format_name" => "a report format",
-          },
-          timestamp: "2015-01-05T10:45:10.000+00:00",
-        },
-        {
-          file: {
-            "base_path" => "/finder-with-content-id",
-            "name" => "finder with content id",
-            "content_id" => "some-random-id",
-            "format" => "a_report_format",
-            "format_name" => "a report format",
-            "signup_content_id" => SecureRandom.uuid,
-          },
-          timestamp: "2015-01-05T10:45:10.000+00:00",
-        },
-      ]
-
-      expect(GdsApi::Rummager).to receive(:new)
-        .with(Plek.new.find("rummager"))
-        .and_return(rummager)
-
-      expect(rummager).not_to receive(:add_document)
-        .with(anything, "/finder-without-content-id", anything)
-
-      expect(rummager).to receive(:add_document)
-        .with(anything, "/finder-with-content-id", anything)
-
-      RummagerFinderPublisher.new(metadata, logger: test_logger).call
-    end
-
     context 'with preview_only false metadata and RAILS_ENV is "production"' do
       let(:metadata) do
         [


### PR DESCRIPTION
In order to prevent Finders going into Elastic Search on Production we use
the `preview_only` flag to decide if it should be published or not. This
commit follows the same logic in the `PublishingApiFinderPublisher` but
keeps them separate. There's nothing to stop these being merged in
future but as this is preventing deploys I thought I'd go down the
simplest route now.

This PR also removes the funtionality which stops Finders being deployed
without a content ID. As we can now restrict them to Preview, there's no
need to keep this feature around.

[Ticket](https://trello.com/c/Nn0DoEN2/120-preview-only-finders-should-not-be-published-to-rummager).