### PR TITLE
Multiple finder nav

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ private
   end
 
   def formats_user_can_access
-    if current_user.permissions.include?('gds_editor')
+    if current_user.gds_editor?
       document_types
     else
       Hash(document_types.select { |k, v| v.organisations.include?(current_user.organisation_content_id) })

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,8 +48,8 @@ private
     # }
 
     data = {
-      "CMA Case" => CmaCase,
       "AAIB Report" => AaibReport,
+      "CMA Case" => CmaCase,
     }
 
     data.map do |k, v|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_filter :require_signin_permission!
 
   helper_method :current_format
+  helper_method :formats_user_can_access
 
 private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,8 @@ class User
   field :organisation_content_id, type: String
   field :disabled, type: Boolean, default: false
 
+  def gds_editor?
+    permissions.include?('gds_editor')
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,23 @@
 <% content_for :app_title, "GOV.UK Specialist Publisher" %>
 
 <% content_for :navbar_items do %>
+  <% if current_user.gds_editor? %>
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <%= current_format.title.pluralize %>
+        <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu" role="menu">
+  <% end %>
 
+  <% formats_user_can_access.each do |key, value| %>
+    <li><%= link_to value.title.pluralize, documents_path(key) %></li>
+  <% end %>
+
+  <% if current_user.gds_editor? %>
+      </ul>
+    </li>
+  <% end %>
 <% end %>
 
 <% content_for :content do %>


### PR DESCRIPTION
This commit pulls over the Multiple Finder from Specialist Publisher. The Frontend is very similar to Master. If you're a `gds_editor`, it will render the list as a dropdown. If not, it will render each format the User have access to as an element in the Nav. [Ticket](https://trello.com/c/oAZWkOFl/473-multiple-finder-nav).

## Screenshot:
![screen shot 2016-01-28 at 15 00 42](https://cloud.githubusercontent.com/assets/449004/12648407/baba8a04-c5d1-11e5-8285-e571e06ca899.png)
