### PR TITLE
Speed up sub-format check

### DIFF
--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -10,10 +10,6 @@ RSpec.feature "Access control", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     publishing_api_has_fields_for_format('specialist_document', [], fields)

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -66,10 +66,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     publishing_api_has_fields_for_format('specialist_document', [cma_case_content_item], fields)

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -64,10 +64,6 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     publishing_api_has_fields_for_format('specialist_document', [cma_case_content_item], fields)

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -100,10 +100,6 @@ RSpec.feature "Editing a published CMA case", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     publishing_api_has_fields_for_format('specialist_document', [published_cma_case_content_item], fields)

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -109,10 +109,6 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     publishing_api_has_fields_for_format('specialist_document', [cma_case_content_item], fields)

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -58,10 +58,6 @@ RSpec.feature "Viewing a specific case", type: :feature do
     fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     cma_cases = []

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -37,6 +37,7 @@ describe AaibReport do
   let(:non_aaib_report_content_item) {
     {
       "content_id" => SecureRandom.uuid,
+      "base_path" => "/other-documents/not-an-aaib-report",
       "format" => "specialist_document",
       "details" => {
         "metadata" => {
@@ -92,10 +93,6 @@ describe AaibReport do
     @fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     @aaib_reports = []

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -40,6 +40,7 @@ describe CmaCase do
   let(:non_cma_case_content_item) {
     {
       "content_id" => SecureRandom.uuid,
+      "base_path" => "/other-documents/not-a-cma-case",
       "format" => "specialist_document",
       "details" => {
         "metadata" => {
@@ -100,10 +101,6 @@ describe CmaCase do
     @fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     @cma_cases = []

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -36,6 +36,7 @@ describe MaibReport do
   let(:non_maib_report_content_item) {
     {
       "content_id" => SecureRandom.uuid,
+      "base_path" => "/other-reports/not-a-maib-report",
       "format" => "specialist_document",
       "details" => {
         "metadata" => {
@@ -92,10 +93,6 @@ describe MaibReport do
     @fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     @maib_reports = []

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -36,6 +36,7 @@ describe RaibReport do
   let(:non_raib_report_content_item) {
     {
       "content_id" => SecureRandom.uuid,
+      "base_path" => "/other-documents/not-a-raib-report",
       "format" => "specialist_document",
       "details" => {
         "metadata" => {
@@ -92,10 +93,6 @@ describe RaibReport do
     @fields = [
       :base_path,
       :content_id,
-      :title,
-      :public_updated_at,
-      :details,
-      :description,
     ]
 
     @raib_reports = []


### PR DESCRIPTION
- This avoids making lots of requests to get expanded `details`, and
  just checks `base_path` the finder's base path, as that's all we need.

(Paired completely with @tommyp on this.)