### PR TITLE
Support manual ID in CliManualDeleter

### DIFF
--- a/bin/delete_draft_manual
+++ b/bin/delete_draft_manual
@@ -4,4 +4,5 @@ require File.expand_path("../../config/environment", __FILE__)
 require "cli_manual_deleter"
 
 manual_slug = ARGV.any? ? ARGV.fetch(0) : nil
-CliManualDeleter.new(manual_slug).call
+manual_id = ARGV.any? ? ARGV.fetch(1, nil) : nil
+CliManualDeleter.new(manual_slug, manual_id: manual_id).call

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -1,6 +1,7 @@
 class CliManualDeleter
-  def initialize(manual_slug, stdin: STDIN, stdout: STDOUT)
+  def initialize(manual_slug, manual_id: nil, stdin: STDIN, stdout: STDOUT)
     @manual_slug = manual_slug
+    @manual_id = manual_id
     @stdin = stdin
     @stdout = stdout
   end
@@ -14,10 +15,15 @@ class CliManualDeleter
   end
 
 private
-  attr_reader :manual_slug, :stdin, :stdout
+  attr_reader :manual_slug, :manual_id, :stdin, :stdout
 
   def find_manual_record
-    manual_records = ManualRecord.where(slug: manual_slug)
+    if manual_id
+      manual_records = ManualRecord.where(manual_id: manual_id)
+    else
+      manual_records = ManualRecord.where(slug: manual_slug)
+    end
+
     validate_manual_records(manual_records)
 
     manual_records.first.tap do |manual_record|


### PR DESCRIPTION
It's possible (due to a bug) to create multiple manuals with the same slug. The CliManualDeleter correctly gives an ambiguous slug error and refuses to delete anything.

This commit allows `bin/delete_draft_manual` to be called with an optional identifier in addition to the slug. If the identifier is present it will be used instead of the slug.

---

This is my first time looking at specialist-publisher and I'm not set up in any way to test this so be gentle.