### PR TITLE
Always republish manual sections to Publishing API

### DIFF
--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -44,7 +44,7 @@ class ManualObserversRegistry
 
 private
   def publication_logger
-    ->(manual) {
+    ->(manual, _: nil) {
       manual.documents.each do |doc|
         next unless doc.needs_exporting?
 
@@ -59,7 +59,7 @@ private
   end
 
   def rummager_exporter
-    ->(manual) {
+    ->(manual, _ = nil) {
       indexer = RummagerIndexer.new
 
       indexer.add(
@@ -78,7 +78,7 @@ private
   end
 
   def rummager_withdrawer
-    ->(manual) {
+    ->(manual, _ = nil) {
       indexer = RummagerIndexer.new
 
       indexer.delete(
@@ -97,7 +97,7 @@ private
   end
 
   def publishing_api_exporter
-    ->(manual) {
+    ->(manual, action = nil) {
       manual_renderer = SpecialistPublisherWiring.get(:manual_renderer)
       ManualPublishingAPIExporter.new(
         publishing_api.method(:put_content_item),
@@ -109,7 +109,7 @@ private
 
       document_renderer = SpecialistPublisherWiring.get(:manual_document_renderer)
       manual.documents.each do |document|
-        next unless document.needs_exporting?
+        next if !document.needs_exporting? && action != :republish
 
         ManualSectionPublishingAPIExporter.new(
           publishing_api.method(:put_content_item),
@@ -125,7 +125,7 @@ private
   end
 
   def publishing_api_draft_exporter
-    ->(manual) {
+    ->(manual, _ = nil) {
       manual_renderer = SpecialistPublisherWiring.get(:manual_renderer)
       ManualPublishingAPIExporter.new(
         publishing_api.method(:put_draft_content_item),
@@ -138,7 +138,7 @@ private
   end
 
   def publishing_api_withdrawer
-    ->(manual) {
+    ->(manual, _ = nil) {
       PublishingAPIWithdrawer.new(
         publishing_api: publishing_api,
         entity: manual,

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -21,7 +21,7 @@ private
 
   def notify_listeners
     update_manual_with_tags
-    listeners.each { |l| l.call(manual) }
+    listeners.each { |l| l.call(manual, :republish) }
   end
 
   def manual

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+require "sidekiq/testing"
+
+RSpec.describe "Saving invalid documents", type: :feature do
+  before do
+    Sidekiq::Testing.inline!
+    login_as(:generic_editor)
+    stub_organisation_details(GDS::SSO.test_user.organisation_slug)
+  end
+
+  let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
+  let(:manual_slug) { "guidance/example-manual-title" }
+
+  def create_manual_with_sections
+    @manual_fields = manual_fields # this is necessary to be able to use `create_documents_for_manual` from `manual_helpers`
+
+    create_manual(manual_fields)
+    @attributes_for_documents = create_documents_for_manual(manual_fields: manual_fields, count: 2)
+    publish_manual
+
+    check_manual_is_published_to_publishing_api(manual_slug)
+    WebMock::RequestRegistry.instance.reset!
+  end
+
+  def republish_manuals
+    repository = SpecialistPublisherWiring.get(:repository_registry).manual_repository
+    repository.all.each do |manual|
+      ManualServiceRegistry.new.republish(manual.id).call
+    end
+  end
+
+  describe "republishing a manual with sections" do
+    before do
+      create_manual_with_sections
+    end
+
+    it "sends the manual and the sections to the Publishing API" do
+      republish_manuals
+
+      @attributes_for_documents.each do |document_attributes|
+        check_manual_and_documents_were_published(
+          manual_slug,
+          manual_fields,
+          document_attributes[:slug],
+          document_attributes[:fields],
+        )
+      end
+    end
+  end
+end

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RepublishManualService do
 
     it "republishes the manual" do
       subject.call
-      expect(listener).to have_received(:call).with(manual)
+      expect(listener).to have_received(:call).with(manual, :republish)
     end
 
     it "updates the manuals tags" do


### PR DESCRIPTION
Currently, republishing a manual won't republish the manual sections to Publishing API unless they're marked as `needs_exporting?`. This means that it's not possible to update the Publishing API payloads for manual sections without DB changes, which feels wrong.

Questions about this:

- is this the right way to implement this feature?
- how should this be done within the Specialist Publisher rewrite?

/cc @tommyp @jennyd @jamiecobbett 