### PR TITLE
Refactor document base_path

### DIFF
--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -22,8 +22,4 @@ class AaibReport < Document
   def self.format
     "aaib_report"
   end
-
-  def public_path
-    "/aaib-reports"
-  end
 end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -24,8 +24,4 @@ class CmaCase < Document
   def self.format
     "cma_case"
   end
-
-  def public_path
-    "/cma-cases"
-  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -29,7 +29,7 @@ class Document
   end
 
   def base_path
-    @base_path ||= "#{public_path}/#{title.parameterize}"
+    @base_path ||= "#{finder_schema.base_path}/#{title.parameterize}"
   end
 
   def format
@@ -42,10 +42,6 @@ class Document
 
   def phase
     "live"
-  end
-
-  def public_path
-    raise NoMethodError
   end
 
   %w{draft live redrafted}.each do |state|

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -1,9 +1,10 @@
 class FinderSchema
 
-  attr_reader :organisations
+  attr_reader :base_path, :organisations
 
   def initialize(schema_type)
     @schema ||= load_schema_for(schema_type)
+    @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
   end
 


### PR DESCRIPTION
This is already present in the schema so we can remove the hardcoded string from the Model and instead pull it from the schema. This commit also drops the method entirely and changes the call to it to be direct from within the `Document.base_path` method.