### PR TITLE
 Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "plek", "1.7.0"
 gem "quiet_assets", "1.0.3"
 gem "rack", "~> 1.4.6" # explicitly requiring patched version re: CVE-2015-3225
 gem "sidekiq", "3.2.1"
+gem "sidekiq-statsd", "0.1.5"
 gem "unicorn", "4.8.2"
 
 if ENV["GOVSPEAK_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,10 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -330,6 +334,7 @@ GEM
     sprockets-rails (0.0.1)
       sprockets (>= 1.0.2)
     state_machine (1.2.0)
+    statsd-ruby (1.2.1)
     thor (0.19.1)
     tilt (1.4.1)
     timecop (0.7.1)
@@ -403,6 +408,7 @@ DEPENDENCIES
   sass-rails (= 3.2.6)
   select2-rails (= 3.5.9)
   sidekiq (= 3.2.1)
+  sidekiq-statsd (= 0.1.5)
   simplecov
   sinatra
   timecop

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,10 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_
 Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.error_handlers << Proc.new {|ex, context_hash| Airbrake.notify(ex, context_hash) }
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: "govuk.app.specialist-publisher", prefix: "workers"
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq