### PR TITLE
Redirect if manual not found

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", :path => "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "28.1.1"
+  gem "gds-api-adapters", "28.2.1"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (28.1.1)
+    gds-api-adapters (28.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -305,7 +305,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 28.1.1)
+  gds-api-adapters (= 28.2.1)
   gds-sso (= 11.0.0)
   govspeak (= 3.4.0)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -9,7 +9,14 @@ class ManualsController <  ApplicationController
   end
 
   def show
-    @manual = Manual.find(content_id: params[:content_id])
+    begin
+      @manual = Manual.find(content_id: params[:content_id])
+    rescue Manual::RecordNotFound => e
+      flash[:danger] = "Manual not found"
+      redirect_to manuals_path
+
+      Airbrake.notify(e)
+    end
   end
 
 end

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -452,5 +452,16 @@ RSpec.feature "Viewing a Manual", type: :feature do
       expect(page).to have_content("First section")
       expect(page).to have_content("Second section")
     end
+
+    scenario "which doesnt exist" do
+      content_id = "a-case-that-doesnt-exist"
+      publishing_api_does_not_have_item(content_id)
+      publishing_api_does_not_have_links(content_id)
+
+      visit "/manuals/#{content_id}"
+
+      expect(page.current_path).to eq("/manuals")
+      expect(page).to have_content("Manual not found")
+    end
   end
 end


### PR DESCRIPTION
Similar to #662 this PR will redirect the User to `manuals_path` if the Manual isn't found. We do this by raising a `Manual::RecordNotFound` in the model and rescuing from it in the `ManualsController`, which redirects the user to the `manuals_path`.