### PR TITLE
Refactor Document.document_type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,11 +40,11 @@ private
     #
     # {
     #   "gds-reports" => FormatStruct.new(
-    #     klass: GdsReports
-    #     document_type: "gds-reports",
-    #     format_name: "gds_report",
-    #     title: "GDS Report",
-    #     organisations: ["a-content-id"],
+    #     klass: GdsReports, # This is the class name of the model
+    #     document_type: "gds-reports", # This is internally used for building urls
+    #     format_name: "gds_report", # This is used for fetching the params of the format
+    #     title: "GDS Report", # Rendered as the format name to the User
+    #     organisations: ["a-content-id"], # Content IDs for the Orgs fetched from the schema
     #   )
     # }
 

--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -19,7 +19,7 @@ class AaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def self.document_type
+  def self.publishing_api_document_type
     "aaib_report"
   end
 end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -21,7 +21,7 @@ class CmaCase < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def self.document_type
+  def self.publishing_api_document_type
     "cma_case"
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -32,11 +32,13 @@ class Document
     @base_path ||= "#{finder_schema.base_path}/#{title.parameterize}"
   end
 
-  def document_type
-    self.class.document_type
+  def publishing_api_document_type
+    self.class.publishing_api_document_type
   end
 
-  def self.document_type
+  def self.publishing_api_document_type
+    # This is the string sent as `document_type` in the `details["metadata"]` hash
+    # and should be redefined within the child classes
     raise NotImplementedError
   end
 
@@ -162,7 +164,7 @@ class Document
     payloads = response.map { |payload| publishing_api.get_content(payload.content_id).to_ostruct }
 
     # Select the ones which match the current document type
-    payloads_of_format = payloads.select { |payload| payload.details.metadata.document_type == self.document_type }
+    payloads_of_format = payloads.select { |payload| payload.details.metadata.document_type == self.publishing_api_document_type }
 
     # Deserialize the payloads into real Objects and return them
     payloads_of_format.map { |payload| self.from_publishing_api(payload) }
@@ -227,7 +229,7 @@ class Document
   end
 
   def finder_schema
-    @finder_schema ||= FinderSchema.new(document_type.pluralize)
+    @finder_schema ||= FinderSchema.new(publishing_api_document_type.pluralize)
   end
   private :finder_schema
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,6 +42,10 @@ class Document
     raise NotImplementedError
   end
 
+  def search_document_type
+    finder_schema.document_type_filter
+  end
+
   def phase
     "live"
   end
@@ -205,7 +209,7 @@ class Document
       update_type = self.update_type || 'major'
       publish_request = publishing_api.publish(content_id, update_type)
       rummager_request = rummager.add_document(
-        document_type,
+        search_document_type,
         base_path,
         indexable_document.to_json,
       )

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -13,8 +13,7 @@ class RaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def self.document_type
+  def self.publishing_api_document_type
     "raib_report"
   end
 end
-

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -43,7 +43,7 @@ private
       {
         f => document.send(f)
       }
-    }.reduce({}, :merge).merge(document_type: document.document_type).reject { |k, v| v.blank? }
+    }.reduce({}, :merge).merge(document_type: document.publishing_api_document_type).reject { |k, v| v.blank? }
   end
 
   def public_updated_at

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -1,11 +1,12 @@
 class FinderSchema
 
-  attr_reader :base_path, :organisations
+  attr_reader :base_path, :organisations, :document_type_filter
 
   def initialize(schema_type)
     @schema ||= load_schema_for(schema_type)
     @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
+    @document_type_filter = schema.fetch("filter", {}).fetch("document_type")
   end
 
   def facets


### PR DESCRIPTION
This PR separates the `Document.document_type` method into `publishing_api_document_type` and `search_document_type`. This is needed for the formats in which these 2 strings are different. The `search_document_type` is the same as the `filter["document_type"]` in the Schema, so this PR also pulls the string from there.

Some comments have been added to the FormStruct methods within the application_controller to describe to what they are and what they are used for.