### PR TITLE
Manuals: populate links.organisations in Publishing API

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -52,6 +52,7 @@ private
       ],
       details: details_data,
       locale: "en",
+      links: links_data,
     }
   end
 
@@ -76,6 +77,12 @@ private
       organisations: [
         organisation_info
       ]
+    }
+  end
+
+  def links_data
+    {
+      organisations: [organisation.details.content_id],
     }
   end
 

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -50,7 +50,7 @@ describe ManualPublishingAPIExporter do
     double(:organisation,
       web_url: "https://www.gov.uk/government/organisations/cabinet-office",
       title: "Cabinet Office",
-      details: double(:org_details, abbreviation: "CO"),
+      details: double(:org_details, abbreviation: "CO", content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"),
     )
   }
 
@@ -159,6 +159,19 @@ describe ManualPublishingAPIExporter do
               web_url: "https://www.gov.uk/government/organisations/cabinet-office",
             }
           ],
+        }
+      )
+    )
+  end
+
+  it "exports links for the manual" do
+    subject.call
+
+    expect(export_recipent).to have_received(:call).with(
+      "/guidance/my-first-manual",
+      hash_including(
+        links: {
+          organisations: ["d94d63a5-ce8e-40a1-ab4c-4956eab27259"],
         }
       )
     )


### PR DESCRIPTION
Before this change, the Publishing API organisations information
doesn't contain the content ID and is in the details hash.

Every format now supports links.organisations which is the more
generic solution for specifying organisations.