### PR TITLE
Redirect to index if document not found

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", :path => "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "28.0.2"
+  gem "gds-api-adapters", "28.1.1"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (28.0.2)
+    gds-api-adapters (28.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -305,7 +305,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 28.0.2)
+  gds-api-adapters (= 28.1.1)
   gds-sso (= 11.0.0)
   govspeak (= 3.4.0)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -101,7 +101,14 @@ private
   end
 
   def fetch_document
-    @document = document_klass.find(params[:content_id])
+    begin
+      @document = document_klass.find(params[:content_id])
+    rescue Document::RecordNotFound => e
+      flash[:danger] = "Document not found"
+      redirect_to documents_path(document_type: document_type)
+
+      Airbrake.notify(e)
+    end
   end
 
   def filtered_params(params_of_document)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -172,8 +172,16 @@ class Document
   end
 
   def self.find(content_id)
-    self.from_publishing_api(publishing_api.get_content(content_id).to_ostruct)
+    response = publishing_api.get_content(content_id)
+
+    if response
+      self.from_publishing_api(response.to_ostruct)
+    else
+      raise RecordNotFound
+    end
   end
+
+  class RecordNotFound < StandardError; end
 
   def save!
     if self.valid?

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -92,4 +92,14 @@ RSpec.feature "Viewing a specific case", type: :feature do
     expect(page).to have_content("Energy")
   end
 
+  scenario "that doesn't exist" do
+    content_id = "a-case-that-doesnt-exist"
+    publishing_api_does_not_have_item(content_id)
+
+    visit "/cma-cases/#{content_id}"
+
+    expect(page.current_path).to eq("/cma-cases")
+    expect(page).to have_content("Document not found")
+  end
+
 end


### PR DESCRIPTION
If the User tries to visit a page for a Document which doesn't exist then this change will mean they are redirected back to the index for that format. We do this by raising a `Document::RecordNotFound` in the model and rescuing from it in the `DocumentsController`, which redirects the user to the index for that document format. This PR also bumps `gds-api-adapters` to get new `publishing_api_does_not_have_item` test helper.