### PR TITLE
Add new Safety study report type

### DIFF
--- a/app/models/validators/aaib_report_validator.rb
+++ b/app/models/validators/aaib_report_validator.rb
@@ -9,5 +9,7 @@ class AaibReportValidator < SimpleDelegator
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
-  validates :date_of_occurrence, presence: true, date: true
+  validates :date_of_occurrence, presence: true, date: true, unless: ->(report) {
+    report.report_type == "safety-study" && report.date_of_occurrence.blank?
+  }
 end

--- a/finders/schemas/aaib-reports.json
+++ b/finders/schemas/aaib-reports.json
@@ -30,7 +30,8 @@
         {"label": "Bulletin - Pre-1997 uncategorised monthly report", "value": "pre-1997-monthly-report"},
         {"label": "Foreign report", "value": "foreign-report"},
         {"label": "Formal report", "value": "formal-report"},
-        {"label": "Special bulletin", "value": "special-bulletin"}
+        {"label": "Special bulletin", "value": "special-bulletin"},
+        {"label": "Safety study", "value": "safety-study"}
       ]
     },
     {


### PR DESCRIPTION
Not all safety studies will have a date of occurrence, so we also need
to allow it to be blank when validating.

https://trello.com/c/4euyRTaI/229-add-additional-report-type-to-aaib-reports-finder-large

Requires https://github.com/alphagov/govuk-content-schemas/pull/189 to be merged.