### PR TITLE
Activerecord like interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'factory_girl'
   gem "capybara", "2.5.0"
   gem 'capybara-webkit', '1.7.1'
+  gem 'timecop', '0.8.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.8.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -298,6 +299,7 @@ DEPENDENCIES
   select2-rails (~> 4.0.0)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
+  timecop (= 0.8.0)
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
   webmock

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -67,20 +67,7 @@ class DocumentsController <  ApplicationController
   end
 
   def publish
-    indexable_document = SearchPresenter.new(@document)
-
-    begin
-      publish_request = publishing_api.publish(params[:content_id], "major")
-      rummager_request = rummager.add_document(
-        @document.format,
-        @document.base_path,
-        indexable_document.to_json,
-      )
-    rescue GdsApi::HTTPErrorResponse => e
-      Airbrake.notify(e)
-    end
-
-    if publish_request.code == 200 && rummager_request.code == 200
+    if @document.publish!
       flash[:success] = "Published #{@document.title}"
       redirect_to documents_path(current_format.document_type)
     else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,7 +28,7 @@ class DocumentsController <  ApplicationController
     )
 
     if @document.valid?
-      if save_document
+      if @document.save!
         flash[:success] = "Created #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
@@ -52,10 +52,8 @@ class DocumentsController <  ApplicationController
       @document.public_send(:"#{k}=", v)
     end
 
-    @document.public_updated_at = Time.zone.now.to_s
-
     if @document.valid?
-      if save_document
+      if @document.save!
         flash[:success] = "Updated #{@document.title}"
         redirect_to documents_path(current_format.document_type)
       else
@@ -129,22 +127,6 @@ private
       filtered_value = value.is_a?(Array) ? value.reject(&:blank?) : value
       filtered_params.merge(key => filtered_value)
     }
-  end
-
-  def save_document
-    presented_document = DocumentPresenter.new(@document)
-    presented_links = DocumentLinksPresenter.new(@document)
-
-    begin
-      item_request = publishing_api.put_content(@document.content_id, presented_document.to_json)
-      links_request = publishing_api.put_links(@document.content_id, presented_links.to_json)
-
-      item_request.code == 200 && links_request.code == 200
-    rescue GdsApi::HTTPErrorResponse => e
-      Airbrake.notify(e)
-
-      false
-    end
   end
 
   def publishing_api

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,19 +13,8 @@ class DocumentsController <  ApplicationController
       return
     end
 
-    response = publishing_api.get_content_items(
-      content_format: current_format.format_name,
-      fields: [
-        :base_path,
-        :content_id,
-        :title,
-        :public_updated_at,
-        :details,
-        :description,
-      ]
-    ).to_ostruct
+    @documents = document_klass.all
 
-    @documents = response.map { |payload| document_klass.from_publishing_api(payload) }
     @documents.sort!{ |a, b| a.public_updated_at <=> b.public_updated_at }.reverse!
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -116,7 +116,7 @@ private
   end
 
   def fetch_document
-    @document = document_klass.from_publishing_api(publishing_api.get_content(params[:content_id]).to_ostruct)
+    @document = document_klass.find(params[:content_id])
   end
 
   def filtered_params(params_of_document)

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -25,6 +25,10 @@ class CmaCase < Document
     "cma_case"
   end
 
+  def self.format
+    new.format
+  end
+
   def public_path
     "/cma-cases"
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,7 +30,11 @@ class Document
   end
 
   def format
-    "document"
+    raise NotImplementedError
+  end
+
+  def self.format
+    raise NotImplementedError
   end
 
   def phase
@@ -106,10 +110,29 @@ class Document
     @public_updated_at = Time.parse(timestamp) unless timestamp.nil?
   end
 
-private
+  def self.all
+    response = self.publishing_api.get_content_items(
+      content_format: self.format,
+      fields: [
+        :base_path,
+        :content_id,
+        :title,
+        :public_updated_at,
+        :details,
+        :description,
+      ]
+    ).to_ostruct
+
+    response.map { |payload| self.from_publishing_api(payload) }
+  end
+
+  def self.publishing_api
+    SpecialistPublisher.services(:publishing_api)
+  end
 
   def finder_schema
     @finder_schema ||= FinderSchema.new(format.pluralize)
   end
+  private :finder_schema
 
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -107,7 +107,7 @@ class Document
   end
 
   def public_updated_at=(timestamp)
-    @public_updated_at = Time.parse(timestamp) unless timestamp.nil?
+    @public_updated_at = Time.parse(timestamp.to_s) unless timestamp.nil?
   end
 
   def self.all
@@ -131,7 +131,7 @@ class Document
   end
 
   def save!
-    public_updated_at = Time.zone.now.to_s
+    self.public_updated_at = Time.zone.now
 
     presented_document = DocumentPresenter.new(self)
     presented_links = DocumentLinksPresenter.new(self)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -148,6 +148,27 @@ class Document
     end
   end
 
+  def publish!
+    indexable_document = SearchPresenter.new(self)
+
+    begin
+      publish_request = publishing_api.publish(content_id, "major")
+      rummager_request = rummager.add_document(
+        format,
+        base_path,
+        indexable_document.to_json,
+      )
+
+      publish_request.code == 200 && rummager_request.code == 200
+    rescue GdsApi::HTTPErrorResponse => e
+      Airbrake.notify(e)
+    end
+  end
+
+  def rummager
+    SpecialistPublisher.services(:rummager)
+  end
+
   def publishing_api
     self.class.publishing_api
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -126,6 +126,10 @@ class Document
     response.map { |payload| self.from_publishing_api(payload) }
   end
 
+  def self.find(content_id)
+    self.from_publishing_api(publishing_api.get_content(content_id).to_ostruct)
+  end
+
   def self.publishing_api
     SpecialistPublisher.services(:publishing_api)
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -130,6 +130,28 @@ class Document
     self.from_publishing_api(publishing_api.get_content(content_id).to_ostruct)
   end
 
+  def save!
+    public_updated_at = Time.zone.now.to_s
+
+    presented_document = DocumentPresenter.new(self)
+    presented_links = DocumentLinksPresenter.new(self)
+
+    begin
+      item_request = publishing_api.put_content(self.content_id, presented_document.to_json)
+      links_request = publishing_api.put_links(self.content_id, presented_links.to_json)
+
+      item_request.code == 200 && links_request.code == 200
+    rescue GdsApi::HTTPErrorResponse => e
+      Airbrake.notify(e)
+
+      false
+    end
+  end
+
+  def publishing_api
+    self.class.publishing_api
+  end
+
   def self.publishing_api
     SpecialistPublisher.services(:publishing_api)
   end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -17,7 +17,7 @@ class DocumentPresenter
       rendering_app: "specialist-frontend",
       locale: "en",
       phase: document.phase,
-      public_updated_at: document.public_updated_at,
+      public_updated_at: document.public_updated_at.to_s,
       details: {
         body: document.body,
         metadata: metadata,

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -13,7 +13,7 @@ class SearchPresenter
       link: document.base_path,
       indexable_content: indexable_content,
       organisations: organisation_slugs,
-      public_timestamp: document.public_updated_at,
+      public_timestamp: document.public_updated_at.to_s,
     }.merge(document.format_specific_metadata)
   end
 

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-11-23T14:07:47.240Z",
+      "public_updated_at" => "2015-12-03 16:59:13 UTC",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
@@ -54,7 +54,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     log_in_as_editor(:cma_editor)
 
     allow(SecureRandom).to receive(:uuid).and_return("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    allow(Time.zone).to receive(:now).and_return("2015-11-23T14:07:47.240Z")
+    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_put_links

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -73,12 +73,15 @@ RSpec.feature "Editing a CMA case", type: :feature do
     @changed_json = cma_case_content_item.merge({
       "title" => "Changed title",
       "description" => "Changed summary",
-      "public_updated_at" => "2015-12-03T16:59:13.144Z",
+      "public_updated_at" => "2015-12-03 16:59:13 UTC",
     })
 
     @changed_json.delete("publication_state")
+    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+  end
 
-    allow(Time.zone).to receive(:now).and_return("2015-12-03T16:59:13.144Z")
+  after do
+    Timecop.return
   end
 
   scenario "with some changed attributes" do
@@ -96,7 +99,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(@changed_json))
     expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    expect(@changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13.144Z")
+    expect(@changed_json["public_updated_at"]).to eq("2015-12-03 16:59:13 UTC")
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Changed title")

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "public_updated_at" => "2015-11-16 11:53:30 +0000",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
@@ -88,7 +88,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "description" => "This is the summary of example CMA case",
       "link" => "/cma-cases/example-cma-case",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-      "public_timestamp" => "2015-11-16T11:53:30.000+00:00",
+      "public_timestamp" => "2015-11-16 11:53:30 +0000",
       "opened_date" => "2014-01-01",
       "closed_date" => "",
       "case_type" => "ca98-and-civil-cartels",

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe CmaCase do
+
+  def cma_case_content_item(n)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/cma-cases/example-cma-case-#{n}",
+      "title" => "Example CMA Case #{n}",
+      "description" => "This is the summary of example CMA case #{n}",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        }
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case-#{n}",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }
+  end
+
+  before do
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+      :details,
+      :description,
+    ]
+
+    @cma_cases = []
+
+    10.times do |n|
+      @cma_cases << cma_case_content_item(n)
+    end
+
+    publishing_api_has_fields_for_format('cma_case', @cma_cases, fields)
+
+    publishing_api_has_item(@cma_cases[0])
+  end
+
+  context "#all" do
+    it "returns all CMA Cases" do
+      expect(described_class.all.length).to be(@cma_cases.length)
+    end
+  end
+end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -37,6 +37,53 @@ describe CmaCase do
     }
   end
 
+  def cma_org_content_item
+    {
+      "base_path" => "/government/organisations/competition-and-markets-authority",
+      "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+      "title" => "Competition and Markets Authority",
+      "format" => "placeholder_organisation",
+      "need_ids" => [],
+      "locale" => "en",
+      "updated_at" => "2015-10-26T09:21:17.645Z",
+      "public_updated_at" => "2015-03-10T16:23:14.000+00:00",
+      "phase" => "live",
+      "analytics_identifier" => "D550",
+      "links" => {
+        "available_translations" => [
+          {
+            "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+            "title" => "Competition and Markets Authority",
+            "base_path" => "/government/organisations/competition-and-markets-authority",
+            "description" => nil,
+            "api_url" => "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+            "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority",
+            "locale" => "en"
+          }
+        ]
+      },
+      "description" => nil,
+      "details" => {}
+    }
+  end
+
+  def indexable_attributes
+    {
+      "title" => "Example CMA Case 0",
+      "description" => "This is the summary of example CMA case 0",
+      "link" => "/cma-cases/example-cma-case-0",
+      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+      "public_timestamp" => "2015-11-16 11:53:30 +0000",
+      "opened_date" => "2014-01-01",
+      "closed_date" => "",
+      "case_type" => "ca98-and-civil-cartels",
+      "case_state" => "open",
+      "market_sector" => ["energy"],
+      "outcome_type" => "",
+      "organisations" => ["competition-and-markets-authority"],
+    }
+  end
+
   before do
     fields = [
       :base_path,
@@ -95,6 +142,20 @@ describe CmaCase do
       expect(c.save!).to eq(true)
 
       assert_publishing_api_put_content(c.content_id, request_json_including(@cma_cases[0]))
+    end
+  end
+
+  context "#publish!" do
+    it "publishes the CMA Case" do
+      stub_publishing_api_publish(@cma_cases[0]["content_id"], {})
+      stub_any_rummager_post
+      publishing_api_has_fields_for_format('organisation', [cma_org_content_item], [:base_path, :content_id])
+
+      c = described_class.find(@cma_cases[0]["content_id"])
+      expect(c.publish!).to eq(true)
+
+      assert_publishing_api_publish(c.content_id)
+      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -56,6 +56,8 @@ describe CmaCase do
     publishing_api_has_fields_for_format('cma_case', @cma_cases, fields)
 
     publishing_api_has_item(@cma_cases[0])
+
+    allow(Time.zone).to receive(:now).and_return("2015-12-18 10:12:26 UTC")
   end
 
   context "#all" do
@@ -79,6 +81,20 @@ describe CmaCase do
       expect(cma_case.case_state).to    eq(@cma_cases[0]["details"]["metadata"]["case_state"])
       expect(cma_case.market_sector).to eq(@cma_cases[0]["details"]["metadata"]["market_sector"])
       expect(cma_case.outcome_type).to  eq(@cma_cases[0]["details"]["metadata"]["outcome_type"])
+    end
+  end
+
+  context "#save!" do
+    it "saves the CMA Case" do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_put_links
+
+      @cma_cases[0].merge("public_updated_at" => "2015-12-18 10:12:26 UTC")
+
+      c = described_class.find(@cma_cases[0]["content_id"])
+      expect(c.save!).to eq(true)
+
+      assert_publishing_api_put_content(c.content_id, request_json_including(@cma_cases[0]))
     end
   end
 end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -63,4 +63,22 @@ describe CmaCase do
       expect(described_class.all.length).to be(@cma_cases.length)
     end
   end
+
+  context "#find" do
+    it "returns a CMA Case" do
+      content_id = @cma_cases[0]["content_id"]
+      cma_case = described_class.find(content_id)
+
+      expect(cma_case.base_path).to     eq(@cma_cases[0]["base_path"])
+      expect(cma_case.title).to         eq(@cma_cases[0]["title"])
+      expect(cma_case.summary).to       eq(@cma_cases[0]["description"])
+      expect(cma_case.body).to          eq(@cma_cases[0]["details"]["body"])
+      expect(cma_case.opened_date).to   eq(@cma_cases[0]["details"]["metadata"]["opened_date"])
+      expect(cma_case.closed_date).to   eq(@cma_cases[0]["details"]["metadata"]["closed_date"])
+      expect(cma_case.case_type).to     eq(@cma_cases[0]["details"]["metadata"]["case_type"])
+      expect(cma_case.case_state).to    eq(@cma_cases[0]["details"]["metadata"]["case_state"])
+      expect(cma_case.market_sector).to eq(@cma_cases[0]["details"]["metadata"]["market_sector"])
+      expect(cma_case.outcome_type).to  eq(@cma_cases[0]["details"]["metadata"]["outcome_type"])
+    end
+  end
 end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -57,7 +57,7 @@ describe CmaCase do
 
     publishing_api_has_item(@cma_cases[0])
 
-    allow(Time.zone).to receive(:now).and_return("2015-12-18 10:12:26 UTC")
+    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
   context "#all" do
@@ -89,7 +89,7 @@ describe CmaCase do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      @cma_cases[0].merge("public_updated_at" => "2015-12-18 10:12:26 UTC")
+      @cma_cases[0].merge!("public_updated_at" => "2015-12-18 10:12:26 UTC")
 
       c = described_class.find(@cma_cases[0]["content_id"])
       expect(c.save!).to eq(true)


### PR DESCRIPTION
One of the main issues when working with the existing Specialist Publisher is that when trying to do anything via the console the App doesn't work like a standard Rails (or Ruby) App.

This PR gives document formats in Specialist Publisher an ActiveRecord like interface to the Publishing API. More methods may come later but these are the ones I needed to add to get to where I am now.

- `CmaCase#all`: Fetches all payloads and returns all instances of that format.
- `CmaCase#find(content_id)`: Fetches the payload for the content item with a matching `content_id` and returns an instance of the matching format.
- `CmaCase.save!`: Saves the Document to the Publishing API with the current properties.
- `CmaCase.publish!`: Sends the publish command to the Publishing API publishing the current payload and the current version to Rummager.

[Ticket](https://trello.com/c/7cia9ASC/467-active-record-style-interface).

This PR also adds Timecop as a more reliable way of predicting `public_updated_at` in tests.