### PR TITLE
Add tax tribunal decisions finder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,6 +62,10 @@ class ApplicationController < ActionController::Base
         document_type: "raib_report",
         title: "RAIB Reports",
       },
+      "tax-tribunal-decisions" => {
+        document_type: "tax_tribunal_decision",
+        title: "Tax Tribunal Decisions",
+      },
       "utaac-decisions" => {
         document_type: "utaac_decision",
         title: "UTAAC Decisions",

--- a/app/controllers/tax_tribunal_decisions_controller.rb
+++ b/app/controllers/tax_tribunal_decisions_controller.rb
@@ -1,0 +1,2 @@
+class TaxTribunalDecisionsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/tax_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/tax_tribunal_decision_indexable_formatter.rb
@@ -1,0 +1,21 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class TaxTribunalDecisionIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+  def type
+    "tax_tribunal_decision"
+  end
+
+private
+  def extra_attributes
+    {
+      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip,
+      tribunal_decision_category: entity.tribunal_decision_category,
+      tribunal_decision_category_name: expand_value(:tribunal_decision_category).first,
+      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
+    }
+  end
+
+  def organisation_slugs
+    ["upper-tribunal-tax-and-chancery-chamber"]
+  end
+end

--- a/app/exporters/formatters/tax_tribunal_decision_publication_alert_formatter.rb
+++ b/app/exporters/formatters/tax_tribunal_decision_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class TaxTribunalDecisionPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "Upper Tribunal (Tax and Chancery Chamber)"
+  end
+
+private
+  def document_noun
+    "decision"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -27,6 +27,8 @@ class PermissionChecker
       ["rail-accident-investigation-branch"]
     when "countryside_stewardship_grant"
       ["department-for-environment-food-rural-affairs"]
+    when "tax_tribunal_decision"
+      ["upper-tribunal-tax-and-chancery-chamber"]
     when "utaac_decision"
       ["upper-tribunal-administrative-appeals-chamber"]
     when "vehicle_recalls_and_faults_alert"

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -35,6 +35,7 @@ private
     "maib_report" => MaibReportObserversRegistry,
     "medical_safety_alert" => MedicalSafetyAlertObserversRegistry,
     "raib_report" => RaibReportObserversRegistry,
+    "tax_tribunal_decision" => TaxTribunalDecisionObserversRegistry,
     "utaac_decision" => UtaacDecisionObserversRegistry,
     "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertObserversRegistry,
   }.freeze

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -129,6 +129,11 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
       get(:validatable_document_factories).utaac_decision_factory)
   }
 
+  define_factory(:tax_tribunal_decision_builder) {
+    SpecialistDocumentBuilder.new("tax_tribunal_decision",
+      get(:validatable_document_factories).tax_tribunal_decision_factory)
+  }
+
   define_instance(:markdown_attachment_renderer) {
     MarkdownAttachmentProcessor.method(:new)
   }
@@ -262,6 +267,10 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:utaac_decision_finder_schema) {
     FinderSchema.new(Rails.root.join("finders/schemas/utaac-decisions.json"))
+  }
+
+  define_singleton(:tax_tribunal_decision_finder_schema) {
+    FinderSchema.new(Rails.root.join("finders/schemas/tax-tribunal-decisions.json"))
   }
 
   define_singleton(:organisations_api) {

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -14,6 +14,7 @@ require "validators/raib_report_validator"
 require "validators/vehicle_recalls_and_faults_alert_validator"
 require "validators/asylum_support_decision_validator"
 require "validators/utaac_decision_validator"
+require "validators/tax_tribunal_decision_validator"
 
 require "builders/manual_document_builder"
 require "manual_with_documents"
@@ -29,6 +30,7 @@ require "medical_safety_alert"
 require "international_development_fund"
 require "asylum_support_decision"
 require "utaac_decision"
+require "tax_tribunal_decision"
 
 class DocumentFactoryRegistry
   def aaib_report_factory
@@ -203,6 +205,21 @@ class DocumentFactoryRegistry
           UtaacDecision.new(
             SpecialistDocument.new(
               SlugGenerator.new(prefix: "utaac-decisions"),
+              *args,
+            ),
+          )
+        )
+      )
+    }
+  end
+
+  def tax_tribunal_decision_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        TaxTribunalDecisionValidator.new(
+          TaxTribunalDecision.new(
+            SpecialistDocument.new(
+              SlugGenerator.new(prefix: "tax-and-chancery-tribunal-decisions"),
               *args,
             ),
           )

--- a/app/models/tax_tribunal_decision.rb
+++ b/app/models/tax_tribunal_decision.rb
@@ -1,0 +1,9 @@
+require "document_metadata_decorator"
+
+class TaxTribunalDecision < DocumentMetadataDecorator
+  set_extra_field_names [
+    :hidden_indexable_content,
+    :tribunal_decision_category,
+    :tribunal_decision_decision_date,
+  ]
+end

--- a/app/models/validators/tax_tribunal_decision_validator.rb
+++ b/app/models/validators/tax_tribunal_decision_validator.rb
@@ -1,0 +1,15 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class TaxTribunalDecisionValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+  validates :tribunal_decision_category, presence: true
+  validates :tribunal_decision_decision_date, allow_blank: true, date: true
+
+end

--- a/app/observers/tax_tribunal_decision_observers_registry.rb
+++ b/app/observers/tax_tribunal_decision_observers_registry.rb
@@ -1,0 +1,24 @@
+require "formatters/tax_tribunal_decision_indexable_formatter"
+require "formatters/tax_tribunal_decision_publication_alert_formatter"
+require "markdown_attachment_processor"
+
+class TaxTribunalDecisionObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+private
+  def finder_schema
+    SpecialistPublisherWiring.get(:tax_tribunal_decision_finder_schema)
+  end
+
+  def format_document_for_indexing(document)
+    TaxTribunalDecisionIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
+  end
+
+  def publication_alert_formatter(document)
+    TaxTribunalDecisionPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/tax_tribunal_decision_view_adapter.rb
+++ b/app/view_adapters/tax_tribunal_decision_view_adapter.rb
@@ -1,0 +1,27 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class TaxTribunalDecisionViewAdapter < DocumentViewAdapter
+  attributes = [
+    :hidden_indexable_content,
+    :tribunal_decision_category,
+    :tribunal_decision_decision_date,
+  ]
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "TaxTribunalDecision")
+  end
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:tax_tribunal_decision_finder_schema)
+  end
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -15,6 +15,7 @@ private
     "maib_report" => MaibReportViewAdapter,
     "medical_safety_alert" => MedicalSafetyAlertViewAdapter,
     "raib_report" => RaibReportViewAdapter,
+    "tax_tribunal_decision" => TaxTribunalDecisionViewAdapter,
     "utaac_decision" => UtaacDecisionViewAdapter,
     "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertViewAdapter,
   }.freeze

--- a/app/views/tax_tribunal_decisions/_form.html.erb
+++ b/app/views/tax_tribunal_decisions/_form.html.erb
@@ -1,0 +1,21 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+    <%= render partial: "shared/form_errors", locals: { object: document } %>
+    <%= render partial: "shared/form_fields", locals: { f: f } %>
+    <%= render partial: "shared/form_preview" %>
+
+    <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
+    <%= f.text_field :tribunal_decision_decision_date, label: "Release date", placeholder: '2015-07-30', class: 'form-control' %>
+    <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
+
+    <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+    <div class="actions">
+      <button name="save" class="btn btn-success">Save as draft</button>
+    </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "tax_tribunal_decision" } %>

--- a/features/creating-and-editing-a-tax-tribunal-decision.feature
+++ b/features/creating-and-editing-a-tax-tribunal-decision.feature
@@ -1,0 +1,35 @@
+Feature: Creating and editing a tax tribunal decision
+  As an TaxTribunal editor
+  I want to create air investigation report pages in Specialist publisher
+  So that I can add them to the tax tribunal decisions finder
+
+  Background:
+    Given I am logged in as a "TaxTribunal" editor
+
+  Scenario: Create a new tax tribunal decision
+    When I create a tax tribunal decision
+    Then the tax tribunal decision has been created
+    And the tax tribunal decision should be in draft
+    And the document should be sent to content preview
+
+  Scenario: Cannot create a tax tribunal decision with invalid fields
+    When I create a tax tribunal decision with invalid fields
+    Then I should see error messages about missing fields
+    Then I should see an error message about an invalid date field "Release date"
+    And I should see an error message about a "Body" field containing javascript
+    And the tax tribunal decision should not have been created
+
+  Scenario: Cannot edit a tax tribunal decision without entering required fields
+    Given a draft tax tribunal decision exists
+    When I edit a tax tribunal decision and remove required fields
+    Then the tax tribunal decision should not have been updated
+
+  Scenario: Can view a list of all tax tribunal decisions in the publisher
+    Given two tax tribunal decisions exist
+    Then the tax tribunal decisions should be in the publisher report index in the correct order
+
+  Scenario: Edit a draft tax tribunal decision
+    Given a draft tax tribunal decision exists
+    When I edit a tax tribunal decision
+    Then the tax tribunal decision should have been updated
+    And the document should be sent to content preview

--- a/features/publishing-a-tax-tribunal-decision.feature
+++ b/features/publishing-a-tax-tribunal-decision.feature
@@ -1,0 +1,56 @@
+Feature: Publishing a tax tribunal decision
+  As an TaxTribunal editor
+  I want to create a new report in draft
+  So that I can prepare the info for publication
+
+  Background:
+    Given I am logged in as a "TaxTribunal" editor
+
+  Scenario: can publish a draft tax tribunal decision
+    Given a draft tax tribunal decision exists
+    When I publish the tax tribunal decision
+    Then the tax tribunal decision should be published
+
+  Scenario: can create a new tax tribunal decision and publish immediately
+    When I publish a new tax tribunal decision
+    Then the tax tribunal decision should be published
+    And the publish should have been logged 1 times
+
+  Scenario: immediately republish a published tax tribunal decision
+    When I publish a new tax tribunal decision
+    When I am on the tax tribunal decision edit page
+    And I edit the document and republish
+    Then the amended document should be published
+    And previous editions should be archived
+
+  Scenario: Sends an email alert on first publish
+    Given a draft tax tribunal decision exists
+    When I publish the tax tribunal decision
+    Then a publication notification should have been sent
+
+  Scenario: Cannot edit a published tax tribunal decision without a change note
+    Given a published tax tribunal decision exists
+    When I am on the tax tribunal decision edit page
+    And I edit the document without a change note
+    Then I see an error requesting that I provide a change note
+
+  Scenario: Sends an email alert on a major update and updates logs
+    Given a published tax tribunal decision exists
+    Then a publication notification should have been sent
+    And the publish should have been logged 1 time
+    When I am on the tax tribunal decision edit page
+    And I edit the document with a change note
+    And I publish the tax tribunal decision
+    Then a publication notification should have been sent
+    And the publish should have been logged 2 times
+
+  Scenario: Minor updates do not send emails or update logs
+    When I publish a new tax tribunal decision
+    Then the tax tribunal decision should be published
+    And the publish should have been logged 1 time
+    And a publication notification should have been sent
+    When I am on the tax tribunal decision edit page
+    And I edit the document and indicate the change is minor
+    When I publish the tax tribunal decision
+    Then an email alert should not be sent
+    And the publish should still have been logged 1 time

--- a/features/step_definitions/tax_tribunal_decision_steps.rb
+++ b/features/step_definitions/tax_tribunal_decision_steps.rb
@@ -1,0 +1,122 @@
+When(/^I create a tax tribunal decision$/) do
+  @document_title = "Example tax tribunal decision"
+  @slug = "tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision"
+  @document_fields = tax_tribunal_decision_fields(title: @document_title)
+
+  create_tax_tribunal_decision(@document_fields)
+end
+
+Then(/^the tax tribunal decision has been created$/) do
+  fields = @document_fields
+  fields["Hidden indexable content"] = "## Header Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Praesent commodo cursus magna, vel scelerisque nisl c..."
+
+  check_tax_tribunal_decision_exists_with(fields)
+end
+
+When(/^I create a tax tribunal decision with invalid fields$/) do
+  @document_fields = tax_tribunal_decision_fields(
+    title: "",
+    summary: "",
+    body: "<script>alert('Oh noes!)</script>",
+    "Release date" => "Bad data",
+  )
+
+  create_tax_tribunal_decision(@document_fields)
+end
+
+Then(/^the tax tribunal decision should not have been created$/) do
+  check_document_does_not_exist_with(@document_fields)
+end
+
+Given(/^two tax tribunal decisions exist$/) do
+  @document_fields = tax_tribunal_decision_fields(title: "tax tribunal decision 1")
+  create_tax_tribunal_decision(@document_fields)
+
+  @document_fields = tax_tribunal_decision_fields(title: "tax tribunal decision 2")
+  create_tax_tribunal_decision(@document_fields)
+end
+
+Then(/^the tax tribunal decisions should be in the publisher report index in the correct order$/) do
+  visit tax_tribunal_decisions_path
+
+  check_for_documents("tax tribunal decision 2", "tax tribunal decision 1")
+end
+
+Given(/^a draft tax tribunal decision exists$/) do
+  @document_title = "Example tax tribunal decision"
+  @slug = "tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision"
+  @document_fields = tax_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = tax_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_tax_tribunal_decision(@document_fields)
+end
+
+When(/^I edit a tax tribunal decision$/) do
+  @new_title = "Edited Example tax tribunal decision"
+  edit_tax_tribunal_decision(@document_title, title: @new_title)
+end
+
+When(/^I edit a tax tribunal decision and remove required fields$/) do
+  edit_tax_tribunal_decision(@document_title, summary: "")
+end
+
+Then(/^the tax tribunal decision should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
+Then(/^the tax tribunal decision should have been updated$/) do
+  check_for_new_tax_tribunal_decision_title(@new_title)
+end
+
+Given(/^there is a published tax tribunal decision with an attachment$/) do
+  @document_title = "Example tax tribunal decision"
+  @attachment_title = "My attachment"
+
+  @slug = "tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision"
+  @document_fields = tax_tribunal_decision_fields(title: @document_title)
+
+  create_tax_tribunal_decision(@document_fields, publish: true)
+  add_attachment_to_document(@document_title, @attachment_title)
+end
+
+Given(/^a published tax tribunal decision exists$/) do
+  @document_title = "Example tax tribunal decision"
+  @slug = "tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision"
+  @document_fields = tax_tribunal_decision_fields(title: @document_title)
+
+  create_tax_tribunal_decision(@document_fields, publish: true)
+end
+
+When(/^I withdraw a tax tribunal decision$/) do
+  withdraw_tax_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the tax tribunal decision should be withdrawn$/) do
+  check_document_is_withdrawn(@slug, @document_fields.fetch(:title))
+end
+
+When(/^I am on the tax tribunal decision edit page$/) do
+  go_to_edit_page_for_tax_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the tax tribunal decision should be in draft$/) do
+  expect(page).to have_content("Publication state draft")
+end
+
+When(/^I publish the tax tribunal decision$/) do
+  go_to_show_page_for_tax_tribunal_decision(@document_title)
+  publish_document
+end
+
+Then(/^the tax tribunal decision should be published$/) do
+  check_document_is_published(@slug, @rummager_fields)
+end
+
+When(/^I publish a new tax tribunal decision$/) do
+  @document_title = "Example tax tribunal decision"
+  @slug = "tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision"
+  @document_fields = tax_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = tax_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_tax_tribunal_decision(@document_fields, publish: true)
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -62,6 +62,7 @@ module DocumentHelpers
       "maib-reports" => "maib_report",
       "raib-reports" => "raib_report",
       "countryside-stewardship-grants" => "countryside_stewardship_grant",
+      "tax-and-chancery-tribunal-decisions" => "tax_tribunal_decision",
       "utaac-decisions" => "utaac_decision",
       "vehicle-recalls-faults" => "vehicle_recalls_and_faults_alert",
     }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -119,6 +119,7 @@ require "idf_helpers"
 require "maib_report_helpers"
 require "msa_helpers"
 require "raib_report_helpers"
+require "tax_tribunal_decision_helpers"
 require "utaac_decision_helpers"
 require "vehicle_recalls_and_faults_alert_helpers"
 
@@ -145,5 +146,6 @@ World(IdfHelpers)
 World(MaibReportHelpers)
 World(MsaHelpers)
 World(RaibReportHelpers)
+World(TaxTribunalDecisionHelpers)
 World(UtaacDecisionHelpers)
 World(VehicleRecallsAndFaultsAlertHelpers)

--- a/features/support/tax_tribunal_decision_helpers.rb
+++ b/features/support/tax_tribunal_decision_helpers.rb
@@ -1,0 +1,78 @@
+module TaxTribunalDecisionHelpers
+  def create_tax_tribunal_decision(fields, **kwargs)
+    create_document(:tax_tribunal_decision, fields, **kwargs)
+  end
+
+  def go_to_show_page_for_tax_tribunal_decision(*args)
+    go_to_show_page_for_document(:tax_tribunal_decision, *args)
+  end
+
+  def check_tax_tribunal_decision_exists_with(*args)
+    check_document_exists_with(:tax_tribunal_decision, *args)
+  end
+
+  def go_to_tax_tribunal_decision_index
+    visit_path_if_elsewhere(tax_tribunal_decisions_path)
+  end
+
+  def go_to_edit_page_for_tax_tribunal_decision(*args)
+    go_to_edit_page_for_document(:tax_tribunal_decision, *args)
+  end
+
+  def edit_tax_tribunal_decision(title, *args)
+    go_to_edit_page_for_tax_tribunal_decision(title)
+    edit_document(title, *args)
+  end
+
+  def check_for_new_tax_tribunal_decision_title(*args)
+    check_for_new_document_title(:tax_tribunal_decision, *args)
+  end
+
+  def withdraw_tax_tribunal_decision(*args)
+    withdraw_document(:tax_tribunal_decision, *args)
+  end
+
+  def create_multiple_tax_tribunal_decisions(titles)
+    titles.each do |title|
+      create_document(:tax_tribunal_decision, tax_tribunal_decision_fields(title: title))
+    end
+  end
+
+  def tax_tribunal_decisions_are_visible(titles)
+    titles.each { |t| tax_tribunal_decision_is_visible(t) }
+  end
+
+  def tax_tribunal_decision_is_visible(title)
+    expect(page).to have_content(title)
+  end
+
+  def tax_tribunal_decisions_are_not_visible(titles)
+    titles.each do |title|
+      expect(page).not_to have_content(title)
+    end
+  end
+
+  def tax_tribunal_decision_fields(overrides = {})
+    {
+      title: "Lorem ipsum",
+      summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+      body: "## Link to attachement:",
+      "Category" => "Banking",
+      "Release date" => "2015-02-02",
+      "Hidden indexable content" => "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10)
+    }.merge(overrides)
+  end
+
+  def tax_tribunal_decision_rummager_fields(overrides = {})
+    fields = tax_tribunal_decision_fields(overrides)
+    fields.delete(:body)
+    fields.delete("Hidden indexable content")
+    category = fields.delete("Category")
+
+    fields[:tribunal_decision_category] = category.parameterize
+    fields[:tribunal_decision_category_name] = category
+    fields[:tribunal_decision_decision_date] = fields.delete("Release date")
+    fields
+  end
+end
+RSpec.configuration.include TaxTribunalDecisionHelpers, type: :feature

--- a/features/tax-tribunal-decision-attachments.feature
+++ b/features/tax-tribunal-decision-attachments.feature
@@ -1,0 +1,26 @@
+Feature: tax tribunal decision attachments
+  As an TaxTribunal editor
+  I want to upload an attachment to a case via the publisher
+  So that users can access the decision documents
+
+  Background:
+    Given I am logged in as a "TaxTribunal" editor
+
+  @javascript
+  Scenario: TaxTribunal editor can add attachment to report
+    Given a draft tax tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attachment on the page with its example markdown embed code
+
+  Scenario: TaxTribunal editor can replace and attachment
+    Given there is a published tax tribunal decision with an attachment
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page
+
+  @regression
+  Scenario: TaxTribunal editor can add and replace attachment to report
+    Given a draft tax tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page

--- a/features/withdrawing-a-tax-tribunal-decision.feature
+++ b/features/withdrawing-a-tax-tribunal-decision.feature
@@ -1,0 +1,12 @@
+Feature: Withdrawing a tax tribunal decision
+  As a TaxTribunal editor
+  I want to withdraw a tax tribunal decision
+  So that it is not accessible to the public
+
+  Background:
+    Given I am logged in as a "TaxTribunal" editor
+    And a published tax tribunal decision exists
+
+  Scenario: Withdraw a tax tribunal decision
+    When I withdraw a tax tribunal decision
+    Then the tax tribunal decision should be withdrawn

--- a/finders/metadata/tax-tribunal-decisions.json
+++ b/finders/metadata/tax-tribunal-decisions.json
@@ -1,0 +1,62 @@
+{
+  "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
+  "base_path": "/tax-and-chancery-tribunal-decisions",
+  "format_name": "Tax and Chancery tribunal decision",
+  "name": "Tax and Chancery tribunal decisions",
+  "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
+  "beta": true,
+  "filter": {
+    "document_type": "tax_tribunal_decision"
+  },
+  "show_summaries": true,
+  "organisations": [
+    "1a68b2cc-eb52-4528-8989-429f710da00f"
+  ],
+  "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
+  "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
+  "subscription_list_title_prefix": {
+    "singular": "Upper Tribunal (Tax and Chancery Chamber) with the following category: ",
+    "plural": "Upper Tribunal (Tax and Chancery Chamber) with the following categories: "
+  },
+  "email_filter_by": "tribunal_decision_category",
+  "email_signup_choice": [
+    {
+      "key": "banking",
+      "radio_button_name": "Banking",
+      "topic_name": "banking",
+      "prechecked": false
+    },
+    {
+      "key": "charity",
+      "radio_button_name": "Charity",
+      "topic_name": "charity",
+      "prechecked": false
+    },
+    {
+      "key": "financial-services",
+      "radio_button_name": "Financial Services",
+      "topic_name": "financial services",
+      "prechecked": false
+    },
+    {
+      "key": "land-registration",
+      "radio_button_name": "Land Registration",
+      "topic_name": "land registration",
+      "prechecked": false
+    },
+    {
+      "key": "pensions",
+      "radio_button_name": "Pensions",
+      "topic_name": "pensions",
+      "prechecked": false
+    },
+    {
+      "key": "tax",
+      "radio_button_name": "Tax",
+      "topic_name": "tax",
+      "prechecked": false
+    }
+  ],
+  "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
+  "pre_production": true
+}

--- a/finders/schemas/tax-tribunal-decisions.json
+++ b/finders/schemas/tax-tribunal-decisions.json
@@ -1,0 +1,55 @@
+{
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_category",
+      "name": "Category",
+      "short_name": "category",
+      "type": "text",
+      "preposition": "categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Banking",
+          "value": "banking"
+        },
+        {
+          "label": "Charity",
+          "value": "charity"
+        },
+        {
+          "label": "Financial Services",
+          "value": "financial-services"
+        },
+        {
+          "label": "Land Registration",
+          "value": "land-registration"
+        },
+        {
+          "label": "Pensions",
+          "value": "pensions"
+        },
+        {
+          "label": "Tax",
+          "value": "tax"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_category_name",
+      "name": "Category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Release date",
+      "short_name": "Released",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/exporters/formatters/tax_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/tax_tribunal_decision_indexable_formatter_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "formatters/aaib_report_indexable_formatter"
+require_relative "tribunal_decision_indexable_formatter_spec"
+
+RSpec.describe TaxTribunalDecisionIndexableFormatter do
+  let(:document) {
+    double(
+      :tax_tribunal_decision,
+      body: double,
+      slug: "/slug",
+      summary: double,
+      title: double,
+      updated_at: double,
+      minor_update?: false,
+      public_updated_at: double,
+
+      hidden_indexable_content: double,
+      tribunal_decision_category: double,
+      tribunal_decision_decision_date: double,
+    )
+  }
+
+  subject(:formatter) { TaxTribunalDecisionIndexableFormatter.new(document) }
+
+  let(:document_type) { formatter.type }
+  let(:humanized_facet_value) { double }
+  include_context "schema with humanized_facet_value available"
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of tax_tribunal_decision" do
+    expect(formatter.type).to eq("tax_tribunal_decision")
+  end
+
+  context "without hidden_indexable_content" do
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
+    end
+  end
+
+  context "with hidden_indexable_content" do
+    it "should have hidden_indexable_content as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
+    end
+  end
+
+end

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "tax_tribunal_decision"
+
+RSpec.describe TaxTribunalDecision do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(TaxTribunalDecision.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end

--- a/spec/models/validators/tax_tribunal_decision_validator_spec.rb
+++ b/spec/models/validators/tax_tribunal_decision_validator_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+require "validators/tax_tribunal_decision_validator"
+
+RSpec.describe TaxTribunalDecisionValidator do
+
+  let(:entity) {
+    double(
+      :entity,
+      title: double,
+      summary: double,
+      body: "body",
+      tribunal_decision_category: category,
+      tribunal_decision_decision_date: "2015-11-01",
+    )
+  }
+  let(:document_type) { "tax_tribunal_decision" }
+
+  subject(:validatable) { TaxTribunalDecisionValidator.new(entity) }
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -53,6 +53,10 @@ FactoryGirl.define do
     organisation_slug "upper-tribunal-administrative-appeals-chamber"
   end
 
+  factory :taxtribunal_editor, parent: :editor do
+    organisation_slug "upper-tribunal-tax-and-chancery-chamber"
+  end
+
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end


### PR DESCRIPTION
Add a finder for Upper Tribunal (Tax and Chancery Chamber) decisions.

Upper Tribunal (Tax and Chancery Chamber) publishes decisions that describe the outcome of a tribunal case. HMCTS may decide to also publish First-tier Tribunal (Tax) decisions using this same finder. The base_path slug has been named to be flexible enough to allow for this.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.

**Requires this rummager pull request be merged**: https://github.com/alphagov/rummager/pull/526
