### PR TITLE
Update ESIF finder link for NI

### DIFF
--- a/finders/metadata/esi-funds.json
+++ b/finders/metadata/esi-funds.json
@@ -5,7 +5,7 @@
   "name": "European Structural and Investment Funds (ESIF)",
   "description": "Find and apply to run projects backed by ESIF",
   "beta": true,
-  "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
+  "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.dfpni.gov.uk/topics/finance/european-funding-2014-2020\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {
     "document_type": "european_structural_investment_fund"
   },


### PR DESCRIPTION
This link has been updated by DFPNI, and is now also accessible over
HTTPS.