### PR TITLE
Set start month/year for administrative appeals tribunal decisions

### DIFF
--- a/finders/metadata/administrative-appeals-tribunal-decisions.json
+++ b/finders/metadata/administrative-appeals-tribunal-decisions.json
@@ -18,6 +18,6 @@
     "singular": "Upper Tribunal Administrative Appeals Chamber decisions with the following category: ",
     "plural": "Upper Tribunal Administrative Appeals Chamber decisions with the following categories: "
   },
-  "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>Includes decisions after [month year]. Find details of <a rel=\"external\" href=\"http://www.osscsc.gov.uk/Aspx/default.aspx\">older cases.</a></p>",
+  "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>Includes decisions after January 2016. Find details of <a rel=\"external\" href=\"http://www.osscsc.gov.uk/Aspx/default.aspx\">older cases.</a></p>",
   "pre_production": true
 }


### PR DESCRIPTION
Set planned start month and year in description for administrative appeals tribunal decisions finder.

"UTAAC has said they do want to put decisions from January 2016 on the new platform, so that will be the date which needs to go on the summary."