### PR TITLE
Major and minor updates

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -5,4 +5,14 @@ jQuery(function($) {
   $(".select2").select2({
     placeholder: $(this).data('placeholder')
   });
+
+  $('.js-hidden').hide();
+
+  $('.js-update-type-major').click(function() {
+    $('.js-change-note').show();
+  });
+
+  $('.js-update-type-minor').click(function() {
+    $('.js-change-note').hide();
+  });
 });

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -185,7 +185,8 @@ class Document
     indexable_document = SearchPresenter.new(self)
 
     begin
-      publish_request = publishing_api.publish(content_id, "major")
+      update_type = self.update_type || 'major'
+      publish_request = publishing_api.publish(content_id, update_type)
       rummager_request = rummager.add_document(
         format,
         base_path,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -45,12 +45,16 @@ class Document
     raise NoMethodError
   end
 
-  def live?
-    publication_state == "live"
+  %w{draft live redrafted}.each do |state|
+    define_method("#{state}?") do
+      publication_state == state
+    end
   end
 
-  def draft?
-    publication_state == "draft"
+  def published?
+    live? || redrafted?
+  end
+
   end
 
   def users

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,11 +2,14 @@ class Document
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :content_id, :base_path, :title, :summary, :body, :format_specific_fields, :public_updated_at, :state, :bulk_published, :publication_state, :minor_update, :change_note
+  attr_accessor :content_id, :base_path, :title, :summary, :body, :format_specific_fields, :public_updated_at, :state, :bulk_published, :publication_state, :change_note
+  attr_writer :change_history, :update_type
 
   validates :title, presence: true
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
+  validates :update_type, presence: true, if: :live?
+  validates :change_note, presence: true, if: :change_note_required?
 
   COMMON_FIELDS = [
     :title,
@@ -55,6 +58,16 @@ class Document
     live? || redrafted?
   end
 
+  def change_note_required?
+    update_type == 'major' && published?
+  end
+
+  def change_history
+    @change_history ||= []
+  end
+
+  def update_type
+    @update_type || "major"
   end
 
   def users
@@ -98,6 +111,16 @@ class Document
     )
 
     document.base_path = payload.base_path
+    document.update_type = payload.update_type
+
+    # If the document is redrafted remove the last/most
+    # recent change note from the change_history array
+    # and set it as the document's change note
+    document.change_note = payload.details.change_history.pop["note"] if document.redrafted? && payload.details.change_history.length > 1
+
+    # Persist the rest of the change_history on the document
+    # if the document is live or redrafted
+    document.change_history = payload.details.change_history.map(&:to_h) if document.published?
 
     document.format_specific_fields.each do |field|
       document.public_send(:"#{field.to_s}=", payload.details.metadata.send(field))

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -17,10 +17,11 @@ class DocumentPresenter
       rendering_app: "specialist-frontend",
       locale: "en",
       phase: document.phase,
-      public_updated_at: document.public_updated_at.to_s,
+      public_updated_at: public_updated_at,
       details: {
         body: document.body,
         metadata: metadata,
+        change_history: change_history,
       },
       routes: [
         {
@@ -29,7 +30,7 @@ class DocumentPresenter
         }
       ],
       redirects: [],
-      update_type: "major",
+      update_type: document.update_type,
     }
   end
 
@@ -45,4 +46,16 @@ private
     end.reduce({}, :merge).merge(document_type: document.format)
   end
 
+  def public_updated_at
+    document.public_updated_at.to_s
+  end
+
+  def change_history
+    case document.update_type
+    when "major"
+      document.change_history + [{ public_timestamp: public_updated_at, note: document.change_note || "First published." }]
+    when "minor"
+      document.change_history
+    end
+  end
 end

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -6,8 +6,6 @@
 
     <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
 
-    <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
-
     <div class="actions">
       <button name="save" class="btn btn-success">Save as draft</button>
     </div>

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -1,11 +1,17 @@
-<% if document.live? %>
+<% if document.published? %>
   <div class="checkbox add-vertical-margins">
-    <%= f.check_box :minor_update,
-      note: {
-        text: "Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.",
-        class: "help-block"
-      }
-    %>
+    <%= f.radio_button :update_type, :minor, class: 'js-update-type-minor' %>
+    <%= f.label :update_type_minor %>
+    <p class="help-block">Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.</p>
   </div>
-  <%= f.text_area :change_note, class: 'form-control short-textarea' %>
+  <div class="checkbox add-vertical-margins">
+    <%= f.radio_button :update_type, :major, class: 'js-update-type-major' %>
+    <%= f.label :update_type_major %>
+    <p class="help-block">This will notify subscribers to <%= current_format.title.pluralize %>.</p>
+  </div>
+  <div class="<%= document.update_type != 'major' ? 'js-hidden' : nil %> js-change-note">
+    <%= f.label :change_note %>
+    <%= f.text_area :change_note, class: 'form-control short-textarea' %>
+    <p class="help-block">This will be publically viewable on GOV.UK</p>
+  </div>
 <% end %>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -28,7 +28,13 @@ RSpec.feature "Creating a CMA case", type: :feature do
           "market_sector" => ["energy"],
           "outcome_type" => "",
           "document_type" => "cma_case",
-        }
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "note" => "First published."
+          }
+        ]
       },
       "routes" => [
         {

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature "Editing a CMA case", type: :feature do
+RSpec.feature "Editing a draft CMA case", type: :feature do
   def log_in_as_editor(editor)
     user = FactoryGirl.create(editor)
     GDS::SSO.test_user = user
@@ -29,7 +29,13 @@ RSpec.feature "Editing a CMA case", type: :feature do
           "market_sector" => ["energy"],
           "outcome_type" => "",
           "document_type" => "cma_case",
-        }
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "note" => "First published."
+          }
+        ]
       },
       "routes" => [
         {
@@ -75,6 +81,15 @@ RSpec.feature "Editing a CMA case", type: :feature do
       "description" => "Changed summary",
       "public_updated_at" => "2015-12-03 16:59:13 UTC",
     })
+
+    @changed_json["details"].merge!(
+      "change_history" => [
+        {
+          "public_timestamp" => "2015-12-03 16:59:13 UTC",
+          "note" => "First published.",
+        }
+      ]
+    )
 
     @changed_json.delete("publication_state")
     Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+
+RSpec.feature "Editing a published CMA case", type: :feature do
+  def log_in_as_editor(editor)
+    user = FactoryGirl.create(editor)
+    GDS::SSO.test_user = user
+  end
+
+  def published_cma_case_content_item
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "base_path" => "/cma-cases/example-cma-case",
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of a published example CMA case",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-23 14:07:47 UTC",
+      "publication_state" => "live",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-11-23T14:07:47.240Z",
+            "note" => "First published."
+          }
+        ]
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }
+  end
+
+  def redrafted_cma_case_content_item
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "base_path" => "/cma-cases/example-cma-case",
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of a redrafted example CMA case",
+      "format" => "cma_case",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-23T14:07:47.240Z",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "closed_date" => "",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "outcome_type" => "",
+          "document_type" => "cma_case",
+        }
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }
+  end
+
+
+  def cma_case_content_item_links
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "links" => {
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+      }
+    }
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_put_links
+
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+      :details,
+      :description,
+    ]
+
+    publishing_api_has_fields_for_format('cma_case', [published_cma_case_content_item], fields)
+
+    publishing_api_has_item(published_cma_case_content_item)
+
+    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  scenario "with a minor update" do
+    changed_json = published_cma_case_content_item.merge({
+      "title" => "Minor update title",
+      "description" => "Minor update summary",
+      "update_type" => "minor",
+    })
+
+    changed_json.delete("publication_state")
+
+    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+
+    click_link "Edit document"
+
+    fill_in "Title", with: "Minor update title"
+    fill_in "Summary", with: "Minor update summary"
+    fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 10)
+    fill_in "Opened date", with: "2014-01-01"
+
+    choose("cma_case_update_type_minor")
+
+    click_button "Save as draft"
+
+    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(changed_json))
+    expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    expect(changed_json["public_updated_at"]).to eq("2015-11-23 14:07:47 UTC")
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Updated Minor update title")
+  end
+
+  scenario "with a major update" do
+    changed_json = published_cma_case_content_item.merge({
+      "title" => "Major update title",
+      "description" => "Major update summary",
+      "public_updated_at" => "2015-12-03 16:59:13 UTC",
+      "update_type" => "major",
+    })
+
+    changed_json["details"]["change_history"] << { "public_timestamp" => "2015-12-03 16:59:13 UTC", "note" => "This is a change note." }
+
+    changed_json.delete("publication_state")
+
+    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+
+    click_link "Edit document"
+
+    fill_in "Title", with: "Major update title"
+    fill_in "Summary", with: "Major update summary"
+    fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 10)
+    fill_in "Opened date", with: "2014-01-01"
+
+    choose("cma_case_update_type_major")
+
+    fill_in "Change note", with: "This is a change note."
+
+    click_button "Save as draft"
+
+    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(changed_json))
+    expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    expect(changed_json["public_updated_at"]).to eq("2015-12-03 16:59:13 UTC")
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Updated Major update title")
+  end
+end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -33,7 +33,13 @@ RSpec.feature "Publishing a CMA case", type: :feature do
           "market_sector" => ["energy"],
           "outcome_type" => "",
           "document_type" => "cma_case",
-        }
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "note" => "First published."
+          }
+        ]
       },
       "routes" => [
         {

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -29,7 +29,13 @@ RSpec.feature "Viewing a specific case", type: :feature do
           "market_sector" => ["energy"],
           "outcome_type" => "",
           "document_type" => "cma_case",
-        }
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "note" => "First published."
+          }
+        ]
       },
       "routes" => [
         {
@@ -41,7 +47,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       "update_type" => "major",
       "links" => {
         "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
-      }
+      },
+      "publication_state" => "draft"
     }
   end
 

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -14,6 +14,7 @@ describe CmaCase do
       "locale" => "en",
       "phase" => "live",
       "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "publication_state" => "draft",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
@@ -24,7 +25,8 @@ describe CmaCase do
           "market_sector" => ["energy"],
           "outcome_type" => "",
           "document_type" => "cma_case",
-        }
+        },
+        "change_history" => [],
       },
       "routes" => [
         {
@@ -138,12 +140,24 @@ describe CmaCase do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      @cma_cases[0].merge!("public_updated_at" => "2015-12-18 10:12:26 UTC")
 
-      c = described_class.find(@cma_cases[0]["content_id"])
+      cma_case = @cma_cases[0]
+
+      cma_case.delete("publication_state")
+      cma_case.merge!("public_updated_at" => "2015-12-18 10:12:26 UTC")
+      cma_case["details"].merge!(
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-18 10:12:26 UTC",
+            "note" => "First published.",
+          }
+        ]
+      )
+
+      c = described_class.find(cma_case["content_id"])
       expect(c.save!).to eq(true)
 
-      assert_publishing_api_put_content(c.content_id, request_json_including(@cma_cases[0]))
+      assert_publishing_api_put_content(c.content_id, request_json_including(cma_case))
     end
   end
 


### PR DESCRIPTION
This PR allows editors to specify major/minor updates do documents and to add a change note to the change history if the change is major. The workflow UI is slightly different to what exists in Specialist Publisher at the moment but it is more similar to the UI within Whitehall.  [Ticket](https://trello.com/c/guqmRnt9/459-major-and-minor-updates).

Screenshot:
![screen shot 2016-01-18 at 14 53 25](https://cloud.githubusercontent.com/assets/449004/12394414/9a6f77ae-bdf3-11e5-9a97-c3197cc8ea9a.png)