### PR TITLE
No longer sends empty organisations array to rummager

### DIFF
--- a/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
+++ b/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
@@ -8,7 +8,6 @@
   "filter": {
     "document_type": "vehicle_recalls_and_faults_alert"
   },
-  "organisations": [],
   "document_noun": "alert",
   "facets": [
     {

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -89,7 +89,6 @@ describe VehicleRecallsAndFaultsAlert do
       "alert_issue_date" => "2015-04-28",
       "build_start_date" => "2015-04-28",
       "build_end_date" => "2015-06-28",
-      "organisations" => [],
     }
   }
 


### PR DESCRIPTION
Fixes `VehicleRecallsAndFaultsAlert` model spec by removing the empty `organisations` array. This is to co-operate with [this commit](https://github.com/alphagov/specialist-publisher/commit/6a452f71e0aea76c4ba5d11710b7a7739fb15432) which does not allow blank values from metadata to be sent to Rummager.