### PR TITLE
Allow multiple categories for administrative appeals tribunal decisions

### DIFF
--- a/app/exporters/formatters/utaac_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/utaac_decision_indexable_formatter.rb
@@ -9,13 +9,13 @@ private
   def extra_attributes
     {
       indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip,
-      tribunal_decision_category: entity.tribunal_decision_category,
-      tribunal_decision_category_name: expand_value(:tribunal_decision_category).first,
+      tribunal_decision_categories: entity.tribunal_decision_categories,
+      tribunal_decision_categories_name: expand_value(:tribunal_decision_categories),
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
       tribunal_decision_judges: entity.tribunal_decision_judges,
       tribunal_decision_judges_name: expand_value(:tribunal_decision_judges),
-      tribunal_decision_sub_category: entity.tribunal_decision_sub_category.first,
-      tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category).first,
+      tribunal_decision_sub_categories: entity.tribunal_decision_sub_categories,
+      tribunal_decision_sub_categories_name: expand_value(:tribunal_decision_sub_categories),
     }
   end
 

--- a/app/models/utaac_decision.rb
+++ b/app/models/utaac_decision.rb
@@ -3,9 +3,9 @@ require "document_metadata_decorator"
 class UtaacDecision < DocumentMetadataDecorator
   set_extra_field_names [
     :hidden_indexable_content,
-    :tribunal_decision_category,
+    :tribunal_decision_categories,
     :tribunal_decision_decision_date,
     :tribunal_decision_judges,
-    :tribunal_decision_sub_category
+    :tribunal_decision_sub_categories
   ]
 end

--- a/app/models/validators/utaac_decision_validator.rb
+++ b/app/models/validators/utaac_decision_validator.rb
@@ -1,7 +1,6 @@
 require "delegate"
 require "validators/date_validator"
 require "validators/safe_html_validator"
-require "validators/tribunal_decision_sub_category_relates_to_parent_validator"
 
 class UtaacDecisionValidator < SimpleDelegator
   include ActiveModel::Validations
@@ -10,9 +9,8 @@ class UtaacDecisionValidator < SimpleDelegator
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
 
-  validates :tribunal_decision_category, presence: true
+  validates :tribunal_decision_categories, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_judges, presence: true
-  validates :tribunal_decision_sub_category, tribunal_decision_sub_category_relates_to_parent: true
 
 end

--- a/app/view_adapters/utaac_decision_view_adapter.rb
+++ b/app/view_adapters/utaac_decision_view_adapter.rb
@@ -5,10 +5,10 @@ require "validators/safe_html_validator"
 class UtaacDecisionViewAdapter < DocumentViewAdapter
   attributes = [
     :hidden_indexable_content,
-    :tribunal_decision_category,
+    :tribunal_decision_categories,
     :tribunal_decision_decision_date,
     :tribunal_decision_judges,
-    :tribunal_decision_sub_category,
+    :tribunal_decision_sub_categories,
   ]
 
   def self.model_name

--- a/app/views/utaac_decisions/_form.html.erb
+++ b/app/views/utaac_decisions/_form.html.erb
@@ -4,8 +4,8 @@
     <%= render partial: "shared/form_fields", locals: { f: f } %>
     <%= render partial: "shared/form_preview" %>
 
-    <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
-    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: "select2", multiple: true, data: { placeholder: "Select sub-category when relevant" } } %>
+    <%= f.select :tribunal_decision_categories, f.object.facet_options(:tribunal_decision_categories), { label: "Categories" }, { class: 'select2', multiple: true, data: { placeholder: 'Select categories' } } %>
+    <%= f.select :tribunal_decision_sub_categories, f.object.facet_options(:tribunal_decision_sub_categories), { label: "Sub-categories" }, { class: 'select2', multiple: true, data: { placeholder: 'Select sub-categories' } } %>
     <%= f.select :tribunal_decision_judges, f.object.facet_options(:tribunal_decision_judges), { label: "Judges" }, { class: 'select2', multiple: true, data: { placeholder: 'Select judges' } } %>
     <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-08-30', class: 'form-control' %>
     <%= f.text_area :hidden_indexable_content, class: 'form-control' %>

--- a/features/support/utaac_decision_helpers.rb
+++ b/features/support/utaac_decision_helpers.rb
@@ -57,8 +57,8 @@ module UtaacDecisionHelpers
       title: "Lorem ipsum",
       summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
       body: "## Link to attachement:",
-      "Category" => "Benefits for children",
-      "Sub-category" => "Benefits for children - child benefit",
+      "Categories" => "Benefits for children",
+      "Sub-categories" => "Benefits for children - child benefit",
       "Judges" => "Angus, R",
       "Decision date" => "2015-02-02",
       "Hidden indexable content" => "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10)
@@ -69,14 +69,14 @@ module UtaacDecisionHelpers
     fields = utaac_decision_fields(overrides)
     fields.delete(:body)
     fields.delete("Hidden indexable content")
-    category = fields.delete("Category")
-    sub_category = fields.delete("Sub-category")
+    categories = fields.delete("Categories")
+    sub_categories = fields.delete("Sub-categories")
     judges = fields.delete("Judges")
 
-    fields[:tribunal_decision_category] = category.parameterize
-    fields[:tribunal_decision_category_name] = category
-    fields[:tribunal_decision_sub_category] = sub_category.parameterize
-    fields[:tribunal_decision_sub_category_name] = sub_category
+    fields[:tribunal_decision_categories] = [categories.parameterize]
+    fields[:tribunal_decision_categories_name] = [categories]
+    fields[:tribunal_decision_sub_categories] = [sub_categories.parameterize]
+    fields[:tribunal_decision_sub_categories_name] = [sub_categories]
     fields[:tribunal_decision_judges] = [judges.parameterize]
     fields[:tribunal_decision_judges_name] = [judges]
     fields[:tribunal_decision_decision_date] = fields.delete("Decision date")

--- a/finders/schemas/administrative-appeals-tribunal-decisions.json
+++ b/finders/schemas/administrative-appeals-tribunal-decisions.json
@@ -2,8 +2,8 @@
   "document_noun": "decision",
   "facets": [
     {
-      "key": "tribunal_decision_category",
-      "name": "Category",
+      "key": "tribunal_decision_categories",
+      "name": "Categories",
       "type": "text",
       "preposition": "categorised as",
       "display_as_result_metadata": false,
@@ -260,15 +260,15 @@
       ]
     },
     {
-      "key": "tribunal_decision_category_name",
-      "name": "Category name",
+      "key": "tribunal_decision_categories_name",
+      "name": "Categories name",
       "type": "text",
       "display_as_result_metadata": true,
       "filterable": false
     },
     {
-      "key": "tribunal_decision_sub_category",
-      "name": "Sub-category",
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-categories",
       "type": "text",
       "preposition": "sub-categorised as",
       "display_as_result_metadata": false,
@@ -2037,8 +2037,8 @@
       ]
     },
     {
-      "key": "tribunal_decision_sub_category_name",
-      "name": "Sub-category name",
+      "key": "tribunal_decision_sub_categories_name",
+      "name": "Sub-categories name",
       "type": "text",
       "display_as_result_metadata": true,
       "filterable": false

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -37,23 +37,6 @@ RSpec.describe AsylumSupportDecisionIndexableFormatter do
     expect(formatter.type).to eq("asylum_support_decision")
   end
 
-  context "without hidden_indexable_content" do
-    it "should have body as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-
-      allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
-    end
-  end
-
-  context "with hidden_indexable_content" do
-    it "should have hidden_indexable_content as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
-
-      indexable = formatter.indexable_attributes[:indexable_content]
-      expect(indexable).to eq("hidden indexable content text\nbody text")
-    end
-  end
+  include_examples "tribunal decision hidden_indexable_content"
 
 end

--- a/spec/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter_spec.rb
@@ -27,29 +27,12 @@ RSpec.describe EmploymentAppealTribunalDecisionIndexableFormatter do
   let(:humanized_facet_value) { double }
   include_context "schema with humanized_facet_value available"
 
-  it_should_behave_like "a specialist document indexable formatter"
+  it_behaves_like "a specialist document indexable formatter"
 
   it "should have a type of employment_appeal_tribunal_decision" do
     expect(formatter.type).to eq("employment_appeal_tribunal_decision")
   end
 
-  context "without hidden_indexable_content" do
-    it "should have body as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-
-      allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
-    end
-  end
-
-  context "with hidden_indexable_content" do
-    it "should have hidden_indexable_content as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
-
-      indexable = formatter.indexable_attributes[:indexable_content]
-      expect(indexable).to eq("hidden indexable content text\nbody text")
-    end
-  end
+  include_examples "tribunal decision hidden_indexable_content"
 
 end

--- a/spec/exporters/formatters/employment_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/employment_tribunal_decision_indexable_formatter_spec.rb
@@ -32,23 +32,6 @@ RSpec.describe EmploymentTribunalDecisionIndexableFormatter do
     expect(formatter.type).to eq("employment_tribunal_decision")
   end
 
-  context "without hidden_indexable_content" do
-    it "should have body as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-
-      allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
-    end
-  end
-
-  context "with hidden_indexable_content" do
-    it "should have hidden_indexable_content as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
-
-      indexable = formatter.indexable_attributes[:indexable_content]
-      expect(indexable).to eq("hidden indexable content text\nbody text")
-    end
-  end
+  include_examples "tribunal decision hidden_indexable_content"
 
 end

--- a/spec/exporters/formatters/tax_tribunal_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/tax_tribunal_decision_indexable_formatter_spec.rb
@@ -31,23 +31,6 @@ RSpec.describe TaxTribunalDecisionIndexableFormatter do
     expect(formatter.type).to eq("tax_tribunal_decision")
   end
 
-  context "without hidden_indexable_content" do
-    it "should have body as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-
-      allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
-    end
-  end
-
-  context "with hidden_indexable_content" do
-    it "should have hidden_indexable_content as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
-
-      indexable = formatter.indexable_attributes[:indexable_content]
-      expect(indexable).to eq("hidden indexable content text\nbody text")
-    end
-  end
+  include_examples "tribunal decision hidden_indexable_content"
 
 end

--- a/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 require "formatters/aaib_report_indexable_formatter"
 
 RSpec.describe UtaacDecisionIndexableFormatter do
-  let(:sub_category) { [double] }
   let(:document) {
     double(
       :utaac_decision,
@@ -15,10 +14,10 @@ RSpec.describe UtaacDecisionIndexableFormatter do
       public_updated_at: double,
 
       hidden_indexable_content: double,
-      tribunal_decision_category: double,
+      tribunal_decision_categories: [double],
       tribunal_decision_decision_date: double,
       tribunal_decision_judges: [double],
-      tribunal_decision_sub_category: sub_category,
+      tribunal_decision_sub_categories: [double],
     )
   }
 
@@ -29,7 +28,6 @@ RSpec.describe UtaacDecisionIndexableFormatter do
   include_context "schema with humanized_facet_value available"
 
   it_behaves_like "a specialist document indexable formatter"
-  it_behaves_like "a tribunal decision indexable formatter"
 
   it "should have a type of utaac_decision" do
     expect(formatter.type).to eq("utaac_decision")

--- a/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
@@ -33,23 +33,6 @@ RSpec.describe UtaacDecisionIndexableFormatter do
     expect(formatter.type).to eq("utaac_decision")
   end
 
-  context "without hidden_indexable_content" do
-    it "should have body as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-
-      allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
-    end
-  end
-
-  context "with hidden_indexable_content" do
-    it "should have hidden_indexable_content as its indexable_content" do
-      allow(document).to receive(:body).and_return("body text")
-      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
-
-      indexable = formatter.indexable_attributes[:indexable_content]
-      expect(indexable).to eq("hidden indexable content text\nbody text")
-    end
-  end
+  include_examples "tribunal decision hidden_indexable_content"
 
 end

--- a/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utaac_decision_indexable_formatter_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "formatters/aaib_report_indexable_formatter"
+require "formatters/utaac_decision_indexable_formatter"
 
 RSpec.describe UtaacDecisionIndexableFormatter do
   let(:document) {

--- a/spec/models/validators/employment_appeal_tribunal_decision_validator_spec.rb
+++ b/spec/models/validators/employment_appeal_tribunal_decision_validator_spec.rb
@@ -10,14 +10,16 @@ RSpec.describe EmploymentAppealTribunalDecisionValidator do
       title: double,
       summary: double,
       body: "body",
-      tribunal_decision_categories: [double],
+      tribunal_decision_categories: categories,
       tribunal_decision_decision_date: "2015-11-01",
       tribunal_decision_landmark:  double,
-      tribunal_decision_sub_categories: [double],
+      tribunal_decision_sub_categories: sub_categories,
     )
   }
   let(:document_type) { "employment_appeal_tribunal_decision" }
 
   subject(:validatable) { EmploymentAppealTribunalDecisionValidator.new(entity) }
+
+  include_examples "tribunal decision sub_categories optional"
 
 end

--- a/spec/models/validators/utaac_decision_validator_spec.rb
+++ b/spec/models/validators/utaac_decision_validator_spec.rb
@@ -10,16 +10,14 @@ RSpec.describe UtaacDecisionValidator do
       title: double,
       summary: double,
       body: "body",
-      tribunal_decision_category: category,
+      tribunal_decision_categories: [double],
       tribunal_decision_decision_date: "2015-11-01",
       tribunal_decision_judges: [double],
-      tribunal_decision_sub_category: sub_category,
+      tribunal_decision_sub_categories: [double],
     )
   }
   let(:document_type) { "utaac_decision" }
 
   subject(:validatable) { UtaacDecisionValidator.new(entity) }
-
-  it_behaves_like "tribunal decision sub_category validator"
 
 end

--- a/spec/models/validators/utaac_decision_validator_spec.rb
+++ b/spec/models/validators/utaac_decision_validator_spec.rb
@@ -10,14 +10,16 @@ RSpec.describe UtaacDecisionValidator do
       title: double,
       summary: double,
       body: "body",
-      tribunal_decision_categories: [double],
+      tribunal_decision_categories: categories,
       tribunal_decision_decision_date: "2015-11-01",
       tribunal_decision_judges: [double],
-      tribunal_decision_sub_categories: [double],
+      tribunal_decision_sub_categories: sub_categories,
     )
   }
   let(:document_type) { "utaac_decision" }
 
   subject(:validatable) { UtaacDecisionValidator.new(entity) }
+
+  include_examples "tribunal decision sub_categories optional"
 
 end

--- a/spec/support/shared/tribunal_decision_hidden_indexable_content_examples.rb
+++ b/spec/support/shared/tribunal_decision_hidden_indexable_content_examples.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.shared_examples_for "tribunal decision hidden_indexable_content" do
+
+  context "without hidden_indexable_content" do
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
+    end
+  end
+
+  context "with hidden_indexable_content" do
+    it "should have hidden_indexable_content as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
+    end
+  end
+end

--- a/spec/support/shared/tribunal_decision_sub_categories_optional_examples.rb
+++ b/spec/support/shared/tribunal_decision_sub_categories_optional_examples.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.shared_examples_for "tribunal decision sub_categories optional" do
+
+  context "when sub_categories not provided" do
+    let(:categories) { [double] }
+    let(:sub_categories) { nil }
+
+    it "is valid" do
+      expect(validatable.valid?).to be true
+    end
+  end
+
+  context "when sub_categories present" do
+    let(:categories) { [double] }
+    let(:sub_categories) { [double] }
+
+    it "is valid" do
+      expect(validatable.valid?).to be true
+    end
+  end
+
+  context "when categories not provided" do
+    let(:categories) { nil }
+    let(:sub_categories) { [double] }
+
+    it "is not valid" do
+      expect(validatable.valid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
Domain experts want to be able to set multiple tribunal decision categories and sub-categories for administrative appeals tribunal decisions.

Rename `tribunal_decision_category` to `tribunal_decision_categories`.

Rename `tribunal_decision_sub_category` to `tribunal_decision_sub_categories`.

**Requires this rummager PR is merged also: https://github.com/alphagov/rummager/pull/587**