### PR TITLE
Manual sections: populate links.organisations in Pub API

### DIFF
--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -46,6 +46,9 @@ private
         ],
       },
       locale: "en",
+      links: {
+        organisations: [organisation.details.content_id],
+      },
     }
   end
 

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -21,7 +21,7 @@ describe ManualSectionPublishingAPIExporter do
     double(:organisation,
       web_url: "https://www.gov.uk/government/organisations/cabinet-office",
       title: "Cabinet Office",
-      details: double(:org_details, abbreviation: "CO"),
+      details: double(:org_details, abbreviation: "CO", content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"),
     )
   }
 
@@ -100,6 +100,19 @@ describe ManualSectionPublishingAPIExporter do
               web_url: "https://www.gov.uk/government/organisations/cabinet-office",
             }
           ],
+        }
+      )
+    )
+  end
+
+  it "exports links for the document" do
+    subject.call
+
+    expect(export_recipent).to have_received(:call).with(
+      "/guidance/my-first-manual/first-section",
+      hash_including(
+        links: {
+          organisations: ["d94d63a5-ce8e-40a1-ab4c-4956eab27259"],
         }
       )
     )


### PR DESCRIPTION
This is a follow-up to #607, which added `links.organisations` for manuals but not for manual sections.

Before this change, the Publishing API organisations information
doesn't contain the content ID and is in the details hash.

Every format now supports links.organisations which is the more
generic solution for specifying organisations.

/cc @jamiecobbett @boffbowsh @jennyd 