### PR TITLE
Update model specs

### DIFF
--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -110,7 +110,7 @@ describe AaibReport do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context "#all" do
+  describe "#all" do
     it "returns all AAIB Reports" do
       expect(described_class.all.length).to be(@aaib_reports.length)
     end
@@ -124,7 +124,7 @@ describe AaibReport do
     end
   end
 
-  context "#find" do
+  describe "#find" do
     it "returns a AAIB Report" do
       content_id = @aaib_reports[0]["content_id"]
       aaib_report = described_class.find(content_id)
@@ -137,7 +137,7 @@ describe AaibReport do
     end
   end
 
-  context "#save!" do
+  describe "#save!" do
     it "saves the AAIB Report" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
@@ -163,7 +163,7 @@ describe AaibReport do
     end
   end
 
-  context "#publish!" do
+  describe "#publish!" do
     it "publishes the AAIB Report" do
       stub_publishing_api_publish(@aaib_reports[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -97,65 +97,58 @@ describe CmaCase do
     }
   }
 
+  let(:fields) { %i[base_path content_id] }
+
+  let(:cma_cases) { 10.times.map { |n| cma_case_content_item(n) } }
+
   before do
-    @fields = [
-      :base_path,
-      :content_id,
-    ]
+    publishing_api_has_fields_for_format('specialist_document', cma_cases, fields)
 
-    @cma_cases = []
-
-    10.times do |n|
-      @cma_cases << cma_case_content_item(n)
-    end
-
-    publishing_api_has_fields_for_format('specialist_document', @cma_cases, @fields)
-
-    @cma_cases.each do |cma_case|
+    cma_cases.each do |cma_case|
       publishing_api_has_item(cma_case)
     end
 
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context "#all" do
+  describe "#all" do
     it "returns all CMA Cases" do
-      expect(described_class.all.length).to be(@cma_cases.length)
+      expect(described_class.all.length).to be(cma_cases.length)
     end
 
     it "rejects any non CMA Cases" do
-      all_specialist_documents = [non_cma_case_content_item] + @cma_cases
-      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , @fields)
+      all_specialist_documents = [non_cma_case_content_item] + cma_cases
+      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , fields)
       publishing_api_has_item(non_cma_case_content_item)
 
-      expect(described_class.all.length).to be(@cma_cases.length)
+      expect(described_class.all.length).to be(cma_cases.length)
     end
   end
 
-  context "#find" do
+  describe "#find" do
     it "returns a CMA Case" do
-      content_id = @cma_cases[0]["content_id"]
+      content_id = cma_cases[0]["content_id"]
       cma_case = described_class.find(content_id)
 
-      expect(cma_case.base_path).to     eq(@cma_cases[0]["base_path"])
-      expect(cma_case.title).to         eq(@cma_cases[0]["title"])
-      expect(cma_case.summary).to       eq(@cma_cases[0]["description"])
-      expect(cma_case.body).to          eq(@cma_cases[0]["details"]["body"])
-      expect(cma_case.opened_date).to   eq(@cma_cases[0]["details"]["metadata"]["opened_date"])
-      expect(cma_case.closed_date).to   eq(@cma_cases[0]["details"]["metadata"]["closed_date"])
-      expect(cma_case.case_type).to     eq(@cma_cases[0]["details"]["metadata"]["case_type"])
-      expect(cma_case.case_state).to    eq(@cma_cases[0]["details"]["metadata"]["case_state"])
-      expect(cma_case.market_sector).to eq(@cma_cases[0]["details"]["metadata"]["market_sector"])
-      expect(cma_case.outcome_type).to  eq(@cma_cases[0]["details"]["metadata"]["outcome_type"])
+      expect(cma_case.base_path).to     eq(cma_cases[0]["base_path"])
+      expect(cma_case.title).to         eq(cma_cases[0]["title"])
+      expect(cma_case.summary).to       eq(cma_cases[0]["description"])
+      expect(cma_case.body).to          eq(cma_cases[0]["details"]["body"])
+      expect(cma_case.opened_date).to   eq(cma_cases[0]["details"]["metadata"]["opened_date"])
+      expect(cma_case.closed_date).to   eq(cma_cases[0]["details"]["metadata"]["closed_date"])
+      expect(cma_case.case_type).to     eq(cma_cases[0]["details"]["metadata"]["case_type"])
+      expect(cma_case.case_state).to    eq(cma_cases[0]["details"]["metadata"]["case_state"])
+      expect(cma_case.market_sector).to eq(cma_cases[0]["details"]["metadata"]["market_sector"])
+      expect(cma_case.outcome_type).to  eq(cma_cases[0]["details"]["metadata"]["outcome_type"])
     end
   end
 
-  context "#save!" do
+  describe "#save!" do
     it "saves the CMA Case" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      cma_case = @cma_cases[0]
+      cma_case = cma_cases[0]
 
       cma_case.delete("publication_state")
       cma_case.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
@@ -176,13 +169,13 @@ describe CmaCase do
     end
   end
 
-  context "#publish!" do
+  describe "#publish!" do
     it "publishes the CMA Case" do
-      stub_publishing_api_publish(@cma_cases[0]["content_id"], {})
+      stub_publishing_api_publish(cma_cases[0]["content_id"], {})
       stub_any_rummager_post
       publishing_api_has_fields_for_format('organisation', [cma_org_content_item], [:base_path, :content_id])
 
-      c = described_class.find(@cma_cases[0]["content_id"])
+      c = described_class.find(cma_cases[0]["content_id"])
       expect(c.publish!).to eq(true)
 
       assert_publishing_api_publish(c.content_id)

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -108,60 +108,53 @@ describe EsiFund do
     }
   }
 
+  let(:fields) { %i[base_path content_id] }
+
+  let(:esi_funds) { 10.times.map { |n| esi_fund_content_item(n) } }
+
   before do
-    @fields = [
-      :base_path,
-      :content_id,
-    ]
+    publishing_api_has_fields_for_format('specialist_document', esi_funds, fields)
 
-    @esi_funds = []
-
-    10.times do |n|
-      @esi_funds << esi_fund_content_item(n)
-    end
-
-    publishing_api_has_fields_for_format('specialist_document', @esi_funds, @fields)
-
-    @esi_funds.each do |esi_fund|
+    esi_funds.each do |esi_fund|
       publishing_api_has_item(esi_fund)
     end
 
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context "#all" do
+  describe "#all" do
     it "returns all ESI Funds" do
-      expect(described_class.all.length).to be(@esi_funds.length)
+      expect(described_class.all.length).to be(esi_funds.length)
     end
 
     it "rejects any non ESI Funds" do
-      all_specialist_documents = [non_esi_fund_content_item] + @esi_funds
-      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , @fields)
+      all_specialist_documents = [non_esi_fund_content_item] + esi_funds
+      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , fields)
       publishing_api_has_item(non_esi_fund_content_item)
 
-      expect(described_class.all.length).to be(@esi_funds.length)
+      expect(described_class.all.length).to be(esi_funds.length)
     end
   end
 
-  context "#find" do
+  describe "#find" do
     it "returns an ESI Fund" do
-      content_id = @esi_funds[0]["content_id"]
+      content_id = esi_funds[0]["content_id"]
       esi_fund = described_class.find(content_id)
 
-      expect(esi_fund.base_path).to            eq(@esi_funds[0]["base_path"])
-      expect(esi_fund.title).to                eq(@esi_funds[0]["title"])
-      expect(esi_fund.summary).to              eq(@esi_funds[0]["description"])
-      expect(esi_fund.body).to                 eq(@esi_funds[0]["details"]["body"])
-      expect(esi_fund.closing_date).to         eq(@esi_funds[0]["details"]['metadata']["closing_date"])
+      expect(esi_fund.base_path).to            eq(esi_funds[0]["base_path"])
+      expect(esi_fund.title).to                eq(esi_funds[0]["title"])
+      expect(esi_fund.summary).to              eq(esi_funds[0]["description"])
+      expect(esi_fund.body).to                 eq(esi_funds[0]["details"]["body"])
+      expect(esi_fund.closing_date).to         eq(esi_funds[0]["details"]['metadata']["closing_date"])
     end
   end
 
-  context "#save!" do
+  describe "#save!" do
     it "saves the ESI Fund" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      esi_fund = @esi_funds[0]
+      esi_fund = esi_funds[0]
 
       esi_fund.delete("publication_state")
       esi_fund.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
@@ -182,13 +175,13 @@ describe EsiFund do
     end
   end
 
-  context "#publish!" do
+  describe "#publish!" do
     it "publishes the ESI Fund" do
-      stub_publishing_api_publish(@esi_funds[0]["content_id"], {})
+      stub_publishing_api_publish(esi_funds[0]["content_id"], {})
       stub_any_rummager_post
       publishing_api_has_fields_for_format('organisation', esi_fund_org_content_items, [:base_path, :content_id])
 
-      esi_fund = described_class.find(@esi_funds[0]["content_id"])
+      esi_fund = described_class.find(esi_funds[0]["content_id"])
       expect(esi_fund.publish!).to eq(true)
 
       assert_publishing_api_publish(esi_fund.content_id)

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -89,60 +89,53 @@ describe MaibReport do
     }
   }
 
+  let(:fields) { %i[base_path content_id] }
+
+  let(:maib_reports) { 10.times.map { |n| maib_report_content_item(n) } }
+
   before do
-    @fields = [
-      :base_path,
-      :content_id,
-    ]
+    publishing_api_has_fields_for_format('specialist_document', maib_reports, fields)
 
-    @maib_reports = []
-
-    10.times do |n|
-      @maib_reports << maib_report_content_item(n)
-    end
-
-    publishing_api_has_fields_for_format('specialist_document', @maib_reports, @fields)
-
-    @maib_reports.each do |maib_report|
+    maib_reports.each do |maib_report|
       publishing_api_has_item(maib_report)
     end
 
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context "#all" do
+  describe "#all" do
     it "returns all MAIB Reports" do
-      expect(described_class.all.length).to be(@maib_reports.length)
+      expect(described_class.all.length).to be(maib_reports.length)
     end
 
     it "rejects any non MAIB Reports" do
-      all_specialist_documents = [non_maib_report_content_item] + @maib_reports
-      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , @fields)
+      all_specialist_documents = [non_maib_report_content_item] + maib_reports
+      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , fields)
       publishing_api_has_item(non_maib_report_content_item)
 
-      expect(described_class.all.length).to be(@maib_reports.length)
+      expect(described_class.all.length).to be(maib_reports.length)
     end
   end
 
-  context "#find" do
+  describe "#find" do
     it "returns a MAIB Report" do
-      content_id = @maib_reports[0]["content_id"]
+      content_id = maib_reports[0]["content_id"]
       maib_report = described_class.find(content_id)
 
-      expect(maib_report.base_path).to            eq(@maib_reports[0]["base_path"])
-      expect(maib_report.title).to                eq(@maib_reports[0]["title"])
-      expect(maib_report.summary).to              eq(@maib_reports[0]["description"])
-      expect(maib_report.body).to                 eq(@maib_reports[0]["details"]["body"])
-      expect(maib_report.date_of_occurrence).to   eq(@maib_reports[0]["details"]["metadata"]["date_of_occurrence"])
+      expect(maib_report.base_path).to            eq(maib_reports[0]["base_path"])
+      expect(maib_report.title).to                eq(maib_reports[0]["title"])
+      expect(maib_report.summary).to              eq(maib_reports[0]["description"])
+      expect(maib_report.body).to                 eq(maib_reports[0]["details"]["body"])
+      expect(maib_report.date_of_occurrence).to   eq(maib_reports[0]["details"]["metadata"]["date_of_occurrence"])
     end
   end
 
-  context "#save!" do
+  describe "#save!" do
     it "saves the MAIB Report" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      maib_report = @maib_reports[0]
+      maib_report = maib_reports[0]
 
       maib_report.delete("publication_state")
       maib_report.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
@@ -163,13 +156,13 @@ describe MaibReport do
     end
   end
 
-  context "#publish!" do
+  describe "#publish!" do
     it "publishes the MAIB Report" do
-      stub_publishing_api_publish(@maib_reports[0]["content_id"], {})
+      stub_publishing_api_publish(maib_reports[0]["content_id"], {})
       stub_any_rummager_post
       publishing_api_has_fields_for_format('organisation', [maib_org_content_item], [:base_path, :content_id])
 
-      maib_report = described_class.find(@maib_reports[0]["content_id"])
+      maib_report = described_class.find(maib_reports[0]["content_id"])
       expect(maib_report.publish!).to eq(true)
 
       assert_publishing_api_publish(maib_report.content_id)

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -89,60 +89,53 @@ describe RaibReport do
     }
   }
 
+  let(:fields) { %i[base_path content_id] }
+
+  let(:raib_reports) { 10.times.map { |n| raib_report_content_item(n) } }
+
   before do
-    @fields = [
-      :base_path,
-      :content_id,
-    ]
+    publishing_api_has_fields_for_format('specialist_document', raib_reports, fields)
 
-    @raib_reports = []
-
-    10.times do |n|
-      @raib_reports << raib_report_content_item(n)
-    end
-
-    publishing_api_has_fields_for_format('specialist_document', @raib_reports, @fields)
-
-    @raib_reports.each do |raib_report|
+    raib_reports.each do |raib_report|
       publishing_api_has_item(raib_report)
     end
 
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context "#all" do
+  describe "#all" do
     it "returns all RAIB Reports" do
-      expect(described_class.all.length).to be(@raib_reports.length)
+      expect(described_class.all.length).to be(raib_reports.length)
     end
 
     it "rejects any non RAIB Reports" do
-      all_specialist_documents = [non_raib_report_content_item] + @raib_reports
-      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , @fields)
+      all_specialist_documents = [non_raib_report_content_item] + raib_reports
+      publishing_api_has_fields_for_format('specialist_document', all_specialist_documents , fields)
       publishing_api_has_item(non_raib_report_content_item)
 
-      expect(described_class.all.length).to be(@raib_reports.length)
+      expect(described_class.all.length).to be(raib_reports.length)
     end
   end
 
-  context "#find" do
+  describe "#find" do
     it "returns a AAIB Report" do
-      content_id = @raib_reports[0]["content_id"]
+      content_id = raib_reports[0]["content_id"]
       raib_report = described_class.find(content_id)
 
-      expect(raib_report.base_path).to            eq(@raib_reports[0]["base_path"])
-      expect(raib_report.title).to                eq(@raib_reports[0]["title"])
-      expect(raib_report.summary).to              eq(@raib_reports[0]["description"])
-      expect(raib_report.body).to                 eq(@raib_reports[0]["details"]["body"])
-      expect(raib_report.date_of_occurrence).to   eq(@raib_reports[0]["details"]["metadata"]["date_of_occurrence"])
+      expect(raib_report.base_path).to            eq(raib_reports[0]["base_path"])
+      expect(raib_report.title).to                eq(raib_reports[0]["title"])
+      expect(raib_report.summary).to              eq(raib_reports[0]["description"])
+      expect(raib_report.body).to                 eq(raib_reports[0]["details"]["body"])
+      expect(raib_report.date_of_occurrence).to   eq(raib_reports[0]["details"]["metadata"]["date_of_occurrence"])
     end
   end
 
-  context "#save!" do
+  describe "#save!" do
     it "saves the RAIB Report" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_links
 
-      raib_report = @raib_reports[0]
+      raib_report = raib_reports[0]
 
       raib_report.delete("publication_state")
       raib_report.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
@@ -163,13 +156,13 @@ describe RaibReport do
     end
   end
 
-  context "#publish!" do
+  describe "#publish!" do
     it "publishes the RAIB Report" do
-      stub_publishing_api_publish(@raib_reports[0]["content_id"], {})
+      stub_publishing_api_publish(raib_reports[0]["content_id"], {})
       stub_any_rummager_post
       publishing_api_has_fields_for_format('organisation', [raib_org_content_item], [:base_path, :content_id])
 
-      raib_report = described_class.find(@raib_reports[0]["content_id"])
+      raib_report = described_class.find(raib_reports[0]["content_id"])
       expect(raib_report.publish!).to eq(true)
 
       assert_publishing_api_publish(raib_report.content_id)


### PR DESCRIPTION
As per the comments [here](https://github.com/alphagov/specialist-publisher/pull/654#discussion_r52914670) this commit updates the model spec files to use `let`s and `describe`s.