### PR TITLE
Add documents index and current finders

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,22 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_filter :require_signin_permission!
+
+  helper_method :current_finder
+
+private
+
+  def document_types
+    {
+      "cma-cases" => OpenStruct.new(
+        document_type: "cma_case",
+        title: "CMA Cases",
+      ),
+    }
+  end
+
+  def current_finder
+    document_types.fetch(params.fetch(:document_type, nil), nil)
+  end
+
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,0 +1,7 @@
+class DocumentsController <  ApplicationController
+
+  def index
+    redirect_to "/#{document_types.keys.first}" unless params[:document_type]
+  end
+
+end

--- a/app/views/documents/index.html
+++ b/app/views/documents/index.html
@@ -1,0 +1,1 @@
+<h1><%= current_finder.title.pluralize %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,14 @@ Rails.application.routes.draw do
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
-  # You can have the root of your site routed with "root"
-  # root 'welcome#index'
+  resources :documents, path: "/:document_type", except: :destroy do
+    resources :attachments, only: [:new, :create, :edit, :update]
+
+    post :withdraw, on: :member
+    post :publish, on: :member
+  end
+
+  root 'documents#index'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
This PR adds some barebones  functionality for multiple `document_type`s. We do this by having a generic route which uses `DocumentsController` and finding the current Finder in in a list of Finders from the matching `document_type` in the params. 

So far I've only added the CMA Case format into this but more will be added in forthcoming Pull Requests.