### PR TITLE
Schema Contract testing

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -43,7 +43,7 @@ private
       {
         f => document.send(f)
       }
-    end.reduce({}, :merge).merge(document_type: document.format)
+    end.reduce({}, :merge).merge(document_type: document.format).reject { |k, v| v.blank? }
   end
 
   def public_updated_at

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -12,7 +12,7 @@ class DocumentPresenter
       base_path: document.base_path,
       title: document.title,
       description: document.summary,
-      format: document.format,
+      format: "specialist_document",
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
       locale: "en",

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -47,7 +47,7 @@ private
   end
 
   def public_updated_at
-    document.public_updated_at.to_s
+    document.public_updated_at.to_datetime.rfc3339
   end
 
   def change_history

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -13,7 +13,7 @@ class SearchPresenter
       link: document.base_path,
       indexable_content: indexable_content,
       organisations: organisation_slugs,
-      public_timestamp: document.public_updated_at.to_s,
+      public_timestamp: document.public_updated_at.to_datetime.rfc3339,
     }.merge(document.format_specific_metadata)
   end
 

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -12,26 +12,24 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "base_path" => "/cma-cases/example-cma-case",
       "title" => "Example CMA Case",
       "description" => "This is the summary of an example CMA case",
-      "format" => "cma_case",
+      "format" => "specialist_document",
       "publishing_app" => "specialist-publisher",
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-12-03 16:59:13 UTC",
+      "public_updated_at" => "2015-12-03T16:59:13+00:00",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
           "opened_date" => "2014-01-01",
-          "closed_date" => "",
           "case_type" => "ca98-and-civil-cartels",
           "case_state" => "open",
           "market_sector" => ["energy"],
-          "outcome_type" => "",
           "document_type" => "cma_case",
         },
         "change_history" => [
           {
-            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "public_timestamp" => "2015-12-03T16:59:13+00:00",
             "note" => "First published."
           }
         ]

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
       "base_path" => "/cma-cases/example-cma-case",
       "title" => "Example CMA Case",
       "description" => "This is the summary of an example CMA case",
-      "format" => "cma_case",
+      "format" => "specialist_document",
       "publishing_app" => "specialist-publisher",
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
@@ -23,16 +23,14 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
           "opened_date" => "2014-01-01",
-          "closed_date" => "",
           "case_type" => "ca98-and-civil-cartels",
           "case_state" => "open",
           "market_sector" => ["energy"],
-          "outcome_type" => "",
           "document_type" => "cma_case",
         },
         "change_history" => [
           {
-            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "public_timestamp" => "2015-11-23T14:07:47.240Z",
             "note" => "First published."
           }
         ]
@@ -79,20 +77,20 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
     @changed_json = cma_case_content_item.merge({
       "title" => "Changed title",
       "description" => "Changed summary",
-      "public_updated_at" => "2015-12-03 16:59:13 UTC",
+      "public_updated_at" => "2015-12-03T16:59:13+00:00",
     })
 
     @changed_json["details"].merge!(
       "change_history" => [
         {
-          "public_timestamp" => "2015-12-03 16:59:13 UTC",
+          "public_timestamp" => "2015-12-03T16:59:13+00:00",
           "note" => "First published.",
         }
       ]
     )
 
     @changed_json.delete("publication_state")
-    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+    Timecop.freeze(Time.parse("2015-12-03T16:59:13+00:00"))
   end
 
   after do
@@ -114,7 +112,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
 
     assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(@changed_json))
     expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    expect(@changed_json["public_updated_at"]).to eq("2015-12-03 16:59:13 UTC")
+    expect(@changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13+00:00")
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Changed title")

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -12,27 +12,25 @@ RSpec.feature "Editing a published CMA case", type: :feature do
       "base_path" => "/cma-cases/example-cma-case",
       "title" => "Example CMA Case",
       "description" => "This is the summary of a published example CMA case",
-      "format" => "cma_case",
+      "format" => "specialist_document",
       "publishing_app" => "specialist-publisher",
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-11-23 14:07:47 UTC",
+      "public_updated_at" => "2015-11-23T14:07:47+00:00",
       "publication_state" => "live",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
           "opened_date" => "2014-01-01",
-          "closed_date" => "",
           "case_type" => "ca98-and-civil-cartels",
           "case_state" => "open",
           "market_sector" => ["energy"],
-          "outcome_type" => "",
           "document_type" => "cma_case",
         },
         "change_history" => [
           {
-            "public_timestamp" => "2015-11-23T14:07:47.240Z",
+            "public_timestamp" => "2015-11-23T14:07:47+00:00",
             "note" => "First published."
           }
         ]
@@ -143,7 +141,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(changed_json))
     expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    expect(changed_json["public_updated_at"]).to eq("2015-11-23 14:07:47 UTC")
+    expect(changed_json["public_updated_at"]).to eq("2015-11-23T14:07:47+00:00")
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Minor update title")
@@ -153,11 +151,11 @@ RSpec.feature "Editing a published CMA case", type: :feature do
     changed_json = published_cma_case_content_item.merge({
       "title" => "Major update title",
       "description" => "Major update summary",
-      "public_updated_at" => "2015-12-03 16:59:13 UTC",
+      "public_updated_at" => "2015-12-03T16:59:13+00:00",
       "update_type" => "major",
     })
 
-    changed_json["details"]["change_history"] << { "public_timestamp" => "2015-12-03 16:59:13 UTC", "note" => "This is a change note." }
+    changed_json["details"]["change_history"] << { "public_timestamp" => "2015-12-03T16:59:13+00:00", "note" => "This is a change note." }
 
     changed_json.delete("publication_state")
 
@@ -178,7 +176,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_including(changed_json))
     expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    expect(changed_json["public_updated_at"]).to eq("2015-12-03 16:59:13 UTC")
+    expect(changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13+00:00")
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Major update title")

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -17,26 +17,24 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "base_path" => "/cma-cases/example-cma-case",
       "title" => "Example CMA Case",
       "description" => "This is the summary of example CMA case",
-      "format" => "cma_case",
+      "format" => "specialist_document",
       "publishing_app" => "specialist-publisher",
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-11-16 11:53:30 +0000",
+      "public_updated_at" => "2015-11-16T11:53:30+00:00",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
           "opened_date" => "2014-01-01",
-          "closed_date" => "",
           "case_type" => "ca98-and-civil-cartels",
           "case_state" => "open",
           "market_sector" => ["energy"],
-          "outcome_type" => "",
           "document_type" => "cma_case",
         },
         "change_history" => [
           {
-            "public_timestamp" => "2015-12-03 16:59:13 UTC",
+            "public_timestamp" => "2015-11-16T11:53:30+00:00",
             "note" => "First published."
           }
         ]
@@ -94,13 +92,13 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "description" => "This is the summary of example CMA case",
       "link" => "/cma-cases/example-cma-case",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-      "public_timestamp" => "2015-11-16 11:53:30 +0000",
+      "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "opened_date" => "2014-01-01",
-      "closed_date" => "",
+      "closed_date" => nil,
       "case_type" => "ca98-and-civil-cartels",
       "case_state" => "open",
       "market_sector" => ["energy"],
-      "outcome_type" => "",
+      "outcome_type" => nil,
       "organisations" => ["competition-and-markets-authority"],
     }
   end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -155,6 +155,7 @@ describe CmaCase do
       expect(c.save!).to eq(true)
 
       assert_publishing_api_put_content(c.content_id, request_json_including(cma_case))
+      expect(cma_case.to_json).to be_valid_against_schema('specialist_document')
     end
   end
 

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -8,22 +8,20 @@ describe CmaCase do
       "base_path" => "/cma-cases/example-cma-case-#{n}",
       "title" => "Example CMA Case #{n}",
       "description" => "This is the summary of example CMA case #{n}",
-      "format" => "cma_case",
+      "format" => "specialist_document",
       "publishing_app" => "specialist-publisher",
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
+      "public_updated_at" => "2015-11-16T11:53:30",
       "publication_state" => "draft",
       "details" => {
         "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
         "metadata" => {
           "opened_date" => "2014-01-01",
-          "closed_date" => "",
           "case_type" => "ca98-and-civil-cartels",
           "case_state" => "open",
           "market_sector" => ["energy"],
-          "outcome_type" => "",
           "document_type" => "cma_case",
         },
         "change_history" => [],
@@ -75,13 +73,13 @@ describe CmaCase do
       "description" => "This is the summary of example CMA case 0",
       "link" => "/cma-cases/example-cma-case-0",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-      "public_timestamp" => "2015-11-16 11:53:30 +0000",
+      "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "opened_date" => "2014-01-01",
-      "closed_date" => "",
+      "closed_date" => nil,
       "case_type" => "ca98-and-civil-cartels",
       "case_state" => "open",
       "market_sector" => ["energy"],
-      "outcome_type" => "",
+      "outcome_type" => nil,
       "organisations" => ["competition-and-markets-authority"],
     }
   end
@@ -140,15 +138,14 @@ describe CmaCase do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-
       cma_case = @cma_cases[0]
 
       cma_case.delete("publication_state")
-      cma_case.merge!("public_updated_at" => "2015-12-18 10:12:26 UTC")
+      cma_case.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
       cma_case["details"].merge!(
         "change_history" => [
           {
-            "public_timestamp" => "2015-12-18 10:12:26 UTC",
+            "public_timestamp" => "2015-12-18T10:12:26+00:00",
             "note" => "First published.",
           }
         ]


### PR DESCRIPTION
This PR adds contract testing for the only format that Phase 2 of Specialist Publisher deals with, CMA Cases. In adding the schema contract testing I discovered that there were a few issues with the data I was sending:

- the format of the payload should be `specialist_document`
- blank metadata should be omitted from the Publishing API
- `public_updated_at` should be sent as RFC3339

This PR corrects those, updates the tests to reflect this and then tests CMA Cases against the content schema. [Ticket](https://trello.com/c/16tEBnby/444-schema-contract-testing).