### PR TITLE
Bugfix: Duplicate document creation on validation errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     byebug (2.7.0)
       columnize (~> 0.3)
       debugger-linecache (~> 1.2)
-    capybara (2.2.1)
+    capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -145,6 +145,10 @@ class SpecialistDocument
     edition.save
   end
 
+  def persisted?
+    editions.any?(&:persisted?)
+  end
+
 protected
 
   attr_reader :slug_generator, :edition_factory

--- a/app/view_adapters/document_view_adapter.rb
+++ b/app/view_adapters/document_view_adapter.rb
@@ -15,7 +15,7 @@ class DocumentViewAdapter < SimpleDelegator
   end
 
   def persisted?
-    document && document.updated_at
+    document && document.persisted?
   end
 
   def to_param

--- a/features/support/aaib_report_helpers.rb
+++ b/features/support/aaib_report_helpers.rb
@@ -1,6 +1,6 @@
 module AaibReportHelpers
-  def create_aaib_report(*args)
-    create_document(:aaib_report, *args)
+  def create_aaib_report(fields, **kwargs)
+    create_document(:aaib_report, fields, **kwargs)
   end
 
   def go_to_show_page_for_aaib_report(*args)

--- a/features/support/aaib_report_helpers.rb
+++ b/features/support/aaib_report_helpers.rb
@@ -58,3 +58,4 @@ module AaibReportHelpers
     end
   end
 end
+RSpec.configuration.include AaibReportHelpers, type: :feature

--- a/features/support/access_control_helpers.rb
+++ b/features/support/access_control_helpers.rb
@@ -15,3 +15,4 @@ module AccessControlHelpers
     expect(page).to have_content(content)
   end
 end
+RSpec.configuration.include AccessControlHelpers, type: :feature

--- a/features/support/attachment_helpers.rb
+++ b/features/support/attachment_helpers.rb
@@ -116,3 +116,4 @@ module AttachmentHelpers
     click_on "Save attachment"
   end
 end
+RSpec.configuration.include AttachmentHelpers, type: :feature

--- a/features/support/cma_case_helpers.rb
+++ b/features/support/cma_case_helpers.rb
@@ -103,3 +103,4 @@ module CmaCaseHelpers
     expect(page).not_to have_button("Withdraw")
   end
 end
+RSpec.configuration.include CmaCaseHelpers, type: :feature

--- a/features/support/csg_helpers.rb
+++ b/features/support/csg_helpers.rb
@@ -32,3 +32,4 @@ module CsgHelpers
     withdraw_document(:countryside_stewardship_grant, *args)
   end
 end
+RSpec.configuration.include CsgHelpers, type: :feature

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -98,20 +98,20 @@ module DocumentHelpers
 
   def check_for_documents(*titles)
     titles.each do |title|
-      page.should have_content(title)
+      expect(page).to have_content(title)
     end
   end
 
   def check_for_missing_title_error
-    page.should have_content("Title can't be blank")
+    expect(page).to have_content("Title can't be blank")
   end
 
   def check_for_missing_summary_error
-    page.should have_content("Summary can't be blank")
+    expect(page).to have_content("Summary can't be blank")
   end
 
   def check_for_invalid_date_error(date_field)
-    page.should have_content("#{date_field} should be formatted YYYY-MM-DD")
+    expect(page).to have_content("#{date_field} should be formatted YYYY-MM-DD")
   end
 
   def check_content_preview_link(slug)
@@ -189,7 +189,7 @@ module DocumentHelpers
 
   def check_for_new_document_title(type, title)
     visit send(:"#{type.to_s.pluralize}_path")
-    page.should have_content(title)
+    expect(page).to have_content(title)
   end
 
   def go_to_edit_page_for_document(type, title)
@@ -233,3 +233,4 @@ module DocumentHelpers
     }
   end
 end
+RSpec.configuration.include DocumentHelpers, type: :feature

--- a/features/support/dsu_helpers.rb
+++ b/features/support/dsu_helpers.rb
@@ -32,5 +32,5 @@ module DsuHelpers
   def withdraw_drug_safety_update(*args)
     withdraw_document(:drug_safety_update, *args)
   end
-
 end
+RSpec.configuration.include DsuHelpers, type: :feature

--- a/features/support/email_alert_api_helpers.rb
+++ b/features/support/email_alert_api_helpers.rb
@@ -26,3 +26,4 @@ module EmailAlertAPIHelpers
     FakeEmailAlertAPI.instance
   end
 end
+RSpec.configuration.include EmailAlertAPIHelpers, type: :feature

--- a/features/support/esi_fund_helpers.rb
+++ b/features/support/esi_fund_helpers.rb
@@ -32,3 +32,4 @@ module EsiFundHelpers
     withdraw_document(:esi_fund, *args)
   end
 end
+RSpec.configuration.include EsiFundHelpers, type: :feature

--- a/features/support/file_fixture_helpers.rb
+++ b/features/support/file_fixture_helpers.rb
@@ -6,3 +6,4 @@ module FileFixtureHelpers
     filepath
   end
 end
+RSpec.configuration.include FileFixtureHelpers, type: :feature

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -15,3 +15,4 @@ module FormHelpers
     end
   end
 end
+RSpec.configuration.include FormHelpers, type: :feature

--- a/features/support/gds_sso_helpers.rb
+++ b/features/support/gds_sso_helpers.rb
@@ -14,3 +14,4 @@ module GdsSsoHelpers
     logout # warden
   end
 end
+RSpec.configuration.include GdsSsoHelpers, type: :feature

--- a/features/support/idf_helpers.rb
+++ b/features/support/idf_helpers.rb
@@ -32,3 +32,4 @@ module IdfHelpers
     withdraw_document(:international_development_fund, *args)
   end
 end
+RSpec.configuration.include IdfHelpers, type: :feature

--- a/features/support/maib_report_helpers.rb
+++ b/features/support/maib_report_helpers.rb
@@ -32,3 +32,4 @@ module MaibReportHelpers
     withdraw_document(:maib_report, *args)
   end
 end
+RSpec.configuration.include MaibReportHelpers, type: :feature

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -357,3 +357,4 @@ module ManualHelpers
     attributes_for_documents
   end
 end
+RSpec.configuration.include ManualHelpers, type: :feature

--- a/features/support/msa_helpers.rb
+++ b/features/support/msa_helpers.rb
@@ -31,5 +31,5 @@ module MsaHelpers
   def withdraw_medical_safety_alert(*args)
     withdraw_document(:medical_safety_alert, *args)
   end
-
 end
+RSpec.configuration.include MsaHelpers, type: :feature

--- a/features/support/organisations_api_helpers.rb
+++ b/features/support/organisations_api_helpers.rb
@@ -6,3 +6,4 @@ module OrganisationsAPIHelpers
     organisations_api_has_organisation(organisation_slug)
   end
 end
+RSpec.configuration.include OrganisationsAPIHelpers, type: :feature

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -11,3 +11,4 @@ module PublishingAPIHelpers
     WebMock::RequestRegistry.instance.reset!
   end
 end
+RSpec.configuration.include PublishingAPIHelpers, type: :feature

--- a/features/support/raib_report_helpers.rb
+++ b/features/support/raib_report_helpers.rb
@@ -32,3 +32,4 @@ module RaibReportHelpers
     withdraw_document(:raib_report, *args)
   end
 end
+RSpec.configuration.include RaibReportHelpers, type: :feature

--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -36,3 +36,4 @@ module RummagerHelpers
     allow(fake_rummager).to receive(:delete_document).and_raise(GdsApi::HTTPClientError.new(400))
   end
 end
+RSpec.configuration.include RummagerHelpers, type: :feature

--- a/features/support/search_helpers.rb
+++ b/features/support/search_helpers.rb
@@ -4,3 +4,4 @@ module SearchHelpers
     click_on "Search"
   end
 end
+RSpec.configuration.include SearchHelpers, type: :feature

--- a/features/support/vehicle_recalls_and_faults_alert_helpers.rb
+++ b/features/support/vehicle_recalls_and_faults_alert_helpers.rb
@@ -24,3 +24,4 @@ module VehicleRecallsAndFaultsAlertHelpers
     edit_document(title, *args)
   end
 end
+RSpec.configuration.include VehicleRecallsAndFaultsAlertHelpers, type: :feature

--- a/spec/features/saving_invalid_documents_spec.rb
+++ b/spec/features/saving_invalid_documents_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe "Saving invalid documents", type: :feature do
+  before do
+    login_as(:aaib_editor)
+    stub_organisation_details(GDS::SSO.test_user.organisation_slug)
+  end
+
+  context "with a published AAIB report" do
+    before do
+      create_aaib_report title: "A title", summary: "A summary", body: "A body", date_of_occurrence: "2015-01-01"
+    end
+
+    it "lists the report" do
+      check_for_new_aaib_report_title "A title"
+    end
+  end
+end

--- a/spec/features/saving_invalid_documents_spec.rb
+++ b/spec/features/saving_invalid_documents_spec.rb
@@ -6,13 +6,82 @@ RSpec.describe "Saving invalid documents", type: :feature do
     stub_organisation_details(GDS::SSO.test_user.organisation_slug)
   end
 
-  context "with a published AAIB report" do
+  let(:title) { "A title" }
+  let(:summary) { "A summary" }
+  let(:body) { "A body" }
+  let(:date_of_occurrence) { "2015-01-01" }
+
+  let(:create_report) do
+    create_aaib_report({ title: title,
+                         summary: summary,
+                         body: body,
+                         date_of_occurrence: date_of_occurrence
+                       },
+                      save: true,
+                      publish: true)
+  end
+
+  describe "saving edits to a published AAIB report" do
     before do
-      create_aaib_report title: "A title", summary: "A summary", body: "A body", date_of_occurrence: "2015-01-01"
+      create_report
+      go_to_edit_page_for_aaib_report(title)
     end
 
-    it "lists the report" do
-      check_for_new_aaib_report_title "A title"
+    context "when valid" do
+      before do
+        fill_in :aaib_report_body, with: "A different body"
+        check :aaib_report_minor_update
+        click_button "Save"
+        click_button "Publish"
+      end
+
+      it "should publish the new body" do
+        go_to_show_page_for_aaib_report(title)
+        expect(page).to have_content "published"
+        expect(page).to have_content "A different body"
+      end
+
+      it "should be the only document" do
+        go_to_aaib_report_index
+        expect(page).to have_css "ul.document-list li.document", count: 1
+      end
+    end
+
+    context "when invalid" do
+      before do
+        fill_in :aaib_report_body, with: "A different body"
+        uncheck :aaib_report_minor_update
+        click_button "Save"
+      end
+
+      it "should not publish the new body" do
+        go_to_show_page_for_aaib_report(title)
+        expect(page).to have_content "published"
+        expect(page).to have_content "A body"
+      end
+
+      it "should be the only document" do
+        go_to_aaib_report_index
+        expect(page).to have_css "ul.document-list li.document", count: 1
+      end
+
+      describe "fixing the validation errors" do
+        before do
+          check :aaib_report_minor_update
+          click_button "Save"
+        end
+
+        it "should persist the new body" do
+          go_to_show_page_for_aaib_report(title)
+          expect(page).to have_content "draft"
+          expect(page).to have_content "A different body"
+        end
+
+        it "should be the only document" do
+          go_to_aaib_report_index
+          expect(page).to have_css "ul.document-list li.document", count: 1
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,14 @@ ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"
+require "webmock/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("features/support/**/*_helpers.rb")]
+  .reject { |f| f =~ %r{/api_helpers.rb$} }
+  .each { |f| require f }
 
 require "database_cleaner"
 DatabaseCleaner.strategy = :truncation
@@ -27,6 +31,14 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
   end
+
+  config.before(:each, type: :feature) do
+    stub_rummager
+    stub_publishing_api
+    stub_email_alert_api
+  end
+
+  config.include Capybara::DSL, type: :feature
 
   config.after(:each) do
     DatabaseCleaner.clean


### PR DESCRIPTION
`updated_at` doesn't seem to be set correctly on the document
instance. The document is really just a wrapper around a
collection of editions, so to check if a document is persisted,
we need to check if any of the editions are persisted.

This fixes a bug where `persisted?` was returning a false negative
when a document was invalid, causing the form to post to the
`#create` method. This caused duplicate documents to be created,
which would then be invalid due to the duplicate slug.

/cc @jennyd @tommyp @mikejustdoit 