### PR TITLE
Temp fix for missing details

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -123,7 +123,7 @@ class Document
       ]
     ).to_ostruct
 
-    response.map { |payload| self.from_publishing_api(payload) }
+    response.map { |payload| self.find(payload.content_id) }
   end
 
   def self.find(content_id)

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -69,6 +69,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     ]
 
     publishing_api_has_fields_for_format('cma_case', [cma_case_content_item], fields)
+    publishing_api_has_item(cma_case_content_item)
   end
 
   scenario "with valid data" do

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -65,7 +65,9 @@ RSpec.feature "Viewing a specific case", type: :feature do
 
     publishing_api_has_fields_for_format('cma_case', cma_cases, fields)
 
-    publishing_api_has_item(cma_cases[0])
+    cma_cases.each do |cma_case|
+      publishing_api_has_item(cma_case)
+    end
   end
 
   scenario "from the index" do

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -102,7 +102,9 @@ describe CmaCase do
 
     publishing_api_has_fields_for_format('cma_case', @cma_cases, fields)
 
-    publishing_api_has_item(@cma_cases[0])
+    @cma_cases.each do |cma_case|
+      publishing_api_has_item(cma_case)
+    end
 
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end


### PR DESCRIPTION
As `details` is currently not expanded from the index `GET` endpoint this is a temp fix to request each individual payload when you hit the index endpoint for a format. This is obviously an N+1 query but by the time this is going into Production we should be expanding `details`.