### PR TITLE
Rename `preview_only` flag to `pre-production`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bundle exec rake
 1. Add the document_type to the `document_types` array in `config/routes.rb`
 1. Add a controller that inherits `AbstractDocumentsController`
 1. Add the schema to the `finders/schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
-1. Add the metadata about the Finder to `finders/metadata`. This can contain `"preview_only": true` to limit the Finder to the preview environment.
+1. Add the metadata about the Finder to `finders/metadata`. This can contain `"pre_production": true` to limit the Finder to the preview environment.
 1. [Add an example](https://github.com/alphagov/govuk-content-schemas/tree/master/formats/specialist_document/frontend/examples) of this format to govuk-content-schemas
 1. Use the [finder schema converter](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/converting-finder-schemas.md) to modify the [`details.json`](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document/publisher/details.json) to include the new format
 1. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.

--- a/finders/metadata/asylum-support-decisions.json
+++ b/finders/metadata/asylum-support-decisions.json
@@ -40,5 +40,5 @@
     }
   ],
   "summary": "<p>Find details of <a rel=\"external\" href=\"http://www.asylum-support-tribunal.gov.uk/public/search.aspx\">earlier decisions</a>.</p>",
-  "preview_only": true
+  "pre_production": true
 }

--- a/finders/metadata/utaac-decisions.json
+++ b/finders/metadata/utaac-decisions.json
@@ -376,5 +376,5 @@
     }
   ],
   "summary": "",
-  "preview_only": true
+  "pre_production": true
 }

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -13,7 +13,7 @@ class PublishingApiFinderPublisher
       if should_publish_in_this_environment?(finder)
         publish(finder)
       else
-        logger.info("Not publishing #{finder[:metadata]["name"]} because it is preview_only")
+        logger.info("Not publishing #{finder[:metadata]["name"]} because it is pre_production")
       end
     end
   end
@@ -27,11 +27,11 @@ private
   end
 
   def should_publish_in_this_environment?(finder)
-    !preview_only?(finder) || preview_domain_or_not_production?
+    !pre_production?(finder) || preview_domain_or_not_production?
   end
 
-  def preview_only?(finder)
-    finder[:metadata]["preview_only"] == true
+  def pre_production?(finder)
+    finder[:metadata]["pre_production"] == true
   end
 
   def preview_domain_or_not_production?

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -12,7 +12,7 @@ class RummagerFinderPublisher
       if should_publish_in_this_environment?(metadata)
         export_finder(metadata)
       else
-        logger.info("Not publishing #{metadata[:file]["name"]} because it is preview_only")
+        logger.info("Not publishing #{metadata[:file]["name"]} because it is pre_production")
       end
     end
   end
@@ -22,11 +22,11 @@ private
   attr_reader :metadatas, :logger
 
   def should_publish_in_this_environment?(metadata)
-    !preview_only?(metadata) || preview_domain_or_not_production?
+    !pre_production?(metadata) || preview_domain_or_not_production?
   end
 
-  def preview_only?(metadata)
-    metadata[:file]["preview_only"] == true
+  def pre_production?(metadata)
+    metadata[:file]["pre_production"] == true
   end
 
   def preview_domain_or_not_production?

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -83,33 +83,33 @@ describe PublishingApiFinderPublisher do
       PublishingApiFinderPublisher.new(finders, logger: test_logger).call
     end
 
-    context 'with preview_only false metadata and RAILS_ENV is "production"' do
+    context 'with pre_production false metadata and RAILS_ENV is "production"' do
       it "does publish finder" do
         finders = [
-          make_finder("/finder-with-preview-only-true", "preview_only" => false)
+          make_finder("/finder-with-pre-production-true", "pre_production" => false)
         ]
 
         production = ActiveSupport::StringInquirer.new("production")
         allow(Rails).to receive(:env).and_return(production)
 
         expect(publishing_api).to receive(:put_content_item)
-          .with("/finder-with-preview-only-true", anything)
+          .with("/finder-with-pre-production-true", anything)
 
         PublishingApiFinderPublisher.new(finders, logger: test_logger).call
       end
     end
 
-    context "with preview_only true metadata" do
+    context "with pre_production true metadata" do
       let(:finders) do
         [
-          make_finder("/finder-with-preview-only-true", "preview_only" => true)
+          make_finder("/finder-with-pre-production-true", "pre_production" => true)
         ]
       end
 
       context 'and RAILS_ENV is not "production"' do
         it "publishes finder" do
           expect(publishing_api).to receive(:put_content_item)
-            .with("/finder-with-preview-only-true", anything)
+            .with("/finder-with-pre-production-true", anything)
 
           PublishingApiFinderPublisher.new(finders, logger: test_logger).call
         end
@@ -124,7 +124,7 @@ describe PublishingApiFinderPublisher do
         context 'and GOVUK_APP_DOMAIN does not contain "preview"' do
           it "does not publish finder" do
             expect(publishing_api).not_to receive(:put_content_item)
-              .with("/finder-with-preview-only-true", anything)
+              .with("/finder-with-pre-production-true", anything)
 
             PublishingApiFinderPublisher.new(finders, logger: test_logger).call
           end
@@ -134,7 +134,7 @@ describe PublishingApiFinderPublisher do
           it "publishes finder" do
             allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN", "").and_return("preview")
             expect(publishing_api).to receive(:put_content_item)
-              .with("/finder-with-preview-only-true", anything)
+              .with("/finder-with-pre-production-true", anything)
 
             PublishingApiFinderPublisher.new(finders, logger: test_logger).call
           end

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -74,17 +74,17 @@ describe RummagerFinderPublisher do
       RummagerFinderPublisher.new(metadata, logger: test_logger).call
     end
 
-    context 'with preview_only false metadata and RAILS_ENV is "production"' do
+    context 'with pre_production false metadata and RAILS_ENV is "production"' do
       let(:metadata) do
         [
           {
             file: {
-              "base_path" => "/finder-with-preview-only-true",
+              "base_path" => "/finder-with-pre-production-true",
               "content_id" => SecureRandom.uuid,
-              "name" => "finder with preview only true",
+              "name" => "finder with pre-production true",
               "format" => "a_report_format",
               "format_name" => "a report format",
-              "preview_only" => false,
+              "pre_production" => false,
             },
             timestamp: "2015-01-05T10:45:10.000+00:00",
           },
@@ -102,22 +102,22 @@ describe RummagerFinderPublisher do
           .and_return(rummager)
 
         expect(rummager).to receive(:add_document)
-          .with(anything, "/finder-with-preview-only-true", anything)
+          .with(anything, "/finder-with-pre-production-true", anything)
 
         RummagerFinderPublisher.new(metadata, logger: test_logger).call
       end
     end
 
-    context "with preview_only true metadata" do
+    context "with pre_production true metadata" do
       let(:metadata) do
         [
           {
             file: {
-              "base_path" => "/finder-with-preview-only-true",
-              "name" => "finder with preview only true",
+              "base_path" => "/finder-with-pre-production-true",
+              "name" => "finder with pre-production true",
               "format" => "a_report_format",
               "format_name" => "a report format",
-              "preview_only" => true,
+              "pre_production" => true,
             },
             timestamp: "2015-01-05T10:45:10.000+00:00",
           },
@@ -132,7 +132,7 @@ describe RummagerFinderPublisher do
             .and_return(rummager)
 
           expect(rummager).to receive(:add_document)
-            .with(anything, "/finder-with-preview-only-true", anything)
+            .with(anything, "/finder-with-pre-production-true", anything)
 
           RummagerFinderPublisher.new(metadata, logger: test_logger).call
         end
@@ -143,12 +143,12 @@ describe RummagerFinderPublisher do
           [
             {
               file: {
-                "base_path" => "/finder-with-preview-only-true",
+                "base_path" => "/finder-with-pre-production-true",
                 "content_id" => SecureRandom.uuid,
-                "name" => "finder with preview only true",
+                "name" => "finder with pre-production true",
                 "format" => "a_report_format",
                 "format_name" => "a report format",
-                "preview_only" => true,
+                "pre_production" => true,
               },
               timestamp: "2015-01-05T10:45:10.000+00:00",
             },
@@ -169,7 +169,7 @@ describe RummagerFinderPublisher do
         context 'and GOVUK_APP_DOMAIN does not contain "preview"' do
           it "does not publish finder" do
             expect(rummager).not_to receive(:add_document)
-              .with(anything, "/finder-with-preview-only-true", anything)
+              .with(anything, "/finder-with-pre-production-true", anything)
 
             RummagerFinderPublisher.new(metadata, logger: test_logger).call
           end
@@ -179,7 +179,7 @@ describe RummagerFinderPublisher do
           it "publishes finder" do
             allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN", "").and_return("preview")
             expect(rummager).to receive(:add_document)
-              .with(anything, "/finder-with-preview-only-true", anything)
+              .with(anything, "/finder-with-pre-production-true", anything)
 
             RummagerFinderPublisher.new(metadata, logger: test_logger).call
           end


### PR DESCRIPTION
- Preview might change its name, so that we're not tied to a specific
  environment, make this flag generic as `pre-production` to absolutely
  not publish these finders to production.

(Paired with @mikejustdoit on this.)