### PR TITLE
Rename format to document type

### DIFF
--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -19,7 +19,7 @@ class AaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def self.format
+  def self.document_type
     "aaib_report"
   end
 end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -21,7 +21,7 @@ class CmaCase < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def self.format
+  def self.document_type
     "cma_case"
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -32,11 +32,11 @@ class Document
     @base_path ||= "#{finder_schema.base_path}/#{title.parameterize}"
   end
 
-  def format
-    self.class.format
+  def document_type
+    self.class.document_type
   end
 
-  def self.format
+  def self.document_type
     raise NotImplementedError
   end
 
@@ -161,8 +161,8 @@ class Document
     # Fetch individual payloads for each `specialist_document`
     payloads = response.map { |payload| publishing_api.get_content(payload.content_id).to_ostruct }
 
-    # Select the ones which match the current format
-    payloads_of_format = payloads.select { |payload| payload.details.metadata.document_type == self.format }
+    # Select the ones which match the current document type
+    payloads_of_format = payloads.select { |payload| payload.details.metadata.document_type == self.document_type }
 
     # Deserialize the payloads into real Objects and return them
     payloads_of_format.map { |payload| self.from_publishing_api(payload) }
@@ -203,7 +203,7 @@ class Document
       update_type = self.update_type || 'major'
       publish_request = publishing_api.publish(content_id, update_type)
       rummager_request = rummager.add_document(
-        format,
+        document_type,
         base_path,
         indexable_document.to_json,
       )
@@ -227,7 +227,7 @@ class Document
   end
 
   def finder_schema
-    @finder_schema ||= FinderSchema.new(format.pluralize)
+    @finder_schema ||= FinderSchema.new(document_type.pluralize)
   end
   private :finder_schema
 

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -43,7 +43,7 @@ private
       {
         f => document.send(f)
       }
-    }.reduce({}, :merge).merge(document_type: document.format).reject { |k, v| v.blank? }
+    }.reduce({}, :merge).merge(document_type: document.document_type).reject { |k, v| v.blank? }
   end
 
   def public_updated_at


### PR DESCRIPTION
As this is what it's called within the Publishing API, it makes sense to rename this to `document_type`.