### PR TITLE
Document index and show

### DIFF
--- a/app/assets/stylesheets/_document-list.scss
+++ b/app/assets/stylesheets/_document-list.scss
@@ -1,0 +1,30 @@
+.document-list {
+  margin: 0;
+  margin-bottom: $gutter;
+  padding: 0;
+  list-style: none;
+  clear: both;
+
+  li:first-child {
+    padding-top: 0;
+  }
+
+  .document {
+    border-bottom: 1px solid $grey-2;
+    padding: $gutter-one-third 0;
+  }
+  .document-title {
+    @include core-19;
+    display: block;
+  }
+  .metadata {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: inline-block;
+      min-width: 300px;
+    }
+  }
+}

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,0 +1,21 @@
+.page-header {
+  border-bottom: none;
+
+  .document-slug {
+    color: $text-muted;
+    font-size: $font-size-large;
+    display: block;
+    margin-top: 5px;
+    font-weight: normal;
+    padding: 0;
+
+    & li {
+      display: inline;
+      list-style: none;
+
+      & + li:before {
+        content: "– ";
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 
 @import 'govuk_admin_template';
 @import 'forms';
+@import 'document-list';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import 'govuk_admin_template';
 @import 'forms';
 @import 'document-list';
+@import 'header'

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -63,6 +63,9 @@ class DocumentsController <  ApplicationController
     end
   end
 
+  def show
+    @document = current_format.klass.from_publishing_api(publishing_api.get_content(params[:id]).to_ostruct)
+  end
 private
 
   def document_type

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,20 @@ class DocumentsController <  ApplicationController
   include ActionView::Helpers::TextHelper
 
   def index
-    redirect_to "/#{document_types.keys.first}" unless params[:document_type]
+    unless params[:document_type]
+      redirect_to "/#{document_types.keys.first}"
+      return
+    end
+
+    @documents = publishing_api.get_content_items(
+      content_format: current_format.format_name,
+      fields: [
+        :base_path,
+        :content_id,
+        :title,
+        :public_updated_at,
+      ]
+    ).to_ostruct
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,8 @@ module ApplicationHelper
   def facet_options(form, facet)
     form.object.facet_options(facet)
   end
+
+  def published_document_path(document)
+    Plek.current.find("website-root") + document.base_path
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -69,6 +69,16 @@ class Document
     end
   end
 
+  def humanized_attributes
+    format_specific_metadata.inject({}) do |attributes, (key, value)|
+      humanized_name = finder_schema.humanized_facet_name(key) { key }
+      humanized_value = finder_schema.humanized_facet_value(key, value) { value }
+
+      attributes.merge(humanized_name => humanized_value)
+    end
+  end
+
+
   def self.from_publishing_api(payload)
     document = self.new(
       {

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,4 +1,27 @@
-<div class="page-title">
-  <h1><%= current_format.title.pluralize %></h1>
+<% content_for :breadcrumbs do %>
+  <li class='active'><%= current_format.title.pluralize %></li>
+<% end %>
+
+<h1 class="page-header"><%= current_format.title.pluralize %></h1>
+
+<div class="row">
+  <div class="sidebar col-md-3">
+    <%= link_to "New #{current_format.title}", new_document_path(document_type: current_format.document_type), class: 'action-link' %>
+  </div>
+
+  <div class="col-md-9">
+    <ul class="document-list">
+      <% @documents.each do |document| %>
+        <li class="document">
+          <%= link_to document.title, document_path(document_type: current_format.document_type, id: document.content_id), class: 'document-title' %>
+          <ul class="metadata">
+            <li class="text-muted">Updated <%= time_ago_in_words(document.public_updated_at) %> ago</li>
+            <li>
+              <%= document.publication_state %>
+            </li>
+          </ul>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 </div>
-<p class="subtitle"><%= link_to "New #{current_format.title}", new_document_path(document_type: current_format.document_type) %></p>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -15,10 +15,14 @@
   <div class=" col-md-8">
     <h2>Metadata</h2>
     <dl class="metadata-list">
-      <% @document.format_specific_metadata.each_pair do |label, values| %>
+      <% @document.humanized_attributes.each_pair do |label, values| %>
         <dt><%= label.to_s.humanize %></dt>
-        <% Array(values).each do |value| %>
-          <dd><%= truncate(value.to_s, length: 140) %></dd>
+        <% if values.is_a?(Time) %>
+          <dd><time><%= values.to_s(:govuk_date) %></time></dd>
+        <% else %>
+          <% Array(values).each do |value| %>
+            <dd><%= truncate(value.to_s, length: 140) %></dd>
+          <% end %>
         <% end %>
       <% end %>
     </dl>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,0 +1,35 @@
+<% content_for :breadcrumbs do %>
+  <li><%= link_to "Your documents", documents_path(current_format.document_type) %></li>
+  <li class='active'><%= @document.title %></li>
+<% end %>
+
+<%= render partial: "shared/title", locals: { document: @document, public_url: published_document_path(@document) } %>
+
+<div class="row">
+  <div class="col-md-8">
+    <h2>Summary</h2>
+    <p class="lead"><%= @document.summary %></p>
+  </div>
+</div>
+<div class="row add-bottom-margin">
+  <div class=" col-md-8">
+    <h2>Metadata</h2>
+    <dl class="metadata-list">
+      <% @document.format_specific_metadata.each_pair do |label, values| %>
+        <dt><%= label.to_s.humanize %></dt>
+        <% Array(values).each do |value| %>
+          <dd><%= truncate(value.to_s, length: 140) %></dd>
+        <% end %>
+      <% end %>
+    </dl>
+  </div>
+</div>
+
+<% if @document.body.present? %>
+  <div class="row">
+    <div class="col-md-8">
+      <h2>Body</h2>
+      <pre class="body-pre add-bottom-margin"><%= @document.body %></pre>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,0 +1,13 @@
+<h1 class="page-header"><%= document.title %>
+  <ul class='document-slug'>
+    <li title='<% if !document.published? %>When published this document will appear at this URL<% end %>'>
+      <%= document.base_path %>
+    </li>
+    <% if document.published? %>
+      <li><%= link_to "View on website", public_url %></li>
+    <% end %>
+    <% if document.draft? %>
+      <li><%= link_to "Preview draft", content_preview_url(document) %></li>
+    <% end %>
+  </li>
+</h1>

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -27,6 +27,10 @@ class FinderSchema
     end
   end
 
+  def humanized_facet_name(key, &block)
+    facet_data_for(key).fetch("name", &block)
+  end
+
 private
 
   attr_reader :schema

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -58,6 +58,15 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_put_links
+
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+    ]
+
+    publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
   end
 
   scenario "with valid data" do

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+RSpec.feature "Viewing a specific case", type: :feature do
+
+  def log_in_as_editor(editor)
+    user = FactoryGirl.create(editor)
+    GDS::SSO.test_user = user
+  end
+
+  def cma_case_content_item(n)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/cma-cases/example-cma-case-#{n}",
+      "title" => "Example CMA Case #{n}",
+      "description" => "This is the summary of example CMA case #{n}",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        }
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" => {
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+      }
+    }
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+    ]
+
+    cma_cases = []
+
+    10.times do |n|
+      cma_cases << cma_case_content_item(n)
+    end
+
+    publishing_api_has_fields_for_format('cma_case', cma_cases, fields)
+
+    publishing_api_has_item(cma_cases[0])
+  end
+
+  scenario "from the index" do
+    visit "/cma-cases"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Example CMA Case 0")
+    expect(page).to have_content("Example CMA Case 1")
+    expect(page).to have_content("Example CMA Case 2")
+
+    click_link "Example CMA Case 0"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Example CMA Case 0")
+    expect(page).to have_content("This is the long body of an example CMA case")
+    expect(page).to have_content("This is the summary of example CMA case 0")
+    expect(page).to have_content("2014-01-01")
+    expect(page).to have_content("CA98 and civil cartels")
+    expect(page).to have_content("Energy")
+  end
+
+end


### PR DESCRIPTION
This PR allows users to see a list of created Documents in the Publishing API V2 for a format (currently only CMA Cases) and to view the show page. The interesting commits are probably [this](https://github.com/alphagov/specialist-publisher/commit/3afd35ba6dc8683207af74a59e62a952b6ae078d), [this](https://github.com/alphagov/specialist-publisher/commit/3cd07eb0c365097c2d72a49817ca2baf18272cde) and [this](https://github.com/alphagov/specialist-publisher/commit/6761608a46ce62178210e7753fbd0034753014ea).

This PR supersedes #604. 