### PR TITLE
Add a script to report on duplicate Specialist Documents

### DIFF
--- a/bin/find_duplicate_documents
+++ b/bin/find_duplicate_documents
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+
+slug_hash = {}
+SpecialistDocumentEdition.all.each do |edition|
+  slug_hash[edition.slug] ||= {}
+  slug_hash[edition.slug][edition.document_id] ||= {state: edition.state, created_at: edition.created_at, editions: 0}
+  slug_hash[edition.slug][edition.document_id][:editions] += 1
+end
+
+slug_hash.reject! { |_slug, document_ids| document_ids.size == 1 }
+
+slug_hash.each do |slug, documents|
+  documents.each do |document_id, data|
+    puts [slug, document_id, data[:state], data[:created_at], data[:editions]].join(",")
+  end
+end


### PR DESCRIPTION
We fixed a bug recently that was causing new document ids to be
assigned to editions for existing documents. This caused what appear to
be duplicate documents to be created, where one slug is represented by
multiple document ids. This script will report on these instances as a
CSV.

Run as `bundle exec bin/find_duplicate_documents > duplicate_documents.csv`

https://trello.com/c/IoqudHqe/136-specialist-publisher-bug-check-to-see-whether-there-are-still-duplicated-editions-left-over-medium