### PR TITLE
Fix display of dates in specialist documents

### DIFF
--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -17,8 +17,12 @@
     <dl class="metadata-list">
       <% document.humanized_attributes.each_pair do |label, values| %>
         <dt><%= label.to_s.humanize %></dt>
-        <% Array(values).each do |value| %>
-          <dd><%= truncate(value.to_s, length: 140) %></dd>
+        <% if values.is_a?(Time) %>
+          <dd><time><%= values.to_s(:govuk_date) %></time></dd>
+        <% else %>
+          <% Array(values).each do |value| %>
+            <dd><%= truncate(value.to_s, length: 140) %></dd>
+          <% end %>
         <% end %>
       <% end %>
       <dt>Publication state</dt>


### PR DESCRIPTION
When a Time object was provided it was looping over each part of it and producing a new `<dd>` element, eg one for year, date, day, hour, etc. Check for Time objects and render them in a human readable way.

## Before
![screen shot 2015-10-23 at 11 57 57](https://cloud.githubusercontent.com/assets/319055/10690975/67b312cc-797d-11e5-9fef-48a0d36127b6.png)

## After
![screen shot 2015-10-23 at 11 57 32](https://cloud.githubusercontent.com/assets/319055/10690977/6ad97608-797d-11e5-9df8-a83cd129e87f.png)