### PR TITLE
Feature flag for pre-production finders

### DIFF
--- a/config/initializers/publish_pre_production_finders_feature_flag.rb
+++ b/config/initializers/publish_pre_production_finders_feature_flag.rb
@@ -1,0 +1,1 @@
+SpecialistPublisher::Application.config.publish_pre_production_finders = ENV["PUBLISH_PRE_PRODUCTION_FINDERS"].present?

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -27,15 +27,15 @@ private
   end
 
   def should_publish_in_this_environment?(finder)
-    !pre_production?(finder) || preview_domain_or_not_production?
+    !pre_production?(finder) || should_publish_pre_production_finders?
   end
 
   def pre_production?(finder)
     finder[:metadata]["pre_production"] == true
   end
 
-  def preview_domain_or_not_production?
-    ENV.fetch("GOVUK_APP_DOMAIN", "")[/preview/] || !Rails.env.production?
+  def should_publish_pre_production_finders?
+    ENV.fetch("PUBLISH_PRE_PRODUCTION_FINDERS", false)
   end
 
   def export_finder(finder)

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -35,7 +35,7 @@ private
   end
 
   def should_publish_pre_production_finders?
-    ENV.fetch("PUBLISH_PRE_PRODUCTION_FINDERS", false)
+    SpecialistPublisher::Application.config.publish_pre_production_finders
   end
 
   def export_finder(finder)

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -22,15 +22,15 @@ private
   attr_reader :metadatas, :logger
 
   def should_publish_in_this_environment?(metadata)
-    !pre_production?(metadata) || preview_domain_or_not_production?
+    !pre_production?(metadata) || should_publish_pre_production_finders?
   end
 
   def pre_production?(metadata)
     metadata[:file]["pre_production"] == true
   end
 
-  def preview_domain_or_not_production?
-    ENV.fetch("GOVUK_APP_DOMAIN", "")[/preview/] || !Rails.env.production?
+  def should_publish_pre_production_finders?
+    ENV.fetch("PUBLISH_PRE_PRODUCTION_FINDERS", false)
   end
 
   def export_finder(metadata)

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -30,7 +30,7 @@ private
   end
 
   def should_publish_pre_production_finders?
-    ENV.fetch("PUBLISH_PRE_PRODUCTION_FINDERS", false)
+    SpecialistPublisher::Application.config.publish_pre_production_finders
   end
 
   def export_finder(metadata)

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -112,13 +112,15 @@ describe PublishingApiFinderPublisher do
         ]
       }
 
-      context "and PUBLISH_PRE_PRODUCTION_FINDERS is set" do
+      context "and the app is configured to publish pre-production finders" do
         before do
-          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = "1"
+          SpecialistPublisher::Application.config
+            .publish_pre_production_finders = true
         end
 
         after do
-          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = nil
+          SpecialistPublisher::Application.config
+            .publish_pre_production_finders = false
         end
 
         it "publishes finder" do
@@ -129,7 +131,7 @@ describe PublishingApiFinderPublisher do
         end
       end
 
-      context "and PUBLISH_PRE_PRODUCTION_FINDERS is not set" do
+      context "and is not configured to publish pre-production finders" do
         it "doesn't publish the finder" do
           expect(publishing_api).not_to receive(:put_content_item)
             .with("/pre-production-finder", anything)

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -124,13 +124,15 @@ describe RummagerFinderPublisher do
         ]
       }
 
-      context "and PUBLISH_PRE_PRODUCTION_FINDERS is set" do
+      context "and the app is configured to publish pre-production finders" do
         before do
-          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = "1"
+          SpecialistPublisher::Application.config
+            .publish_pre_production_finders = true
         end
 
         after do
-          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = nil
+          SpecialistPublisher::Application.config
+            .publish_pre_production_finders = false
         end
 
         it "publishes finder" do
@@ -145,7 +147,7 @@ describe RummagerFinderPublisher do
         end
       end
 
-      context "and PUBLISH_PRE_PRODUCTION_FINDERS is not set" do
+      context "and is not configured to publish pre-production finders" do
         it "does not publish finder" do
           expect(rummager).not_to receive(:add_document)
             .with(anything, "/pre-production-finder", anything)

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -2,84 +2,88 @@ require "spec_helper"
 require "rummager_finder_publisher"
 
 describe RummagerFinderPublisher do
-  let(:rummager) { double }
+  let(:rummager) { double(:rummager) }
 
   let(:test_logger) { Logger.new(nil) }
 
-  describe ".call" do
-    it "uses GdsApi::Rummager to publish the Finders" do
-      metadata = [
-        {
-          file: {
-            "base_path" => "/first-finder",
-            "name" => "first finder",
-            "format_name" => "first finder things",
-            "description" => "first finder description",
-            "content_id" => SecureRandom.uuid,
-            "format" => "a_report_format",
-            "signup_content_id" => SecureRandom.uuid,
-            "logo_path" => "http://example.com/logo.png",
-            "topics" => [
-              "business-tax/paye",
-            ],
-          },
-          timestamp: "2015-01-05T10:45:10.000+00:00",
-        },
-        {
-          file: {
-            "base_path" => "/second-finder",
-            "name" => "second finder",
-            "format_name" => "second finder things",
-            "content_id" => SecureRandom.uuid,
-            "format" => "some_case_format",
-            "logo_path" => "http://example.com/logo.png",
-            "topics" => [
-              "competition/mergers",
-              "competition/markets",
-            ],
-          },
-          timestamp: "2015-02-14T11:43:23.000+00:00",
-        }
-      ]
-
-      expect(GdsApi::Rummager).to receive(:new)
-        .with(Plek.new.find("rummager"))
-        .and_return(rummager)
-
-      expect(rummager).to receive(:add_document)
-        .with("edition", "/first-finder", {
-          "title" => "first finder",
-          "description" => "first finder description",
-          "link" => "/first-finder",
-          "format" => "finder",
-          "public_timestamp" => "2015-01-05T10:45:10.000+00:00",
-          "specialist_sectors" => [
-            "business-tax/paye",
-          ]
-        })
-
-      expect(rummager).to receive(:add_document)
-        .with("edition", "/second-finder", {
-          "title" => "second finder",
-          "description" => "",
-          "link" => "/second-finder",
-          "format" => "finder",
-          "public_timestamp" => "2015-02-14T11:43:23.000+00:00",
-          "specialist_sectors" => [
-            "competition/mergers",
-            "competition/markets",
-          ],
-        })
-
-      RummagerFinderPublisher.new(metadata, logger: test_logger).call
-    end
-
-    context 'with pre_production false metadata and RAILS_ENV is "production"' do
-      let(:metadata) do
+  describe "#call" do
+    describe "publishing finders" do
+      let(:metadata) {
         [
           {
             file: {
-              "base_path" => "/finder-with-pre-production-true",
+              "base_path" => "/first-finder",
+              "name" => "first finder",
+              "format_name" => "first finder things",
+              "description" => "first finder description",
+              "content_id" => SecureRandom.uuid,
+              "format" => "a_report_format",
+              "signup_content_id" => SecureRandom.uuid,
+              "logo_path" => "http://example.com/logo.png",
+              "topics" => [
+                "business-tax/paye",
+              ],
+            },
+            timestamp: "2015-01-05T10:45:10.000+00:00",
+          },
+          {
+            file: {
+              "base_path" => "/second-finder",
+              "name" => "second finder",
+              "format_name" => "second finder things",
+              "content_id" => SecureRandom.uuid,
+              "format" => "some_case_format",
+              "logo_path" => "http://example.com/logo.png",
+              "topics" => [
+                "competition/mergers",
+                "competition/markets",
+              ],
+            },
+            timestamp: "2015-02-14T11:43:23.000+00:00",
+          },
+        ]
+      }
+
+      it "uses GdsApi::Rummager" do
+        expect(GdsApi::Rummager).to receive(:new)
+          .with(Plek.new.find("rummager"))
+          .and_return(rummager)
+
+        expect(rummager).to receive(:add_document)
+          .with("edition", "/first-finder", {
+            "title" => "first finder",
+            "description" => "first finder description",
+            "link" => "/first-finder",
+            "format" => "finder",
+            "public_timestamp" => "2015-01-05T10:45:10.000+00:00",
+            "specialist_sectors" => [
+              "business-tax/paye",
+            ]
+          })
+
+        expect(rummager).to receive(:add_document)
+          .with("edition", "/second-finder", {
+            "title" => "second finder",
+            "description" => "",
+            "link" => "/second-finder",
+            "format" => "finder",
+            "public_timestamp" => "2015-02-14T11:43:23.000+00:00",
+            "specialist_sectors" => [
+              "competition/mergers",
+              "competition/markets",
+            ],
+          })
+
+        RummagerFinderPublisher.new(metadata, logger: test_logger).call
+      end
+    end
+
+    context "when the finder isn't `pre_production`" do
+      let(:metadata) {
+        [
+          {
+            file: {
+              "base_path" => "/not-pre-production-finder",
               "content_id" => SecureRandom.uuid,
               "name" => "finder with pre-production true",
               "format" => "a_report_format",
@@ -89,31 +93,27 @@ describe RummagerFinderPublisher do
             timestamp: "2015-01-05T10:45:10.000+00:00",
           },
         ]
-      end
+      }
 
-      it "does publish finder" do
-        rummager = double("rummager")
-
-        production = ActiveSupport::StringInquirer.new("production")
-        allow(Rails).to receive(:env).and_return(production)
-
+      it "publishes finder" do
         expect(GdsApi::Rummager).to receive(:new)
           .with(Plek.new.find("rummager"))
           .and_return(rummager)
 
         expect(rummager).to receive(:add_document)
-          .with(anything, "/finder-with-pre-production-true", anything)
+          .with(anything, "/not-pre-production-finder", anything)
 
         RummagerFinderPublisher.new(metadata, logger: test_logger).call
       end
     end
 
-    context "with pre_production true metadata" do
-      let(:metadata) do
+    context "when the finder is `pre_production`" do
+      let(:metadata) {
         [
           {
             file: {
-              "base_path" => "/finder-with-pre-production-true",
+              "base_path" => "/pre-production-finder",
+              "content_id" => SecureRandom.uuid,
               "name" => "finder with pre-production true",
               "format" => "a_report_format",
               "format_name" => "a report format",
@@ -122,41 +122,22 @@ describe RummagerFinderPublisher do
             timestamp: "2015-01-05T10:45:10.000+00:00",
           },
         ]
-      end
+      }
 
-      context 'and RAILS_ENV is not "production"' do
+      context "and RAILS_ENV is not 'production'" do
         it "publishes finder" do
-          rummager = double("rummager")
           expect(GdsApi::Rummager).to receive(:new)
             .with(Plek.new.find("rummager"))
             .and_return(rummager)
 
           expect(rummager).to receive(:add_document)
-            .with(anything, "/finder-with-pre-production-true", anything)
+            .with(anything, "/pre-production-finder", anything)
 
           RummagerFinderPublisher.new(metadata, logger: test_logger).call
         end
       end
 
-      context 'and RAILS_ENV is "production"' do
-        let(:metadata) do
-          [
-            {
-              file: {
-                "base_path" => "/finder-with-pre-production-true",
-                "content_id" => SecureRandom.uuid,
-                "name" => "finder with pre-production true",
-                "format" => "a_report_format",
-                "format_name" => "a report format",
-                "pre_production" => true,
-              },
-              timestamp: "2015-01-05T10:45:10.000+00:00",
-            },
-          ]
-        end
-
-        let(:rummager) { double("rummager") }
-
+      context "and RAILS_ENV is 'production'" do
         before do
           production = ActiveSupport::StringInquirer.new("production")
           allow(Rails).to receive(:env).and_return(production)
@@ -166,20 +147,20 @@ describe RummagerFinderPublisher do
             .and_return(rummager)
         end
 
-        context 'and GOVUK_APP_DOMAIN does not contain "preview"' do
+        context "and GOVUK_APP_DOMAIN does not contain 'preview'" do
           it "does not publish finder" do
             expect(rummager).not_to receive(:add_document)
-              .with(anything, "/finder-with-pre-production-true", anything)
+              .with(anything, "/pre-production-finder", anything)
 
             RummagerFinderPublisher.new(metadata, logger: test_logger).call
           end
         end
 
-        context 'and GOVUK_APP_DOMAIN contains "preview"' do
+        context "and GOVUK_APP_DOMAIN contains 'preview'" do
           it "publishes finder" do
             allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN", "").and_return("preview")
             expect(rummager).to receive(:add_document)
-              .with(anything, "/finder-with-pre-production-true", anything)
+              .with(anything, "/pre-production-finder", anything)
 
             RummagerFinderPublisher.new(metadata, logger: test_logger).call
           end

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -124,7 +124,15 @@ describe RummagerFinderPublisher do
         ]
       }
 
-      context "and RAILS_ENV is not 'production'" do
+      context "and PUBLISH_PRE_PRODUCTION_FINDERS is set" do
+        before do
+          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = "1"
+        end
+
+        after do
+          ENV["PUBLISH_PRE_PRODUCTION_FINDERS"] = nil
+        end
+
         it "publishes finder" do
           expect(GdsApi::Rummager).to receive(:new)
             .with(Plek.new.find("rummager"))
@@ -137,33 +145,12 @@ describe RummagerFinderPublisher do
         end
       end
 
-      context "and RAILS_ENV is 'production'" do
-        before do
-          production = ActiveSupport::StringInquirer.new("production")
-          allow(Rails).to receive(:env).and_return(production)
+      context "and PUBLISH_PRE_PRODUCTION_FINDERS is not set" do
+        it "does not publish finder" do
+          expect(rummager).not_to receive(:add_document)
+            .with(anything, "/pre-production-finder", anything)
 
-          allow(GdsApi::Rummager).to receive(:new)
-            .with(Plek.new.find("rummager"))
-            .and_return(rummager)
-        end
-
-        context "and GOVUK_APP_DOMAIN does not contain 'preview'" do
-          it "does not publish finder" do
-            expect(rummager).not_to receive(:add_document)
-              .with(anything, "/pre-production-finder", anything)
-
-            RummagerFinderPublisher.new(metadata, logger: test_logger).call
-          end
-        end
-
-        context "and GOVUK_APP_DOMAIN contains 'preview'" do
-          it "publishes finder" do
-            allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN", "").and_return("preview")
-            expect(rummager).to receive(:add_document)
-              .with(anything, "/pre-production-finder", anything)
-
-            RummagerFinderPublisher.new(metadata, logger: test_logger).call
-          end
+          RummagerFinderPublisher.new(metadata, logger: test_logger).call
         end
       end
     end


### PR DESCRIPTION
Finders that shouldn't be published in production environments are known as "pre-production finders". (The corresponding metadata attribute was recently renamed from `preview_only` to `pre_production` https://github.com/alphagov/specialist-publisher/pull/575.)

We're currently checking the environment variable `GOVUK_APP_DOMAIN` _and_ `Rails.env`, but a dedicated environment (`PUBLISH_PRE_PRODUCTION_FINDERS`) variable has just been introduced to the Preview and Development environments via Puppet (https://github.gds/gds/puppet/pull/3446) and here we've made the move to make use of that.

In this change, for both uses of the _feature flag_ we're accessing `ENV["PUBLISH_PRE_PRODUCTION_FINDERS"]` directly, but it might be cleaner to move it into application config (an initialiser). Opinions welcome.