### PR TITLE
Employment tribunal decisions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,10 @@ class ApplicationController < ActionController::Base
         document_type: "countryside_stewardship_grant",
         title: "Countryside Stewardship Grants",
       },
+      "employment-tribunal-decisions" => {
+        document_type: "employment_tribunal_decision",
+        title: "ET Decisions",
+      },
       "international-development-funds" => {
         document_type: "international_development_fund",
         title: "International Development Funds",

--- a/app/controllers/employment_tribunal_decisions_controller.rb
+++ b/app/controllers/employment_tribunal_decisions_controller.rb
@@ -1,0 +1,2 @@
+class EmploymentTribunalDecisionsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/employment_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/employment_tribunal_decision_indexable_formatter.rb
@@ -1,0 +1,23 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class EmploymentTribunalDecisionIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+  def type
+    "employment_tribunal_decision"
+  end
+
+private
+  def extra_attributes
+    {
+      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip,
+      tribunal_decision_categories: entity.tribunal_decision_categories,
+      tribunal_decision_categories_name: expand_value(:tribunal_decision_categories),
+      tribunal_decision_country: entity.tribunal_decision_country,
+      tribunal_decision_country_name: expand_value(:tribunal_decision_country).first,
+      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
+    }
+  end
+
+  def organisation_slugs
+    ["employment-tribunal"]
+  end
+end

--- a/app/exporters/formatters/employment_tribunal_decision_publication_alert_formatter.rb
+++ b/app/exporters/formatters/employment_tribunal_decision_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class EmploymentTribunalDecisionPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "Employment tribunal decisions"
+  end
+
+private
+  def document_noun
+    "decision"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -16,6 +16,8 @@ class PermissionChecker
       ["medicines-and-healthcare-products-regulatory-agency"]
     when "employment_appeal_tribunal_decision"
       ["employment-appeal-tribunal"]
+    when "employment_tribunal_decision"
+      ["employment-tribunal"]
     when "esi_fund"
       %w(
         department-for-communities-and-local-government

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -31,6 +31,7 @@ private
     "countryside_stewardship_grant" => CountrysideStewardshipGrantObserversRegistry,
     "drug_safety_update" => DrugSafetyUpdateObserversRegistry,
     "employment_appeal_tribunal_decision" => EmploymentAppealTribunalDecisionObserversRegistry,
+    "employment_tribunal_decision" => EmploymentTribunalDecisionObserversRegistry,
     "esi_fund" => EsiFundObserversRegistry,
     "international_development_fund" => InternationalDevelopmentFundObserversRegistry,
     "maib_report" => MaibReportObserversRegistry,

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -139,6 +139,11 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
       get(:validatable_document_factories).employment_appeal_tribunal_decision_factory)
   }
 
+  define_factory(:employment_tribunal_decision_builder) {
+    SpecialistDocumentBuilder.new("employment_tribunal_decision",
+      get(:validatable_document_factories).employment_tribunal_decision_factory)
+  }
+
   define_instance(:markdown_attachment_renderer) {
     MarkdownAttachmentProcessor.method(:new)
   }
@@ -280,6 +285,10 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:employment_appeal_tribunal_decision_finder_schema) {
     FinderSchema.new(Rails.root.join("finders/schemas/employment-appeal-tribunal-decisions.json"))
+  }
+
+  define_singleton(:employment_tribunal_decision_finder_schema) {
+    FinderSchema.new(Rails.root.join("finders/schemas/employment-tribunal-decisions.json"))
   }
 
   define_singleton(:organisations_api) {

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -16,6 +16,7 @@ require "validators/asylum_support_decision_validator"
 require "validators/utaac_decision_validator"
 require "validators/tax_tribunal_decision_validator"
 require "validators/employment_appeal_tribunal_decision_validator"
+require "validators/employment_tribunal_decision_validator"
 
 require "builders/manual_document_builder"
 require "manual_with_documents"
@@ -33,6 +34,7 @@ require "asylum_support_decision"
 require "utaac_decision"
 require "tax_tribunal_decision"
 require "employment_appeal_tribunal_decision"
+require "employment_tribunal_decision"
 
 class DocumentFactoryRegistry
   def aaib_report_factory
@@ -237,6 +239,21 @@ class DocumentFactoryRegistry
           EmploymentAppealTribunalDecision.new(
             SpecialistDocument.new(
               SlugGenerator.new(prefix: "employment-appeal-tribunal-decisions"),
+              *args,
+            ),
+          )
+        )
+      )
+    }
+  end
+
+  def employment_tribunal_decision_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        EmploymentTribunalDecisionValidator.new(
+          EmploymentTribunalDecision.new(
+            SpecialistDocument.new(
+              SlugGenerator.new(prefix: "employment-tribunal-decisions"),
               *args,
             ),
           )

--- a/app/models/employment_tribunal_decision.rb
+++ b/app/models/employment_tribunal_decision.rb
@@ -1,0 +1,10 @@
+require "document_metadata_decorator"
+
+class EmploymentTribunalDecision < DocumentMetadataDecorator
+  set_extra_field_names [
+    :hidden_indexable_content,
+    :tribunal_decision_categories,
+    :tribunal_decision_country,
+    :tribunal_decision_decision_date
+  ]
+end

--- a/app/models/validators/employment_tribunal_decision_validator.rb
+++ b/app/models/validators/employment_tribunal_decision_validator.rb
@@ -1,0 +1,16 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class EmploymentTribunalDecisionValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+  validates :tribunal_decision_categories, presence: true
+  validates :tribunal_decision_country, presence: true
+  validates :tribunal_decision_decision_date, presence: true, date: true
+
+end

--- a/app/observers/employment_tribunal_decision_observers_registry.rb
+++ b/app/observers/employment_tribunal_decision_observers_registry.rb
@@ -1,0 +1,24 @@
+require "formatters/employment_tribunal_decision_indexable_formatter"
+require "formatters/employment_tribunal_decision_publication_alert_formatter"
+require "markdown_attachment_processor"
+
+class EmploymentTribunalDecisionObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+private
+  def finder_schema
+    SpecialistPublisherWiring.get(:employment_tribunal_decision_finder_schema)
+  end
+
+  def format_document_for_indexing(document)
+    EmploymentTribunalDecisionIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
+  end
+
+  def publication_alert_formatter(document)
+    EmploymentTribunalDecisionPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/employment_tribunal_decision_view_adapter.rb
+++ b/app/view_adapters/employment_tribunal_decision_view_adapter.rb
@@ -1,0 +1,28 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class EmploymentTribunalDecisionViewAdapter < DocumentViewAdapter
+  attributes = [
+    :hidden_indexable_content,
+    :tribunal_decision_categories,
+    :tribunal_decision_country,
+    :tribunal_decision_decision_date,
+  ]
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "EmploymentTribunalDecision")
+  end
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:employment_tribunal_decision_finder_schema)
+  end
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -11,6 +11,7 @@ private
     "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
     "drug_safety_update" => DrugSafetyUpdateViewAdapter,
     "employment_appeal_tribunal_decision" => EmploymentAppealTribunalDecisionViewAdapter,
+    "employment_tribunal_decision" => EmploymentTribunalDecisionViewAdapter,
     "esi_fund" => EsiFundViewAdapter,
     "international_development_fund" => InternationalDevelopmentFundViewAdapter,
     "maib_report" => MaibReportViewAdapter,

--- a/app/views/employment_tribunal_decisions/_form.html.erb
+++ b/app/views/employment_tribunal_decisions/_form.html.erb
@@ -1,0 +1,22 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+    <%= render partial: "shared/form_errors", locals: { object: document } %>
+    <%= render partial: "shared/form_fields", locals: { f: f } %>
+    <%= render partial: "shared/form_preview" %>
+
+    <%= f.select :tribunal_decision_country, f.object.facet_options(:tribunal_decision_country), { label: "Country" }, { class: 'form-control' } %>
+    <%= f.select :tribunal_decision_categories, f.object.facet_options(:tribunal_decision_categories), { label: "Jurisdiction code" }, { class: 'select2', multiple: true, data: { placeholder: '' } } %>
+    <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-07-30', class: 'form-control' %>
+    <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
+
+    <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+    <div class="actions">
+      <button name="save" class="btn btn-success">Save as draft</button>
+    </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "employment_tribunal_decision" } %>

--- a/features/creating-and-editing-an-employment-tribunal-decision.feature
+++ b/features/creating-and-editing-an-employment-tribunal-decision.feature
@@ -1,0 +1,35 @@
+Feature: Creating and editing an employment tribunal decision
+  As an EmploymentTribunal editor
+  I want to create air investigation report pages in Specialist publisher
+  So that I can add them to the employment tribunal decisions finder
+
+  Background:
+    Given I am logged in as a "EmploymentTribunal" editor
+
+  Scenario: Create a new employment tribunal decision
+    When I create a employment tribunal decision
+    Then the employment tribunal decision has been created
+    And the employment tribunal decision should be in draft
+    And the document should be sent to content preview
+
+  Scenario: Cannot create a employment tribunal decision with invalid fields
+    When I create a employment tribunal decision with invalid fields
+    Then I should see error messages about missing fields
+    Then I should see an error message about an invalid date field "Decision date"
+    And I should see an error message about a "Body" field containing javascript
+    And the employment tribunal decision should not have been created
+
+  Scenario: Cannot edit an employment tribunal decision without entering required fields
+    Given a draft employment tribunal decision exists
+    When I edit an employment tribunal decision and remove required fields
+    Then the employment tribunal decision should not have been updated
+
+  Scenario: Can view a list of all employment tribunal decisions in the publisher
+    Given two employment tribunal decisions exist
+    Then the employment tribunal decisions should be in the publisher report index in the correct order
+
+  Scenario: Edit a draft employment tribunal decision
+    Given a draft employment tribunal decision exists
+    When I edit a employment tribunal decision
+    Then the employment tribunal decision should have been updated
+    And the document should be sent to content preview

--- a/features/employment-tribunal-decision-attachments.feature
+++ b/features/employment-tribunal-decision-attachments.feature
@@ -1,0 +1,26 @@
+Feature: employment tribunal decision attachments
+  As an EmploymentTribunal editor
+  I want to upload an attachment to a case via the publisher
+  So that users can access the decision documents
+
+  Background:
+    Given I am logged in as a "EmploymentTribunal" editor
+
+  @javascript
+  Scenario: EmploymentTribunal editor can add attachment to report
+    Given a draft employment tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attachment on the page with its example markdown embed code
+
+  Scenario: EmploymentTribunal editor can replace and attachment
+    Given there is a published employment tribunal decision with an attachment
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page
+
+  @regression
+  Scenario: EmploymentTribunal editor can add and replace attachment to report
+    Given a draft employment tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page

--- a/features/publishing-an-employment-tribunal-decision.feature
+++ b/features/publishing-an-employment-tribunal-decision.feature
@@ -1,0 +1,56 @@
+Feature: Publishing an employment tribunal decision
+  As an EmploymentTribunal editor
+  I want to create a new report in draft
+  So that I can prepare the info for publication
+
+  Background:
+    Given I am logged in as a "EmploymentTribunal" editor
+
+  Scenario: can publish a draft employment tribunal decision
+    Given a draft employment tribunal decision exists
+    When I publish the employment tribunal decision
+    Then the employment tribunal decision should be published
+
+  Scenario: can create a new employment tribunal decision and publish immediately
+    When I publish a new employment tribunal decision
+    Then the employment tribunal decision should be published
+    And the publish should have been logged 1 times
+
+  Scenario: immediately republish a published employment tribunal decision
+    When I publish a new employment tribunal decision
+    When I am on the employment tribunal decision edit page
+    And I edit the document and republish
+    Then the amended document should be published
+    And previous editions should be archived
+
+  Scenario: Sends an email alert on first publish
+    Given a draft employment tribunal decision exists
+    When I publish the employment tribunal decision
+    Then a publication notification should have been sent
+
+  Scenario: Cannot edit a published employment tribunal decision without a change note
+    Given a published employment tribunal decision exists
+    When I am on the employment tribunal decision edit page
+    And I edit the document without a change note
+    Then I see an error requesting that I provide a change note
+
+  Scenario: Sends an email alert on a major update and updates logs
+    Given a published employment tribunal decision exists
+    Then a publication notification should have been sent
+    And the publish should have been logged 1 time
+    When I am on the employment tribunal decision edit page
+    And I edit the document with a change note
+    And I publish the employment tribunal decision
+    Then a publication notification should have been sent
+    And the publish should have been logged 2 times
+
+  Scenario: Minor updates do not send emails or update logs
+    When I publish a new employment tribunal decision
+    Then the employment tribunal decision should be published
+    And the publish should have been logged 1 time
+    And a publication notification should have been sent
+    When I am on the employment tribunal decision edit page
+    And I edit the document and indicate the change is minor
+    When I publish the employment tribunal decision
+    Then an email alert should not be sent
+    And the publish should still have been logged 1 time

--- a/features/step_definitions/employment_tribunal_decision_steps.rb
+++ b/features/step_definitions/employment_tribunal_decision_steps.rb
@@ -1,0 +1,122 @@
+When(/^I create a employment tribunal decision$/) do
+  @document_title = "Example employment tribunal decision"
+  @slug = "employment-tribunal-decisions/example-employment-tribunal-decision"
+  @document_fields = employment_tribunal_decision_fields(title: @document_title)
+
+  create_employment_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment tribunal decision has been created$/) do
+  fields = @document_fields
+  fields["Hidden indexable content"] = "## Header Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Praesent commodo cursus magna, vel scelerisque nisl c..."
+
+  check_employment_tribunal_decision_exists_with(fields)
+end
+
+When(/^I create a employment tribunal decision with invalid fields$/) do
+  @document_fields = employment_tribunal_decision_fields(
+    title: "",
+    summary: "",
+    body: "<script>alert('Oh noes!)</script>",
+    "Decision date" => "Bad data",
+  )
+
+  create_employment_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment tribunal decision should not have been created$/) do
+  check_document_does_not_exist_with(@document_fields)
+end
+
+Given(/^two employment tribunal decisions exist$/) do
+  @document_fields = employment_tribunal_decision_fields(title: "employment tribunal decision 1")
+  create_employment_tribunal_decision(@document_fields)
+
+  @document_fields = employment_tribunal_decision_fields(title: "employment tribunal decision 2")
+  create_employment_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment tribunal decisions should be in the publisher report index in the correct order$/) do
+  visit employment_tribunal_decisions_path
+
+  check_for_documents("employment tribunal decision 2", "employment tribunal decision 1")
+end
+
+Given(/^a draft employment tribunal decision exists$/) do
+  @document_title = "Example employment tribunal decision"
+  @slug = "employment-tribunal-decisions/example-employment-tribunal-decision"
+  @document_fields = employment_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = employment_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_employment_tribunal_decision(@document_fields)
+end
+
+When(/^I edit a employment tribunal decision$/) do
+  @new_title = "Edited Example employment tribunal decision"
+  edit_employment_tribunal_decision(@document_title, title: @new_title)
+end
+
+When(/^I edit an employment tribunal decision and remove required fields$/) do
+  edit_employment_tribunal_decision(@document_title, summary: "")
+end
+
+Then(/^the employment tribunal decision should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
+Then(/^the employment tribunal decision should have been updated$/) do
+  check_for_new_employment_tribunal_decision_title(@new_title)
+end
+
+Given(/^there is a published employment tribunal decision with an attachment$/) do
+  @document_title = "Example employment tribunal decision"
+  @attachment_title = "My attachment"
+
+  @slug = "employment-tribunal-decisions/example-employment-tribunal-decision"
+  @document_fields = employment_tribunal_decision_fields(title: @document_title)
+
+  create_employment_tribunal_decision(@document_fields, publish: true)
+  add_attachment_to_document(@document_title, @attachment_title)
+end
+
+Given(/^a published employment tribunal decision exists$/) do
+  @document_title = "Example employment tribunal decision"
+  @slug = "employment-tribunal-decisions/example-employment-tribunal-decision"
+  @document_fields = employment_tribunal_decision_fields(title: @document_title)
+
+  create_employment_tribunal_decision(@document_fields, publish: true)
+end
+
+When(/^I withdraw an employment tribunal decision$/) do
+  withdraw_employment_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the employment tribunal decision should be withdrawn$/) do
+  check_document_is_withdrawn(@slug, @document_fields.fetch(:title))
+end
+
+When(/^I am on the employment tribunal decision edit page$/) do
+  go_to_edit_page_for_employment_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the employment tribunal decision should be in draft$/) do
+  expect(page).to have_content("Publication state draft")
+end
+
+When(/^I publish the employment tribunal decision$/) do
+  go_to_show_page_for_employment_tribunal_decision(@document_title)
+  publish_document
+end
+
+Then(/^the employment tribunal decision should be published$/) do
+  check_document_is_published(@slug, @rummager_fields)
+end
+
+When(/^I publish a new employment tribunal decision$/) do
+  @document_title = "Example employment tribunal decision"
+  @slug = "employment-tribunal-decisions/example-employment-tribunal-decision"
+  @document_fields = employment_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = employment_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_employment_tribunal_decision(@document_fields, publish: true)
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -59,6 +59,7 @@ module DocumentHelpers
       "drug-safety-update" => "drug_safety_update",
       "drug-device-alerts" => "medical_safety_alert",
       "employment-appeal-tribunal-decisions" => "employment_appeal_tribunal_decision",
+      "employment-tribunal-decisions" => "employment_tribunal_decision",
       "european-structural-investment-funds" => "european_structural_investment_fund",
       "maib-reports" => "maib_report",
       "raib-reports" => "raib_report",

--- a/features/support/employment_tribunal_decision_helpers.rb
+++ b/features/support/employment_tribunal_decision_helpers.rb
@@ -1,0 +1,78 @@
+module EmploymentTribunalDecisionHelpers
+  def create_employment_tribunal_decision(fields, **kwargs)
+    create_document(:employment_tribunal_decision, fields, **kwargs)
+  end
+
+  def go_to_show_page_for_employment_tribunal_decision(*args)
+    go_to_show_page_for_document(:employment_tribunal_decision, *args)
+  end
+
+  def check_employment_tribunal_decision_exists_with(*args)
+    check_document_exists_with(:employment_tribunal_decision, *args)
+  end
+
+  def go_to_employment_tribunal_decision_index
+    visit_path_if_elsewhere(employment_tribunal_decisions_path)
+  end
+
+  def go_to_edit_page_for_employment_tribunal_decision(*args)
+    go_to_edit_page_for_document(:employment_tribunal_decision, *args)
+  end
+
+  def edit_employment_tribunal_decision(title, *args)
+    go_to_edit_page_for_employment_tribunal_decision(title)
+    edit_document(title, *args)
+  end
+
+  def check_for_new_employment_tribunal_decision_title(*args)
+    check_for_new_document_title(:employment_tribunal_decision, *args)
+  end
+
+  def withdraw_employment_tribunal_decision(*args)
+    withdraw_document(:employment_tribunal_decision, *args)
+  end
+
+  def create_multiple_employment_tribunal_decisions(titles)
+    titles.each do |title|
+      create_document(:employment_tribunal_decision, employment_tribunal_decision_fields(title: title))
+    end
+  end
+
+  def employment_tribunal_decisions_are_visible(titles)
+    titles.each { |t| employment_tribunal_decision_is_visible(t) }
+  end
+
+  def employment_tribunal_decision_is_visible(title)
+    expect(page).to have_content(title)
+  end
+
+  def employment_tribunal_decisions_are_not_visible(titles)
+    titles.each do |title|
+      expect(page).not_to have_content(title)
+    end
+  end
+
+  def employment_tribunal_decision_fields(overrides = {})
+    {
+      title: "Lorem ipsum",
+      summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+      body: "## Link to attachement:",
+      "Jurisdiction code" => "Age Discrimination",
+      "Decision date" => "2015-02-02",
+      "Hidden indexable content" => "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10)
+    }.merge(overrides)
+  end
+
+  def employment_tribunal_decision_rummager_fields(overrides = {})
+    fields = employment_tribunal_decision_fields(overrides)
+    fields.delete(:body)
+    fields.delete("Hidden indexable content")
+    category = fields.delete("Jurisdiction code")
+
+    fields[:tribunal_decision_categories] = [category.parameterize]
+    fields[:tribunal_decision_categories_name] = [category]
+    fields[:tribunal_decision_decision_date] = fields.delete("Decision date")
+    fields
+  end
+end
+RSpec.configuration.include EmploymentTribunalDecisionHelpers, type: :feature

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -115,6 +115,7 @@ require "cma_case_helpers"
 require "csg_helpers"
 require "dsu_helpers"
 require "employment_appeal_tribunal_decision_helpers"
+require "employment_tribunal_decision_helpers"
 require "esi_fund_helpers"
 require "idf_helpers"
 require "maib_report_helpers"
@@ -143,6 +144,7 @@ World(CmaCaseHelpers)
 World(CsgHelpers)
 World(DsuHelpers)
 World(EmploymentAppealTribunalDecisionHelpers)
+World(EmploymentTribunalDecisionHelpers)
 World(EsiFundHelpers)
 World(IdfHelpers)
 World(MaibReportHelpers)

--- a/features/withdrawing-an-employment-tribunal-decision.feature
+++ b/features/withdrawing-an-employment-tribunal-decision.feature
@@ -1,0 +1,12 @@
+Feature: Withdrawing an employment tribunal decision
+  As a EmploymentTribunal editor
+  I want to withdraw an employment tribunal decision
+  So that it is not accessible to the public
+
+  Background:
+    Given I am logged in as a "EmploymentTribunal" editor
+    And a published employment tribunal decision exists
+
+  Scenario: Withdraw an employment tribunal decision
+    When I withdraw an employment tribunal decision
+    Then the employment tribunal decision should be withdrawn

--- a/finders/metadata/employment-tribunal-decisions.json
+++ b/finders/metadata/employment-tribunal-decisions.json
@@ -1,0 +1,284 @@
+{
+  "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
+  "base_path": "/employment-tribunal-decisions",
+  "format_name": "Employment tribunal decision",
+  "name": "Employment tribunal decisions",
+  "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
+  "beta": true,
+  "filter": {
+    "document_type": "employment_tribunal_decision"
+  },
+  "show_summaries": true,
+  "organisations": [
+    "8bb37087-a5a7-4493-8afe-900b36ebc927"
+  ],
+  "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
+  "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
+  "subscription_list_title_prefix": {
+    "singular": "Employment tribunal decisions with the following jurisdiction code: ",
+    "plural": "Employment tribunal decisions with the following jurisdiction codes: "
+  },
+  "email_filter_by": "tribunal_decision_categories",
+  "email_signup_choice": [
+    {
+      "key": "age-discrimination",
+      "radio_button_name": "Age Discrimination",
+      "topic_name": "age discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "agency-workers",
+      "radio_button_name": "Agency Workers",
+      "topic_name": "agency workers",
+      "prechecked": false
+    },
+    {
+      "key": "blacklisting-regulations",
+      "radio_button_name": "Blacklisting Regulations",
+      "topic_name": "blacklisting regulations",
+      "prechecked": false
+    },
+    {
+      "key": "central-arbitration-committee-cac",
+      "radio_button_name": "Central Arbitration Committee (CAC)",
+      "topic_name": "central arbitration committee cac",
+      "prechecked": false
+    },
+    {
+      "key": "certification-officer",
+      "radio_button_name": "Certification Officer",
+      "topic_name": "certification officer",
+      "prechecked": false
+    },
+    {
+      "key": "contract-of-employment",
+      "radio_button_name": "Contract of Employment",
+      "topic_name": "contract of employment",
+      "prechecked": false
+    },
+    {
+      "key": "disability-discrimination",
+      "radio_button_name": "Disability Discrimination",
+      "topic_name": "disability discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "employment-agencies-act-1973",
+      "radio_button_name": "Employment Agencies Act 1973",
+      "topic_name": "employment agencies act 1973",
+      "prechecked": false
+    },
+    {
+      "key": "employment-agencies-act-1973-obsolete-topic",
+      "radio_button_name": "Employment Agencies Act 1973 (obsolete topic)",
+      "topic_name": "employment agencies act 1973 obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "equal-pay-act",
+      "radio_button_name": "Equal Pay Act",
+      "topic_name": "equal pay act",
+      "prechecked": false
+    },
+    {
+      "key": "european-material-obsolete-topic",
+      "radio_button_name": "European Material (obsolete topic)",
+      "topic_name": "european material obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "fixed-term-regulations",
+      "radio_button_name": "Fixed Term Regulations",
+      "topic_name": "fixed term regulations",
+      "prechecked": false
+    },
+    {
+      "key": "flexible-working",
+      "radio_button_name": "Flexible Working",
+      "topic_name": "flexible working",
+      "prechecked": false
+    },
+    {
+      "key": "harassment",
+      "radio_button_name": "Harassment",
+      "topic_name": "harassment",
+      "prechecked": false
+    },
+    {
+      "key": "health-safety",
+      "radio_button_name": "Health & Safety",
+      "topic_name": "health safety",
+      "prechecked": false
+    },
+    {
+      "key": "human-rights",
+      "radio_button_name": "Human Rights",
+      "topic_name": "human rights",
+      "prechecked": false
+    },
+    {
+      "key": "jurisdiction-obsolete-topic",
+      "radio_button_name": "Jurisdiction (obsolete topic)",
+      "topic_name": "jurisdiction obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "jurisdictional-points",
+      "radio_button_name": "Jurisdictional Points",
+      "topic_name": "jurisdictional points",
+      "prechecked": false
+    },
+    {
+      "key": "maternity-rights-and-parental-leave",
+      "radio_button_name": "Maternity Rights and Parental Leave",
+      "topic_name": "maternity rights and parental leave",
+      "prechecked": false
+    },
+    {
+      "key": "national-minimum-wage",
+      "radio_button_name": "National Minimum Wage",
+      "topic_name": "national minimum wage",
+      "prechecked": false
+    },
+    {
+      "key": "national-security",
+      "radio_button_name": "National Security",
+      "topic_name": "national security",
+      "prechecked": false
+    },
+    {
+      "key": "part-time-workers",
+      "radio_button_name": "Part Time Workers",
+      "topic_name": "part time workers",
+      "prechecked": false
+    },
+    {
+      "key": "practice-and-procedure",
+      "radio_button_name": "Practice and Procedure",
+      "topic_name": "practice and procedure",
+      "prechecked": false
+    },
+    {
+      "key": "procedural-issues-obsolete-topic",
+      "radio_button_name": "Procedural Issues (obsolete topic)",
+      "topic_name": "procedural issues obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "public-interest-disclosure-obsolete-topic",
+      "radio_button_name": "Public Interest Disclosure (obsolete topic)",
+      "topic_name": "public interest disclosure obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "race-discrimination",
+      "radio_button_name": "Race Discrimination",
+      "topic_name": "race discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "redundancy",
+      "radio_button_name": "Redundancy",
+      "topic_name": "redundancy",
+      "prechecked": false
+    },
+    {
+      "key": "religion-or-belief-discrimination",
+      "radio_button_name": "Religion or Belief Discrimination",
+      "topic_name": "religion or belief discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "reserved-forces-act-obsolete-topic",
+      "radio_button_name": "Reserved Forces Act (obsolete topic)",
+      "topic_name": "reserved forces act obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "right-to-be-accompanied",
+      "radio_button_name": "Right To Be Accompanied",
+      "topic_name": "right to be accompanied",
+      "prechecked": false
+    },
+    {
+      "key": "rights-on-insolvency",
+      "radio_button_name": "Rights on Insolvency",
+      "topic_name": "rights on insolvency",
+      "prechecked": false
+    },
+    {
+      "key": "sex-discrimination",
+      "radio_button_name": "Sex Discrimination",
+      "topic_name": "sex discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "sexual-orientation-discrimination-transexualism",
+      "radio_button_name": "Sexual Orientation Discrimination/Transexualism",
+      "topic_name": "sexual orientation discrimination transexualism",
+      "prechecked": false
+    },
+    {
+      "key": "statutory-discipline-and-grievance-procedures",
+      "radio_button_name": "Statutory Discipline and Grievance Procedures",
+      "topic_name": "statutory discipline and grievance procedures",
+      "prechecked": false
+    },
+    {
+      "key": "time-limits-obsolete-topic",
+      "radio_button_name": "Time Limits (obsolete topic)",
+      "topic_name": "time limits obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "time-off",
+      "radio_button_name": "Time Off",
+      "topic_name": "time off",
+      "prechecked": false
+    },
+    {
+      "key": "trade-union-membership",
+      "radio_button_name": "Trade Union Membership",
+      "topic_name": "trade union membership",
+      "prechecked": false
+    },
+    {
+      "key": "trade-union-rights",
+      "radio_button_name": "Trade Union Rights",
+      "topic_name": "trade union rights",
+      "prechecked": false
+    },
+    {
+      "key": "transfer-of-undertakings",
+      "radio_button_name": "Transfer of Undertakings",
+      "topic_name": "transfer of undertakings",
+      "prechecked": false
+    },
+    {
+      "key": "unfair-dismissal",
+      "radio_button_name": "Unfair Dismissal",
+      "topic_name": "unfair dismissal",
+      "prechecked": false
+    },
+    {
+      "key": "unlawful-deduction-from-wages",
+      "radio_button_name": "Unlawful Deduction from Wages",
+      "topic_name": "unlawful deduction from wages",
+      "prechecked": false
+    },
+    {
+      "key": "victimisation-discrimination",
+      "radio_button_name": "Victimisation Discrimination",
+      "topic_name": "victimisation discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "working-time-regulations",
+      "radio_button_name": "Working Time Regulations",
+      "topic_name": "working time regulations",
+      "prechecked": false
+    }
+  ],
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
+  "pre_production": true
+}

--- a/finders/schemas/employment-tribunal-decisions.json
+++ b/finders/schemas/employment-tribunal-decisions.json
@@ -1,0 +1,227 @@
+{
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_country",
+      "name": "Country",
+      "type": "text",
+      "preposition": "by country",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "England and Wales",
+          "value": "england-and-wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_country_name",
+      "name": "Country name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_categories",
+      "name": "Jurisdiction code",
+      "type": "text",
+      "preposition": "by jurisdiction",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Age Discrimination",
+          "value": "age-discrimination"
+        },
+        {
+          "label": "Agency Workers",
+          "value": "agency-workers"
+        },
+        {
+          "label": "Blacklisting Regulations",
+          "value": "blacklisting-regulations"
+        },
+        {
+          "label": "Central Arbitration Committee (CAC)",
+          "value": "central-arbitration-committee-cac"
+        },
+        {
+          "label": "Certification Officer",
+          "value": "certification-officer"
+        },
+        {
+          "label": "Contract of Employment",
+          "value": "contract-of-employment"
+        },
+        {
+          "label": "Disability Discrimination",
+          "value": "disability-discrimination"
+        },
+        {
+          "label": "Employment Agencies Act 1973",
+          "value": "employment-agencies-act-1973"
+        },
+        {
+          "label": "Employment Agencies Act 1973 (obsolete topic)",
+          "value": "employment-agencies-act-1973-obsolete-topic"
+        },
+        {
+          "label": "Equal Pay Act",
+          "value": "equal-pay-act"
+        },
+        {
+          "label": "European Material (obsolete topic)",
+          "value": "european-material-obsolete-topic"
+        },
+        {
+          "label": "Fixed Term Regulations",
+          "value": "fixed-term-regulations"
+        },
+        {
+          "label": "Flexible Working",
+          "value": "flexible-working"
+        },
+        {
+          "label": "Harassment",
+          "value": "harassment"
+        },
+        {
+          "label": "Health & Safety",
+          "value": "health-safety"
+        },
+        {
+          "label": "Human Rights",
+          "value": "human-rights"
+        },
+        {
+          "label": "Jurisdiction (obsolete topic)",
+          "value": "jurisdiction-obsolete-topic"
+        },
+        {
+          "label": "Jurisdictional Points",
+          "value": "jurisdictional-points"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave",
+          "value": "maternity-rights-and-parental-leave"
+        },
+        {
+          "label": "National Minimum Wage",
+          "value": "national-minimum-wage"
+        },
+        {
+          "label": "National Security",
+          "value": "national-security"
+        },
+        {
+          "label": "Part Time Workers",
+          "value": "part-time-workers"
+        },
+        {
+          "label": "Practice and Procedure",
+          "value": "practice-and-procedure"
+        },
+        {
+          "label": "Procedural Issues (obsolete topic)",
+          "value": "procedural-issues-obsolete-topic"
+        },
+        {
+          "label": "Public Interest Disclosure (obsolete topic)",
+          "value": "public-interest-disclosure-obsolete-topic"
+        },
+        {
+          "label": "Race Discrimination",
+          "value": "race-discrimination"
+        },
+        {
+          "label": "Redundancy",
+          "value": "redundancy"
+        },
+        {
+          "label": "Religion or Belief Discrimination",
+          "value": "religion-or-belief-discrimination"
+        },
+        {
+          "label": "Reserved Forces Act (obsolete topic)",
+          "value": "reserved-forces-act-obsolete-topic"
+        },
+        {
+          "label": "Right To Be Accompanied",
+          "value": "right-to-be-accompanied"
+        },
+        {
+          "label": "Rights on Insolvency",
+          "value": "rights-on-insolvency"
+        },
+        {
+          "label": "Sex Discrimination",
+          "value": "sex-discrimination"
+        },
+        {
+          "label": "Sexual Orientation Discrimination/Transexualism",
+          "value": "sexual-orientation-discrimination-transexualism"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures",
+          "value": "statutory-discipline-and-grievance-procedures"
+        },
+        {
+          "label": "Time Limits (obsolete topic)",
+          "value": "time-limits-obsolete-topic"
+        },
+        {
+          "label": "Time Off",
+          "value": "time-off"
+        },
+        {
+          "label": "Trade Union Membership",
+          "value": "trade-union-membership"
+        },
+        {
+          "label": "Trade Union Rights",
+          "value": "trade-union-rights"
+        },
+        {
+          "label": "Transfer of Undertakings",
+          "value": "transfer-of-undertakings"
+        },
+        {
+          "label": "Unfair Dismissal",
+          "value": "unfair-dismissal"
+        },
+        {
+          "label": "Unlawful Deduction from Wages",
+          "value": "unlawful-deduction-from-wages"
+        },
+        {
+          "label": "Victimisation Discrimination",
+          "value": "victimisation-discrimination"
+        },
+        {
+          "label": "Working Time Regulations",
+          "value": "working-time-regulations"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_categories_name",
+      "name": "Jurisdiction code name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Decision date",
+      "short_name": "Decided",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/exporters/formatters/employment_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/employment_tribunal_decision_indexable_formatter_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "formatters/aaib_report_indexable_formatter"
+require_relative "tribunal_decision_indexable_formatter_spec"
+
+RSpec.describe EmploymentTribunalDecisionIndexableFormatter do
+  let(:document) {
+    double(
+      :employment_tribunal_decision,
+      body: double,
+      slug: "/slug",
+      summary: double,
+      title: double,
+      updated_at: double,
+      minor_update?: false,
+      public_updated_at: double,
+
+      hidden_indexable_content: double,
+      tribunal_decision_categories: [double],
+      tribunal_decision_country: double,
+      tribunal_decision_decision_date: double,
+    )
+  }
+
+  subject(:formatter) { EmploymentTribunalDecisionIndexableFormatter.new(document) }
+
+  let(:document_type) { formatter.type }
+  let(:humanized_facet_value) { double }
+  include_context "schema with humanized_facet_value available"
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of employment_tribunal_decision" do
+    expect(formatter.type).to eq("employment_tribunal_decision")
+  end
+
+  context "without hidden_indexable_content" do
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
+    end
+  end
+
+  context "with hidden_indexable_content" do
+    it "should have hidden_indexable_content as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
+    end
+  end
+
+end

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "employment_tribunal_decision"
+
+RSpec.describe EmploymentTribunalDecision do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(EmploymentTribunalDecision.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end

--- a/spec/models/validators/employment_tribunal_decision_validator_spec.rb
+++ b/spec/models/validators/employment_tribunal_decision_validator_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+require "validators/employment_tribunal_decision_validator"
+
+RSpec.describe EmploymentTribunalDecisionValidator do
+
+  let(:entity) {
+    double(
+      :entity,
+      title: double,
+      summary: double,
+      body: "body",
+      tribunal_decision_categories: [double],
+      tribunal_decision_country:  double,
+      tribunal_decision_decision_date: "2015-11-01",
+    )
+  }
+  let(:document_type) { "employment_tribunal_decision" }
+
+  subject(:validatable) { EmploymentTribunalDecisionValidator.new(entity) }
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -65,6 +65,10 @@ FactoryGirl.define do
     organisation_slug "employment-appeal-tribunal"
   end
 
+  factory :employmenttribunal_editor, parent: :editor do
+    organisation_slug "employment-tribunal"
+  end
+
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end


### PR DESCRIPTION
Add a finder for employment tribunal decisions. The Employment Tribunal publishes decisions that
describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.

**Requires this rummager pull request be merged**: https://github.com/alphagov/rummager/pull/534