### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "fetchable", "1.0.0"
 gem "foreman", "0.74.0"
 gem "gds-sso", "10.0.0"
 gem "generic_form_builder", "0.11.0"
-gem "govuk_admin_template", "2.3.1"
+gem 'govuk_admin_template', '3.0.0'
 gem "kaminari", "0.16.1"
 gem "logstasher", "0.4.8"
 gem "mongoid", "2.5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       multi_json
     arel (3.0.3)
     ast (2.0.0)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     awesome_print (1.2.0)
@@ -44,9 +44,9 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     bson (1.12.1)
     bson_ext (1.12.1)
       bson (~> 1.12.1)
@@ -125,7 +125,7 @@ GEM
       sanitize (~> 2.1.0)
     govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -153,7 +153,7 @@ GEM
       railties (>= 3.1.0)
       sprockets-rails
     journey (1.0.4)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -380,7 +380,7 @@ DEPENDENCIES
   generic_form_builder (= 0.11.0)
   govspeak (= 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
-  govuk_admin_template (= 2.3.1)
+  govuk_admin_template (= 3.0.0)
   govuk_content_models (= 28.7.0)
   govuk_frontend_toolkit (= 0.44.0)
   jasmine-rails


### PR DESCRIPTION
Trello: https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools

Ensures the Analytics domain is set to the 
`GOVUK_APP_DOMAIN` env variable rather than 
being hardcoded.