### PR TITLE
Output old and new slugs on stdout for import

### DIFF
--- a/app/importers/medical_safety_alert_import/mapper.rb
+++ b/app/importers/medical_safety_alert_import/mapper.rb
@@ -9,11 +9,8 @@ module MedicalSafetyAlertImport
     def call(raw_data)
       document = document_creator.call(desired_attributes(raw_data))
       document = document_publisher.call(document.id)
+      puts "#{raw_data["slug"]} => #{document.slug}"
       document
-    end
-
-    def import_notes
-      []
     end
 
   private


### PR DESCRIPTION
When the import process is run, the old documents need withdrawing
in Whitehall. In order to do this, we need to know both the old and
new URLs.

This doesn't output them in a very nice way, but it's only a small
number of documents affected, so a manual process is fine.

/cc @tommyp 