### PR TITLE
Redirect a manual and sections

### DIFF
--- a/bin/redirect_manual_and_sections
+++ b/bin/redirect_manual_and_sections
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+require "manual_and_sections_redirecter"
+
+def usage
+  STDERR.puts %(
+USAGE:
+
+  ./#{File.basename(__FILE__)} base_path destination
+  )
+end
+
+unless ARGV.size == 2
+  usage
+  exit 1
+end
+
+base_path = ARGV.fetch(0)
+destination = ARGV.fetch(1)
+
+ManualAndSectionsRedirecter.new(
+  base_path: base_path,
+  destination: destination,
+).redirect

--- a/lib/manual_and_sections_redirecter.rb
+++ b/lib/manual_and_sections_redirecter.rb
@@ -1,0 +1,64 @@
+require "gds_api/content_store"
+
+class ManualAndSectionsRedirecter
+  def initialize(args)
+    @publishing_api ||= SpecialistPublisherWiring.get(:publishing_api)
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+    @logger = args[:logger] || STDOUT
+    @base_path = args[:base_path]
+    @destination = args[:destination]
+  end
+
+  def redirect
+    run(redirect: true)
+  end
+
+  def report
+    run(redirect: false)
+  end
+
+private
+
+  attr_reader :base_path, :content_store, :destination, :logger, :publishing_api
+
+  def run(redirect:)
+    manual_response = content_store.content_item(base_path)
+
+    raise "Could not retrieve manual with base_path: #{base_path} from content store" unless manual_response.code == 200
+    manual = manual_response.to_hash.deep_symbolize_keys
+
+    manual_slug = base_path[1..-1]
+    manual_record = ManualRecord.where(slug: manual_slug).first
+
+    if manual_record
+      logger.puts "Redirecting #{base_path} to #{destination}"
+
+      if redirect
+        # Redirect the manual
+        PublishingAPIRedirecter.new(
+          publishing_api: publishing_api,
+          entity: manual_record,
+          redirect_to_location: destination
+        ).call
+
+        if manual[:links]
+          manual[:links][:sections].each do |section|
+            section_slug = section["base_path"][1..-1]
+            section_edition = SpecialistDocumentEdition.where(slug: section_slug).last
+
+            if section_edition
+              logger.puts "Redirecting /#{section_edition.slug} to #{destination}"
+
+              # Redirect each manual section
+              PublishingAPIRedirecter.new(
+                publishing_api: publishing_api,
+                entity: section_edition,
+                redirect_to_location: destination
+              ).call
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/manual_and_sections_redirecter_spec.rb
+++ b/spec/lib/manual_and_sections_redirecter_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+require "manual_and_sections_redirecter"
+
+RSpec.describe ManualAndSectionsRedirecter, :redirect do
+  include GdsApi::TestHelpers::ContentStore
+
+  let(:manual_record) { FactoryGirl.create(:manual_record, slug: "foo") }
+  let(:section_1) { FactoryGirl.create(:specialist_document_edition, slug: "foo/part-1", document_id: SecureRandom.uuid, document_type: "manual") }
+  let(:section_2) { FactoryGirl.create(:specialist_document_edition, slug: "foo/part-2", document_id: SecureRandom.uuid, document_type: "manual") }
+  let(:section_3) { FactoryGirl.create(:specialist_document_edition, slug: "foo/part-3", document_id: SecureRandom.uuid, document_type: "manual") }
+  let(:links) do
+    {
+      "sections" => [
+        { "base_path" => "/foo/part-1" },
+        { "base_path" => "/foo/part-2" },
+        { "base_path" => "/foo/part-3" },
+      ]
+    }
+  end
+
+  let(:redirecter) { double(:redirecter) }
+  let(:publishing_api) { SpecialistPublisherWiring.get(:publishing_api) }
+  let(:destination) { "/bar" }
+  let(:logger) { double(:logger) }
+
+  before do
+    content_store_has_item("/foo", {"links" => links})
+    allow(logger).to receive(:puts)
+  end
+
+  it "publishes a redirect for the manual and redirects for each section" do
+    expect(PublishingAPIRedirecter).to receive(:new)
+      .with(
+        publishing_api: publishing_api,
+        entity: manual_record,
+        redirect_to_location: destination
+      ).and_return(redirecter)
+
+    expect(PublishingAPIRedirecter).to receive(:new)
+      .with(
+        publishing_api: publishing_api,
+        entity: section_1,
+        redirect_to_location: destination
+      ).and_return(redirecter)
+
+    expect(PublishingAPIRedirecter).to receive(:new)
+      .with(
+        publishing_api: publishing_api,
+        entity: section_2,
+        redirect_to_location: destination
+      ).and_return(redirecter)
+
+    expect(PublishingAPIRedirecter).to receive(:new)
+      .with(
+        publishing_api: publishing_api,
+        entity: section_3,
+        redirect_to_location: destination
+      ).and_return(redirecter)
+
+    expect(redirecter).to receive(:call).exactly(4).times
+
+    described_class.new(logger: logger, base_path: "/foo", destination: "/bar").redirect
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -82,6 +82,12 @@ FactoryGirl.define do
     organisation_slug "government-digital-service"
   end
 
+  factory :manual_record do
+    sequence(:manual_id) {|_| SecureRandom.uuid }
+    sequence(:slug) {|n| "test-manual-record-#{n}" }
+    sequence(:organisation_slug) {|n| "test-manual-organistion-#{n}" }
+  end
+
   factory :specialist_document_edition do
     sequence(:slug) {|n| "test-specialist-document-#{n}" }
     sequence(:title) {|n| "Test Specialist Document #{n}" }


### PR DESCRIPTION
- Adds a bin script wrapped around a utility class
- Passing a base_path and destination will find the manual with the slug matching the base_path and redirect it and the associated sections by publishing redirects to the publishing api.

The task for Specialist Publisher Rebuild [is here](https://github.com/alphagov/specialist-publisher-rebuild/pull/702).

eg. `bin/redirect_manual_and_sections /manual-url /redirected-url`

with @steventux 
