### PR TITLE
Add script and class to handle manual section reslugging

### DIFF
--- a/app/exporters/publishing_api_redirecter.rb
+++ b/app/exporters/publishing_api_redirecter.rb
@@ -1,0 +1,48 @@
+require "securerandom"
+
+class PublishingAPIRedirecter
+  def initialize(publishing_api:, entity:, redirect_to_location:)
+    @publishing_api = publishing_api
+    @entity = entity
+    @redirect_to_location = redirect_to_location
+  end
+
+  def call
+    publishing_api.put_content_item(base_path, exportable_attributes)
+  end
+
+private
+
+  attr_reader(
+    :publishing_api,
+    :entity,
+    :redirect_to_location
+  )
+
+  def base_path
+    "/#{entity.slug}"
+  end
+
+  def exportable_attributes
+    {
+      format: "redirect",
+      publishing_app: "specialist-publisher",
+      update_type: "major",
+      base_path: base_path,
+      redirects: [
+        {
+          path: base_path,
+          type: "exact",
+          destination: redirect_to_location
+        }
+      ],
+      content_id: content_id,
+    }
+  end
+
+  private
+
+  def content_id
+    @_content_id ||= SecureRandom.uuid
+  end
+end

--- a/bin/reslug_manual_section
+++ b/bin/reslug_manual_section
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "manual_section_reslugger"
+require "logger"
+
+def usage
+  $stderr.puts %Q{
+USAGE: #{File.basename(__FILE__)} (manual_slug, old_manual_section_slug, new_manual_section_slug)
+
+manual_slug:
+  slug of manual (eg 'guidance/countryside-stewardship-manual')
+
+old_manual_section_slug:
+  current slug of section to be renamed (eg '8-terms-and-conditions')
+
+new_manual_section_slug:
+  new slug for section (eg '8-scheme-requirements-and-procedures')
+
+}
+  exit(1)
+end
+
+def logger
+  @logger ||= begin
+    logger = Logger.new(STDOUT)
+    logger.formatter = Logger::Formatter.new
+    logger
+  end
+end
+
+usage unless ARGV.count >= 3
+manual_slug = ARGV[0]
+current_slug = ARGV[1]
+new_slug = ARGV[2]
+
+logger.info "Renaming manual document slug"
+
+begin
+  ManualSectionReslugger.new(manual_slug, current_slug, new_slug).call
+  logger.info "Republishing of manual section complete."
+rescue ManualSectionReslugger::Error => e
+  logger.error(e)
+end

--- a/lib/manual_section_reslugger.rb
+++ b/lib/manual_section_reslugger.rb
@@ -2,6 +2,7 @@ require "gds_api/content_store"
 require "manual_service_registry"
 
 class ManualSectionReslugger
+  RUMMAGER_FORMAT = "manual_section"
   class Error < RuntimeError; end
 
   def initialize(manual_slug, current_section_slug, new_section_slug)
@@ -16,6 +17,7 @@ class ManualSectionReslugger
     update_slug
     publish_manual
     redirect_section
+    remove_old_section_from_rummager
   end
 
   private
@@ -143,5 +145,10 @@ class ManualSectionReslugger
 
   def full_section_slug(slug)
     "#{manual_record.slug}/#{slug}"
+  end
+
+  def remove_old_section_from_rummager
+    rummager = SpecialistPublisherWiring.get(:rummager_api)
+    rummager.delete_document(RUMMAGER_FORMAT, "/#{full_current_section_slug}")
   end
 end

--- a/lib/manual_section_reslugger.rb
+++ b/lib/manual_section_reslugger.rb
@@ -1,0 +1,114 @@
+require "gds_api/content_store"
+require "manual_service_registry"
+
+class ManualSectionReslugger
+  class Error < RuntimeError; end
+
+  def initialize(manual_slug, current_section_slug, new_section_slug)
+    @manual_slug = manual_slug
+    @current_section_slug = current_section_slug
+    @new_section_slug = new_section_slug
+  end
+
+  def call
+    validate
+
+    withdraw_section
+    update_slug
+    publish_manual
+  end
+
+  private
+
+  def validate
+    validate_manual
+    validate_current_section
+    validate_new_section
+  end
+
+  def validate_manual
+    raise Error.new("Manual not found for manual_slug `#{manual_slug}`") if manual.nil?
+  end
+
+  def validate_current_section
+    validate_current_section_in_database
+    validate_current_section_in_content_store
+  end
+
+  def validate_current_section_in_database
+    raise Error.new("Manual Section does not exist in database") if current_section.nil?
+  end
+
+  def validate_current_section_in_content_store
+    raise Error.new("Manual Section does not exist in content store") if current_section_in_content_store.nil?
+    raise Error.new("Manual Section already withdrawn") if current_section_in_content_store.format == "gone"
+  end
+
+  def validate_new_section
+    validate_new_section_in_database
+    validate_new_section_in_content_store
+  end
+
+  def validate_new_section_in_database
+    section = section_in_database(full_new_section_slug)
+    raise Error.new("Manual Section already exists in database") if section
+  end
+
+  def validate_new_section_in_content_store
+    section = section_in_content_store(full_new_section_slug)
+    raise Error.new("Manual Section already exists in content store") if section
+  end
+
+  def withdraw_section
+    PublishingAPIWithdrawer.new(
+      publishing_api: SpecialistPublisherWiring.get(:publishing_api),
+      entity: current_section,
+    ).call
+  end
+
+  def update_slug
+    current_section.update_attribute(:slug, full_new_section_slug)
+    #Manual only republishes documents that have exported_at set to nil
+    current_section.update_attribute(:exported_at, nil)
+  end
+
+  def publish_manual
+    ManualServiceRegistry.new.queue_publish(manual.manual_id).call
+  end
+
+  def manual
+    @manual ||= ManualRecord.where(slug: @manual_slug).last
+  end
+
+  def current_section
+    @current_section ||= section_in_database(full_current_section_slug)
+  end
+
+  def current_section_in_content_store
+    @current_section_in_cs ||= section_in_content_store(full_current_section_slug)
+  end
+
+  def section_in_database(slug)
+    SpecialistDocumentEdition.where(slug: slug).last
+  end
+
+  def section_in_content_store(slug)
+    content_store.content_item("/#{slug}")
+  end
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.current.find("content-store"))
+  end
+
+  def full_current_section_slug
+    full_section_slug(@current_section_slug)
+  end
+
+  def full_new_section_slug
+    full_section_slug(@new_section_slug)
+  end
+
+  def full_section_slug(slug)
+    "#{manual.slug}/#{slug}"
+  end
+end

--- a/lib/manual_section_reslugger.rb
+++ b/lib/manual_section_reslugger.rb
@@ -13,9 +13,9 @@ class ManualSectionReslugger
   def call
     validate
 
-    withdraw_section
     update_slug
     publish_manual
+    redirect_section
   end
 
   private
@@ -59,10 +59,11 @@ class ManualSectionReslugger
     raise Error.new("Manual Section already exists in content store") if section
   end
 
-  def withdraw_section
-    PublishingAPIWithdrawer.new(
+  def redirect_section
+    PublishingAPIRedirecter.new(
       publishing_api: SpecialistPublisherWiring.get(:publishing_api),
       entity: current_section,
+      redirect_to_location: "/#{full_new_section_slug}"
     ).call
   end
 


### PR DESCRIPTION
We add a script that calls a class for reslugging manual sections. We first withdraw the old section which places a `gone_item` into the content-store. Then we change the slug of the manual section in the local database. Finally we republish the manual which the section belongs to. This will republish all its sections, but will check to only publish the updated section.

The workflow is inspired by https://github.gds/pages/gds/opsmanual/2nd-line/changing-specialist-publisher-document-slug.html

After running this script in production, a change to router-data will also need to be made (see docs above). UPDATE: Instead of separate PR in router-data, we send a redirect-item to the content-store within this PR