### PR TITLE
Flash on redirect

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -35,7 +35,7 @@ class DocumentsController <  ApplicationController
 
     if @document.valid?
       if save_document
-        flash.now[:success] = "Created #{@document.title}"
+        flash[:success] = "Created #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
         flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
@@ -60,7 +60,7 @@ class DocumentsController <  ApplicationController
 
     if @document.valid?
       if save_document
-        flash.now[:success] = "Updated #{@document.title}"
+        flash[:success] = "Updated #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
         flash.now[:danger] = "There was an error updating #{@document.title}. Please try again later."

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -83,6 +83,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(cma_case_content_item))
 
     expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example CMA Case")
   end
 
   scenario "with no data" do

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -101,6 +101,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
     expect(@changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13.144Z")
 
     expect(page.status_code).to eq(200)
+    expect(page).to have_content("Updated Changed title")
   end
 
   scenario "with some invalid changed attributes" do


### PR DESCRIPTION
`flash.now` doesn't work when redirecting. This commit changes it use `flash` when redirecting which shows the post creation and editing success messages.