### PR TITLE
Bump gds-api-adapters for more detailed errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "logstasher", "0.4.8"
 gem "mongoid", "2.5.2"
 gem "mongoid_rails_migrations", "1.0.0"
 gem "multi_json", "1.10.0"
-gem "plek", "1.7.0"
+gem "plek", "1.12.0"
 gem "quiet_assets", "1.0.3"
 gem "rack", "~> 1.4.6" # explicitly requiring patched version re: CVE-2015-3225
 gem "sidekiq", "3.2.1"
@@ -37,7 +37,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", :path => "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "23.1.0"
+  gem "gds-api-adapters", "28.0.1"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20160128)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
@@ -99,11 +99,11 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (23.1.0)
+    gds-api-adapters (28.0.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (10.0.0)
@@ -193,7 +193,7 @@ GEM
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.5.11)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -215,7 +215,7 @@ GEM
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
     phantomjs (1.9.7.1)
-    plek (1.7.0)
+    plek (1.12.0)
     poltergeist (1.5.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -232,7 +232,7 @@ GEM
     rack (1.4.7)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-protection (1.5.2)
       rack
@@ -348,7 +348,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.8.2)
       kgio (~> 2.6)
       rack
@@ -380,7 +380,7 @@ DEPENDENCIES
   faraday (= 0.9.0)
   fetchable (= 1.0.0)
   foreman (= 0.74.0)
-  gds-api-adapters (= 23.1.0)
+  gds-api-adapters (= 28.0.1)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.11.0)
   govspeak (= 3.1.0)
@@ -396,7 +396,7 @@ DEPENDENCIES
   mongoid_rails_migrations (= 1.0.0)
   multi_json (= 1.10.0)
   phantomjs (>= 1.9.7.1)
-  plek (= 1.7.0)
+  plek (= 1.12.0)
   poltergeist (= 1.5.0)
   pry
   quiet_assets (= 1.0.3)


### PR DESCRIPTION
There's sometimes [an error](https://errbit.integration.publishing.service.gov.uk/apps/52fdf5510da11524c3000004/problems/56bdb90b65786306919e0800) when [it tries to deploy to the integration environment](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/1524/console) which
this will help me investigate. Also: better errors are better.

Since 27.1.0, gds-api-adapters includes the request body in the error message,
allowing you to see much more detail by default. This is particularly helpful
when trying to debug pushing to the publishing-api.

I've bumped to the latest gds-api-adapters because there's no reason not to,
and it includes some useful changes. I had to bump plek because
gds-api-adapters needed me to.