### PR TITLE
Redirect a manual and sections Publishing API V2

### DIFF
--- a/lib/manual_and_sections_redirecter.rb
+++ b/lib/manual_and_sections_redirecter.rb
@@ -1,0 +1,71 @@
+class ManualAndSectionsRedirecter
+  def initialize(args)
+    @publishing_api = SpecialistPublisher.services(:publishing_api)
+    @logger = args[:logger] || STDOUT
+    @base_path = args[:base_path]
+    @destination = args[:destination]
+  end
+
+  def redirect
+    run(redirect: true)
+  end
+
+  def report
+    run(redirect: false)
+  end
+
+private
+
+  attr_reader :base_path, :destination, :logger, :publishing_api
+
+  def run(redirect:)
+    manuals_response = publishing_api.get_content_items(publishing_app: "specialist-publisher", document_type: "manual", fields: %w(base_path content_id))
+
+    raise "Could not retrieve specialist-publisher manuals from publishing api" unless manuals_response.code == 200
+
+    manual = manuals_response.to_hash["results"].find { |item| item["base_path"] == base_path }
+
+    raise "Could not find manual with base_path: #{base_path}" unless manual
+
+    manual_content_id = manual["content_id"]
+
+    redirect_item(manual_content_id, redirect_payload(base_path))
+    redirect_item(manual_content_id, redirect_payload("#{base_path}/updates"))
+
+    logger.puts "Redirecting #{manual["base_path"]} to #{destination}"
+
+    sections_response = publishing_api.get_linked_items(manual_content_id, link_type: "manual", fields: %w(base_path content_id))
+
+    raise "Could not retrieve specialist-publisher sections" unless sections_response.code == 200
+
+    manual_sections = sections_response.to_hash
+
+    if manual_sections.any?
+      manual_sections.each do |section|
+        redirect_item(section["content_id"], redirect_payload(section["base_path"]))
+        logger.puts "Redirecting #{section["base_path"]} to #{destination}"
+      end
+    end
+  end
+
+  def redirect_item(content_id, payload)
+    publishing_api.put_content(content_id, payload)
+    publishing_api.publish(content_id, "major")
+  end
+
+  def redirect_payload(from_path)
+    {
+      format: "redirect",
+      publishing_app: "specialist-publisher",
+      update_type: "major",
+      base_path: from_path,
+      redirects: [
+        {
+          path: from_path,
+          type: "exact",
+          destination: destination
+        }
+      ]
+    }
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,4 +8,15 @@ namespace :publishing_api do
 
     PublishingApiFinderPublisher.new(finder_loader.finders).call
   end
+
+  # Find the manual by base_path from content store.
+  # Publish a redirect for the manual.
+  # Iterate through links[sections], publish a redirect per section.
+  desc "Redirect manual and sections"
+  task :redirect_manual_and_sections, [:base_path, :destination] => :environment do |task, args|
+    ManualAndSectionsRedirecter.new(
+      base_path: args[:base_path],
+      destination: args[:destination]
+    ).redirect
+  end
 end

--- a/spec/lib/manual_and_sections_redirecter_spec.rb
+++ b/spec/lib/manual_and_sections_redirecter_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+require "manual_and_sections_redirecter"
+
+RSpec.describe ManualAndSectionsRedirecter, :redirect do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  def redirect_body(base_path, destination)
+    {
+      "format" => "redirect",
+      "publishing_app" => "specialist-publisher",
+      "update_type" => "major",
+      "base_path" => base_path,
+      "redirects" => [
+        {
+          "path" => base_path,
+          "type" => "exact",
+          "destination" => destination
+        }
+      ]
+    }
+  end
+
+  let(:section_1_content_id) { SecureRandom.uuid }
+  let(:section_2_content_id) { SecureRandom.uuid }
+  let(:section_3_content_id) { SecureRandom.uuid }
+
+  let(:links) do
+    {
+      "sections" => [
+        {
+          "base_path" => "/foo/part-1",
+          "content_id" => section_1_content_id
+         },
+        {
+          "base_path" => "/foo/part-2",
+          "content_id" => section_2_content_id
+        },
+        {
+          "base_path" => "/foo/part-3",
+          "content_id" => section_3_content_id
+        },
+      ]
+    }
+  end
+
+  let(:publishing_api) { SpecialistPublisher.services(:publishing_api) }
+  let(:destination) { "/bar" }
+  let(:logger) { double(:logger) }
+  let(:manual_content_id) { SecureRandom.uuid }
+  let(:publishing_api_endpoint) { GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT }
+
+  before do
+    allow(logger).to receive(:puts)
+
+    stub_request(:get, "#{publishing_api_endpoint}/content?document_type=manual&fields[]=base_path&fields[]=content_id&publishing_app=specialist-publisher").to_return(
+      status: 200, body: {
+        "results" => [
+          {"content_id" => manual_content_id, "base_path" => "/foo"},
+          {"content_id" => SecureRandom.uuid, "base_path" => "/bar"},
+          {"content_id" => SecureRandom.uuid, "base_path" => "/baz"},
+          {"content_id" => SecureRandom.uuid, "base_path" => "/meh"},
+        ]
+      }.to_json
+    )
+    stub_request(:get, "#{publishing_api_endpoint}/linked/#{manual_content_id}?fields%5B%5D=base_path&fields%5B%5D=content_id&link_type=manual").to_return(
+      status: 200, body: links["sections"].to_json
+    )
+
+    publishing_api_has_item({ "content_id" => manual_content_id, "base_path" => "/foo", "links" => links } )
+
+    stub_publishing_api_put_content(manual_content_id, redirect_body("/foo", destination))
+    stub_publishing_api_put_content(manual_content_id, redirect_body("/foo/updates", destination))
+    stub_publishing_api_publish(manual_content_id, { "update_type" => "major" })
+
+    stub_publishing_api_put_content(section_1_content_id, redirect_body("/foo/part-1", destination))
+    stub_publishing_api_publish(section_1_content_id, { "update_type" => "major" })
+
+    stub_publishing_api_put_content(section_2_content_id, redirect_body("/foo/part-2", destination))
+    stub_publishing_api_publish(section_2_content_id, { "update_type" => "major" })
+
+    stub_publishing_api_put_content(section_3_content_id, redirect_body("/foo/part-3", destination))
+    stub_publishing_api_publish(section_3_content_id, { "update_type" => "major" })
+
+    described_class.new(logger: logger, base_path: "/foo", destination: "/bar").redirect
+  end
+
+  it "publishes a redirect for the manual and redirects for each section" do
+    assert_publishing_api_put_content(manual_content_id, redirect_body("/foo", destination))
+  end
+
+  it "publishes a redirect for each of the manual sections" do
+    assert_publishing_api_put_content(section_1_content_id, redirect_body("/foo/part-1", destination))
+    assert_publishing_api_put_content(section_2_content_id, redirect_body("/foo/part-2", destination))
+    assert_publishing_api_put_content(section_3_content_id, redirect_body("/foo/part-3", destination))
+  end
+end


### PR DESCRIPTION
This performs the same function as the task in [this PR](https://github.com/alphagov/specialist-publisher/pull/676) but is using the version 2 of the publishing API.

- Adds a rake task wrapped around a utility class
- Passing a base_path and destination will find the manual with the slug matching the base_path and redirect it and the associated sections by publishing redirects to the publishing api.

eg. bundle exec rake publishing_api:redirect_manual_and_sections[/manual-url,/redirected-url]

with @steventux 