### PR TITLE
Sort tax tribunal decisions by decision date

### DIFF
--- a/finders/metadata/tax-tribunal-decisions.json
+++ b/finders/metadata/tax-tribunal-decisions.json
@@ -8,6 +8,7 @@
   "filter": {
     "document_type": "tax_tribunal_decision"
   },
+  "default_order": "-tribunal_decision_decision_date",
   "show_summaries": true,
   "organisations": [
     "1a68b2cc-eb52-4528-8989-429f710da00f"


### PR DESCRIPTION
HM Courts & Tribunals Service would like the search results for tax tribunal decisions to be sorted by the decision date, with the most recent decisions listed first.

In order for this to work, the same field `tribunal_decision_decision_date` has also been added to the `ALLOWED_SORT_FIELDS` hash in rummager.

**Requires this rummager pull request be merged**: https://github.com/alphagov/rummager/pull/531
