### PR TITLE
Set phase to beta for all tribunal decision finders

### DIFF
--- a/finders/metadata/administrative-appeals-tribunal-decisions.json
+++ b/finders/metadata/administrative-appeals-tribunal-decisions.json
@@ -4,7 +4,7 @@
   "format_name": "Administrative appeals tribunal decision",
   "name": "Administrative appeals tribunal decisions",
   "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "utaac_decision"
   },

--- a/finders/metadata/asylum-support-tribunal-decisions.json
+++ b/finders/metadata/asylum-support-tribunal-decisions.json
@@ -4,7 +4,7 @@
   "format_name": "Asylum support tribunal decision",
   "name": "Asylum support tribunal decisions",
   "description": "Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "asylum_support_decision"
   },

--- a/finders/metadata/employment-appeal-tribunal-decisions.json
+++ b/finders/metadata/employment-appeal-tribunal-decisions.json
@@ -4,7 +4,7 @@
   "format_name": "Employment appeal tribunal decision",
   "name": "Employment appeal tribunal decisions",
   "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "employment_appeal_tribunal_decision"
   },

--- a/finders/metadata/employment-tribunal-decisions.json
+++ b/finders/metadata/employment-tribunal-decisions.json
@@ -4,7 +4,7 @@
   "format_name": "Employment tribunal decision",
   "name": "Employment tribunal decisions",
   "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "employment_tribunal_decision"
   },

--- a/finders/metadata/tax-tribunal-decisions.json
+++ b/finders/metadata/tax-tribunal-decisions.json
@@ -4,7 +4,7 @@
   "format_name": "Tax and Chancery tribunal decision",
   "name": "Tax and Chancery tribunal decisions",
   "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
-  "beta": true,
+  "phase": "beta",
   "filter": {
     "document_type": "tax_tribunal_decision"
   },


### PR DESCRIPTION
This corrects the configuration for tribunal decision finders. Previously the configuration was set to `"beta": true`. Correct configuration is `"phase": "beta"`.