### PR TITLE
Add Manual Sections relationship to links

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -83,6 +83,7 @@ private
   def links_data
     {
       organisations: [organisation.details.content_id],
+      sections: manual.documents.map(&:id),
     }
   end
 

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -48,6 +48,7 @@ private
       locale: "en",
       links: {
         organisations: [organisation.details.content_id],
+        manual: [manual.id],
       },
     }
   end

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -32,6 +32,7 @@ describe ManualPublishingAPIExporter do
     [
       double(
         :document,
+        id: "60023f27-0657-4812-9339-264f1c0fd90d",
         attributes: document_attributes,
         minor_update?: false,
       )
@@ -172,6 +173,7 @@ describe ManualPublishingAPIExporter do
       hash_including(
         links: {
           organisations: ["d94d63a5-ce8e-40a1-ab4c-4956eab27259"],
+          sections: ["60023f27-0657-4812-9339-264f1c0fd90d"],
         }
       )
     )

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -28,6 +28,7 @@ describe ManualSectionPublishingAPIExporter do
   let(:manual) {
     double(
       :manual,
+      id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       attributes: {
         slug: manual_slug,
         organisation_slug: "cabinet-office",
@@ -113,6 +114,7 @@ describe ManualSectionPublishingAPIExporter do
       hash_including(
         links: {
           organisations: ["d94d63a5-ce8e-40a1-ab4c-4956eab27259"],
+          manual: ["52ab9439-95c8-4d39-9b83-0a2050a0978b"],
         }
       )
     )


### PR DESCRIPTION
When exporting the Manual and its' Sections to the Publishing API, it currently associates these by `base_path`s. In the V2 world we need to find these using `content_id`s so this commit updates the exporters to send them as part of the `links` hash.

Relies on https://github.com/alphagov/govuk-content-schemas/pull/224 and https://github.com/alphagov/govuk-content-schemas/pull/226 being merged first.