### PR TITLE
Set public_updated_at as string

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -56,7 +56,7 @@ class DocumentsController <  ApplicationController
       filtered_params(params[current_format.format_name]).merge({content_id: params[:content_id]})
     )
 
-    @document.public_updated_at = Time.zone.now
+    @document.public_updated_at = Time.zone.now.to_s
 
     if @document.valid?
       if save_document


### PR DESCRIPTION
This commit fixes a bug with setting the `public_updated_at`. Previously setting this would throw an error as `Time.parse(Time.zone.now)` doesn't work. This commit changes it to call `.to_s` passing it the same value as what it gets from the payload.