### PR TITLE
Add new MHRA alert types

### DIFF
--- a/finders/metadata/medical-safety-alerts.json
+++ b/finders/metadata/medical-safety-alerts.json
@@ -33,6 +33,20 @@
       "topic_name": "drug alerts",
       "body": "information published by the MHRA about defective medicines.",
       "prechecked": true
+    },
+    {
+      "key": "field-safety",
+      "radio_button_name": "Field safety notices",
+      "topic_name": "field safety notices",
+      "body": "information from medical device manufacturers.",
+      "prechecked": true
+    },
+    {
+      "key": "company-led-drug",
+      "radio_button_name": "Drug alerts: company-led",
+      "topic_name": "drug alerts: company-led",
+      "body": "recalls of medicines issued by manufacturers.",
+      "prechecked": true
     }
   ]
 }

--- a/finders/schemas/medical-safety-alerts.json
+++ b/finders/schemas/medical-safety-alerts.json
@@ -10,7 +10,9 @@
       "filterable": true,
       "allowed_values": [
         {"label": "Drug alert", "value": "drugs"},
-        {"label": "Medical device alert", "value": "devices"}
+        {"label": "Medical device alert", "value": "devices"},
+        {"label": "Field safety notices", "value": "field-safety"},
+        {"label": "Drug alerts: company-led", "value": "company-led-drug"}
       ]
     },
     {


### PR DESCRIPTION
https://trello.com/c/tiCatwpE/117-add-two-new-alert-types-to-mhra-drug-device-alerts-finder-small

MHRA are removing these remaining alerts away from publications to a finder

Related:
https://github.com/alphagov/govuk-content-schemas/pull/133
https://github.com/alphagov/rummager/pull/530