### PR TITLE
Vehicle recall and faults style fixes

### DIFF
--- a/finders/metadata/vehicle-recalls-and-faults-alert.json
+++ b/finders/metadata/vehicle-recalls-and-faults-alert.json
@@ -4,7 +4,7 @@
   "format_name": "Vehicle recalls and faults",
   "name": "Vehicle recalls and faults",
   "beta": true,
-  "summary": "<p>Find out if your vehicle has been recalled by the manufacturer or has a fault. You can also search for car seats, tyres and other vehicle parts.</p>",
+  "summary": "<p>Find out if your vehicle has been recalled by the manufacturer or has a fault. You can also search for child car seats, tyres and other vehicle parts.</p>",
   "filter": {
     "document_type": "vehicle_recalls_and_faults_alert"
   },

--- a/finders/schemas/vehicle-recalls-and-faults-alert.json
+++ b/finders/schemas/vehicle-recalls-and-faults-alert.json
@@ -3,7 +3,7 @@
   "facets": [
     {
       "key": "fault_type",
-      "name": "Fault Type",
+      "name": "Fault type",
       "type": "text",
       "preposition": "of type",
       "display_as_result_metadata": true,
@@ -15,14 +15,14 @@
     },
     {
       "key": "faulty_item_type",
-      "name": "Item Type",
+      "name": "Item type",
       "type": "text",
       "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [
         {"label": "Vehicle", "value": "vehicle"},
-        {"label": "Baby seat", "value": "baby-seat"},
+        {"label": "Child car seat", "value": "child-car-seat"},
         {"label": "Tyres", "value": "tyres"},
         {"label": "Parts", "value": "parts"},
         {"label": "Agricultural equipment", "value": "agricultural-equipment"},
@@ -63,7 +63,7 @@
     },
     {
       "key": "serial_number",
-      "name": "Serial number/Vehicle ID",
+      "name": "Serial number or vehicle ID",
       "short_name": "SN",
       "type": "text",
       "display_as_result_metadata": false,


### PR DESCRIPTION
Corrections to terminology and style from the Driver and Vehicle Standards Agency (DVSA). Until recently, I worked at DVSA, and I was involved in setting up this finder during firebreak in April 2015. Renamed the incorrect terms 'baby seats' and 'car seats' to 'child car seats'. Style guide corrections to filter options.