### PR TITLE
Change employment appeal tribunal decision sub-categories validation

### DIFF
--- a/app/models/validators/employment_appeal_tribunal_decision_validator.rb
+++ b/app/models/validators/employment_appeal_tribunal_decision_validator.rb
@@ -12,6 +12,5 @@ class EmploymentAppealTribunalDecisionValidator < SimpleDelegator
   validates :tribunal_decision_categories, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_landmark, presence: true
-  validates :tribunal_decision_sub_categories, presence: true
 
 end


### PR DESCRIPTION
Domain experts want employment appeal tribunal decision sub-categories not to be mandatory as some parent categories do not have any sub-categories.

Remove the validation requiring `tribunal_decision_sub_categories` be present.