### PR TITLE
[Merge after add attachments PR] refactor content items into payload

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,66 +1,28 @@
 require "spec_helper"
 
 RSpec.describe AttachmentsController, type: :controller do
-  def cma_case_content_item
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "base_path" => "/cma-cases/example-cma-case",
-      "title" => "Example CMA Case",
-      "description" => "This is the summary of an example CMA case",
-      "document_type" => "cma_case",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-23T14:07:47.240Z",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "attachments" => [
-          {
-            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-            "content_type" => "application/jpeg",
-            "title" => "asylum report image title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          },
-          {
-            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-            "content_type" => "application/pdf",
-            "title" => "asylum report pdf title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          }
-        ],
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
-        },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-23T14:07:47.240Z",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
+  let(:cma_case) {
+    Payloads.cma_case_content_item("details" => {
+      "attachments" => [
         {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
+          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+          "content_type" => "application/jpeg",
+          "title" => "asylum report image title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
+        },
+        {
+          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
+          "content_type" => "application/pdf",
+          "title" => "asylum report pdf title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
-  end
+      ]
+    })}
 
-  let(:cma_case) { cma_case_content_item }
   let(:document_type) { 'cma-cases' }
   let(:document_content_id) { cma_case['content_id'] }
   let(:attachment_content_id) { cma_case['details']['attachments'][0]['content_id'] }
@@ -68,7 +30,6 @@ RSpec.describe AttachmentsController, type: :controller do
   let(:asset_id) { SecureRandom.uuid }
   let(:file_name) { "cma_case_image.jpg" }
   let(:file_url) { "http://assets-origin.dev.gov.uk/media/#{asset_id}/#{file_name}" }
-  let(:file_id) { "http://asset-manager.dev.gov.uk/assets/#{asset_id}" }
 
   let(:asset_url) { "http://assets-origin.dev.gov.uk/media/#{asset_id}/#{file_name}" }
   let(:asset_manager_response) {

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -10,73 +10,30 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
     }
   }
 
-  def cma_case_content_item
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "base_path" => "/cma-cases/example-cma-case",
-      "title" => "Example CMA Case",
-      "description" => "This is the summary of an example CMA case",
-      "document_type" => "cma_case",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-23T14:07:47.240Z",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "attachments" => [
-          {
-            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-            "content_type" => "application/jpeg",
-            "title" => "asylum report image title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          },
-          {
-            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-            "content_type" => "application/pdf",
-            "title" => "asylum report pdf title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          }
-        ],
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
-        },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-23T14:07:47.240Z",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
+  let(:cma_case) {
+    Payloads.cma_case_content_item("details" => {
+      "attachments" => [
         {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
+          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+          "content_type" => "application/jpeg",
+          "title" => "asylum report image title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
+        },
+        {
+          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
+          "content_type" => "application/pdf",
+          "title" => "asylum report pdf title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
-  end
-
-  def cma_case_content_item_links
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "links" => {
-        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
-      }
-    }
-  end
+      ]
+    },
+    "publication_state" => "draft")
+  }
+  let(:content_id) { cma_case['content_id'] }
 
   let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
 
@@ -86,13 +43,16 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
 
-    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case_content_item], fields)
+    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case], fields)
 
-    publishing_api_has_item(cma_case_content_item)
+    publishing_api_has_item(cma_case)
 
-    @changed_json = cma_case_content_item.merge("title" => "Changed title",
+
+    @changed_json = cma_case.merge(
+      "title" => "Changed title",
       "description" => "Changed summary",
-      "public_updated_at" => "2015-12-03T16:59:13+00:00",)
+      "public_updated_at" => "2015-12-03T16:59:13+00:00",
+    )
 
     @changed_json["details"].merge!(
       "change_history" => [
@@ -116,7 +76,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
   end
 
   scenario "with some changed attributes" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -131,8 +91,8 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
 
     click_button "Save as draft"
 
-    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_includes(@changed_json))
-    expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    assert_publishing_api_put_content(content_id, request_json_includes(@changed_json))
+    expect(@changed_json["content_id"]).to eq(content_id)
     expect(@changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13+00:00")
 
     expect(page.status_code).to eq(200)
@@ -140,7 +100,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
   end
 
   scenario "with some invalid changed attributes" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -152,7 +112,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
 
     click_button "Save as draft"
 
-    expect(@changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    expect(@changed_json["content_id"]).to eq(content_id)
     expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
     expect(page).to have_content("Body cannot include invalid Govspeak")
 
@@ -160,7 +120,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
   end
 
   scenario "adding an attachment" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -177,7 +137,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
   end
 
   scenario "editing an attachment" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -1,112 +1,32 @@
 require 'spec_helper'
 
 RSpec.feature "Editing a published CMA case", type: :feature do
-  def published_cma_case_content_item
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "base_path" => "/cma-cases/example-cma-case",
-      "title" => "Example CMA Case",
-      "description" => "This is the summary of a published example CMA case",
-      "document_type" => "cma_case",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-23T14:07:47+00:00",
-      "publication_state" => "live",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "attachments" => [
-          {
-            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-            "content_type" => "application/jpeg",
-            "title" => "asylum report image title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          },
-          {
-            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-            "content_type" => "application/pdf",
-            "title" => "asylum report pdf title",
-            "created_at" => "2015-12-03T16:59:13+00:00",
-            "updated_at" => "2015-12-03T16:59:13+00:00"
-          }
-        ],
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
+  let(:published_cma_case) {
+    Payloads.cma_case_content_item("details" => {
+      "attachments" => [
+        {
+          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+          "content_type" => "application/jpeg",
+          "title" => "asylum report image title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
         },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-23T14:07:47+00:00",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
         {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
+          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
+          "content_type" => "application/pdf",
+          "title" => "asylum report pdf title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
-  end
+      ]
+    },
+    "publication_state" => "live")
+  }
 
-  def redrafted_cma_case_content_item
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "base_path" => "/cma-cases/example-cma-case",
-      "title" => "Example CMA Case",
-      "description" => "This is the summary of a redrafted example CMA case",
-      "format" => "cma_case",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-23T14:07:47.240Z",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "closed_date" => "",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "outcome_type" => "",
-          "document_type" => "cma_case",
-        }
-      },
-      "routes" => [
-        {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
-        }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
-  end
-
-
-  def cma_case_content_item_links
-    {
-      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
-      "links" => {
-        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
-      }
-    }
-  end
-
+  let(:content_id) { published_cma_case['content_id'] }
   let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
-
   let(:file_name) { "cma_case_image.jpg" }
   let(:asset_url) { "http://assets-origin.dev.gov.uk/media/56c45553759b740609000000/#{file_name}" }
   let(:asset_manager_response) {
@@ -122,9 +42,9 @@ RSpec.feature "Editing a published CMA case", type: :feature do
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
 
-    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [published_cma_case_content_item], fields)
+    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [published_cma_case], fields)
 
-    publishing_api_has_item(published_cma_case_content_item)
+    publishing_api_has_item(published_cma_case)
 
     stub_request(:post, "#{Plek.find('asset-manager')}/assets")
       .with(body: %r{.*})
@@ -138,13 +58,15 @@ RSpec.feature "Editing a published CMA case", type: :feature do
   end
 
   scenario "with a minor update" do
-    changed_json = published_cma_case_content_item.merge("title" => "Minor update title",
+    changed_json = published_cma_case.merge(
+      "title" => "Minor update title",
       "description" => "Minor update summary",
-      "update_type" => "minor",)
+      "update_type" => "minor",
+    )
 
     changed_json.delete("publication_state")
 
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -160,25 +82,27 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     click_button "Save as draft"
 
-    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_includes(changed_json))
-    expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
-    expect(changed_json["public_updated_at"]).to eq("2015-11-23T14:07:47+00:00")
+    assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+    expect(changed_json["content_id"]).to eq(content_id)
+    expect(changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13+00:00")
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Minor update title")
   end
 
   scenario "with a major update" do
-    changed_json = published_cma_case_content_item.merge("title" => "Major update title",
+    changed_json = published_cma_case.merge(
+      "title" => "Major update title",
       "description" => "Major update summary",
       "public_updated_at" => "2015-12-03T16:59:13+00:00",
-      "update_type" => "major",)
+      "update_type" => "major",
+    )
 
     changed_json["details"]["change_history"] << { "public_timestamp" => "2015-12-03T16:59:13+00:00", "note" => "This is a change note." }
 
     changed_json.delete("publication_state")
 
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -196,8 +120,8 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     click_button "Save as draft"
 
-    assert_publishing_api_put_content("4a656f42-35ad-4034-8c7a-08870db7fffe", request_json_includes(changed_json))
-    expect(changed_json["content_id"]).to eq("4a656f42-35ad-4034-8c7a-08870db7fffe")
+    assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+    expect(changed_json["content_id"]).to eq(content_id)
     expect(changed_json["public_updated_at"]).to eq("2015-12-03T16:59:13+00:00")
 
     expect(page.status_code).to eq(200)
@@ -205,7 +129,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
   end
 
   scenario "adding an attachment" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 
@@ -222,7 +146,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
   end
 
   scenario "editing an attachment" do
-    visit "/cma-cases/4a656f42-35ad-4034-8c7a-08870db7fffe"
+    visit "/cma-cases/#{content_id}"
 
     click_link "Edit document"
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -1,54 +1,6 @@
 require 'spec_helper'
 
 RSpec.feature "Publishing a CMA case", type: :feature do
-  def content_id
-    "4a656f42-35ad-4034-8c7a-08870db7fffe"
-  end
-
-  def cma_case_content_item
-    {
-      "content_id" => content_id,
-      "base_path" => "/cma-cases/example-cma-case",
-      "title" => "Example CMA Case",
-      "description" => "This is the summary of example CMA case",
-      "format" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30+00:00",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
-        },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-16T11:53:30+00:00",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
-        {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
-        }
-      ],
-      "redirects" => [],
-      "need_ids" => [],
-      "update_type" => "major",
-      "publication_state" => "live",
-      "links" => {
-        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
-      }
-    }
-  end
-
   def cma_org_content_item
     {
       "base_path" => "/government/organisations/competition-and-markets-authority",
@@ -82,7 +34,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
   def indexable_attributes
     {
       "title" => "Example CMA Case",
-      "description" => "This is the summary of example CMA case",
+      "description" => "This is the summary of an example CMA case",
       "link" => "/cma-cases/example-cma-case",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
@@ -96,15 +48,24 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     }
   end
 
+  let(:cma_case) {
+    Payloads.cma_case_content_item(
+      "public_updated_at" => "2015-11-16T11:53:30+00:00",
+      "need_ids" => [],
+      "publication_state" => "live",
+    )
+  }
+  let(:content_id) { cma_case['content_id'] }
+
   let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
 
   before do
     log_in_as_editor(:cma_editor)
 
-    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case_content_item], fields)
+    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case], fields)
     publishing_api_has_fields_for_document('organisation', [cma_org_content_item], [:base_path, :content_id])
 
-    publishing_api_has_item(cma_case_content_item)
+    publishing_api_has_item(cma_case)
 
     stub_publishing_api_publish(content_id, {})
     stub_any_rummager_post

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -1,61 +1,20 @@
 require 'spec_helper'
 
 RSpec.feature "Viewing a specific case", type: :feature do
-  def cma_case_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
-      "base_path" => "/cma-cases/example-cma-case-#{n}",
-      "title" => "Example CMA Case #{n}",
-      "description" => "This is the summary of example CMA case #{n}",
-      "format" => "cma_case",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30.000+00:00",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "closed_date" => "",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "outcome_type" => "",
-          "document_type" => "cma_case",
-        },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-03 16:59:13 UTC",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
-        {
-          "path" => "/cma-cases/example-cma-case",
-          "type" => "exact",
-        }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-      "links" => {
-        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
-      },
-      "publication_state" => "draft"
-    }
-  end
-
   let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
+  let(:cma_cases) {
+    10.times.collect do |n|
+      Payloads.cma_case_content_item(
+        "title" => "Example CMA Case #{n}",
+        "description" => "This is the summary of example CMA case #{n}",
+        "base_path" => "/cma-cases/example-cma-case-#{n}",
+        "publication_state" => "draft",
+      )
+    end
+  }
 
   before do
     log_in_as_editor(:cma_editor)
-
-    cma_cases = []
-
-    10.times do |n|
-      cma_cases << cma_case_content_item(n)
-    end
 
     publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, cma_cases, fields)
 

--- a/spec/models/payload_spec.rb
+++ b/spec/models/payload_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+# Validate payloads
+RSpec.describe Payloads do
+  describe ".cma_case_content_item" do
+    it "is valid against the content schema" do
+      expect(Payloads.cma_case_content_item).to be_valid_against_schema("specialist_document")
+    end
+  end
+end

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -1,0 +1,41 @@
+module Payloads
+  def self.cma_case_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/cma-cases/example-cma-case",
+      "title" => "Example CMA Case",
+      "description" => "This is the summary of an example CMA case",
+      "document_type" => "cma_case",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-12-03T16:59:13+00:00",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "metadata" => {
+          "opened_date" => "2014-01-01",
+          "case_type" => "ca98-and-civil-cartels",
+          "case_state" => "open",
+          "market_sector" => ["energy"],
+          "document_type" => "cma_case",
+        },
+        "change_history" => [
+          {
+            "public_timestamp" => "2015-12-03T16:59:13+00:00",
+            "note" => "First published."
+          }
+        ]
+      },
+      "routes" => [
+        {
+          "path" => "/cma-cases/example-cma-case",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+end


### PR DESCRIPTION
- Test were becoming very long and unreadable, so extracted the cma_case_content_item into a Payload;
- This branch was created form the add-attachments branch because it uses some of the code in it;