### PR TITLE
Employment appeal tribunal decisions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,10 @@ class ApplicationController < ActionController::Base
         document_type: "drug_safety_update",
         title: "Drug Safety Update",
       },
+      "employment-appeal-tribunal-decisions" => {
+        document_type: "employment_appeal_tribunal_decision",
+        title: "EAT Decisions",
+      },
       "esi-funds" => {
         document_type: "esi_fund",
         title: "ESI Funds",

--- a/app/controllers/employment_appeal_tribunal_decisions_controller.rb
+++ b/app/controllers/employment_appeal_tribunal_decisions_controller.rb
@@ -1,0 +1,2 @@
+class EmploymentAppealTribunalDecisionsController < AbstractDocumentsController
+end

--- a/app/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter.rb
@@ -1,0 +1,25 @@
+require "formatters/abstract_specialist_document_indexable_formatter"
+
+class EmploymentAppealTribunalDecisionIndexableFormatter < AbstractSpecialistDocumentIndexableFormatter
+  def type
+    "employment_appeal_tribunal_decision"
+  end
+
+private
+  def extra_attributes
+    {
+      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip,
+      tribunal_decision_categories: entity.tribunal_decision_categories,
+      tribunal_decision_categories_name: expand_value(:tribunal_decision_categories),
+      tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
+      tribunal_decision_landmark: entity.tribunal_decision_landmark,
+      tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark).first,
+      tribunal_decision_sub_categories: entity.tribunal_decision_sub_categories,
+      tribunal_decision_sub_categories_name: expand_value(:tribunal_decision_sub_categories),
+    }
+  end
+
+  def organisation_slugs
+    ["employment-appeal-tribunal"]
+  end
+end

--- a/app/exporters/formatters/employment_appeal_tribunal_decision_publication_alert_formatter.rb
+++ b/app/exporters/formatters/employment_appeal_tribunal_decision_publication_alert_formatter.rb
@@ -1,0 +1,13 @@
+require "formatters/abstract_document_publication_alert_formatter"
+
+class EmploymentAppealTribunalDecisionPublicationAlertFormatter < AbstractDocumentPublicationAlertFormatter
+
+  def name
+    "Employment appeal tribunal decisions"
+  end
+
+private
+  def document_noun
+    "decision"
+  end
+end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -14,6 +14,8 @@ class PermissionChecker
       ["department-for-international-development"]
     when "drug_safety_update", "medical_safety_alert"
       ["medicines-and-healthcare-products-regulatory-agency"]
+    when "employment_appeal_tribunal_decision"
+      ["employment-appeal-tribunal"]
     when "esi_fund"
       %w(
         department-for-communities-and-local-government

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -30,6 +30,7 @@ private
     "cma_case" => CmaCaseObserversRegistry,
     "countryside_stewardship_grant" => CountrysideStewardshipGrantObserversRegistry,
     "drug_safety_update" => DrugSafetyUpdateObserversRegistry,
+    "employment_appeal_tribunal_decision" => EmploymentAppealTribunalDecisionObserversRegistry,
     "esi_fund" => EsiFundObserversRegistry,
     "international_development_fund" => InternationalDevelopmentFundObserversRegistry,
     "maib_report" => MaibReportObserversRegistry,

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -134,6 +134,11 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
       get(:validatable_document_factories).tax_tribunal_decision_factory)
   }
 
+  define_factory(:employment_appeal_tribunal_decision_builder) {
+    SpecialistDocumentBuilder.new("employment_appeal_tribunal_decision",
+      get(:validatable_document_factories).employment_appeal_tribunal_decision_factory)
+  }
+
   define_instance(:markdown_attachment_renderer) {
     MarkdownAttachmentProcessor.method(:new)
   }
@@ -271,6 +276,10 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:tax_tribunal_decision_finder_schema) {
     FinderSchema.new(Rails.root.join("finders/schemas/tax-tribunal-decisions.json"))
+  }
+
+  define_singleton(:employment_appeal_tribunal_decision_finder_schema) {
+    FinderSchema.new(Rails.root.join("finders/schemas/employment-appeal-tribunal-decisions.json"))
   }
 
   define_singleton(:organisations_api) {

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -15,6 +15,7 @@ require "validators/vehicle_recalls_and_faults_alert_validator"
 require "validators/asylum_support_decision_validator"
 require "validators/utaac_decision_validator"
 require "validators/tax_tribunal_decision_validator"
+require "validators/employment_appeal_tribunal_decision_validator"
 
 require "builders/manual_document_builder"
 require "manual_with_documents"
@@ -31,6 +32,7 @@ require "international_development_fund"
 require "asylum_support_decision"
 require "utaac_decision"
 require "tax_tribunal_decision"
+require "employment_appeal_tribunal_decision"
 
 class DocumentFactoryRegistry
   def aaib_report_factory
@@ -220,6 +222,21 @@ class DocumentFactoryRegistry
           TaxTribunalDecision.new(
             SpecialistDocument.new(
               SlugGenerator.new(prefix: "tax-and-chancery-tribunal-decisions"),
+              *args,
+            ),
+          )
+        )
+      )
+    }
+  end
+
+  def employment_appeal_tribunal_decision_factory
+    ->(*args) {
+      ChangeNoteValidator.new(
+        EmploymentAppealTribunalDecisionValidator.new(
+          EmploymentAppealTribunalDecision.new(
+            SpecialistDocument.new(
+              SlugGenerator.new(prefix: "employment-appeal-tribunal-decisions"),
               *args,
             ),
           )

--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -1,0 +1,11 @@
+require "document_metadata_decorator"
+
+class EmploymentAppealTribunalDecision < DocumentMetadataDecorator
+  set_extra_field_names [
+    :hidden_indexable_content,
+    :tribunal_decision_categories,
+    :tribunal_decision_decision_date,
+    :tribunal_decision_landmark,
+    :tribunal_decision_sub_categories
+  ]
+end

--- a/app/models/validators/employment_appeal_tribunal_decision_validator.rb
+++ b/app/models/validators/employment_appeal_tribunal_decision_validator.rb
@@ -1,0 +1,17 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class EmploymentAppealTribunalDecisionValidator < SimpleDelegator
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  validates :summary, presence: true
+  validates :body, presence: true, safe_html: true
+
+  validates :tribunal_decision_categories, presence: true
+  validates :tribunal_decision_decision_date, presence: true, date: true
+  validates :tribunal_decision_landmark, presence: true
+  validates :tribunal_decision_sub_categories, presence: true
+
+end

--- a/app/observers/employment_appeal_tribunal_decision_observers_registry.rb
+++ b/app/observers/employment_appeal_tribunal_decision_observers_registry.rb
@@ -1,0 +1,24 @@
+require "formatters/employment_appeal_tribunal_decision_indexable_formatter"
+require "formatters/employment_appeal_tribunal_decision_publication_alert_formatter"
+require "markdown_attachment_processor"
+
+class EmploymentAppealTribunalDecisionObserversRegistry < AbstractSpecialistDocumentObserversRegistry
+
+private
+  def finder_schema
+    SpecialistPublisherWiring.get(:employment_appeal_tribunal_decision_finder_schema)
+  end
+
+  def format_document_for_indexing(document)
+    EmploymentAppealTribunalDecisionIndexableFormatter.new(
+      MarkdownAttachmentProcessor.new(document)
+    )
+  end
+
+  def publication_alert_formatter(document)
+    EmploymentAppealTribunalDecisionPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
+  end
+end

--- a/app/view_adapters/employment_appeal_tribunal_decision_view_adapter.rb
+++ b/app/view_adapters/employment_appeal_tribunal_decision_view_adapter.rb
@@ -1,0 +1,29 @@
+require "delegate"
+require "validators/date_validator"
+require "validators/safe_html_validator"
+
+class EmploymentAppealTribunalDecisionViewAdapter < DocumentViewAdapter
+  attributes = [
+    :hidden_indexable_content,
+    :tribunal_decision_categories,
+    :tribunal_decision_decision_date,
+    :tribunal_decision_landmark,
+    :tribunal_decision_sub_categories,
+  ]
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "EmploymentAppealTribunalDecision")
+  end
+
+  attributes.each do |attribute_name|
+    define_method(attribute_name) do
+      delegate_if_document_exists(attribute_name)
+    end
+  end
+
+private
+
+  def finder_schema
+    SpecialistPublisherWiring.get(:employment_appeal_tribunal_decision_finder_schema)
+  end
+end

--- a/app/view_adapters/view_adapter_registry.rb
+++ b/app/view_adapters/view_adapter_registry.rb
@@ -10,6 +10,7 @@ private
     "cma_case" => CmaCaseViewAdapter,
     "countryside_stewardship_grant" => CountrysideStewardshipGrantViewAdapter,
     "drug_safety_update" => DrugSafetyUpdateViewAdapter,
+    "employment_appeal_tribunal_decision" => EmploymentAppealTribunalDecisionViewAdapter,
     "esi_fund" => EsiFundViewAdapter,
     "international_development_fund" => InternationalDevelopmentFundViewAdapter,
     "maib_report" => MaibReportViewAdapter,

--- a/app/views/employment_appeal_tribunal_decisions/_form.html.erb
+++ b/app/views/employment_appeal_tribunal_decisions/_form.html.erb
@@ -1,0 +1,23 @@
+<div class="col-md-8">
+  <%= form_for document do |f| %>
+    <%= render partial: "shared/form_errors", locals: { object: document } %>
+    <%= render partial: "shared/form_fields", locals: { f: f } %>
+    <%= render partial: "shared/form_preview" %>
+
+    <%= f.select :tribunal_decision_categories, f.object.facet_options(:tribunal_decision_categories), { label: "Category" }, { class: 'select2', multiple: true, data: { placeholder: 'Select category' } } %>
+    <%= f.select :tribunal_decision_sub_categories, f.object.facet_options(:tribunal_decision_sub_categories), { label: "Sub-category" }, { class: 'select2', multiple: true, data: { placeholder: 'Select sub-category' } } %>
+    <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
+    <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-07-30', class: 'form-control' %>
+    <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
+
+    <%= render partial: "specialist_documents/minor_major_update_fields", locals: { f: f, document: document } %>
+
+    <div class="actions">
+      <button name="save" class="btn btn-success">Save as draft</button>
+    </div>
+  <% end %>
+</div>
+
+<%= render partial: "specialist_documents/attachments_form", locals: { document: document } %>
+
+<%= render partial: "specialist_documents/js_preview", locals: { document: document, form_namespace: "employment_appeal_tribunal_decision" } %>

--- a/features/creating-and-editing-an-employment-appeal-tribunal-decision.feature
+++ b/features/creating-and-editing-an-employment-appeal-tribunal-decision.feature
@@ -1,0 +1,35 @@
+Feature: Creating and editing an employment appeal tribunal decision
+  As an EmploymentAppealTribunal editor
+  I want to create air investigation report pages in Specialist publisher
+  So that I can add them to the employment appeal tribunal decisions finder
+
+  Background:
+    Given I am logged in as a "EmploymentAppealTribunal" editor
+
+  Scenario: Create a new employment appeal tribunal decision
+    When I create a employment appeal tribunal decision
+    Then the employment appeal tribunal decision has been created
+    And the employment appeal tribunal decision should be in draft
+    And the document should be sent to content preview
+
+  Scenario: Cannot create a employment appeal tribunal decision with invalid fields
+    When I create a employment appeal tribunal decision with invalid fields
+    Then I should see error messages about missing fields
+    Then I should see an error message about an invalid date field "Decision date"
+    And I should see an error message about a "Body" field containing javascript
+    And the employment appeal tribunal decision should not have been created
+
+  Scenario: Cannot edit an employment appeal tribunal decision without entering required fields
+    Given a draft employment appeal tribunal decision exists
+    When I edit an employment appeal tribunal decision and remove required fields
+    Then the employment appeal tribunal decision should not have been updated
+
+  Scenario: Can view a list of all employment appeal tribunal decisions in the publisher
+    Given two employment appeal tribunal decisions exist
+    Then the employment appeal tribunal decisions should be in the publisher report index in the correct order
+
+  Scenario: Edit a draft employment appeal tribunal decision
+    Given a draft employment appeal tribunal decision exists
+    When I edit a employment appeal tribunal decision
+    Then the employment appeal tribunal decision should have been updated
+    And the document should be sent to content preview

--- a/features/employment-appeal-tribunal-decision-attachments.feature
+++ b/features/employment-appeal-tribunal-decision-attachments.feature
@@ -1,0 +1,26 @@
+Feature: employment appeal tribunal decision attachments
+  As an EmploymentAppealTribunal editor
+  I want to upload an attachment to a case via the publisher
+  So that users can access the decision documents
+
+  Background:
+    Given I am logged in as a "EmploymentAppealTribunal" editor
+
+  @javascript
+  Scenario: EmploymentAppealTribunal editor can add attachment to report
+    Given a draft employment appeal tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attachment on the page with its example markdown embed code
+
+  Scenario: EmploymentAppealTribunal editor can replace and attachment
+    Given there is a published employment appeal tribunal decision with an attachment
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page
+
+  @regression
+  Scenario: EmploymentAppealTribunal editor can add and replace attachment to report
+    Given a draft employment appeal tribunal decision exists
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page

--- a/features/publishing-an-employment-appeal-tribunal-decision.feature
+++ b/features/publishing-an-employment-appeal-tribunal-decision.feature
@@ -1,0 +1,56 @@
+Feature: Publishing an employment appeal tribunal decision
+  As an EmploymentAppealTribunal editor
+  I want to create a new report in draft
+  So that I can prepare the info for publication
+
+  Background:
+    Given I am logged in as a "EmploymentAppealTribunal" editor
+
+  Scenario: can publish a draft employment appeal tribunal decision
+    Given a draft employment appeal tribunal decision exists
+    When I publish the employment appeal tribunal decision
+    Then the employment appeal tribunal decision should be published
+
+  Scenario: can create a new employment appeal tribunal decision and publish immediately
+    When I publish a new employment appeal tribunal decision
+    Then the employment appeal tribunal decision should be published
+    And the publish should have been logged 1 times
+
+  Scenario: immediately republish a published employment appeal tribunal decision
+    When I publish a new employment appeal tribunal decision
+    When I am on the employment appeal tribunal decision edit page
+    And I edit the document and republish
+    Then the amended document should be published
+    And previous editions should be archived
+
+  Scenario: Sends an email alert on first publish
+    Given a draft employment appeal tribunal decision exists
+    When I publish the employment appeal tribunal decision
+    Then a publication notification should have been sent
+
+  Scenario: Cannot edit a published employment appeal tribunal decision without a change note
+    Given a published employment appeal tribunal decision exists
+    When I am on the employment appeal tribunal decision edit page
+    And I edit the document without a change note
+    Then I see an error requesting that I provide a change note
+
+  Scenario: Sends an email alert on a major update and updates logs
+    Given a published employment appeal tribunal decision exists
+    Then a publication notification should have been sent
+    And the publish should have been logged 1 time
+    When I am on the employment appeal tribunal decision edit page
+    And I edit the document with a change note
+    And I publish the employment appeal tribunal decision
+    Then a publication notification should have been sent
+    And the publish should have been logged 2 times
+
+  Scenario: Minor updates do not send emails or update logs
+    When I publish a new employment appeal tribunal decision
+    Then the employment appeal tribunal decision should be published
+    And the publish should have been logged 1 time
+    And a publication notification should have been sent
+    When I am on the employment appeal tribunal decision edit page
+    And I edit the document and indicate the change is minor
+    When I publish the employment appeal tribunal decision
+    Then an email alert should not be sent
+    And the publish should still have been logged 1 time

--- a/features/step_definitions/employment_appeal_tribunal_decision_steps.rb
+++ b/features/step_definitions/employment_appeal_tribunal_decision_steps.rb
@@ -1,0 +1,122 @@
+When(/^I create a employment appeal tribunal decision$/) do
+  @document_title = "Example employment appeal tribunal decision"
+  @slug = "employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
+  @document_fields = employment_appeal_tribunal_decision_fields(title: @document_title)
+
+  create_employment_appeal_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment appeal tribunal decision has been created$/) do
+  fields = @document_fields
+  fields["Hidden indexable content"] = "## Header Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Praesent commodo cursus magna, vel scelerisque nisl c..."
+
+  check_employment_appeal_tribunal_decision_exists_with(fields)
+end
+
+When(/^I create a employment appeal tribunal decision with invalid fields$/) do
+  @document_fields = employment_appeal_tribunal_decision_fields(
+    title: "",
+    summary: "",
+    body: "<script>alert('Oh noes!)</script>",
+    "Decision date" => "Bad data",
+  )
+
+  create_employment_appeal_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment appeal tribunal decision should not have been created$/) do
+  check_document_does_not_exist_with(@document_fields)
+end
+
+Given(/^two employment appeal tribunal decisions exist$/) do
+  @document_fields = employment_appeal_tribunal_decision_fields(title: "employment appeal tribunal decision 1")
+  create_employment_appeal_tribunal_decision(@document_fields)
+
+  @document_fields = employment_appeal_tribunal_decision_fields(title: "employment appeal tribunal decision 2")
+  create_employment_appeal_tribunal_decision(@document_fields)
+end
+
+Then(/^the employment appeal tribunal decisions should be in the publisher report index in the correct order$/) do
+  visit employment_appeal_tribunal_decisions_path
+
+  check_for_documents("employment appeal tribunal decision 2", "employment appeal tribunal decision 1")
+end
+
+Given(/^a draft employment appeal tribunal decision exists$/) do
+  @document_title = "Example employment appeal tribunal decision"
+  @slug = "employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
+  @document_fields = employment_appeal_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = employment_appeal_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_employment_appeal_tribunal_decision(@document_fields)
+end
+
+When(/^I edit a employment appeal tribunal decision$/) do
+  @new_title = "Edited Example employment appeal tribunal decision"
+  edit_employment_appeal_tribunal_decision(@document_title, title: @new_title)
+end
+
+When(/^I edit an employment appeal tribunal decision and remove required fields$/) do
+  edit_employment_appeal_tribunal_decision(@document_title, summary: "")
+end
+
+Then(/^the employment appeal tribunal decision should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
+Then(/^the employment appeal tribunal decision should have been updated$/) do
+  check_for_new_employment_appeal_tribunal_decision_title(@new_title)
+end
+
+Given(/^there is a published employment appeal tribunal decision with an attachment$/) do
+  @document_title = "Example employment appeal tribunal decision"
+  @attachment_title = "My attachment"
+
+  @slug = "employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
+  @document_fields = employment_appeal_tribunal_decision_fields(title: @document_title)
+
+  create_employment_appeal_tribunal_decision(@document_fields, publish: true)
+  add_attachment_to_document(@document_title, @attachment_title)
+end
+
+Given(/^a published employment appeal tribunal decision exists$/) do
+  @document_title = "Example employment appeal tribunal decision"
+  @slug = "employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
+  @document_fields = employment_appeal_tribunal_decision_fields(title: @document_title)
+
+  create_employment_appeal_tribunal_decision(@document_fields, publish: true)
+end
+
+When(/^I withdraw an employment appeal tribunal decision$/) do
+  withdraw_employment_appeal_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the employment appeal tribunal decision should be withdrawn$/) do
+  check_document_is_withdrawn(@slug, @document_fields.fetch(:title))
+end
+
+When(/^I am on the employment appeal tribunal decision edit page$/) do
+  go_to_edit_page_for_employment_appeal_tribunal_decision(@document_fields.fetch(:title))
+end
+
+Then(/^the employment appeal tribunal decision should be in draft$/) do
+  expect(page).to have_content("Publication state draft")
+end
+
+When(/^I publish the employment appeal tribunal decision$/) do
+  go_to_show_page_for_employment_appeal_tribunal_decision(@document_title)
+  publish_document
+end
+
+Then(/^the employment appeal tribunal decision should be published$/) do
+  check_document_is_published(@slug, @rummager_fields)
+end
+
+When(/^I publish a new employment appeal tribunal decision$/) do
+  @document_title = "Example employment appeal tribunal decision"
+  @slug = "employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
+  @document_fields = employment_appeal_tribunal_decision_fields(title: @document_title)
+  @rummager_fields = employment_appeal_tribunal_decision_rummager_fields(title: @document_title)
+
+  create_employment_appeal_tribunal_decision(@document_fields, publish: true)
+end

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -58,6 +58,7 @@ module DocumentHelpers
       "international-development-funding" => "international_development_fund",
       "drug-safety-update" => "drug_safety_update",
       "drug-device-alerts" => "medical_safety_alert",
+      "employment-appeal-tribunal-decisions" => "employment_appeal_tribunal_decision",
       "european-structural-investment-funds" => "european_structural_investment_fund",
       "maib-reports" => "maib_report",
       "raib-reports" => "raib_report",

--- a/features/support/employment_appeal_tribunal_decision_helpers.rb
+++ b/features/support/employment_appeal_tribunal_decision_helpers.rb
@@ -1,0 +1,86 @@
+module EmploymentAppealTribunalDecisionHelpers
+  def create_employment_appeal_tribunal_decision(fields, **kwargs)
+    create_document(:employment_appeal_tribunal_decision, fields, **kwargs)
+  end
+
+  def go_to_show_page_for_employment_appeal_tribunal_decision(*args)
+    go_to_show_page_for_document(:employment_appeal_tribunal_decision, *args)
+  end
+
+  def check_employment_appeal_tribunal_decision_exists_with(*args)
+    check_document_exists_with(:employment_appeal_tribunal_decision, *args)
+  end
+
+  def go_to_employment_appeal_tribunal_decision_index
+    visit_path_if_elsewhere(employment_appeal_tribunal_decisions_path)
+  end
+
+  def go_to_edit_page_for_employment_appeal_tribunal_decision(*args)
+    go_to_edit_page_for_document(:employment_appeal_tribunal_decision, *args)
+  end
+
+  def edit_employment_appeal_tribunal_decision(title, *args)
+    go_to_edit_page_for_employment_appeal_tribunal_decision(title)
+    edit_document(title, *args)
+  end
+
+  def check_for_new_employment_appeal_tribunal_decision_title(*args)
+    check_for_new_document_title(:employment_appeal_tribunal_decision, *args)
+  end
+
+  def withdraw_employment_appeal_tribunal_decision(*args)
+    withdraw_document(:employment_appeal_tribunal_decision, *args)
+  end
+
+  def create_multiple_employment_appeal_tribunal_decisions(titles)
+    titles.each do |title|
+      create_document(:employment_appeal_tribunal_decision, employment_appeal_tribunal_decision_fields(title: title))
+    end
+  end
+
+  def employment_appeal_tribunal_decisions_are_visible(titles)
+    titles.each { |t| employment_appeal_tribunal_decision_is_visible(t) }
+  end
+
+  def employment_appeal_tribunal_decision_is_visible(title)
+    expect(page).to have_content(title)
+  end
+
+  def employment_appeal_tribunal_decisions_are_not_visible(titles)
+    titles.each do |title|
+      expect(page).not_to have_content(title)
+    end
+  end
+
+  def employment_appeal_tribunal_decision_fields(overrides = {})
+    {
+      title: "Lorem ipsum",
+      summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+      body: "## Link to attachement:",
+      "Category" => "Contract of Employment",
+      "Sub-category" => "Contract of Employment - Apprenticeship",
+      "Decision date" => "2015-02-02",
+      "Landmark" => "Landmark",
+      "Hidden indexable content" => "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10)
+    }.merge(overrides)
+  end
+
+  def employment_appeal_tribunal_decision_rummager_fields(overrides = {})
+    fields = employment_appeal_tribunal_decision_fields(overrides)
+    fields.delete(:body)
+    fields.delete("Hidden indexable content")
+    category = fields.delete("Category")
+    sub_category = fields.delete("Sub-category")
+    landmark = fields.delete("Landmark")
+
+    fields[:tribunal_decision_categories] = [category.parameterize]
+    fields[:tribunal_decision_categories_name] = [category]
+    fields[:tribunal_decision_sub_categories] = [sub_category.parameterize]
+    fields[:tribunal_decision_sub_categories_name] = [sub_category]
+    fields[:tribunal_decision_decision_date] = fields.delete("Decision date")
+    fields[:tribunal_decision_landmark] = landmark.parameterize
+    fields[:tribunal_decision_landmark_name] = landmark
+    fields
+  end
+end
+RSpec.configuration.include EmploymentAppealTribunalDecisionHelpers, type: :feature

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -114,6 +114,7 @@ require "asylum_support_decision_helpers"
 require "cma_case_helpers"
 require "csg_helpers"
 require "dsu_helpers"
+require "employment_appeal_tribunal_decision_helpers"
 require "esi_fund_helpers"
 require "idf_helpers"
 require "maib_report_helpers"
@@ -141,6 +142,7 @@ World(AsylumSupportDecisionHelpers)
 World(CmaCaseHelpers)
 World(CsgHelpers)
 World(DsuHelpers)
+World(EmploymentAppealTribunalDecisionHelpers)
 World(EsiFundHelpers)
 World(IdfHelpers)
 World(MaibReportHelpers)

--- a/features/withdrawing-an-employment-appeal-tribunal-decision.feature
+++ b/features/withdrawing-an-employment-appeal-tribunal-decision.feature
@@ -1,0 +1,12 @@
+Feature: Withdrawing an employment appeal tribunal decision
+  As a EmploymentAppealTribunal editor
+  I want to withdraw an employment appeal tribunal decision
+  So that it is not accessible to the public
+
+  Background:
+    Given I am logged in as a "EmploymentAppealTribunal" editor
+    And a published employment appeal tribunal decision exists
+
+  Scenario: Withdraw an employment appeal tribunal decision
+    When I withdraw an employment appeal tribunal decision
+    Then the employment appeal tribunal decision should be withdrawn

--- a/finders/metadata/employment-appeal-tribunal-decisions.json
+++ b/finders/metadata/employment-appeal-tribunal-decisions.json
@@ -1,0 +1,284 @@
+{
+  "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
+  "base_path": "/employment-appeal-tribunal-decisions",
+  "format_name": "Employment appeal tribunal decision",
+  "name": "Employment appeal tribunal decisions",
+  "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
+  "beta": true,
+  "filter": {
+    "document_type": "employment_appeal_tribunal_decision"
+  },
+  "show_summaries": true,
+  "organisations": [
+    "caeb418c-d11c-4352-92e9-47b21289f696"
+  ],
+  "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",
+  "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
+  "subscription_list_title_prefix": {
+    "singular": "Employment Appeal Tribunal decisions with the following category: ",
+    "plural": "Employment Appeal Tribunal decisions with the following categories: "
+  },
+  "email_filter_by": "tribunal_decision_categories",
+  "email_signup_choice": [
+    {
+      "key": "age-discrimination",
+      "radio_button_name": "Age Discrimination",
+      "topic_name": "age discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "agency-workers",
+      "radio_button_name": "Agency Workers",
+      "topic_name": "agency workers",
+      "prechecked": false
+    },
+    {
+      "key": "blacklisting-regulations",
+      "radio_button_name": "Blacklisting Regulations",
+      "topic_name": "blacklisting regulations",
+      "prechecked": false
+    },
+    {
+      "key": "central-arbitration-committee-cac",
+      "radio_button_name": "Central Arbitration Committee (CAC)",
+      "topic_name": "central arbitration committee cac",
+      "prechecked": false
+    },
+    {
+      "key": "certification-officer",
+      "radio_button_name": "Certification Officer",
+      "topic_name": "certification officer",
+      "prechecked": false
+    },
+    {
+      "key": "contract-of-employment",
+      "radio_button_name": "Contract of Employment",
+      "topic_name": "contract of employment",
+      "prechecked": false
+    },
+    {
+      "key": "disability-discrimination",
+      "radio_button_name": "Disability Discrimination",
+      "topic_name": "disability discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "employment-agencies-act-1973",
+      "radio_button_name": "Employment Agencies Act 1973",
+      "topic_name": "employment agencies act 1973",
+      "prechecked": false
+    },
+    {
+      "key": "employment-agencies-act-1973-obsolete-topic",
+      "radio_button_name": "Employment Agencies Act 1973 (obsolete topic)",
+      "topic_name": "employment agencies act 1973 obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "equal-pay-act",
+      "radio_button_name": "Equal Pay Act",
+      "topic_name": "equal pay act",
+      "prechecked": false
+    },
+    {
+      "key": "european-material-obsolete-topic",
+      "radio_button_name": "European Material (obsolete topic)",
+      "topic_name": "european material obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "fixed-term-regulations",
+      "radio_button_name": "Fixed Term Regulations",
+      "topic_name": "fixed term regulations",
+      "prechecked": false
+    },
+    {
+      "key": "flexible-working",
+      "radio_button_name": "Flexible Working",
+      "topic_name": "flexible working",
+      "prechecked": false
+    },
+    {
+      "key": "harassment",
+      "radio_button_name": "Harassment",
+      "topic_name": "harassment",
+      "prechecked": false
+    },
+    {
+      "key": "health-safety",
+      "radio_button_name": "Health & Safety",
+      "topic_name": "health safety",
+      "prechecked": false
+    },
+    {
+      "key": "human-rights",
+      "radio_button_name": "Human Rights",
+      "topic_name": "human rights",
+      "prechecked": false
+    },
+    {
+      "key": "jurisdiction-obsolete-topic",
+      "radio_button_name": "Jurisdiction (obsolete topic)",
+      "topic_name": "jurisdiction obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "jurisdictional-points",
+      "radio_button_name": "Jurisdictional Points",
+      "topic_name": "jurisdictional points",
+      "prechecked": false
+    },
+    {
+      "key": "maternity-rights-and-parental-leave",
+      "radio_button_name": "Maternity Rights and Parental Leave",
+      "topic_name": "maternity rights and parental leave",
+      "prechecked": false
+    },
+    {
+      "key": "national-minimum-wage",
+      "radio_button_name": "National Minimum Wage",
+      "topic_name": "national minimum wage",
+      "prechecked": false
+    },
+    {
+      "key": "national-security",
+      "radio_button_name": "National Security",
+      "topic_name": "national security",
+      "prechecked": false
+    },
+    {
+      "key": "part-time-workers",
+      "radio_button_name": "Part Time Workers",
+      "topic_name": "part time workers",
+      "prechecked": false
+    },
+    {
+      "key": "practice-and-procedure",
+      "radio_button_name": "Practice and Procedure",
+      "topic_name": "practice and procedure",
+      "prechecked": false
+    },
+    {
+      "key": "procedural-issues-obsolete-topic",
+      "radio_button_name": "Procedural Issues (obsolete topic)",
+      "topic_name": "procedural issues obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "public-interest-disclosure-obsolete-topic",
+      "radio_button_name": "Public Interest Disclosure (obsolete topic)",
+      "topic_name": "public interest disclosure obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "race-discrimination",
+      "radio_button_name": "Race Discrimination",
+      "topic_name": "race discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "redundancy",
+      "radio_button_name": "Redundancy",
+      "topic_name": "redundancy",
+      "prechecked": false
+    },
+    {
+      "key": "religion-or-belief-discrimination",
+      "radio_button_name": "Religion or Belief Discrimination",
+      "topic_name": "religion or belief discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "reserved-forces-act-obsolete-topic",
+      "radio_button_name": "Reserved Forces Act (obsolete topic)",
+      "topic_name": "reserved forces act obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "right-to-be-accompanied",
+      "radio_button_name": "Right To Be Accompanied",
+      "topic_name": "right to be accompanied",
+      "prechecked": false
+    },
+    {
+      "key": "rights-on-insolvency",
+      "radio_button_name": "Rights on Insolvency",
+      "topic_name": "rights on insolvency",
+      "prechecked": false
+    },
+    {
+      "key": "sex-discrimination",
+      "radio_button_name": "Sex Discrimination",
+      "topic_name": "sex discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "sexual-orientation-discrimination-transexualism",
+      "radio_button_name": "Sexual Orientation Discrimination/Transexualism",
+      "topic_name": "sexual orientation discrimination transexualism",
+      "prechecked": false
+    },
+    {
+      "key": "statutory-discipline-and-grievance-procedures",
+      "radio_button_name": "Statutory Discipline and Grievance Procedures",
+      "topic_name": "statutory discipline and grievance procedures",
+      "prechecked": false
+    },
+    {
+      "key": "time-limits-obsolete-topic",
+      "radio_button_name": "Time Limits (obsolete topic)",
+      "topic_name": "time limits obsolete topic",
+      "prechecked": false
+    },
+    {
+      "key": "time-off",
+      "radio_button_name": "Time Off",
+      "topic_name": "time off",
+      "prechecked": false
+    },
+    {
+      "key": "trade-union-membership",
+      "radio_button_name": "Trade Union Membership",
+      "topic_name": "trade union membership",
+      "prechecked": false
+    },
+    {
+      "key": "trade-union-rights",
+      "radio_button_name": "Trade Union Rights",
+      "topic_name": "trade union rights",
+      "prechecked": false
+    },
+    {
+      "key": "transfer-of-undertakings",
+      "radio_button_name": "Transfer of Undertakings",
+      "topic_name": "transfer of undertakings",
+      "prechecked": false
+    },
+    {
+      "key": "unfair-dismissal",
+      "radio_button_name": "Unfair Dismissal",
+      "topic_name": "unfair dismissal",
+      "prechecked": false
+    },
+    {
+      "key": "unlawful-deduction-from-wages",
+      "radio_button_name": "Unlawful Deduction from Wages",
+      "topic_name": "unlawful deduction from wages",
+      "prechecked": false
+    },
+    {
+      "key": "victimisation-discrimination",
+      "radio_button_name": "Victimisation Discrimination",
+      "topic_name": "victimisation discrimination",
+      "prechecked": false
+    },
+    {
+      "key": "working-time-regulations",
+      "radio_button_name": "Working Time Regulations",
+      "topic_name": "working time regulations",
+      "prechecked": false
+    }
+  ],
+  "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
+  "pre_production": true
+}

--- a/finders/schemas/employment-appeal-decisions.json
+++ b/finders/schemas/employment-appeal-decisions.json
@@ -1,0 +1,1015 @@
+{
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_categories",
+      "name": "Category",
+      "type": "text",
+      "preposition": "categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Age Discrimination",
+          "value": "age-discrimination"
+        },
+        {
+          "label": "Agency Workers",
+          "value": "agency-workers"
+        },
+        {
+          "label": "Blacklisting Regulations",
+          "value": "blacklisting-regulations"
+        },
+        {
+          "label": "Central Arbitration Committee (CAC)",
+          "value": "central-arbitration-committee-cac"
+        },
+        {
+          "label": "Certification Officer",
+          "value": "certification-officer"
+        },
+        {
+          "label": "Contract of Employment",
+          "value": "contract-of-employment"
+        },
+        {
+          "label": "Disability Discrimination",
+          "value": "disability-discrimination"
+        },
+        {
+          "label": "Employment Agencies Act 1973",
+          "value": "employment-agencies-act-1973"
+        },
+        {
+          "label": "Employment Agencies Act 1973 (obsolete topic)",
+          "value": "employment-agencies-act-1973-obsolete-topic"
+        },
+        {
+          "label": "Equal Pay Act",
+          "value": "equal-pay-act"
+        },
+        {
+          "label": "European Material (obsolete topic)",
+          "value": "european-material-obsolete-topic"
+        },
+        {
+          "label": "Fixed Term Regulations",
+          "value": "fixed-term-regulations"
+        },
+        {
+          "label": "Flexible Working",
+          "value": "flexible-working"
+        },
+        {
+          "label": "Harassment",
+          "value": "harassment"
+        },
+        {
+          "label": "Health & Safety",
+          "value": "health-safety"
+        },
+        {
+          "label": "Human Rights",
+          "value": "human-rights"
+        },
+        {
+          "label": "Jurisdiction (obsolete topic)",
+          "value": "jurisdiction-obsolete-topic"
+        },
+        {
+          "label": "Jurisdictional Points",
+          "value": "jurisdictional-points"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave",
+          "value": "maternity-rights-and-parental-leave"
+        },
+        {
+          "label": "National Minimum Wage",
+          "value": "national-minimum-wage"
+        },
+        {
+          "label": "National Security",
+          "value": "national-security"
+        },
+        {
+          "label": "Part Time Workers",
+          "value": "part-time-workers"
+        },
+        {
+          "label": "Practice and Procedure",
+          "value": "practice-and-procedure"
+        },
+        {
+          "label": "Procedural Issues (obsolete topic)",
+          "value": "procedural-issues-obsolete-topic"
+        },
+        {
+          "label": "Public Interest Disclosure (obsolete topic)",
+          "value": "public-interest-disclosure-obsolete-topic"
+        },
+        {
+          "label": "Race Discrimination",
+          "value": "race-discrimination"
+        },
+        {
+          "label": "Redundancy",
+          "value": "redundancy"
+        },
+        {
+          "label": "Religion or Belief Discrimination",
+          "value": "religion-or-belief-discrimination"
+        },
+        {
+          "label": "Reserved Forces Act (obsolete topic)",
+          "value": "reserved-forces-act-obsolete-topic"
+        },
+        {
+          "label": "Right To Be Accompanied",
+          "value": "right-to-be-accompanied"
+        },
+        {
+          "label": "Rights on Insolvency",
+          "value": "rights-on-insolvency"
+        },
+        {
+          "label": "Sex Discrimination",
+          "value": "sex-discrimination"
+        },
+        {
+          "label": "Sexual Orientation Discrimination/Transexualism",
+          "value": "sexual-orientation-discrimination-transexualism"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures",
+          "value": "statutory-discipline-and-grievance-procedures"
+        },
+        {
+          "label": "Time Limits (obsolete topic)",
+          "value": "time-limits-obsolete-topic"
+        },
+        {
+          "label": "Time Off",
+          "value": "time-off"
+        },
+        {
+          "label": "Trade Union Membership",
+          "value": "trade-union-membership"
+        },
+        {
+          "label": "Trade Union Rights",
+          "value": "trade-union-rights"
+        },
+        {
+          "label": "Transfer of Undertakings",
+          "value": "transfer-of-undertakings"
+        },
+        {
+          "label": "Unfair Dismissal",
+          "value": "unfair-dismissal"
+        },
+        {
+          "label": "Unlawful Deduction from Wages",
+          "value": "unlawful-deduction-from-wages"
+        },
+        {
+          "label": "Victimisation Discrimination",
+          "value": "victimisation-discrimination"
+        },
+        {
+          "label": "Working Time Regulations",
+          "value": "working-time-regulations"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_categories_name",
+      "name": "Category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-category",
+      "type": "text",
+      "preposition": "sub-categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Contract of Employment - Apprenticeship",
+          "value": "contract-of-employment-apprenticeship"
+        },
+        {
+          "label": "Contract of Employment - Breach of Contract (obsolete sub-topic)",
+          "value": "contract-of-employment-breach-of-contract-obsolete-sub-topic"
+        },
+        {
+          "label": "Contract of Employment - Damages for breach of contract",
+          "value": "contract-of-employment-damages-for-breach-of-contract"
+        },
+        {
+          "label": "Contract of Employment - Definition of employee",
+          "value": "contract-of-employment-definition-of-employee"
+        },
+        {
+          "label": "Contract of Employment - Disciplinary and grievance procedure",
+          "value": "contract-of-employment-disciplinary-and-grievance-procedure"
+        },
+        {
+          "label": "Contract of Employment - Frustration",
+          "value": "contract-of-employment-frustration"
+        },
+        {
+          "label": "Contract of Employment - Implied Term/Variation/Construction of Term",
+          "value": "contract-of-employment-implied-term-variation-construction-of-term"
+        },
+        {
+          "label": "Contract of Employment - Incorporation into Contract",
+          "value": "contract-of-employment-incorporation-into-contract"
+        },
+        {
+          "label": "Contract of Employment - Itemised pay statement",
+          "value": "contract-of-employment-itemised-pay-statement"
+        },
+        {
+          "label": "Contract of Employment - Mitigation",
+          "value": "contract-of-employment-mitigation"
+        },
+        {
+          "label": "Contract of Employment - Mutual trust and confidence",
+          "value": "contract-of-employment-mutual-trust-and-confidence"
+        },
+        {
+          "label": "Contract of Employment - Notice and pay in lieu",
+          "value": "contract-of-employment-notice-and-pay-in-lieu"
+        },
+        {
+          "label": "Contract of Employment - Sick pay and holiday pay",
+          "value": "contract-of-employment-sick-pay-and-holiday-pay"
+        },
+        {
+          "label": "Contract of Employment - Whether established",
+          "value": "contract-of-employment-whether-established"
+        },
+        {
+          "label": "Contract of Employment - Written particulars",
+          "value": "contract-of-employment-written-particulars"
+        },
+        {
+          "label": "Contract of Employment - Wrongful dismissal",
+          "value": "contract-of-employment-wrongful-dismissal"
+        },
+        {
+          "label": "Equal Pay Act - Article 141/European law",
+          "value": "equal-pay-act-article-141-european-law"
+        },
+        {
+          "label": "Equal Pay Act - Case management",
+          "value": "equal-pay-act-case-management"
+        },
+        {
+          "label": "Equal Pay Act - Damages/Compensation",
+          "value": "equal-pay-act-damages-compensation"
+        },
+        {
+          "label": "Equal Pay Act - Equal value",
+          "value": "equal-pay-act-equal-value"
+        },
+        {
+          "label": "Equal Pay Act - European law",
+          "value": "equal-pay-act-european-law"
+        },
+        {
+          "label": "Equal Pay Act - Indirect discrimination",
+          "value": "equal-pay-act-indirect-discrimination"
+        },
+        {
+          "label": "Equal Pay Act - Like work",
+          "value": "equal-pay-act-like-work"
+        },
+        {
+          "label": "Equal Pay Act - Material factor defence and justification",
+          "value": "equal-pay-act-material-factor-defence-and-justification"
+        },
+        {
+          "label": "Equal Pay Act - Other establishments",
+          "value": "equal-pay-act-other-establishments"
+        },
+        {
+          "label": "Equal Pay Act - Out of time",
+          "value": "equal-pay-act-out-of-time"
+        },
+        {
+          "label": "Equal Pay Act - Part-time Pensions",
+          "value": "equal-pay-act-part-time-pensions"
+        },
+        {
+          "label": "Equal Pay Act - Work rated equivalent",
+          "value": "equal-pay-act-work-rated-equivalent"
+        },
+        {
+          "label": "Harassment - Compensation",
+          "value": "harassment-compensation"
+        },
+        {
+          "label": "Harassment - Conduct",
+          "value": "harassment-conduct"
+        },
+        {
+          "label": "Harassment - Purpose",
+          "value": "harassment-purpose"
+        },
+        {
+          "label": "Health & Safety - Detriment",
+          "value": "health-safety-detriment"
+        },
+        {
+          "label": "Jurisdictional Points - 2002 Act and pre-action requirements",
+          "value": "jurisdictional-points-2002-act-and-pre-action-requirements"
+        },
+        {
+          "label": "Jurisdictional Points - Agency relationships",
+          "value": "jurisdictional-points-agency-relationships"
+        },
+        {
+          "label": "Jurisdictional Points - Claim in time and effective date of termination",
+          "value": "jurisdictional-points-claim-in-time-and-effective-date-of-termination"
+        },
+        {
+          "label": "Jurisdictional Points - Continuity of employment",
+          "value": "jurisdictional-points-continuity-of-employment"
+        },
+        {
+          "label": "Jurisdictional Points - Excluded employments",
+          "value": "jurisdictional-points-excluded-employments"
+        },
+        {
+          "label": "Jurisdictional Points - Extension of time: just and equitable",
+          "value": "jurisdictional-points-extension-of-time-just-and-equitable"
+        },
+        {
+          "label": "Jurisdictional Points - Extension of time: reasonably practicable",
+          "value": "jurisdictional-points-extension-of-time-reasonably-practicable"
+        },
+        {
+          "label": "Jurisdictional Points - Fraud and illegality",
+          "value": "jurisdictional-points-fraud-and-illegality"
+        },
+        {
+          "label": "Jurisdictional Points - State immunity",
+          "value": "jurisdictional-points-state-immunity"
+        },
+        {
+          "label": "Jurisdictional Points - Worker employee or neither",
+          "value": "jurisdictional-points-worker-employee-or-neither"
+        },
+        {
+          "label": "Jurisdictional Points - Working outside the jurisdiction",
+          "value": "jurisdictional-points-working-outside-the-jurisdiction"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Detriment",
+          "value": "maternity-rights-and-parental-leave-detriment"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Pregnancy",
+          "value": "maternity-rights-and-parental-leave-pregnancy"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Return to work",
+          "value": "maternity-rights-and-parental-leave-return-to-work"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Sex discrimination",
+          "value": "maternity-rights-and-parental-leave-sex-discrimination"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Unfair dismissal",
+          "value": "maternity-rights-and-parental-leave-unfair-dismissal"
+        },
+        {
+          "label": "Practice and Procedure - 2002 Act and pre-action requirements",
+          "value": "practice-and-procedure-2002-act-and-pre-action-requirements"
+        },
+        {
+          "label": "Practice and Procedure - Absence of Party",
+          "value": "practice-and-procedure-absence-of-party"
+        },
+        {
+          "label": "Practice and Procedure - Admissibility of evidence",
+          "value": "practice-and-procedure-admissibility-of-evidence"
+        },
+        {
+          "label": "Practice and Procedure - Amendment",
+          "value": "practice-and-procedure-amendment"
+        },
+        {
+          "label": "Practice and Procedure - Appearance/Response",
+          "value": "practice-and-procedure-appearance-response"
+        },
+        {
+          "label": "Practice and Procedure - Appellate jurisdiction/Reasons/Burns-Barke",
+          "value": "practice-and-procedure-appellate-jurisdiction-reasons-burns-barke"
+        },
+        {
+          "label": "Practice and Procedure - Application/Claim",
+          "value": "practice-and-procedure-application-claim"
+        },
+        {
+          "label": "Practice and Procedure - Bias misconduct and procedural irregularity",
+          "value": "practice-and-procedure-bias-misconduct-and-procedural-irregularity"
+        },
+        {
+          "label": "Practice and Procedure - Case Management",
+          "value": "practice-and-procedure-case-management"
+        },
+        {
+          "label": "Practice and Procedure - Chairman alone",
+          "value": "practice-and-procedure-chairman-alone"
+        },
+        {
+          "label": "Practice and Procedure - Chairmans notes of evidence",
+          "value": "practice-and-procedure-chairmans-notes-of-evidence"
+        },
+        {
+          "label": "Practice and Procedure - Compromise",
+          "value": "practice-and-procedure-compromise"
+        },
+        {
+          "label": "Practice and Procedure - Contribution",
+          "value": "practice-and-procedure-contribution"
+        },
+        {
+          "label": "Practice and Procedure - Costs",
+          "value": "practice-and-procedure-costs"
+        },
+        {
+          "label": "Practice and Procedure - Delay in ET judgment",
+          "value": "practice-and-procedure-delay-in-et-judgment"
+        },
+        {
+          "label": "Practice and Procedure - Disclosure",
+          "value": "practice-and-procedure-disclosure"
+        },
+        {
+          "label": "Practice and Procedure - Disposal of appeal including remission",
+          "value": "practice-and-procedure-disposal-of-appeal-including-remission"
+        },
+        {
+          "label": "Practice and Procedure - Estoppel or Abuse of Process",
+          "value": "practice-and-procedure-estoppel-or-abuse-of-process"
+        },
+        {
+          "label": "Practice and Procedure - Imposition of Deposit",
+          "value": "practice-and-procedure-imposition-of-deposit"
+        },
+        {
+          "label": "Practice and Procedure - Insolvency",
+          "value": "practice-and-procedure-insolvency"
+        },
+        {
+          "label": "Practice and Procedure - New evidence on appeal",
+          "value": "practice-and-procedure-new-evidence-on-appeal"
+        },
+        {
+          "label": "Practice and Procedure - No case to answer",
+          "value": "practice-and-procedure-no-case-to-answer"
+        },
+        {
+          "label": "Practice and Procedure - Parties",
+          "value": "practice-and-procedure-parties"
+        },
+        {
+          "label": "Practice and Procedure - Permission to appeal further",
+          "value": "practice-and-procedure-permission-to-appeal-further"
+        },
+        {
+          "label": "Practice and Procedure - Perversity",
+          "value": "practice-and-procedure-perversity"
+        },
+        {
+          "label": "Practice and Procedure - Postponement or stay",
+          "value": "practice-and-procedure-postponement-or-stay"
+        },
+        {
+          "label": "Practice and Procedure - Preliminary issues",
+          "value": "practice-and-procedure-preliminary-issues"
+        },
+        {
+          "label": "Practice and Procedure - Questionnaires",
+          "value": "practice-and-procedure-questionnaires"
+        },
+        {
+          "label": "Practice and Procedure - Restricted Reporting Order",
+          "value": "practice-and-procedure-restricted-reporting-order"
+        },
+        {
+          "label": "Practice and Procedure - Restriction of proceedings order",
+          "value": "practice-and-procedure-restriction-of-proceedings-order"
+        },
+        {
+          "label": "Practice and Procedure - Review",
+          "value": "practice-and-procedure-review"
+        },
+        {
+          "label": "Practice and Procedure - Right to be heard",
+          "value": "practice-and-procedure-right-to-be-heard"
+        },
+        {
+          "label": "Practice and Procedure - Service",
+          "value": "practice-and-procedure-service"
+        },
+        {
+          "label": "Practice and Procedure - Split hearings",
+          "value": "practice-and-procedure-split-hearings"
+        },
+        {
+          "label": "Practice and Procedure - Striking-out/dismissal",
+          "value": "practice-and-procedure-striking-out-dismissal"
+        },
+        {
+          "label": "Practice and Procedure - Time for appealing",
+          "value": "practice-and-procedure-time-for-appealing"
+        },
+        {
+          "label": "Practice and Procedure - Transfer/Hearing together",
+          "value": "practice-and-procedure-transfer-hearing-together"
+        },
+        {
+          "label": "Practice and Procedure - Withdrawal",
+          "value": "practice-and-procedure-withdrawal"
+        },
+        {
+          "label": "Race Discrimination - Aiding and abetting",
+          "value": "race-discrimination-aiding-and-abetting"
+        },
+        {
+          "label": "Race Discrimination - Burden of proof",
+          "value": "race-discrimination-burden-of-proof"
+        },
+        {
+          "label": "Race Discrimination - Comparison",
+          "value": "race-discrimination-comparison"
+        },
+        {
+          "label": "Race Discrimination - Continuing act",
+          "value": "race-discrimination-continuing-act"
+        },
+        {
+          "label": "Race Discrimination - Contract workers",
+          "value": "race-discrimination-contract-workers"
+        },
+        {
+          "label": "Race Discrimination - Detriment",
+          "value": "race-discrimination-detriment"
+        },
+        {
+          "label": "Race Discrimination - Direct",
+          "value": "race-discrimination-direct"
+        },
+        {
+          "label": "Race Discrimination - Discrimination by other bodies",
+          "value": "race-discrimination-discrimination-by-other-bodies"
+        },
+        {
+          "label": "Race Discrimination - Illegality/Fraud",
+          "value": "race-discrimination-illegality-fraud"
+        },
+        {
+          "label": "Race Discrimination - Indirect",
+          "value": "race-discrimination-indirect"
+        },
+        {
+          "label": "Race Discrimination - Inferring discrimination",
+          "value": "race-discrimination-inferring-discrimination"
+        },
+        {
+          "label": "Race Discrimination - Injury to feelings",
+          "value": "race-discrimination-injury-to-feelings"
+        },
+        {
+          "label": "Race Discrimination - Jurisdiction",
+          "value": "race-discrimination-jurisdiction"
+        },
+        {
+          "label": "Race Discrimination - Other losses",
+          "value": "race-discrimination-other-losses"
+        },
+        {
+          "label": "Race Discrimination - Out of Time",
+          "value": "race-discrimination-out-of-time"
+        },
+        {
+          "label": "Race Discrimination - Post Employment",
+          "value": "race-discrimination-post-employment"
+        },
+        {
+          "label": "Race Discrimination - Prospective employees",
+          "value": "race-discrimination-prospective-employees"
+        },
+        {
+          "label": "Race Discrimination - Protected by s41",
+          "value": "race-discrimination-protected-by-s41"
+        },
+        {
+          "label": "Race Discrimination - Recommendations",
+          "value": "race-discrimination-recommendations"
+        },
+        {
+          "label": "Race Discrimination - Vicarious liability",
+          "value": "race-discrimination-vicarious-liability"
+        },
+        {
+          "label": "Race Discrimination - Victimisation",
+          "value": "race-discrimination-victimisation"
+        },
+        {
+          "label": "Redundancy - Collective consultation and information",
+          "value": "redundancy-collective-consultation-and-information"
+        },
+        {
+          "label": "Redundancy - Contractual scheme",
+          "value": "redundancy-contractual-scheme"
+        },
+        {
+          "label": "Redundancy - Definition",
+          "value": "redundancy-definition"
+        },
+        {
+          "label": "Redundancy - Exclusion",
+          "value": "redundancy-exclusion"
+        },
+        {
+          "label": "Redundancy - Fairness",
+          "value": "redundancy-fairness"
+        },
+        {
+          "label": "Redundancy - Protective award",
+          "value": "redundancy-protective-award"
+        },
+        {
+          "label": "Redundancy - Suitable alternative employment",
+          "value": "redundancy-suitable-alternative-employment"
+        },
+        {
+          "label": "Redundancy - Trial period",
+          "value": "redundancy-trial-period"
+        },
+        {
+          "label": "Sex Discrimination - Aiding and abetting",
+          "value": "sex-discrimination-aiding-and-abetting"
+        },
+        {
+          "label": "Sex Discrimination - Burden of proof",
+          "value": "sex-discrimination-burden-of-proof"
+        },
+        {
+          "label": "Sex Discrimination - Comparison",
+          "value": "sex-discrimination-comparison"
+        },
+        {
+          "label": "Sex Discrimination - Continuing act",
+          "value": "sex-discrimination-continuing-act"
+        },
+        {
+          "label": "Sex Discrimination - Contract workers",
+          "value": "sex-discrimination-contract-workers"
+        },
+        {
+          "label": "Sex Discrimination - Detriment",
+          "value": "sex-discrimination-detriment"
+        },
+        {
+          "label": "Sex Discrimination - Direct",
+          "value": "sex-discrimination-direct"
+        },
+        {
+          "label": "Sex Discrimination - Discrimination by other bodies",
+          "value": "sex-discrimination-discrimination-by-other-bodies"
+        },
+        {
+          "label": "Sex Discrimination - Equal treatment directive",
+          "value": "sex-discrimination-equal-treatment-directive"
+        },
+        {
+          "label": "Sex Discrimination - Illegality/Fraud",
+          "value": "sex-discrimination-illegality-fraud"
+        },
+        {
+          "label": "Sex Discrimination - Indirect",
+          "value": "sex-discrimination-indirect"
+        },
+        {
+          "label": "Sex Discrimination - Inferring discrimination",
+          "value": "sex-discrimination-inferring-discrimination"
+        },
+        {
+          "label": "Sex Discrimination - Injury to feelings",
+          "value": "sex-discrimination-injury-to-feelings"
+        },
+        {
+          "label": "Sex Discrimination - Jurisdiction",
+          "value": "sex-discrimination-jurisdiction"
+        },
+        {
+          "label": "Sex Discrimination - Justification",
+          "value": "sex-discrimination-justification"
+        },
+        {
+          "label": "Sex Discrimination - Marital status",
+          "value": "sex-discrimination-marital-status"
+        },
+        {
+          "label": "Sex Discrimination - Other losses",
+          "value": "sex-discrimination-other-losses"
+        },
+        {
+          "label": "Sex Discrimination - Post Employment",
+          "value": "sex-discrimination-post-employment"
+        },
+        {
+          "label": "Sex Discrimination - Pregnancy and discrimination",
+          "value": "sex-discrimination-pregnancy-and-discrimination"
+        },
+        {
+          "label": "Sex Discrimination - S4(2) Defence",
+          "value": "sex-discrimination-s4-2-defence"
+        },
+        {
+          "label": "Sex Discrimination - Sexual harassment",
+          "value": "sex-discrimination-sexual-harassment"
+        },
+        {
+          "label": "Sex Discrimination - Sexual orientation",
+          "value": "sex-discrimination-sexual-orientation"
+        },
+        {
+          "label": "Sex Discrimination - Transsexualism",
+          "value": "sex-discrimination-transsexualism"
+        },
+        {
+          "label": "Sex Discrimination - Vicarious liability",
+          "value": "sex-discrimination-vicarious-liability"
+        },
+        {
+          "label": "Sex Discrimination - Victimisation",
+          "value": "sex-discrimination-victimisation"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Impact on compensation",
+          "value": "statutory-discipline-and-grievance-procedures-impact-on-compensation"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Whether applicable",
+          "value": "statutory-discipline-and-grievance-procedures-whether-applicable"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Whether infringed",
+          "value": "statutory-discipline-and-grievance-procedures-whether-infringed"
+        },
+        {
+          "label": "Time Off - Parental leave",
+          "value": "time-off-parental-leave"
+        },
+        {
+          "label": "Time Off - Public duties",
+          "value": "time-off-public-duties"
+        },
+        {
+          "label": "Time Off - Trade union activities",
+          "value": "time-off-trade-union-activities"
+        },
+        {
+          "label": "Trade Union Rights - Action short of dismissal",
+          "value": "trade-union-rights-action-short-of-dismissal"
+        },
+        {
+          "label": "Trade Union Rights - Dismissal",
+          "value": "trade-union-rights-dismissal"
+        },
+        {
+          "label": "Trade Union Rights - Interim relief",
+          "value": "trade-union-rights-interim-relief"
+        },
+        {
+          "label": "Transfer of Undertakings - Acquired rights directive",
+          "value": "transfer-of-undertakings-acquired-rights-directive"
+        },
+        {
+          "label": "Transfer of Undertakings - Consultation and other information",
+          "value": "transfer-of-undertakings-consultation-and-other-information"
+        },
+        {
+          "label": "Transfer of Undertakings - Continuity of employment",
+          "value": "transfer-of-undertakings-continuity-of-employment"
+        },
+        {
+          "label": "Transfer of Undertakings - Dismissal/automatically unfair dismissal",
+          "value": "transfer-of-undertakings-dismissal-automatically-unfair-dismissal"
+        },
+        {
+          "label": "Transfer of Undertakings - Economic technical or organisational reason",
+          "value": "transfer-of-undertakings-economic-technical-or-organisational-reason"
+        },
+        {
+          "label": "Transfer of Undertakings - Entity",
+          "value": "transfer-of-undertakings-entity"
+        },
+        {
+          "label": "Transfer of Undertakings - Insolvency",
+          "value": "transfer-of-undertakings-insolvency"
+        },
+        {
+          "label": "Transfer of Undertakings - Insolvent Employer (obsolete sub-topic)",
+          "value": "transfer-of-undertakings-insolvent-employer-obsolete-sub-topic"
+        },
+        {
+          "label": "Transfer of Undertakings - Objection to transfer",
+          "value": "transfer-of-undertakings-objection-to-transfer"
+        },
+        {
+          "label": "Transfer of Undertakings - Pensions and other terms",
+          "value": "transfer-of-undertakings-pensions-and-other-terms"
+        },
+        {
+          "label": "Transfer of Undertakings - Service Provision Change",
+          "value": "transfer-of-undertakings-service-provision-change"
+        },
+        {
+          "label": "Transfer of Undertakings - Transfer",
+          "value": "transfer-of-undertakings-transfer"
+        },
+        {
+          "label": "Transfer of Undertakings - Varying terms of employment",
+          "value": "transfer-of-undertakings-varying-terms-of-employment"
+        },
+        {
+          "label": "Unfair Dismissal - Automatically unfair reasons",
+          "value": "unfair-dismissal-automatically-unfair-reasons"
+        },
+        {
+          "label": "Unfair Dismissal - Compensation",
+          "value": "unfair-dismissal-compensation"
+        },
+        {
+          "label": "Unfair Dismissal - Constructive dismissal",
+          "value": "unfair-dismissal-constructive-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Contributory fault",
+          "value": "unfair-dismissal-contributory-fault"
+        },
+        {
+          "label": "Unfair Dismissal - Dismissal/ambiguous resignation",
+          "value": "unfair-dismissal-dismissal-ambiguous-resignation"
+        },
+        {
+          "label": "Unfair Dismissal - Exclusions including worker/jurisdiction",
+          "value": "unfair-dismissal-exclusions-including-worker-jurisdiction"
+        },
+        {
+          "label": "Unfair Dismissal - Illegality/Fraud",
+          "value": "unfair-dismissal-illegality-fraud"
+        },
+        {
+          "label": "Unfair Dismissal - Mitigation of loss",
+          "value": "unfair-dismissal-mitigation-of-loss"
+        },
+        {
+          "label": "Unfair Dismissal - National Security",
+          "value": "unfair-dismissal-national-security"
+        },
+        {
+          "label": "Unfair Dismissal - Polkey deduction",
+          "value": "unfair-dismissal-polkey-deduction"
+        },
+        {
+          "label": "Unfair Dismissal - Procedural fairness/automatically unfair dismissal",
+          "value": "unfair-dismissal-procedural-fairness-automatically-unfair-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Reason for dismissal including substantial other reason",
+          "value": "unfair-dismissal-reason-for-dismissal-including-substantial-other-reason"
+        },
+        {
+          "label": "Unfair Dismissal - Reasonableness of dismissal",
+          "value": "unfair-dismissal-reasonableness-of-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Reinstatement/re-engagement",
+          "value": "unfair-dismissal-reinstatement-re-engagement"
+        },
+        {
+          "label": "Unfair Dismissal - Retirement",
+          "value": "unfair-dismissal-retirement"
+        },
+        {
+          "label": "Unfair Dismissal - S.98A(2) ERA",
+          "value": "unfair-dismissal-s-98a-2-era"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Exclusions",
+          "value": "unlawful-deduction-from-wages-exclusions"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Out of Time",
+          "value": "unlawful-deduction-from-wages-out-of-time"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Ready, Willing and Able to Work",
+          "value": "unlawful-deduction-from-wages-ready-willing-and-able-to-work"
+        },
+        {
+          "label": "Victimisation Discrimination - Detriment",
+          "value": "victimisation-discrimination-detriment"
+        },
+        {
+          "label": "Victimisation Discrimination - Dismissal",
+          "value": "victimisation-discrimination-dismissal"
+        },
+        {
+          "label": "Victimisation Discrimination - Health and safety",
+          "value": "victimisation-discrimination-health-and-safety"
+        },
+        {
+          "label": "Victimisation Discrimination - Interim relief",
+          "value": "victimisation-discrimination-interim-relief"
+        },
+        {
+          "label": "Victimisation Discrimination - Other forms of victimisation",
+          "value": "victimisation-discrimination-other-forms-of-victimisation"
+        },
+        {
+          "label": "Victimisation Discrimination - Protected disclosure",
+          "value": "victimisation-discrimination-protected-disclosure"
+        },
+        {
+          "label": "Victimisation Discrimination - Whistleblowing",
+          "value": "victimisation-discrimination-whistleblowing"
+        },
+        {
+          "label": "Working Time Regulations - Holiday pay",
+          "value": "working-time-regulations-holiday-pay"
+        },
+        {
+          "label": "Working Time Regulations - S.43A detriment",
+          "value": "working-time-regulations-s-43a-detriment"
+        },
+        {
+          "label": "Working Time Regulations - Worker",
+          "value": "working-time-regulations-worker"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_sub_categories_name",
+      "name": "Sub-category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_judge",
+      "name": "Judge",
+      "type": "text",
+      "preposition": "by judge",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "tribunal_decision_landmark",
+      "name": "Landmark",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "allowed_values": [
+        {
+          "label": "Landmark",
+          "value": "landmark"
+        },
+        {
+          "label": "Not landmark",
+          "value": "not-landmark"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_landmark_name",
+      "name": "Landmark name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Decision date",
+      "short_name": "Decided",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/finders/schemas/employment-appeal-tribunal-decisions.json
+++ b/finders/schemas/employment-appeal-tribunal-decisions.json
@@ -1,0 +1,1007 @@
+{
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_categories",
+      "name": "Category",
+      "type": "text",
+      "preposition": "categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Age Discrimination",
+          "value": "age-discrimination"
+        },
+        {
+          "label": "Agency Workers",
+          "value": "agency-workers"
+        },
+        {
+          "label": "Blacklisting Regulations",
+          "value": "blacklisting-regulations"
+        },
+        {
+          "label": "Central Arbitration Committee (CAC)",
+          "value": "central-arbitration-committee-cac"
+        },
+        {
+          "label": "Certification Officer",
+          "value": "certification-officer"
+        },
+        {
+          "label": "Contract of Employment",
+          "value": "contract-of-employment"
+        },
+        {
+          "label": "Disability Discrimination",
+          "value": "disability-discrimination"
+        },
+        {
+          "label": "Employment Agencies Act 1973",
+          "value": "employment-agencies-act-1973"
+        },
+        {
+          "label": "Employment Agencies Act 1973 (obsolete topic)",
+          "value": "employment-agencies-act-1973-obsolete-topic"
+        },
+        {
+          "label": "Equal Pay Act",
+          "value": "equal-pay-act"
+        },
+        {
+          "label": "European Material (obsolete topic)",
+          "value": "european-material-obsolete-topic"
+        },
+        {
+          "label": "Fixed Term Regulations",
+          "value": "fixed-term-regulations"
+        },
+        {
+          "label": "Flexible Working",
+          "value": "flexible-working"
+        },
+        {
+          "label": "Harassment",
+          "value": "harassment"
+        },
+        {
+          "label": "Health & Safety",
+          "value": "health-safety"
+        },
+        {
+          "label": "Human Rights",
+          "value": "human-rights"
+        },
+        {
+          "label": "Jurisdiction (obsolete topic)",
+          "value": "jurisdiction-obsolete-topic"
+        },
+        {
+          "label": "Jurisdictional Points",
+          "value": "jurisdictional-points"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave",
+          "value": "maternity-rights-and-parental-leave"
+        },
+        {
+          "label": "National Minimum Wage",
+          "value": "national-minimum-wage"
+        },
+        {
+          "label": "National Security",
+          "value": "national-security"
+        },
+        {
+          "label": "Part Time Workers",
+          "value": "part-time-workers"
+        },
+        {
+          "label": "Practice and Procedure",
+          "value": "practice-and-procedure"
+        },
+        {
+          "label": "Procedural Issues (obsolete topic)",
+          "value": "procedural-issues-obsolete-topic"
+        },
+        {
+          "label": "Public Interest Disclosure (obsolete topic)",
+          "value": "public-interest-disclosure-obsolete-topic"
+        },
+        {
+          "label": "Race Discrimination",
+          "value": "race-discrimination"
+        },
+        {
+          "label": "Redundancy",
+          "value": "redundancy"
+        },
+        {
+          "label": "Religion or Belief Discrimination",
+          "value": "religion-or-belief-discrimination"
+        },
+        {
+          "label": "Reserved Forces Act (obsolete topic)",
+          "value": "reserved-forces-act-obsolete-topic"
+        },
+        {
+          "label": "Right To Be Accompanied",
+          "value": "right-to-be-accompanied"
+        },
+        {
+          "label": "Rights on Insolvency",
+          "value": "rights-on-insolvency"
+        },
+        {
+          "label": "Sex Discrimination",
+          "value": "sex-discrimination"
+        },
+        {
+          "label": "Sexual Orientation Discrimination/Transexualism",
+          "value": "sexual-orientation-discrimination-transexualism"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures",
+          "value": "statutory-discipline-and-grievance-procedures"
+        },
+        {
+          "label": "Time Limits (obsolete topic)",
+          "value": "time-limits-obsolete-topic"
+        },
+        {
+          "label": "Time Off",
+          "value": "time-off"
+        },
+        {
+          "label": "Trade Union Membership",
+          "value": "trade-union-membership"
+        },
+        {
+          "label": "Trade Union Rights",
+          "value": "trade-union-rights"
+        },
+        {
+          "label": "Transfer of Undertakings",
+          "value": "transfer-of-undertakings"
+        },
+        {
+          "label": "Unfair Dismissal",
+          "value": "unfair-dismissal"
+        },
+        {
+          "label": "Unlawful Deduction from Wages",
+          "value": "unlawful-deduction-from-wages"
+        },
+        {
+          "label": "Victimisation Discrimination",
+          "value": "victimisation-discrimination"
+        },
+        {
+          "label": "Working Time Regulations",
+          "value": "working-time-regulations"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_categories_name",
+      "name": "Category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-category",
+      "type": "text",
+      "preposition": "sub-categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Contract of Employment - Apprenticeship",
+          "value": "contract-of-employment-apprenticeship"
+        },
+        {
+          "label": "Contract of Employment - Breach of Contract (obsolete sub-topic)",
+          "value": "contract-of-employment-breach-of-contract-obsolete-sub-topic"
+        },
+        {
+          "label": "Contract of Employment - Damages for breach of contract",
+          "value": "contract-of-employment-damages-for-breach-of-contract"
+        },
+        {
+          "label": "Contract of Employment - Definition of employee",
+          "value": "contract-of-employment-definition-of-employee"
+        },
+        {
+          "label": "Contract of Employment - Disciplinary and grievance procedure",
+          "value": "contract-of-employment-disciplinary-and-grievance-procedure"
+        },
+        {
+          "label": "Contract of Employment - Frustration",
+          "value": "contract-of-employment-frustration"
+        },
+        {
+          "label": "Contract of Employment - Implied Term/Variation/Construction of Term",
+          "value": "contract-of-employment-implied-term-variation-construction-of-term"
+        },
+        {
+          "label": "Contract of Employment - Incorporation into Contract",
+          "value": "contract-of-employment-incorporation-into-contract"
+        },
+        {
+          "label": "Contract of Employment - Itemised pay statement",
+          "value": "contract-of-employment-itemised-pay-statement"
+        },
+        {
+          "label": "Contract of Employment - Mitigation",
+          "value": "contract-of-employment-mitigation"
+        },
+        {
+          "label": "Contract of Employment - Mutual trust and confidence",
+          "value": "contract-of-employment-mutual-trust-and-confidence"
+        },
+        {
+          "label": "Contract of Employment - Notice and pay in lieu",
+          "value": "contract-of-employment-notice-and-pay-in-lieu"
+        },
+        {
+          "label": "Contract of Employment - Sick pay and holiday pay",
+          "value": "contract-of-employment-sick-pay-and-holiday-pay"
+        },
+        {
+          "label": "Contract of Employment - Whether established",
+          "value": "contract-of-employment-whether-established"
+        },
+        {
+          "label": "Contract of Employment - Written particulars",
+          "value": "contract-of-employment-written-particulars"
+        },
+        {
+          "label": "Contract of Employment - Wrongful dismissal",
+          "value": "contract-of-employment-wrongful-dismissal"
+        },
+        {
+          "label": "Equal Pay Act - Article 141/European law",
+          "value": "equal-pay-act-article-141-european-law"
+        },
+        {
+          "label": "Equal Pay Act - Case management",
+          "value": "equal-pay-act-case-management"
+        },
+        {
+          "label": "Equal Pay Act - Damages/Compensation",
+          "value": "equal-pay-act-damages-compensation"
+        },
+        {
+          "label": "Equal Pay Act - Equal value",
+          "value": "equal-pay-act-equal-value"
+        },
+        {
+          "label": "Equal Pay Act - European law",
+          "value": "equal-pay-act-european-law"
+        },
+        {
+          "label": "Equal Pay Act - Indirect discrimination",
+          "value": "equal-pay-act-indirect-discrimination"
+        },
+        {
+          "label": "Equal Pay Act - Like work",
+          "value": "equal-pay-act-like-work"
+        },
+        {
+          "label": "Equal Pay Act - Material factor defence and justification",
+          "value": "equal-pay-act-material-factor-defence-and-justification"
+        },
+        {
+          "label": "Equal Pay Act - Other establishments",
+          "value": "equal-pay-act-other-establishments"
+        },
+        {
+          "label": "Equal Pay Act - Out of time",
+          "value": "equal-pay-act-out-of-time"
+        },
+        {
+          "label": "Equal Pay Act - Part-time Pensions",
+          "value": "equal-pay-act-part-time-pensions"
+        },
+        {
+          "label": "Equal Pay Act - Work rated equivalent",
+          "value": "equal-pay-act-work-rated-equivalent"
+        },
+        {
+          "label": "Harassment - Compensation",
+          "value": "harassment-compensation"
+        },
+        {
+          "label": "Harassment - Conduct",
+          "value": "harassment-conduct"
+        },
+        {
+          "label": "Harassment - Purpose",
+          "value": "harassment-purpose"
+        },
+        {
+          "label": "Health & Safety - Detriment",
+          "value": "health-safety-detriment"
+        },
+        {
+          "label": "Jurisdictional Points - 2002 Act and pre-action requirements",
+          "value": "jurisdictional-points-2002-act-and-pre-action-requirements"
+        },
+        {
+          "label": "Jurisdictional Points - Agency relationships",
+          "value": "jurisdictional-points-agency-relationships"
+        },
+        {
+          "label": "Jurisdictional Points - Claim in time and effective date of termination",
+          "value": "jurisdictional-points-claim-in-time-and-effective-date-of-termination"
+        },
+        {
+          "label": "Jurisdictional Points - Continuity of employment",
+          "value": "jurisdictional-points-continuity-of-employment"
+        },
+        {
+          "label": "Jurisdictional Points - Excluded employments",
+          "value": "jurisdictional-points-excluded-employments"
+        },
+        {
+          "label": "Jurisdictional Points - Extension of time: just and equitable",
+          "value": "jurisdictional-points-extension-of-time-just-and-equitable"
+        },
+        {
+          "label": "Jurisdictional Points - Extension of time: reasonably practicable",
+          "value": "jurisdictional-points-extension-of-time-reasonably-practicable"
+        },
+        {
+          "label": "Jurisdictional Points - Fraud and illegality",
+          "value": "jurisdictional-points-fraud-and-illegality"
+        },
+        {
+          "label": "Jurisdictional Points - State immunity",
+          "value": "jurisdictional-points-state-immunity"
+        },
+        {
+          "label": "Jurisdictional Points - Worker employee or neither",
+          "value": "jurisdictional-points-worker-employee-or-neither"
+        },
+        {
+          "label": "Jurisdictional Points - Working outside the jurisdiction",
+          "value": "jurisdictional-points-working-outside-the-jurisdiction"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Detriment",
+          "value": "maternity-rights-and-parental-leave-detriment"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Pregnancy",
+          "value": "maternity-rights-and-parental-leave-pregnancy"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Return to work",
+          "value": "maternity-rights-and-parental-leave-return-to-work"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Sex discrimination",
+          "value": "maternity-rights-and-parental-leave-sex-discrimination"
+        },
+        {
+          "label": "Maternity Rights and Parental Leave - Unfair dismissal",
+          "value": "maternity-rights-and-parental-leave-unfair-dismissal"
+        },
+        {
+          "label": "Practice and Procedure - 2002 Act and pre-action requirements",
+          "value": "practice-and-procedure-2002-act-and-pre-action-requirements"
+        },
+        {
+          "label": "Practice and Procedure - Absence of Party",
+          "value": "practice-and-procedure-absence-of-party"
+        },
+        {
+          "label": "Practice and Procedure - Admissibility of evidence",
+          "value": "practice-and-procedure-admissibility-of-evidence"
+        },
+        {
+          "label": "Practice and Procedure - Amendment",
+          "value": "practice-and-procedure-amendment"
+        },
+        {
+          "label": "Practice and Procedure - Appearance/Response",
+          "value": "practice-and-procedure-appearance-response"
+        },
+        {
+          "label": "Practice and Procedure - Appellate jurisdiction/Reasons/Burns-Barke",
+          "value": "practice-and-procedure-appellate-jurisdiction-reasons-burns-barke"
+        },
+        {
+          "label": "Practice and Procedure - Application/Claim",
+          "value": "practice-and-procedure-application-claim"
+        },
+        {
+          "label": "Practice and Procedure - Bias misconduct and procedural irregularity",
+          "value": "practice-and-procedure-bias-misconduct-and-procedural-irregularity"
+        },
+        {
+          "label": "Practice and Procedure - Case Management",
+          "value": "practice-and-procedure-case-management"
+        },
+        {
+          "label": "Practice and Procedure - Chairman alone",
+          "value": "practice-and-procedure-chairman-alone"
+        },
+        {
+          "label": "Practice and Procedure - Chairmans notes of evidence",
+          "value": "practice-and-procedure-chairmans-notes-of-evidence"
+        },
+        {
+          "label": "Practice and Procedure - Compromise",
+          "value": "practice-and-procedure-compromise"
+        },
+        {
+          "label": "Practice and Procedure - Contribution",
+          "value": "practice-and-procedure-contribution"
+        },
+        {
+          "label": "Practice and Procedure - Costs",
+          "value": "practice-and-procedure-costs"
+        },
+        {
+          "label": "Practice and Procedure - Delay in ET judgment",
+          "value": "practice-and-procedure-delay-in-et-judgment"
+        },
+        {
+          "label": "Practice and Procedure - Disclosure",
+          "value": "practice-and-procedure-disclosure"
+        },
+        {
+          "label": "Practice and Procedure - Disposal of appeal including remission",
+          "value": "practice-and-procedure-disposal-of-appeal-including-remission"
+        },
+        {
+          "label": "Practice and Procedure - Estoppel or Abuse of Process",
+          "value": "practice-and-procedure-estoppel-or-abuse-of-process"
+        },
+        {
+          "label": "Practice and Procedure - Imposition of Deposit",
+          "value": "practice-and-procedure-imposition-of-deposit"
+        },
+        {
+          "label": "Practice and Procedure - Insolvency",
+          "value": "practice-and-procedure-insolvency"
+        },
+        {
+          "label": "Practice and Procedure - New evidence on appeal",
+          "value": "practice-and-procedure-new-evidence-on-appeal"
+        },
+        {
+          "label": "Practice and Procedure - No case to answer",
+          "value": "practice-and-procedure-no-case-to-answer"
+        },
+        {
+          "label": "Practice and Procedure - Parties",
+          "value": "practice-and-procedure-parties"
+        },
+        {
+          "label": "Practice and Procedure - Permission to appeal further",
+          "value": "practice-and-procedure-permission-to-appeal-further"
+        },
+        {
+          "label": "Practice and Procedure - Perversity",
+          "value": "practice-and-procedure-perversity"
+        },
+        {
+          "label": "Practice and Procedure - Postponement or stay",
+          "value": "practice-and-procedure-postponement-or-stay"
+        },
+        {
+          "label": "Practice and Procedure - Preliminary issues",
+          "value": "practice-and-procedure-preliminary-issues"
+        },
+        {
+          "label": "Practice and Procedure - Questionnaires",
+          "value": "practice-and-procedure-questionnaires"
+        },
+        {
+          "label": "Practice and Procedure - Restricted Reporting Order",
+          "value": "practice-and-procedure-restricted-reporting-order"
+        },
+        {
+          "label": "Practice and Procedure - Restriction of proceedings order",
+          "value": "practice-and-procedure-restriction-of-proceedings-order"
+        },
+        {
+          "label": "Practice and Procedure - Review",
+          "value": "practice-and-procedure-review"
+        },
+        {
+          "label": "Practice and Procedure - Right to be heard",
+          "value": "practice-and-procedure-right-to-be-heard"
+        },
+        {
+          "label": "Practice and Procedure - Service",
+          "value": "practice-and-procedure-service"
+        },
+        {
+          "label": "Practice and Procedure - Split hearings",
+          "value": "practice-and-procedure-split-hearings"
+        },
+        {
+          "label": "Practice and Procedure - Striking-out/dismissal",
+          "value": "practice-and-procedure-striking-out-dismissal"
+        },
+        {
+          "label": "Practice and Procedure - Time for appealing",
+          "value": "practice-and-procedure-time-for-appealing"
+        },
+        {
+          "label": "Practice and Procedure - Transfer/Hearing together",
+          "value": "practice-and-procedure-transfer-hearing-together"
+        },
+        {
+          "label": "Practice and Procedure - Withdrawal",
+          "value": "practice-and-procedure-withdrawal"
+        },
+        {
+          "label": "Race Discrimination - Aiding and abetting",
+          "value": "race-discrimination-aiding-and-abetting"
+        },
+        {
+          "label": "Race Discrimination - Burden of proof",
+          "value": "race-discrimination-burden-of-proof"
+        },
+        {
+          "label": "Race Discrimination - Comparison",
+          "value": "race-discrimination-comparison"
+        },
+        {
+          "label": "Race Discrimination - Continuing act",
+          "value": "race-discrimination-continuing-act"
+        },
+        {
+          "label": "Race Discrimination - Contract workers",
+          "value": "race-discrimination-contract-workers"
+        },
+        {
+          "label": "Race Discrimination - Detriment",
+          "value": "race-discrimination-detriment"
+        },
+        {
+          "label": "Race Discrimination - Direct",
+          "value": "race-discrimination-direct"
+        },
+        {
+          "label": "Race Discrimination - Discrimination by other bodies",
+          "value": "race-discrimination-discrimination-by-other-bodies"
+        },
+        {
+          "label": "Race Discrimination - Illegality/Fraud",
+          "value": "race-discrimination-illegality-fraud"
+        },
+        {
+          "label": "Race Discrimination - Indirect",
+          "value": "race-discrimination-indirect"
+        },
+        {
+          "label": "Race Discrimination - Inferring discrimination",
+          "value": "race-discrimination-inferring-discrimination"
+        },
+        {
+          "label": "Race Discrimination - Injury to feelings",
+          "value": "race-discrimination-injury-to-feelings"
+        },
+        {
+          "label": "Race Discrimination - Jurisdiction",
+          "value": "race-discrimination-jurisdiction"
+        },
+        {
+          "label": "Race Discrimination - Other losses",
+          "value": "race-discrimination-other-losses"
+        },
+        {
+          "label": "Race Discrimination - Out of Time",
+          "value": "race-discrimination-out-of-time"
+        },
+        {
+          "label": "Race Discrimination - Post Employment",
+          "value": "race-discrimination-post-employment"
+        },
+        {
+          "label": "Race Discrimination - Prospective employees",
+          "value": "race-discrimination-prospective-employees"
+        },
+        {
+          "label": "Race Discrimination - Protected by s41",
+          "value": "race-discrimination-protected-by-s41"
+        },
+        {
+          "label": "Race Discrimination - Recommendations",
+          "value": "race-discrimination-recommendations"
+        },
+        {
+          "label": "Race Discrimination - Vicarious liability",
+          "value": "race-discrimination-vicarious-liability"
+        },
+        {
+          "label": "Race Discrimination - Victimisation",
+          "value": "race-discrimination-victimisation"
+        },
+        {
+          "label": "Redundancy - Collective consultation and information",
+          "value": "redundancy-collective-consultation-and-information"
+        },
+        {
+          "label": "Redundancy - Contractual scheme",
+          "value": "redundancy-contractual-scheme"
+        },
+        {
+          "label": "Redundancy - Definition",
+          "value": "redundancy-definition"
+        },
+        {
+          "label": "Redundancy - Exclusion",
+          "value": "redundancy-exclusion"
+        },
+        {
+          "label": "Redundancy - Fairness",
+          "value": "redundancy-fairness"
+        },
+        {
+          "label": "Redundancy - Protective award",
+          "value": "redundancy-protective-award"
+        },
+        {
+          "label": "Redundancy - Suitable alternative employment",
+          "value": "redundancy-suitable-alternative-employment"
+        },
+        {
+          "label": "Redundancy - Trial period",
+          "value": "redundancy-trial-period"
+        },
+        {
+          "label": "Sex Discrimination - Aiding and abetting",
+          "value": "sex-discrimination-aiding-and-abetting"
+        },
+        {
+          "label": "Sex Discrimination - Burden of proof",
+          "value": "sex-discrimination-burden-of-proof"
+        },
+        {
+          "label": "Sex Discrimination - Comparison",
+          "value": "sex-discrimination-comparison"
+        },
+        {
+          "label": "Sex Discrimination - Continuing act",
+          "value": "sex-discrimination-continuing-act"
+        },
+        {
+          "label": "Sex Discrimination - Contract workers",
+          "value": "sex-discrimination-contract-workers"
+        },
+        {
+          "label": "Sex Discrimination - Detriment",
+          "value": "sex-discrimination-detriment"
+        },
+        {
+          "label": "Sex Discrimination - Direct",
+          "value": "sex-discrimination-direct"
+        },
+        {
+          "label": "Sex Discrimination - Discrimination by other bodies",
+          "value": "sex-discrimination-discrimination-by-other-bodies"
+        },
+        {
+          "label": "Sex Discrimination - Equal treatment directive",
+          "value": "sex-discrimination-equal-treatment-directive"
+        },
+        {
+          "label": "Sex Discrimination - Illegality/Fraud",
+          "value": "sex-discrimination-illegality-fraud"
+        },
+        {
+          "label": "Sex Discrimination - Indirect",
+          "value": "sex-discrimination-indirect"
+        },
+        {
+          "label": "Sex Discrimination - Inferring discrimination",
+          "value": "sex-discrimination-inferring-discrimination"
+        },
+        {
+          "label": "Sex Discrimination - Injury to feelings",
+          "value": "sex-discrimination-injury-to-feelings"
+        },
+        {
+          "label": "Sex Discrimination - Jurisdiction",
+          "value": "sex-discrimination-jurisdiction"
+        },
+        {
+          "label": "Sex Discrimination - Justification",
+          "value": "sex-discrimination-justification"
+        },
+        {
+          "label": "Sex Discrimination - Marital status",
+          "value": "sex-discrimination-marital-status"
+        },
+        {
+          "label": "Sex Discrimination - Other losses",
+          "value": "sex-discrimination-other-losses"
+        },
+        {
+          "label": "Sex Discrimination - Post Employment",
+          "value": "sex-discrimination-post-employment"
+        },
+        {
+          "label": "Sex Discrimination - Pregnancy and discrimination",
+          "value": "sex-discrimination-pregnancy-and-discrimination"
+        },
+        {
+          "label": "Sex Discrimination - S4(2) Defence",
+          "value": "sex-discrimination-s4-2-defence"
+        },
+        {
+          "label": "Sex Discrimination - Sexual harassment",
+          "value": "sex-discrimination-sexual-harassment"
+        },
+        {
+          "label": "Sex Discrimination - Sexual orientation",
+          "value": "sex-discrimination-sexual-orientation"
+        },
+        {
+          "label": "Sex Discrimination - Transsexualism",
+          "value": "sex-discrimination-transsexualism"
+        },
+        {
+          "label": "Sex Discrimination - Vicarious liability",
+          "value": "sex-discrimination-vicarious-liability"
+        },
+        {
+          "label": "Sex Discrimination - Victimisation",
+          "value": "sex-discrimination-victimisation"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Impact on compensation",
+          "value": "statutory-discipline-and-grievance-procedures-impact-on-compensation"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Whether applicable",
+          "value": "statutory-discipline-and-grievance-procedures-whether-applicable"
+        },
+        {
+          "label": "Statutory Discipline and Grievance Procedures - Whether infringed",
+          "value": "statutory-discipline-and-grievance-procedures-whether-infringed"
+        },
+        {
+          "label": "Time Off - Parental leave",
+          "value": "time-off-parental-leave"
+        },
+        {
+          "label": "Time Off - Public duties",
+          "value": "time-off-public-duties"
+        },
+        {
+          "label": "Time Off - Trade union activities",
+          "value": "time-off-trade-union-activities"
+        },
+        {
+          "label": "Trade Union Rights - Action short of dismissal",
+          "value": "trade-union-rights-action-short-of-dismissal"
+        },
+        {
+          "label": "Trade Union Rights - Dismissal",
+          "value": "trade-union-rights-dismissal"
+        },
+        {
+          "label": "Trade Union Rights - Interim relief",
+          "value": "trade-union-rights-interim-relief"
+        },
+        {
+          "label": "Transfer of Undertakings - Acquired rights directive",
+          "value": "transfer-of-undertakings-acquired-rights-directive"
+        },
+        {
+          "label": "Transfer of Undertakings - Consultation and other information",
+          "value": "transfer-of-undertakings-consultation-and-other-information"
+        },
+        {
+          "label": "Transfer of Undertakings - Continuity of employment",
+          "value": "transfer-of-undertakings-continuity-of-employment"
+        },
+        {
+          "label": "Transfer of Undertakings - Dismissal/automatically unfair dismissal",
+          "value": "transfer-of-undertakings-dismissal-automatically-unfair-dismissal"
+        },
+        {
+          "label": "Transfer of Undertakings - Economic technical or organisational reason",
+          "value": "transfer-of-undertakings-economic-technical-or-organisational-reason"
+        },
+        {
+          "label": "Transfer of Undertakings - Entity",
+          "value": "transfer-of-undertakings-entity"
+        },
+        {
+          "label": "Transfer of Undertakings - Insolvency",
+          "value": "transfer-of-undertakings-insolvency"
+        },
+        {
+          "label": "Transfer of Undertakings - Insolvent Employer (obsolete sub-topic)",
+          "value": "transfer-of-undertakings-insolvent-employer-obsolete-sub-topic"
+        },
+        {
+          "label": "Transfer of Undertakings - Objection to transfer",
+          "value": "transfer-of-undertakings-objection-to-transfer"
+        },
+        {
+          "label": "Transfer of Undertakings - Pensions and other terms",
+          "value": "transfer-of-undertakings-pensions-and-other-terms"
+        },
+        {
+          "label": "Transfer of Undertakings - Service Provision Change",
+          "value": "transfer-of-undertakings-service-provision-change"
+        },
+        {
+          "label": "Transfer of Undertakings - Transfer",
+          "value": "transfer-of-undertakings-transfer"
+        },
+        {
+          "label": "Transfer of Undertakings - Varying terms of employment",
+          "value": "transfer-of-undertakings-varying-terms-of-employment"
+        },
+        {
+          "label": "Unfair Dismissal - Automatically unfair reasons",
+          "value": "unfair-dismissal-automatically-unfair-reasons"
+        },
+        {
+          "label": "Unfair Dismissal - Compensation",
+          "value": "unfair-dismissal-compensation"
+        },
+        {
+          "label": "Unfair Dismissal - Constructive dismissal",
+          "value": "unfair-dismissal-constructive-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Contributory fault",
+          "value": "unfair-dismissal-contributory-fault"
+        },
+        {
+          "label": "Unfair Dismissal - Dismissal/ambiguous resignation",
+          "value": "unfair-dismissal-dismissal-ambiguous-resignation"
+        },
+        {
+          "label": "Unfair Dismissal - Exclusions including worker/jurisdiction",
+          "value": "unfair-dismissal-exclusions-including-worker-jurisdiction"
+        },
+        {
+          "label": "Unfair Dismissal - Illegality/Fraud",
+          "value": "unfair-dismissal-illegality-fraud"
+        },
+        {
+          "label": "Unfair Dismissal - Mitigation of loss",
+          "value": "unfair-dismissal-mitigation-of-loss"
+        },
+        {
+          "label": "Unfair Dismissal - National Security",
+          "value": "unfair-dismissal-national-security"
+        },
+        {
+          "label": "Unfair Dismissal - Polkey deduction",
+          "value": "unfair-dismissal-polkey-deduction"
+        },
+        {
+          "label": "Unfair Dismissal - Procedural fairness/automatically unfair dismissal",
+          "value": "unfair-dismissal-procedural-fairness-automatically-unfair-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Reason for dismissal including substantial other reason",
+          "value": "unfair-dismissal-reason-for-dismissal-including-substantial-other-reason"
+        },
+        {
+          "label": "Unfair Dismissal - Reasonableness of dismissal",
+          "value": "unfair-dismissal-reasonableness-of-dismissal"
+        },
+        {
+          "label": "Unfair Dismissal - Reinstatement/re-engagement",
+          "value": "unfair-dismissal-reinstatement-re-engagement"
+        },
+        {
+          "label": "Unfair Dismissal - Retirement",
+          "value": "unfair-dismissal-retirement"
+        },
+        {
+          "label": "Unfair Dismissal - S.98A(2) ERA",
+          "value": "unfair-dismissal-s-98a-2-era"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Exclusions",
+          "value": "unlawful-deduction-from-wages-exclusions"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Out of Time",
+          "value": "unlawful-deduction-from-wages-out-of-time"
+        },
+        {
+          "label": "Unlawful Deduction from Wages - Ready, Willing and Able to Work",
+          "value": "unlawful-deduction-from-wages-ready-willing-and-able-to-work"
+        },
+        {
+          "label": "Victimisation Discrimination - Detriment",
+          "value": "victimisation-discrimination-detriment"
+        },
+        {
+          "label": "Victimisation Discrimination - Dismissal",
+          "value": "victimisation-discrimination-dismissal"
+        },
+        {
+          "label": "Victimisation Discrimination - Health and safety",
+          "value": "victimisation-discrimination-health-and-safety"
+        },
+        {
+          "label": "Victimisation Discrimination - Interim relief",
+          "value": "victimisation-discrimination-interim-relief"
+        },
+        {
+          "label": "Victimisation Discrimination - Other forms of victimisation",
+          "value": "victimisation-discrimination-other-forms-of-victimisation"
+        },
+        {
+          "label": "Victimisation Discrimination - Protected disclosure",
+          "value": "victimisation-discrimination-protected-disclosure"
+        },
+        {
+          "label": "Victimisation Discrimination - Whistleblowing",
+          "value": "victimisation-discrimination-whistleblowing"
+        },
+        {
+          "label": "Working Time Regulations - Holiday pay",
+          "value": "working-time-regulations-holiday-pay"
+        },
+        {
+          "label": "Working Time Regulations - S.43A detriment",
+          "value": "working-time-regulations-s-43a-detriment"
+        },
+        {
+          "label": "Working Time Regulations - Worker",
+          "value": "working-time-regulations-worker"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_sub_categories_name",
+      "name": "Sub-category name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_landmark",
+      "name": "Landmark",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "allowed_values": [
+        {
+          "label": "Landmark",
+          "value": "landmark"
+        },
+        {
+          "label": "Not landmark",
+          "value": "not-landmark"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_landmark_name",
+      "name": "Landmark name",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Decision date",
+      "short_name": "Decided",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "formatters/aaib_report_indexable_formatter"
+
+RSpec.describe EmploymentAppealTribunalDecisionIndexableFormatter do
+  let(:document) {
+    double(
+      :employment_appeal_tribunal_decision,
+      body: double,
+      slug: "/slug",
+      summary: double,
+      title: double,
+      updated_at: double,
+      minor_update?: false,
+      public_updated_at: double,
+
+      hidden_indexable_content: double,
+      tribunal_decision_categories: [double],
+      tribunal_decision_decision_date: double,
+      tribunal_decision_landmark: double,
+      tribunal_decision_sub_categories: [double],
+    )
+  }
+
+  subject(:formatter) { EmploymentAppealTribunalDecisionIndexableFormatter.new(document) }
+
+  let(:document_type) { formatter.type }
+  let(:humanized_facet_value) { double }
+  include_context "schema with humanized_facet_value available"
+
+  it_should_behave_like "a specialist document indexable formatter"
+
+  it "should have a type of employment_appeal_tribunal_decision" do
+    expect(formatter.type).to eq("employment_appeal_tribunal_decision")
+  end
+
+  context "without hidden_indexable_content" do
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
+    end
+  end
+
+  context "with hidden_indexable_content" do
+    it "should have hidden_indexable_content as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
+    end
+  end
+
+end

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -1,0 +1,11 @@
+require "fast_spec_helper"
+require "employment_appeal_tribunal_decision"
+
+RSpec.describe EmploymentAppealTribunalDecision do
+
+  it "is a DocumentMetadataDecorator" do
+    doc = double(:document)
+    expect(EmploymentAppealTribunalDecision.new(doc)).to be_a(DocumentMetadataDecorator)
+  end
+
+end

--- a/spec/models/validators/employment_appeal_tribunal_decision_validator_spec.rb
+++ b/spec/models/validators/employment_appeal_tribunal_decision_validator_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+require "validators/employment_appeal_tribunal_decision_validator"
+
+RSpec.describe EmploymentAppealTribunalDecisionValidator do
+
+  let(:entity) {
+    double(
+      :entity,
+      title: double,
+      summary: double,
+      body: "body",
+      tribunal_decision_categories: [double],
+      tribunal_decision_decision_date: "2015-11-01",
+      tribunal_decision_landmark:  double,
+      tribunal_decision_sub_categories: [double],
+    )
+  }
+  let(:document_type) { "employment_appeal_tribunal_decision" }
+
+  subject(:validatable) { EmploymentAppealTribunalDecisionValidator.new(entity) }
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -61,6 +61,10 @@ FactoryGirl.define do
     organisation_slug "upper-tribunal-tax-and-chancery-chamber"
   end
 
+  factory :employmentappealtribunal_editor, parent: :editor do
+    organisation_slug "employment-appeal-tribunal"
+  end
+
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end


### PR DESCRIPTION
Add a finder for employment appeal tribunal decisions. The Employment Appeal Tribunal publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.

**Requires this rummager pull request be merged**: alphagov/rummager#539