### PR TITLE
Email alerts

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -217,7 +217,15 @@ class Document
         base_path,
         indexable_document.to_json,
       )
-      email_alert_api.send_alert({})
+
+      if self.update_type == "major"
+        email_alert_api.send_alert(
+          {
+            "tags" => {},
+            "links" => [self.content_id],
+            "document_type" => self.publishing_api_document_type
+          })
+      end
 
       publish_request.code == 200 && rummager_request.code == 200
     rescue GdsApi::HTTPErrorResponse => e

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -217,6 +217,7 @@ class Document
         base_path,
         indexable_document.to_json,
       )
+      email_alert_api.send_alert({})
 
       publish_request.code == 200 && rummager_request.code == 200
     rescue GdsApi::HTTPErrorResponse => e
@@ -232,6 +233,10 @@ private
 
   def self.attachments(payload)
     payload.details.attachments.map{|attachment|Attachment.new(attachment)}
+  end
+
+  def email_alert_api
+    SpecialistPublisher.services(:email_alert_api)
   end
 
   def rummager

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,6 +1,7 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/rummager'
 require 'gds_api/asset_manager'
+require 'gds_api/email_alert_api'
 
 module SpecialistPublisher
 
@@ -29,3 +30,7 @@ SpecialistPublisher.register_service(:asset_api, GdsApi::AssetManager.new(
   bearer_token: ENV['ASSET_MANAGER_BEARER_TOKEN'] || '12345678'
 ))
 
+SpecialistPublisher.register_service(:email_alert_api, GdsApi::EmailAlertApi.new(
+  Plek.current.find('email-alert-api'),
+  bearer_token: ENV['EMAIL_ALERT_API_BEARER_TOKEN'] || 'example123'
+))

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -98,15 +98,20 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     }
   end
 
+  def minor_update_item
+    cma_case_content_item.merge({
+                                  "title" => "Minor Update Case",
+                                  "update_type" => "minor"
+                                })
+  end
+
   let(:fields){ [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
 
   before do
     log_in_as_editor(:cma_editor)
 
-    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case_content_item], fields)
+    publishing_api_has_fields_for_document(CmaCase.publishing_api_document_type, [cma_case_content_item, minor_update_item], fields)
     publishing_api_has_fields_for_document('organisation', [cma_org_content_item], [:base_path, :content_id])
-
-    publishing_api_has_item(cma_case_content_item)
 
     stub_publishing_api_publish(content_id, {})
     stub_any_rummager_post
@@ -114,6 +119,8 @@ RSpec.feature "Publishing a CMA case", type: :feature do
   end
 
   scenario "from the index" do
+    publishing_api_has_item(cma_case_content_item)
+
     visit "/cma-cases"
 
     expect(page.status_code).to eq(200)
@@ -130,6 +137,27 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     assert_publishing_api_publish(content_id)
     assert_rummager_posted_item(indexable_attributes)
     assert_email_alert_sent()
+  end
+
+  scenario "alerts should not be sent when update type is minor" do
+    publishing_api_has_item(minor_update_item)
+
+    visit "/cma-cases"
+
+    expect(page.status_code).to eq(200)
+
+    click_link "Minor Update Case"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Minor Update Case")
+
+    click_button "Publish"
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Published Minor Update Case")
+
+    assert_publishing_api_publish(content_id)
+
+    assert_not_requested(:post, Plek.current.find('email-alert-api') + "/notifications")
   end
 
 end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -110,6 +110,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
     stub_publishing_api_publish(content_id, {})
     stub_any_rummager_post
+    email_alert_api_accepts_alert
   end
 
   scenario "from the index" do
@@ -123,12 +124,12 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     expect(page).to have_content("Example CMA Case")
 
     click_button "Publish"
-
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Published Example CMA Case")
 
     assert_publishing_api_publish(content_id)
     assert_rummager_posted_item(indexable_attributes)
+    assert_email_alert_sent()
   end
 
 end

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -147,6 +147,10 @@ describe AaibReport do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the AAIB Report" do
       stub_publishing_api_publish(aaib_reports[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -197,6 +197,10 @@ RSpec.describe CmaCase do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the CMA Case" do
       stub_publishing_api_publish(cma_cases[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe CmaCase do
 
   let(:cma_cases) { 10.times.map { |n| cma_case_content_item(n) } }
 
+  let(:email_alert_payload) do
+    {
+      "tags" => {},
+      "links" => [cma_cases[0]["content_id"]],
+      "document_type" => "cma_case"
+    }
+  end
 
   before do
     publishing_api_has_fields_for_document(described_class.publishing_api_document_type, cma_cases, fields)
@@ -211,6 +218,7 @@ RSpec.describe CmaCase do
 
       assert_publishing_api_publish(c.content_id)
       assert_rummager_posted_item(indexable_attributes)
+      assert_email_alert_sent(email_alert_payload)
     end
   end
 

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -139,6 +139,10 @@ describe CountrysideStewardshipGrant do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Countryside Stewardship Grant" do
       stub_publishing_api_publish(countryside_stewardship_grants[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -134,6 +134,10 @@ describe DrugSafetyUpdate do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Drug Safety Update" do
       stub_publishing_api_publish(drug_safety_updates[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -146,6 +146,10 @@ describe EmploymentAppealTribunalDecision do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Employment Appeal Tribunal Decision" do
       stub_publishing_api_publish(employment_appeal_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -143,6 +143,10 @@ describe EmploymentTribunalDecision do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Employment Tribunal Decision" do
       stub_publishing_api_publish(employment_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -156,6 +156,10 @@ describe EsiFund do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the ESI Fund" do
       stub_publishing_api_publish(esi_funds[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -137,6 +137,10 @@ describe MaibReport do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the MAIB Report" do
       stub_publishing_api_publish(maib_reports[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -139,6 +139,10 @@ describe MedicalSafetyAlert do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Medical Safety Alert" do
       stub_publishing_api_publish(medical_safety_alerts[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -137,6 +137,10 @@ describe RaibReport do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the RAIB Report" do
       stub_publishing_api_publish(raib_reports[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -142,6 +142,10 @@ describe TaxTribunalDecision do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Tax Tribunal Decision" do
       stub_publishing_api_publish(tax_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -141,6 +141,10 @@ describe VehicleRecallsAndFaultsAlert do
   end
 
   describe "#publish!" do
+    before do
+      email_alert_api_accepts_alert
+    end
+
     it "publishes the Vehicle Recall and Fault" do
       stub_publishing_api_publish(vehicle_recalls_and_faults[0]["content_id"], {})
       stub_any_rummager_post

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ Capybara.javascript_driver = :webkit
 
 require 'gds_api/test_helpers/publishing_api_v2'
 require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/email_alert_api'
 
 # Quiet down now Mongo
 Mongo::Logger.logger.level = ::Logger::FATAL
@@ -59,6 +60,7 @@ RSpec.configure do |config|
   config.include(Capybara::Webkit::RspecMatchers, :type => :feature)
   config.include(GdsApi::TestHelpers::PublishingApiV2)
   config.include(GdsApi::TestHelpers::Rummager)
+  config.include(GdsApi::TestHelpers::EmailAlertApi)
 
   config.after(:each) do
     #DatabaseCleaner.clean


### PR DESCRIPTION
Need to configure new env var EMAIL_ALERT_API_BEARER_TOKEN
When a finders document is published with an update_type of "major", it will notify email-alert-api to send email to the respective subscriber_list.