### PR TITLE
Access limiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.3'
   gem 'simplecov', '0.10.0', require: false
   gem 'simplecov-rcov', '0.2.3', require: false
-  gem 'database_cleaner', '1.5.0'
+  gem 'database_cleaner', '1.5.1'
   gem 'factory_girl'
   gem "capybara", "2.5.0"
   gem 'capybara-webkit', '1.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     coderay (1.1.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    database_cleaner (1.5.0)
+    database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -284,7 +284,7 @@ DEPENDENCIES
   binding_of_caller (~> 0.7.2)
   capybara (= 2.5.0)
   capybara-webkit (= 1.7.1)
-  database_cleaner (= 1.5.0)
+  database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
   gds-api-adapters (= 26.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ private
 
   def document_types
     # For each format that follows the standard naming convention, this
-    # method takes the title and name of the model class of eacg format
+    # method takes the title and name of the model class of each format
     # like this:
     #
     # data = {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,14 @@ private
     document_types.fetch(params.fetch(:document_type, nil), nil)
   end
 
+  def formats_user_can_access
+    if current_user.permissions.include?('gds_editor')
+      document_types
+    else
+      Hash(document_types.select { |k, v| v.organisations.include?(current_user.organisation_content_id) })
+    end
+  end
+
   # This Struct is for the document_types method below
   FormatStruct = Struct.new(:klass, :document_type, :format_name, :title, :organisations)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ private
   end
 
   # This Struct is for the document_types method below
-  FormatStruct = Struct.new(:klass, :document_type, :format_name, :title)
+  FormatStruct = Struct.new(:klass, :document_type, :format_name, :title, :organisations)
 
   def document_types
     # For each format that follows the standard naming convention, this
@@ -30,12 +30,13 @@ private
     # which will become this:
     #
     # {
-    #   "gds-reports" => {
+    #   "gds-reports" => FormatStruct.new(
     #     klass: GdsReports
     #     document_type: "gds-reports",
     #     format_name: "gds_report",
-    #     title: "GDS Report"
-    #   }
+    #     title: "GDS Report",
+    #     organisations: ["a-content-id"],
+    #   )
     # }
 
     data = {
@@ -49,7 +50,8 @@ private
           v,
           k.downcase.parameterize.pluralize,
           k.downcase.parameterize.underscore,
-          k
+          k,
+          v.organisations,
         )
       }
     end.reduce({}, :merge)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,6 +82,10 @@ class Document
     finder_schema.organisations
   end
 
+  def self.organisations
+    new.organisations
+  end
+
   def format_specific_metadata
     format_specific_fields.each_with_object({}) do |f, fields|
       fields[f] = send(f)

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.feature "Access control", type: :feature do
+  def log_in_as_editor(editor)
+    user = FactoryGirl.create(editor)
+    GDS::SSO.test_user = user
+  end
+
+  before do
+    fields = [
+      :base_path,
+      :content_id,
+      :title,
+      :public_updated_at,
+      :details,
+      :description,
+    ]
+
+    publishing_api_has_fields_for_format('specialist_document', [], fields)
+  end
+
+  context "as a CMA Editor" do
+    before do
+      log_in_as_editor(:cma_editor)
+    end
+
+    scenario "visiting /cma-cases" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("CMA Cases")
+    end
+
+    scenario "visiting /aaib-reports" do
+      visit "/aaib-reports"
+
+      expect(page.current_path).to eq("/cma-cases")
+      expect(page).to have_content("You aren't permitted to access AAIB Reports")
+    end
+  end
+
+  context "as an AAIB Editor" do
+    before do
+      log_in_as_editor(:aaib_editor)
+    end
+
+    scenario "visiting /aaib-reports" do
+      visit "/aaib-reports"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("AAIB Reports")
+    end
+
+    scenario "visiting /cma-cases" do
+      visit "/cma-cases"
+
+      expect(page.current_path).to eq("/aaib-reports")
+      expect(page).to have_content("You aren't permitted to access CMA Cases")
+    end
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -15,6 +15,12 @@ FactoryGirl.define do
 
   factory :cma_editor, parent: :user do
     organisation_slug "competition-and-markets-authority"
+    organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+  end
+
+  factory :aaib_editor, parent: :user do
+    organisation_slug "air-accidents-investigation-branch"
+    organisation_content_id "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,8 @@ Dir[Rails.root.join("features/support/**/*_helpers.rb")]
   .each { |f| require f }
 
 require "database_cleaner"
-# DatabaseCleaner[:mongoid].strategy = :truncation
-# DatabaseCleaner.clean
+DatabaseCleaner[:mongoid].strategy = :truncation
+DatabaseCleaner.clean
 
 require 'capybara/rspec'
 require 'capybara/webkit/matchers'


### PR DESCRIPTION
This PR introduces Access limiting by Organisation to Specialist Publisher Phase 2. It does this by comparing the `organisation_content_id`s listed in the Finder schema to the `organisation_content_id` received from Signon as part of the User hash, using this to get a list of the formats that the User can access, and on every action checking that the format they're attempting to access is within that list. 

This PR also updates `database_cleaner` to a version which works with Mongoid and fixes a typo.

[Ticket](https://trello.com/c/ge13v8RF/474-org-permissions).