### PR TITLE
Redirect to Manuals for unknown formats

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -134,8 +134,11 @@ private
   def permitted?
     if formats_user_can_access.fetch(document_type, nil)
       true
-    else
+    elsif current_format
       flash[:danger] = "You aren't permitted to access #{current_format.title.pluralize}. If you feel you've reached this in error, contact your SPOC."
+      redirect_to manuals_path
+    else
+      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
       redirect_to manuals_path
     end
   end

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -34,6 +34,13 @@ RSpec.feature "Access control", type: :feature do
       expect(page.current_path).to eq("/manuals")
       expect(page).to have_content("You aren't permitted to access AAIB Reports")
     end
+
+    scenario "visiting a format which doesn't exist" do
+      visit "/a-format-which-doesnt-exist"
+
+      expect(page.current_path).to eq("/manuals")
+      expect(page).to have_content("That format doesn't exist.")
+    end
   end
 
   context "as an AAIB Editor" do


### PR DESCRIPTION
When a User reaches an unknown format, it would 500. This change redirects the User to `/manuals` and informs them that this doesn't exist.