### PR TITLE
Add script to import MHRA alerts from whitehall

### DIFF
--- a/app/importers/document_import.rb
+++ b/app/importers/document_import.rb
@@ -24,7 +24,8 @@ module DocumentImport
     end
 
     def success(document, data)
-      write("SUCCESS", document.import_notes.join("\t"), data)
+      import_notes = document.respond_to?(:import_notes) ? document.import_notes : []
+      write("SUCCESS", import_notes.join("\t"), data)
     end
 
     def failure(document, data)

--- a/app/importers/medical_safety_alert_import.rb
+++ b/app/importers/medical_safety_alert_import.rb
@@ -1,0 +1,89 @@
+require "medical_safety_alert_import/mapper"
+
+module MedicalSafetyAlertImport
+  def self.call(data_file)
+    DependencyContainer.new(data_file).get_instance.call
+  end
+
+  class DependencyContainer
+    def initialize(data_file)
+      @data_file = data_file
+    end
+
+    def get_instance
+      DocumentImport::BulkImporter.new(
+        import_job_builder: import_job_builder,
+        data_enum: data_enum
+      )
+    end
+
+    private
+
+    def import_job_builder
+      ->(data) {
+        DocumentImport::SingleImport.new(
+          document_creator: import_mapper,
+          logger: DocumentImport::Logger.new(STDOUT),
+          data: data,
+        )
+      }
+    end
+
+    def data_enum
+      parse_json_file(@data_file).map do |item|
+        item.merge("import_source" => File.basename(@data_file))
+      end
+    end
+
+    def parse_json_file(filename)
+      JSON.parse(File.read(filename))
+    end
+
+    def import_mapper
+      public_updated_at_setter = Proc.new { |document|
+        document.latest_edition.public_updated_at = Date.parse(document.issued_date)
+      }
+
+      Mapper.new(
+        ->(attrs) {
+          CreateDocumentService.new(
+            report_builder,
+            repo,
+            [],
+            attrs,
+          ).call
+        },
+        ->(document_id) {
+          PublishDocumentService.new(
+            repo,
+            [public_updated_at_setter] + MedicalSafetyAlertObserversRegistry.new.republication,
+            document_id,
+            true
+          ).call
+        },
+        repo,
+      )
+    end
+
+    def report_builder
+      SpecialistDocumentBuilder.new("medical_safety_alert",
+        ->(*args) {
+          null_validator(
+            SpecialistPublisherWiring
+            .get(:validatable_document_factories)
+            .medical_safety_alert_factory
+            .call(*args)
+          )
+        }
+      )
+    end
+
+    def repo
+      SpecialistPublisherWiring.get(:repository_registry).for_type("medical_safety_alert")
+    end
+
+    def null_validator(thing)
+      NullValidator.new(thing)
+    end
+  end
+end

--- a/app/importers/medical_safety_alert_import/mapper.rb
+++ b/app/importers/medical_safety_alert_import/mapper.rb
@@ -1,0 +1,59 @@
+module MedicalSafetyAlertImport
+  class Mapper
+    def initialize(document_creator, document_publisher, repo)
+      @document_creator = document_creator
+      @document_publisher = document_publisher
+      @repo = repo
+    end
+
+    def call(raw_data)
+      document = document_creator.call(desired_attributes(raw_data))
+      document = document_publisher.call(document.id)
+      document
+    end
+
+    def import_notes
+      []
+    end
+
+  private
+    attr_reader :document_creator, :document_publisher, :repo
+
+    def desired_attributes(data)
+      massage(data)
+        .slice(*desired_keys)
+        .symbolize_keys
+    end
+
+    def massage(data)
+      alert_type = case data["import_source"]
+                   when /safety-information-from-manufacturers-field-safety-notices/
+                     "field-safety"
+                   when /medicines-company-led-recalls/
+                     "company-led-drug"
+                   end
+
+      title_date = /\d\d? \w+ 2015/.match(data["title"])
+      begin
+        issued_date = Date.parse(title_date[0])
+      rescue ArgumentError
+        issued_date = Date.parse(data["issued_date"])
+      end
+
+      data.merge(
+        "alert_type" => alert_type,
+        "issued_date" => issued_date.strftime("%Y-%m-%d"),
+      )
+    end
+
+    def desired_keys
+      %w(
+        body
+        title
+        alert_type
+        issued_date
+        summary
+      )
+    end
+  end
+end

--- a/bin/import_mhra_alerts
+++ b/bin/import_mhra_alerts
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "medical_safety_alert_import"
+
+data_file = ARGV.fetch(0)
+
+MedicalSafetyAlertImport.call(data_file)


### PR DESCRIPTION
This is based on a resurrection of https://github.com/alphagov/specialist-publisher/pull/300.

This is used for importing Field Safety Notices and Company-led Drug
Alerts from their respective Whitehall publications into the
`/drug-device-alerts` finder (which is confusingly the
`medical_safety_alert` document type). A related Whitehall PR
(https://github.com/alphagov/whitehall/pull/2364) is used to export the
HTML attachments as a JSON file, each of which should be supplied to
the importer. The filename is used to determine the alert type to
import the document as.

The `issued_date` is parsed explicitly from the document title. This is
not ideal but works well with the current set of documents we have.
From this, the `public_updated_at` date is set before publish, in order
to ensure the alerts appear in the correct order in the finder. This is
done by prepending the `public_updated_at_setter` observer in a similar
pattern to the `publish_cma_cases` script.

Once this import has been completed in production, it’s expected that
we’ll revert this commit in much the same way as the initial imports
occurred, so please forgive the inclusion of `2015` in the date parsing
regex.

/cc @jamiecobbett @benilovj 