### PR TITLE
Publish a document

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController <  ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
-  before_action :fetch_document, only: [:edit, :show, :publish]
+  before_action :fetch_document, only: [:edit, :show, :publish, :update]
 
   def index
     unless params[:document_type]
@@ -52,9 +52,11 @@ class DocumentsController <  ApplicationController
   def edit; end
 
   def update
-    @document = document_klass.new(
-      filtered_params(params[current_format.format_name]).merge({content_id: params[:content_id]})
-    )
+    new_params = filtered_params(params[current_format.format_name])
+
+    new_params.each do |k, v|
+      @document.public_send(:"#{k}=", v)
+    end
 
     @document.public_updated_at = Time.zone.now.to_s
 
@@ -109,7 +111,7 @@ private
   end
 
   def fetch_document
-    @document = current_format.klass.from_publishing_api(publishing_api.get_content(params[:content_id]).to_ostruct)
+    @document = document_klass.from_publishing_api(publishing_api.get_content(params[:content_id]).to_ostruct)
   end
 
   def filtered_params(params_of_document)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -80,9 +80,16 @@ class DocumentsController <  ApplicationController
   end
 
   def publish
-    publish_request = publishing_api.publish(params[:content_id], "major")
+    indexable_document = SearchPresenter.new(@document)
 
-    if publish_request.code == 200
+    publish_request = publishing_api.publish(params[:content_id], "major")
+    rummager_request = rummager.add_document(
+      @document.format,
+      @document.base_path,
+      indexable_document.to_json,
+    )
+
+    if publish_request.code == 200 && rummager_request.code == 200
       flash[:success] = "Published #{@document.title}"
       redirect_to documents_path(current_format.document_type)
     else
@@ -143,6 +150,10 @@ private
 
   def publishing_api
     @publishing_api ||= SpecialistPublisher.services(:publishing_api)
+  end
+
+  def rummager
+    @rummager ||= SpecialistPublisher.services(:rummager)
   end
 
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,15 +13,20 @@ class DocumentsController <  ApplicationController
       return
     end
 
-    @documents = publishing_api.get_content_items(
+    response = publishing_api.get_content_items(
       content_format: current_format.format_name,
       fields: [
         :base_path,
         :content_id,
         :title,
         :public_updated_at,
+        :details,
+        :description,
       ]
     ).to_ostruct
+
+    @documents = response.map { |payload| document_klass.from_publishing_api(payload) }
+    @documents.sort!{ |a, b| a.public_updated_at <=> b.public_updated_at }.reverse!
   end
 
   def new

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController <  ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
-  before_action :fetch_document, only: [:edit, :show]
+  before_action :fetch_document, only: [:edit, :show, :publish]
 
   def index
     unless params[:document_type]
@@ -71,6 +71,19 @@ class DocumentsController <  ApplicationController
       render :edit, status: 422
     end
   end
+
+  def publish
+    publish_request = publishing_api.publish(params[:content_id], "major")
+
+    if publish_request.code == 200
+      flash[:success] = "Published #{@document.title}"
+      redirect_to documents_path(current_format.document_type)
+    else
+      flash[:danger] = "There was an error publishing #{@document.title}. Please try again later."
+      redirect_to document_path(current_format.document_type, params[:content_id])
+    end
+  end
+
 private
 
   def document_type

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,17 @@ module ApplicationHelper
   def published_document_path(document)
     Plek.current.find("website-root") + document.base_path
   end
+
+  def state(document)
+    state = document.publication_state
+
+    if document.draft?
+     classes = "label label-primary"
+    else
+     classes = "label label-default"
+    end
+
+    content_tag(:span, state, class: classes).html_safe
+  end
+
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,7 +21,7 @@ class Document
   end
 
   def base_path
-    "#{public_path}/#{title.parameterize}"
+    @base_path ||= "#{public_path}/#{title.parameterize}"
   end
 
   def format

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,14 +8,19 @@ class Document
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
+  COMMON_FIELDS = [
+    :title,
+    :summary,
+    :body,
+    :publication_state,
+    :public_updated_at,
+  ]
+
   def initialize(params = {}, format_specific_fields = [])
     @content_id = params.fetch(:content_id, SecureRandom.uuid)
-    @title = params.fetch(:title, nil)
-    @summary = params.fetch(:summary, nil)
-    @body = params.fetch(:body, nil)
     @format_specific_fields = format_specific_fields
 
-    format_specific_fields.each do |field|
+    (COMMON_FIELDS + format_specific_fields).each do |field|
       public_send(:"#{field.to_s}=", params.fetch(field, nil))
     end
   end
@@ -79,15 +84,15 @@ class Document
         title: payload.title,
         summary: payload.description,
         body: payload.details.body,
+        publication_state: payload.publication_state,
+        public_updated_at: payload.public_updated_at
       }
     )
 
     document.base_path = payload.base_path
-    document.public_updated_at = payload.public_updated_at
-    document.publication_state = payload.publication_state
 
     document.format_specific_fields.each do |field|
-      document.public_send(:"#{field.to_s}=", payload.details.metadata.send(:"#{field}"))
+      document.public_send(:"#{field.to_s}=", payload.details.metadata.send(field))
     end
 
     document
@@ -98,7 +103,7 @@ class Document
   end
 
   def public_updated_at=(timestamp)
-    public_updated_at = Time.parse(timestamp)
+    @public_updated_at = Time.parse(timestamp) unless timestamp.nil?
   end
 
 private

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -36,8 +36,8 @@ class Document
     raise NoMethodError
   end
 
-  def published?
-    !draft?
+  def live?
+    publication_state == "live"
   end
 
   def draft?

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -1,0 +1,39 @@
+class SearchPresenter
+
+  delegate :title, to: :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def to_json
+    {
+      title: document.title,
+      description: document.summary,
+      link: document.base_path,
+      indexable_content: indexable_content,
+      organisations: organisation_slugs,
+      public_timestamp: document.public_updated_at,
+    }.merge(document.format_specific_metadata)
+  end
+
+  def indexable_content
+    document.body
+  end
+
+  def organisation_slugs
+    response = publishing_api.get_content_items({content_format: "organisation", fields: [:content_id, :base_path]})
+
+    orgs = response.select { |o| document.organisations.include?(o["content_id"]) }
+    orgs.map { |o| o["base_path"].gsub("/government/organisations/", "")}.map { |o| o.gsub("/courts-tribunals/", "") }
+  end
+
+private
+
+  attr_reader :document
+
+  def publishing_api
+    @publishing_api ||= SpecialistPublisher.services(:publishing_api)
+  end
+
+end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -17,7 +17,7 @@
           <ul class="metadata">
             <li class="text-muted">Updated <%= time_ago_in_words(document.public_updated_at) %> ago</li>
             <li>
-              <%= document.publication_state %>
+              <%= state(document) %>
             </li>
           </ul>
         </li>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -44,5 +44,16 @@
     <div class="well">
       <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>
     </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Publish document</h3>
+      </div>
+      <div class="panel-body">
+        <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
+          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -25,6 +25,8 @@
           <% end %>
         <% end %>
       <% end %>
+      <dt>Publication state</dt>
+      <dd><%= state(@document) %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -1,4 +1,4 @@
-<% if document.published? %>
+<% if document.live? %>
   <div class="checkbox add-vertical-margins">
     <%= f.check_box :minor_update,
       note: {

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,9 +1,9 @@
 <h1 class="page-header"><%= document.title %>
   <ul class='document-slug'>
-    <li title='<% if !document.published? %>When published this document will appear at this URL<% end %>'>
+    <li title='<% if !document.live? %>When published this document will appear at this URL<% end %>'>
       <%= document.base_path %>
     </li>
-    <% if document.published? %>
+    <% if document.live? %>
       <li><%= link_to "View on website", public_url %></li>
     <% end %>
     <% if document.draft? %>

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module SpecialistPublisher
 
@@ -17,3 +18,4 @@ module SpecialistPublisher
 end
 
 SpecialistPublisher.register_service(:publishing_api, GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api')))
+SpecialistPublisher.register_service(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -64,6 +64,8 @@ RSpec.feature "Creating a CMA case", type: :feature do
       :content_id,
       :title,
       :public_updated_at,
+      :details,
+      :description,
     ]
 
     publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
       "locale" => "en",
       "phase" => "live",
       "public_updated_at" => "2015-11-23T14:07:47.240Z",
+      "publication_state" => "draft",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
@@ -61,24 +62,21 @@ RSpec.feature "Editing a CMA case", type: :feature do
       :content_id,
       :title,
       :public_updated_at,
+      :details,
+      :description,
     ]
 
     publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
 
     publishing_api_has_item(cma_case_content_item)
 
-    @changed_json = cma_case_content_item.deep_merge({
-      "base_path" => "/cma-cases/changed-title",
+    @changed_json = cma_case_content_item.merge({
       "title" => "Changed title",
       "description" => "Changed summary",
       "public_updated_at" => "2015-12-03T16:59:13.144Z",
-      "routes" => [
-        {
-          "path" => "/cma-cases/changed-title",
-          "type" => "exact",
-        }
-      ],
     })
+
+    @changed_json.delete("publication_state")
 
     allow(Time.zone).to receive(:now).and_return("2015-12-03T16:59:13.144Z")
   end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -42,10 +42,60 @@ RSpec.feature "Publishing a CMA case", type: :feature do
         }
       ],
       "redirects" => [],
+      "need_ids" => [],
       "update_type" => "major",
+      "phase" => "live",
+      "publication_state" => "live",
       "links" => {
         "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
       }
+    }
+  end
+
+  def cma_org_content_item
+    {
+      "base_path" => "/government/organisations/competition-and-markets-authority",
+      "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+      "title" => "Competition and Markets Authority",
+      "format" => "placeholder_organisation",
+      "need_ids" => [],
+      "locale" => "en",
+      "updated_at" => "2015-10-26T09:21:17.645Z",
+      "public_updated_at" => "2015-03-10T16:23:14.000+00:00",
+      "phase" => "live",
+      "analytics_identifier" => "D550",
+      "links" => {
+        "available_translations" => [
+          {
+            "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+            "title" => "Competition and Markets Authority",
+            "base_path" => "/government/organisations/competition-and-markets-authority",
+            "description" => nil,
+            "api_url" => "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+            "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority",
+            "locale" => "en"
+          }
+        ]
+      },
+      "description" => nil,
+      "details" => {}
+    }
+  end
+
+  def indexable_attributes
+    {
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of example CMA case",
+      "link" => "/cma-cases/example-cma-case",
+      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+      "public_timestamp" => "2015-11-16T11:53:30.000+00:00",
+      "opened_date" => "2014-01-01",
+      "closed_date" => "",
+      "case_type" => "ca98-and-civil-cartels",
+      "case_state" => "open",
+      "market_sector" => ["energy"],
+      "outcome_type" => "",
+      "organisations" => ["competition-and-markets-authority"],
     }
   end
 
@@ -57,13 +107,17 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       :content_id,
       :title,
       :public_updated_at,
+      :details,
+      :description,
     ]
 
     publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
+    publishing_api_has_fields_for_format('organisation', [cma_org_content_item], [:base_path, :content_id])
 
     publishing_api_has_item(cma_case_content_item)
 
     stub_publishing_api_publish(content_id, {})
+    stub_any_rummager_post
   end
 
   scenario "from the index" do
@@ -78,7 +132,11 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
     click_button "Publish"
 
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Published Example CMA Case")
+
     assert_publishing_api_publish(content_id)
+    assert_rummager_posted_item(indexable_attributes)
   end
 
 end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+RSpec.feature "Publishing a CMA case", type: :feature do
+
+  def log_in_as_editor(editor)
+    user = FactoryGirl.create(editor)
+    GDS::SSO.test_user = user
+  end
+
+  def content_id
+    "4a656f42-35ad-4034-8c7a-08870db7fffe"
+  end
+
+  def cma_case_content_item
+    {
+      "content_id" => content_id,
+      "base_path" => "/cma-cases/example-cma-case",
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of example CMA case",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        }
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" => {
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+      }
+    }
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+    ]
+
+    publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
+
+    publishing_api_has_item(cma_case_content_item)
+
+    stub_publishing_api_publish(content_id, {})
+  end
+
+  scenario "from the index" do
+    visit "/cma-cases"
+
+    expect(page.status_code).to eq(200)
+
+    click_link "Example CMA Case"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Example CMA Case")
+
+    click_button "Publish"
+
+    assert_publishing_api_publish(content_id)
+  end
+
+end

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -53,6 +53,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       :content_id,
       :title,
       :public_updated_at,
+      :details,
+      :description,
     ]
 
     cma_cases = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ require 'capybara/webkit/matchers'
 Capybara.javascript_driver = :webkit
 
 require 'gds_api/test_helpers/publishing_api_v2'
+require 'gds_api/test_helpers/rummager'
 
 # Quiet down now Mongo
 Mongo::Logger.logger.level = ::Logger::FATAL
@@ -53,6 +54,7 @@ RSpec.configure do |config|
   config.include Capybara::DSL, type: :feature
   config.include(Capybara::Webkit::RspecMatchers, :type => :feature)
   config.include(GdsApi::TestHelpers::PublishingApiV2)
+  config.include(GdsApi::TestHelpers::Rummager)
 
   config.after(:each) do
     #DatabaseCleaner.clean


### PR DESCRIPTION
This PR allows editors to publish documents to the Publishing API and Rummager. The most interesting commits are:
- https://github.com/alphagov/specialist-publisher/commit/921378426bff8f9ad9446cf03fc2800cebb09a2b
- https://github.com/alphagov/specialist-publisher/commit/5ad6c0a11f10d41d90e172398779501224047a46
- https://github.com/alphagov/specialist-publisher/commit/977702f4a13f4191a170c318d14ecec2d7a07e23
- https://github.com/alphagov/specialist-publisher/commit/c8f192dbddb1327140a637427a722a097b24840d

There's some hairy metaprogramming going on but I need to (re)construct the Objects in 2 different ways. One from the params and one from the payload. I think it's a pretty clean solution and it keeps the weirdness to deserialisation method.

Following on from this work I want to extract all these methods to provide a more Active Record like interface to the Publishing API interaction that the Document Object has to do. [Ticket](https://trello.com/c/JSFw4pRD/429-publish-a-document).