### PR TITLE
Use environment in rake publish tasks

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -3,7 +3,7 @@ require Rails.root.join("app/exporters/formatters/specialist_document_publishing
 
 namespace :publishing_api do
   desc "Publish all Finders to the Publishing API"
-  task :publish_finders do
+  task :publish_finders => :environment do
     require "publishing_api_finder_publisher"
     require "publishing_api_finder_loader"
 

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,7 +1,7 @@
 
 namespace :rummager do
   desc "Publish all Finders to Rummager"
-  task :publish_finders do
+  task :publish_finders => :environment do
     require "rummager_finder_publisher"
 
     require "multi_json"


### PR DESCRIPTION
Without ` => :environment` after the name of each rake task, it fails to
load the environment. This commit adds it, allowing for the rake task
to load the Rails environment.