### PR TITLE
Edit a CMA case

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -48,19 +48,7 @@ class DocumentsController <  ApplicationController
         render :new
       end
     else
-      document_errors = @document.errors.messages
-      errors = content_tag(:p,
-        %Q{
-          There #{document_errors.length > 1 ? 'were' : 'was' } the following
-          #{document_errors.length > 1 ? 'errors' : 'error' } with your
-          #{current_format.title.singularize}:
-        }
-      )
-      errors += content_tag :ul do
-        @document.errors.full_messages.map { |e| content_tag(:li, e) }.join('').html_safe
-      end
-
-      flash.now[:danger] = errors
+      flash.now[:danger] = document_error_messages
       render :new, status: 422
     end
   end
@@ -91,20 +79,8 @@ class DocumentsController <  ApplicationController
         render :edit
       end
     else
-      document_errors = @document.errors.messages
-      errors = content_tag(:p,
-        %Q{
-          There #{document_errors.length > 1 ? 'were' : 'was' } the following
-          #{document_errors.length > 1 ? 'errors' : 'error' } with your
-          #{current_format.title.singularize}:
-        }
-      )
-      errors += content_tag :ul do
-        @document.errors.full_messages.map { |e| content_tag(:li, e) }.join('').html_safe
-      end
-
-      flash.now[:danger] = errors
-      render :new, status: 422
+      flash.now[:danger] = document_error_messages
+      render :edit, status: 422
     end
   end
 private
@@ -115,6 +91,20 @@ private
 
   def document_klass
     current_format.klass
+  end
+
+  def document_error_messages
+    document_errors = @document.errors.messages
+    errors = content_tag(:p,
+      %Q{
+        There #{document_errors.length > 1 ? 'were' : 'was' } the following
+        #{document_errors.length > 1 ? 'errors' : 'error' } with your
+        #{current_format.title.singularize}:
+      }
+    )
+    errors += content_tag :ul do
+      @document.errors.full_messages.map { |e| content_tag(:li, e) }.join('').html_safe
+    end
   end
 
   def fetch_document

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -44,7 +44,7 @@ class DocumentsController <  ApplicationController
         flash.now[:success] = "Created #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
-        flash.now[:danger] = "There was an error publishing #{@document.title}. Please try again later."
+        flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
         render :new
       end
     else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -34,13 +34,7 @@ class DocumentsController <  ApplicationController
     )
 
     if @document.valid?
-      presented_document = DocumentPresenter.new(@document)
-      presented_links = DocumentLinksPresenter.new(@document)
-
-      item_request = publishing_api.put_content(@document.content_id, presented_document.to_json)
-      links_request = publishing_api.put_links(@document.content_id, presented_links.to_json)
-
-      if item_request.code == 200 && links_request.code == 200
+      if save_document
         flash.now[:success] = "Created #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
@@ -58,20 +52,14 @@ class DocumentsController <  ApplicationController
   def edit; end
 
   def update
-    @document = current_format.klass.new(
-      filtered_params(params[:"#{current_format.format_name}"]).merge({content_id: params[:content_id]})
+    @document = document_klass.new(
+      filtered_params(params[current_format.format_name]).merge({content_id: params[:content_id]})
     )
 
     @document.public_updated_at = Time.zone.now
 
     if @document.valid?
-      presented_document = DocumentPresenter.new(@document)
-      presented_links = DocumentLinksPresenter.new(@document)
-
-      item_request = publishing_api.put_content(@document.content_id, presented_document.to_json)
-      links_request = publishing_api.put_links(@document.content_id, presented_links.to_json)
-
-      if item_request.code == 200 && links_request.code == 200
+      if save_document
         flash.now[:success] = "Updated #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
@@ -121,6 +109,16 @@ private
       filtered_value = value.is_a?(Array) ? value.reject(&:blank?) : value
       filtered_params.merge(key => filtered_value)
     }
+  end
+
+  def save_document
+    presented_document = DocumentPresenter.new(@document)
+    presented_links = DocumentLinksPresenter.new(@document)
+
+    item_request = publishing_api.put_content(@document.content_id, presented_document.to_json)
+    links_request = publishing_api.put_links(@document.content_id, presented_links.to_json)
+
+    item_request.code == 200 && links_request.code == 200
   end
 
   def publishing_api

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,6 +5,8 @@ class DocumentsController <  ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
+  before_action :fetch_document, only: [:edit, :show]
+
   def index
     unless params[:document_type]
       redirect_to "/#{document_types.keys.first}"
@@ -63,9 +65,10 @@ class DocumentsController <  ApplicationController
     end
   end
 
-  def show
-    @document = current_format.klass.from_publishing_api(publishing_api.get_content(params[:content_id]).to_ostruct)
-  end
+  def show; end
+
+  def edit; end
+
 private
 
   def document_type
@@ -74,6 +77,10 @@ private
 
   def document_klass
     current_format.klass
+  end
+
+  def fetch_document
+    @document = current_format.klass.from_publishing_api(publishing_api.get_content(params[:content_id]).to_ostruct)
   end
 
   def filtered_params(params_of_document)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -74,6 +74,8 @@ class DocumentsController <  ApplicationController
       filtered_params(params[:"#{current_format.format_name}"]).merge({content_id: params[:content_id]})
     )
 
+    @document.public_updated_at = Time.zone.now
+
     if @document.valid?
       presented_document = DocumentPresenter.new(@document)
       presented_links = DocumentLinksPresenter.new(@document)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -71,7 +71,7 @@ class DocumentsController <  ApplicationController
 
   def update
     @document = current_format.klass.new(
-      filtered_params(params[:"#{current_format.format_name}"])
+      filtered_params(params[:"#{current_format.format_name}"]).merge({content_id: params[:content_id]})
     )
 
     if @document.valid?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,10 @@ module ApplicationHelper
     form.object.facet_options(facet)
   end
 
+  def content_preview_url(document)
+    Plek.current.find("draft-origin") + document.base_path
+  end
+
   def published_document_path(document)
     Plek.current.find("website-root") + document.base_path
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -88,6 +88,7 @@ class Document
 
     document.base_path = payload.base_path
     document.public_updated_at = payload.public_updated_at
+    document.publication_state = payload.publication_state
 
     document.format_specific_fields.each do |field|
       document.public_send(:"#{field.to_s}=", payload.details.metadata.send(:"#{field}"))

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -101,7 +101,7 @@ class Document
   end
 
   def public_updated_at=(timestamp)
-    public_updated_at = Time.zone.parse(timestamp)
+    public_updated_at = Time.parse(timestamp)
   end
 
 private

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,6 +9,7 @@ class Document
   validates :body, presence: true, safe_html: true
 
   def initialize(params = {}, format_specific_fields = [])
+    @content_id = params.fetch(:content_id, SecureRandom.uuid)
     @title = params.fetch(:title, nil)
     @summary = params.fetch(:summary, nil)
     @body = params.fetch(:body, nil)
@@ -21,10 +22,6 @@ class Document
 
   def base_path
     "#{public_path}/#{title.parameterize}"
-  end
-
-  def content_id
-    @content_id ||= SecureRandom.uuid
   end
 
   def format
@@ -82,6 +79,7 @@ class Document
   def self.from_publishing_api(payload)
     document = self.new(
       {
+        content_id: payload.content_id,
         title: payload.title,
         summary: payload.description,
         body: payload.details.body,

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,0 +1,15 @@
+<h2>Editing <%= @document.title %></h2>
+
+<div class="col-md-8">
+  <%= form_for @document, url: document_path(document_type: params[:document_type], content_id: @document.content_id), method: :put do |f| %>
+    <%= render partial: "shared/form_fields", locals: { f: f } %>
+
+    <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
+
+    <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
+
+    <div class="actions">
+      <button name="save" class="btn btn-success">Save as draft</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -6,14 +6,14 @@
 
 <div class="row">
   <div class="sidebar col-md-3">
-    <%= link_to "New #{current_format.title}", new_document_path(document_type: current_format.document_type), class: 'action-link' %>
+    <%= link_to "New #{current_format.title}", new_document_path(current_format.document_type), class: 'action-link' %>
   </div>
 
   <div class="col-md-9">
     <ul class="document-list">
       <% @documents.each do |document| %>
         <li class="document">
-          <%= link_to document.title, document_path(document_type: current_format.document_type, id: document.content_id), class: 'document-title' %>
+          <%= link_to document.title, document_path(current_format.document_type, document.content_id), class: 'document-title' %>
           <ul class="metadata">
             <li class="text-muted">Updated <%= time_ago_in_words(document.public_updated_at) %> ago</li>
             <li>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,12 +1,12 @@
 <h2>New <%= current_format.title.singularize %></h2>
 
 <div class="col-md-8">
-  <%= form_for document, url: documents_path(document, document_type: params[:document_type]) do |f| %>
+  <%= form_for @document, url: documents_path(params[:document_type]) do |f| %>
     <%= render partial: "shared/form_fields", locals: { f: f } %>
 
     <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
 
-    <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: document } %>
+    <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
 
     <div class="actions">
       <button name="save" class="btn btn-success">Save as draft</button>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -37,3 +37,12 @@
     </div>
   </div>
 <% end %>
+
+<div class="row">
+  <div class="col-md-8">
+    <h2>Actions</h2>
+    <div class="well">
+      <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,11 +11,6 @@
 
 <% end %>
 
-<% content_for :navbar_right do %>
-  Hello, <%= link_to current_user.name, Plek.current.find('signon') %>
-  &bull; <%= link_to 'Sign out', gds_sign_out_path %>
-<% end %>
-
 <% content_for :content do %>
 
   <%= yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 
-  resources :documents, path: "/:document_type", except: :destroy do
+  resources :documents, path: "/:document_type", param: :content_id, except: :destroy do
     resources :attachments, only: [:new, :create, :edit, :update]
 
     post :withdraw, on: :member

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+RSpec.feature "Editing a CMA case", type: :feature do
+  def log_in_as_editor(editor)
+    user = FactoryGirl.create(editor)
+    GDS::SSO.test_user = user
+  end
+
+  def cma_case_content_item
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "base_path" => "/cma-cases/example-cma-case",
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of an example CMA case",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-23T14:07:47.240Z",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        }
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }
+  end
+
+  def cma_case_content_item_links
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "links" => {
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+      }
+    }
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_put_links
+
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+    ]
+
+    publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
+
+    publishing_api_has_item(cma_case_content_item)
+
+    @changed_json = cma_case_content_item.deep_merge({
+      "base_path" => "/cma-cases/changed-title",
+      "title" => "Changed title",
+      "description" => "Changed summary",
+      "public_updated_at" => "2015-12-03T16:59:13.144Z",
+      "routes" => [
+        {
+          "path" => "/cma-cases/changed-title",
+          "type" => "exact",
+        }
+      ],
+    })
+
+    allow(Time.zone).to receive(:now).and_return("2015-12-03T16:59:13.144Z")
+  end
+
+  scenario "with some changed attributes" do
+    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+
+    click_link "Edit document"
+
+    fill_in "Title", with: "Changed title"
+    fill_in "Summary", with: "Changed summary"
+    fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 10)
+    fill_in "Opened date", with: "2014-01-01"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(@changed_json))
+    expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    expect(@changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13.144Z")
+
+    expect(page.status_code).to eq(200)
+  end
+
+  scenario "with some invalid changed attributes" do
+    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+
+    click_link "Edit document"
+
+    fill_in "Title", with: "Changed title"
+    fill_in "Summary", with: "Changed summary"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+    fill_in "Opened date", with: "Not a date"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+
+    expect(page.status_code).to eq(422)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,9 @@ Capybara.javascript_driver = :webkit
 
 require 'gds_api/test_helpers/publishing_api_v2'
 
+# Quiet down now Mongo
+Mongo::Logger.logger.level = ::Logger::FATAL
+
 RSpec.configure do |config|
   # config.disable_monkey_patching!
 


### PR DESCRIPTION
This PR allows users to edit a CMA case that exists in the Publishing API.  The interesting commits that are the ones that are unique to the way that Apps are going to have to interact with the Publishing API, such as [setting `content_id` in the params](https://github.com/alphagov/specialist-publisher/commit/58cfa9e35076bc037e2badc1e884b4db441f5b18), the [update action](https://github.com/alphagov/specialist-publisher/commit/c7e064d3b77f01ada69faf1fc46b0896ea68be89) and [persisting `content_id`](https://github.com/alphagov/specialist-publisher/commit/4cb25897c12677fb672b1aa34b9d0e17360661bd). [Ticket](https://trello.com/c/ZaUIPVs6/428-update-an-existing-cma-case).