### PR TITLE
Mark DVSA prototype finder as pre-production

### DIFF
--- a/finders/metadata/vehicle-recalls-and-faults-alert.json
+++ b/finders/metadata/vehicle-recalls-and-faults-alert.json
@@ -8,5 +8,6 @@
   "filter": {
     "document_type": "vehicle_recalls_and_faults_alert"
   },
-  "organisations": []
+  "organisations": [],
+  "pre_production": true
 }


### PR DESCRIPTION
The vehicle-recalls-faults finder should only show in integration at
present, so mark it as pre-production. This will prevent it being
published on deployment in production and staging.