### PR TITLE
Reject specialist documents which dont match format

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -158,7 +158,14 @@ class Document
       ]
     ).to_ostruct
 
-    response.map { |payload| self.find(payload.content_id) }
+    # Fetch individual payloads for each `specialist_document`
+    payloads = response.map { |payload| publishing_api.get_content(payload.content_id).to_ostruct }
+
+    # Select the ones which match the current format
+    payloads_of_format = payloads.select { |payload| payload.details.metadata.document_type == self.format }
+
+    # Deserialize the payloads into real Objects and return them
+    payloads_of_format.map { |payload| self.from_publishing_api(payload) }
   end
 
   def self.find(content_id)

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -37,6 +37,18 @@ describe CmaCase do
     }
   end
 
+  let(:non_cma_case_content_item) {
+    {
+      "content_id" => SecureRandom.uuid,
+      "format" => "specialist_document",
+      "details" => {
+        "metadata" => {
+          "document_type" => "not_a_cma_case",
+        },
+      },
+    }
+  }
+
   let(:cma_org_content_item) {
     {
       "base_path" => "/government/organisations/competition-and-markets-authority",
@@ -82,10 +94,10 @@ describe CmaCase do
       "outcome_type" => nil,
       "organisations" => ["competition-and-markets-authority"],
     }
-  end
+  }
 
   before do
-    fields = [
+    @fields = [
       :base_path,
       :content_id,
       :title,
@@ -100,7 +112,7 @@ describe CmaCase do
       @cma_cases << cma_case_content_item(n)
     end
 
-    publishing_api_has_fields_for_format('specialist_document', @cma_cases, fields)
+    publishing_api_has_fields_for_format('specialist_document', @cma_cases, @fields)
 
     @cma_cases.each do |cma_case|
       publishing_api_has_item(cma_case)
@@ -111,6 +123,14 @@ describe CmaCase do
 
   context "#all" do
     it "returns all CMA Cases" do
+      expect(described_class.all.length).to be(@cma_cases.length)
+    end
+
+    it "rejects any non CMA Cases" do
+      all_specialist_documents = [non_cma_case_content_item] + @cma_cases
+      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , @fields)
+      publishing_api_has_item(non_cma_case_content_item)
+
       expect(described_class.all.length).to be(@cma_cases.length)
     end
   end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -37,7 +37,7 @@ describe CmaCase do
     }
   end
 
-  def cma_org_content_item
+  let(:cma_org_content_item) {
     {
       "base_path" => "/government/organisations/competition-and-markets-authority",
       "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
@@ -65,9 +65,9 @@ describe CmaCase do
       "description" => nil,
       "details" => {}
     }
-  end
+  }
 
-  def indexable_attributes
+  let(:indexable_attributes) {
     {
       "title" => "Example CMA Case 0",
       "description" => "This is the summary of example CMA case 0",


### PR DESCRIPTION
With the changes introduced in #630, all Documents which Specialist Publisher publishes are sent to the Publishing API as `specialist_document`s. As @jamiecobbett correctly pointed out, this meant we couldn't filter by format. After chatting with numerous people I decided that we can filter on the `document_type` attribute which is already part of the metadata. This may be moved to the root level of the `payload` to allow other Applications to behave similarly.

This PR also changes some of the rspec methods in the test to `let` blocks as there was some weird behaviour around using `SecureRandom` in a method and I decided to make it more consistent within the test.