### PR TITLE
Filter manuals by organisation 

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -22,6 +22,19 @@ class ManualsController < ApplicationController
     @manual = Manual.new
   end
 
+  def create
+    @manual = Manual.new(manual_params)
+    @manual.organisation_content_ids = [current_user.organisation_content_id]
+
+    if @manual.save
+      flash[:success] = "Created #{@manual.title}"
+      redirect_to manual_path(@manual.content_id)
+    else
+      flash.now[:danger] = "There was an error creating #{@manual.title}. Please try again later."
+      render :new
+    end
+  end
+
   def edit
     @manual = Manual.find(content_id: params[:content_id])
   end
@@ -35,18 +48,6 @@ class ManualsController < ApplicationController
     else
       flash.now[:danger] = "There was an error updating #{@manual.title}. Please try again later."
       render :edit
-    end
-  end
-
-  def create
-    @manual = Manual.new(manual_params)
-
-    if @manual.save
-      flash[:success] = "Created #{@manual.title}"
-      redirect_to manual_path(@manual.content_id)
-    else
-      flash.now[:danger] = "There was an error creating #{@manual.title}. Please try again later."
-      render :new
     end
   end
 

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -173,11 +173,12 @@ class Manual
   def save
     if self.valid?
       presented_manual = ManualPresenter.new(self)
-
+      presented_links = ManualLinksPresenter.new(self)
       begin
         item_request = publishing_api.put_content(self.content_id, presented_manual.to_json)
+        links_request = publishing_api.patch_links(self.content_id, presented_links.to_json)
 
-        item_request.code == 200
+        item_request.code == 200 && links_request.code == 200
       rescue GdsApi::HTTPErrorResponse => e
         Airbrake.notify(e)
 

--- a/app/presenters/manual_links_presenter.rb
+++ b/app/presenters/manual_links_presenter.rb
@@ -1,5 +1,4 @@
 class ManualLinksPresenter
-
   def initialize(manual)
     @manual = manual
   end
@@ -13,8 +12,7 @@ class ManualLinksPresenter
     }
   end
 
-  private
+private
 
   attr_reader :manual
-
 end

--- a/app/presenters/manual_links_presenter.rb
+++ b/app/presenters/manual_links_presenter.rb
@@ -1,0 +1,20 @@
+class ManualLinksPresenter
+
+  def initialize(manual)
+    @manual = manual
+  end
+
+  def to_json
+    {
+      content_id: manual.content_id,
+      links: {
+        organisations: manual.organisation_content_ids
+      },
+    }
+  end
+
+  private
+
+  attr_reader :manual
+
+end

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -15,17 +15,16 @@ class ManualPresenter
       rendering_app: "specialist-frontend",
       public_updated_at: manual.public_updated_at.to_datetime.rfc3339,
       details: {
-      body: manual.body,
-      child_section_groups: [],
-      change_notes: [],
-      organisations: []
-    },
+        body: manual.body,
+        child_section_groups: [],
+        change_notes: []
+      },
       routes: [
         {
-      path: manual.base_path,
-      type: "exact"
-    }
-    ],
+          path: manual.base_path,
+          type: "exact"
+        }
+      ],
       redirects: [],
       update_type: manual.update_type
     }

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -20,6 +20,11 @@
             <li>
               <%= state(manual) %>
             </li>
+            <% if current_user.gds_editor? && manual.organisations.present? %>
+              <% manual.organisations.each do |organisation| %>
+                <li class="text-muted">From <%= link_to organisation.title, url_for_public_org(organisation.base_path) %></li>
+              <% end %>
+            <% end %>
           </ul>
         </li>
       <% end %>

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -68,12 +68,17 @@ RSpec.feature "Access control", type: :feature do
 
     before do
       publishing_api_has_item(manual_content_item_1)
-      publishing_api_has_links(manual_links_1)
-
       publishing_api_has_item(manual_content_item_2)
-      publishing_api_has_links(manual_links_2)
 
       publishing_api_has_fields_for_document('manual', [manual_content_item_1, manual_content_item_2], [:content_id])
+
+      [manual_links_1, manual_links_2].each do |link_set|
+        publishing_api_has_links(link_set)
+        link_set['links']['organisations'].each do |organisation|
+          organisation = { content_id: organisation, base_path: "/government/organisations/#{organisation}", title: 'Government Digital Service' }
+          publishing_api_has_item(organisation)
+        end
+      end
     end
 
     context 'as a GDS editor' do

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -55,4 +55,53 @@ RSpec.feature "Access control", type: :feature do
       expect(page).to have_content("You aren't permitted to access CMA Cases")
     end
   end
+
+  context "viewing manuals" do
+    let(:manual_content_item_1) { Payloads.manual_content_item("title" => "Example manual") }
+    let(:manual_links_1) { Payloads.manual_links }
+
+    let(:manual_content_id_2) { SecureRandom.uuid }
+    let(:manual_content_item_2) { Payloads.manual_content_item("title" => "Exemplar manual", "content_id" => manual_content_id_2) }
+    let(:manual_links_2) { Payloads.manual_links("content_id" => manual_content_id_2, "links" => { "organisations" => [organisation_user.organisation_content_id] }) }
+
+    let(:organisation_user) { FactoryGirl.create(:cma_editor) }
+
+    before do
+      publishing_api_has_item(manual_content_item_1)
+      publishing_api_has_links(manual_links_1)
+
+      publishing_api_has_item(manual_content_item_2)
+      publishing_api_has_links(manual_links_2)
+
+      publishing_api_has_fields_for_document('manual', [manual_content_item_1, manual_content_item_2], [:content_id])
+    end
+
+    context 'as a GDS editor' do
+      before do
+        log_in_as_editor(:gds_editor)
+      end
+
+      scenario "visiting /manuals" do
+        visit "/manuals"
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content 'Example manual'
+        expect(page).to have_content 'Exemplar manual'
+      end
+    end
+
+    context 'as a organisation editor' do
+      before do
+        log_in_as(organisation_user)
+      end
+
+      scenario "visiting /manuals" do
+        visit "/manuals"
+
+        expect(page.status_code).to eq(200)
+        expect(page).not_to have_content 'Example manual'
+        expect(page).to have_content 'Exemplar manual'
+      end
+    end
+  end
 end

--- a/spec/features/creating_a_manual_spec.rb
+++ b/spec/features/creating_a_manual_spec.rb
@@ -43,6 +43,12 @@ RSpec.feature "Creating a Manual", type: :feature do
       publishing_api_has_item(stub_json)
       publishing_api_has_links(manual_links)
 
+      organisation = {
+        content_id: manual_links['links']['organisations'][0],
+        base_path: "/government/organisations/"
+      }
+      publishing_api_has_item(organisation)
+
       allow(SecureRandom).to receive(:uuid).and_return(stub_json[:content_id])
     end
 
@@ -70,7 +76,6 @@ RSpec.feature "Creating a Manual", type: :feature do
       fill_in "Body", with: "The body of my new manual. The body of my new manual. The body of my new manual."
 
       click_button "Save as draft"
-
 
       assert_publishing_api_put_content(
         test_content_id,

--- a/spec/features/creating_a_manual_spec.rb
+++ b/spec/features/creating_a_manual_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature "Creating a Manual", type: :feature do
         title: "My New Manual",
         description: "Summary of new manual",
         details: {
-        body: "The body of my new manual. The body of my new manual. The body of my new manual."
-      }
+          body: "The body of my new manual. The body of my new manual. The body of my new manual."
+        }
       }
     end
 
@@ -26,11 +26,10 @@ RSpec.feature "Creating a Manual", type: :feature do
       {
         "content_id" => test_content_id,
         "links" => {
-        "sections" => [
-      ],
-      "organisations" => [
-      ]
-      }
+          "sections" => [
+          ],
+          "organisations" => ["af07d5a5-df63-4ddc-9383-6a666845ebe9"]
+        }
       }
     end
 
@@ -40,8 +39,10 @@ RSpec.feature "Creating a Manual", type: :feature do
       publishing_api_has_fields_for_document("manual", [], [:content_id])
 
       stub_publishing_api_put_content(test_content_id, {})
+      stub_publishing_api_patch_links(test_content_id, {})
       publishing_api_has_item(stub_json)
       publishing_api_has_links(manual_links)
+
       allow(SecureRandom).to receive(:uuid).and_return(stub_json[:content_id])
     end
 
@@ -70,8 +71,40 @@ RSpec.feature "Creating a Manual", type: :feature do
 
       click_button "Save as draft"
 
-      assert_publishing_api_put_content(test_content_id, request_json_includes("base_path" => test_base_path))
-      assert_publishing_api_put_content(test_content_id, request_json_includes("routes" => [{ "path" => test_base_path, "type" => "exact" }]))
+
+      assert_publishing_api_put_content(
+        test_content_id,
+        request_json_includes("base_path" => test_base_path)
+      )
+
+      assert_publishing_api_put_content(
+        test_content_id,
+        request_json_includes(
+          "routes" => [
+            { "path" => test_base_path, "type" => "exact" }
+          ]
+        )
+      )
+
+      assert_publishing_api_put_content(
+        test_content_id,
+        request_json_includes(
+          "details" => {
+            "body" => "The body of my new manual. The body of my new manual. The body of my new manual.",
+            "child_section_groups" => [],
+            "change_notes" => [],
+          }
+        )
+      )
+
+      assert_publishing_api_patch_links(
+        test_content_id,
+        request_json_includes(
+          "links" => {
+            "organisations" => ["af07d5a5-df63-4ddc-9383-6a666845ebe9"]
+          }
+        )
+      )
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Summary of new manual")

--- a/spec/features/editing_a_manual_section_spec.rb
+++ b/spec/features/editing_a_manual_section_spec.rb
@@ -15,10 +15,20 @@ RSpec.feature "editing a manual section" do
       log_in_as_editor(:gds_editor)
 
       publishing_api_has_item(manual)
-      publishing_api_has_links(manual_links)
 
       sections.each { |section| publishing_api_has_item(section) }
-      sections_links.each { |section_links| publishing_api_has_links(section_links) }
+
+      links = [manual_links] + sections_links
+      links.each do |link_set|
+        publishing_api_has_links(link_set)
+        link_set['links']['organisations'].each do |organisation|
+          organisation = {
+            content_id: organisation,
+            base_path: "/government/organisations/#{organisation}"
+          }
+          publishing_api_has_item(organisation)
+        end
+      end
 
       section_content_ids.each do |section_content_id|
         stub_publishing_api_put_content(section_content_id, {})

--- a/spec/features/editing_a_manual_spec.rb
+++ b/spec/features/editing_a_manual_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'editing a manual' do
     publishing_api_has_fields_for_document("manual", [manual_content_item], [:content_id])
     publishing_api_has_fields_for_document("manual_section", section_content_items.map { |section| { content_id: section["content_id"] } }, [:content_id])
     stub_publishing_api_put_content(manual_content_item["content_id"], {})
-
+    stub_publishing_api_patch_links(manual_content_item["content_id"], {})
     content_items = [manual_content_item] + section_content_items
 
     content_items.each do |payload|
@@ -22,6 +22,13 @@ RSpec.feature 'editing a manual' do
 
     links.each do |link_set|
       publishing_api_has_links(link_set)
+      link_set['links']['organisations'].each do |organisation|
+        organisation = {
+          content_id: organisation,
+          base_path: "/government/organisations/#{organisation}"
+        }
+        publishing_api_has_item(organisation)
+      end
     end
   end
 

--- a/spec/features/viewing_a_manual_section_spec.rb
+++ b/spec/features/viewing_a_manual_section_spec.rb
@@ -23,6 +23,10 @@ RSpec.feature "Viewing a Manual and its Sections", type: :feature do
 
       links.each do |link_set|
         publishing_api_has_links(link_set)
+        link_set['links']['organisations'].each do |organisation|
+          organisation = { content_id: organisation, base_path: "/government/organisations/#{organisation}" }
+          publishing_api_has_item(organisation)
+        end
       end
     end
 

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -1,215 +1,44 @@
 require 'spec_helper'
 
 RSpec.feature "Viewing a Manual", type: :feature do
+  let(:manual_content_item) { Payloads.manual_content_item }
+  let(:manual_links) { Payloads.manual_links }
+  let(:section_content_items) { Payloads.section_content_items }
+  let(:section_links) { Payloads.section_links }
+
+  before do
+    publishing_api_has_fields_for_document("manual", [manual_content_item], [:content_id])
+    publishing_api_has_fields_for_document(
+      "manual_section",
+      section_content_items.map do |section|
+        {
+          content_id: section["content_id"]
+        }
+      end,
+      [:content_id]
+    )
+
+    content_items = [manual_content_item] + section_content_items
+
+    content_items.each do |payload|
+      publishing_api_has_item(payload)
+    end
+  end
+
   context 'as a GDS editor' do
-    def manual_content_item
-      {
-        "base_path" => "/guidance/a-manual",
-        "content_id" => "b1dc075f-d946-4bcb-a5eb-941f8c8188cf",
-        "description" => "A manual description",
-        "details" => {
-          "body" => "A manual body",
-          "child_section_groups" => [
-            {
-              "title" => "Contents",
-              "child_sections" => [
-                {
-                  "title" => "First section",
-                  "description" => "This is a manual's first section",
-                  "base_path" => "/guidance/a-manual/first-section"
-                },
-                {
-                  "title" => "Second section",
-                  "description" => "This is a manual's second section",
-                  "base_path" => "/guidance/a-manual/second-section"
-                },
-              ]
-            }
-          ],
-          "change_notes" => [
-            {
-              "base_path" => "/guidance/a-manual/first-section",
-              "title" => "First section",
-              "change_note" => "New section added.",
-              "published_at" => "2015-12-23T14:38:51+00:00"
-            },
-            {
-              "base_path" => "/guidance/a-manual/second-section",
-              "title" => "Second section",
-              "change_note" => "New section added.",
-              "published_at" => "2015-12-23T14:38:51+00:00"
-            },
-          ],
-          "organisations" => [
-            {
-              "title" => "Goverment Digital Service",
-              "abbreviation" => "GDS",
-              "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-            }
-          ]
-        },
-        "format" => "manual",
-        "locale" => "en",
-        "public_updated_at" => "2016-02-02T12:28:41.000Z",
-        "publishing_app" => "specialist-publisher",
-        "redirects" => [],
-        "rendering_app" => "manuals-frontend",
-        "routes" => [
-          {
-            "path" => "/guidance/a-manual",
-            "type" => "exact"
-          },
-          {
-            "path" => "/guidance/a-manual/updates",
-            "type" => "exact"
-          }
-        ],
-        "title" => "A Manual",
-        "analytics_identifier" => nil,
-        "phase" => "live",
-        "update_type" => "major",
-        "need_ids" => [],
-        "publication_state" => "live",
-        "live_version" => 2,
-        "version" => 2
-      }
-    end
-
-    def manual_links
-      {
-        "content_id" => "b1dc075f-d946-4bcb-a5eb-941f8c8188cf",
-        "links" => {
-          "sections" => [
-            "f12895fc-58d8-417a-a762-2a5fb2266d63",
-            "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          ],
-          "organisations" => [
-            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-          ]
-        }
-      }
-    end
-
-    def section_content_items
-      [
-        {
-          "base_path" => "/guidance/a-manual/first-section",
-          "content_id" => "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          "description" => "This is a manual's first section",
-          "details" => {
-            "body" => "First section body",
-            "organisations" => [
-              {
-                "title" => "Goverment Digital Service",
-                "abbreviation" => "DVSA",
-                "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-              }
-            ]
-          },
-          "format" => "manual_section",
-          "locale" => "en",
-          "public_updated_at" => "2016-02-02T12:28:41.000Z",
-          "publishing_app" => "specialist-publisher",
-          "redirects" => [],
-          "rendering_app" => "manuals-frontend",
-          "routes" => [
-            {
-              "path" => "/guidance/a-manual/first-section",
-              "type" => "exact"
-            }
-          ],
-          "title" => "First section",
-          "analytics_identifier" => nil,
-          "phase" => "live",
-          "update_type" => "major",
-          "need_ids" => [],
-          "publication_state" => "live",
-          "live_version" => 2,
-          "version" => 2
-        },
-        {
-          "base_path" => "/guidance/a-manual/second-section",
-          "content_id" => "f12895fc-58d8-417a-a762-2a5fb2266d63",
-          "description" => "This is a manual's second section",
-          "details" => {
-            "body" => "Second section body",
-            "organisations" => [
-              {
-                "title" => "Goverment Digital Service",
-                "abbreviation" => "DVSA",
-                "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-              }
-            ]
-          },
-          "format" => "manual_section",
-          "locale" => "en",
-          "public_updated_at" => "2016-02-02T12:28:41.000Z",
-          "publishing_app" => "specialist-publisher",
-          "redirects" => [],
-          "rendering_app" => "manuals-frontend",
-          "routes" => [
-            {
-              "path" => "/guidance/a-manual/second-section",
-              "type" => "exact"
-            }
-          ],
-          "title" => "Second section",
-          "analytics_identifier" => nil,
-          "phase" => "live",
-          "update_type" => "major",
-          "need_ids" => [],
-          "publication_state" => "live",
-          "live_version" => 2,
-          "version" => 2
-        },
-      ]
-    end
-
-    def section_links
-      [
-        {
-          "content_id" => "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          "links" => {
-            "manual" => [
-              "b1dc075f-d946-4bcb-a5eb-941f8c8188cf"
-            ],
-            "organisations" => [
-              "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-            ]
-          }
-        },
-        {
-          "content_id" => "f12895fc-58d8-417a-a762-2a5fb2266d63",
-          "links" => {
-            "manual" => [
-              "b1dc075f-d946-4bcb-a5eb-941f8c8188cf"
-            ],
-            "organisations" => [
-              "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-            ]
-          }
-        }
-      ]
-    end
-
     before do
       log_in_as_editor(:gds_editor)
-
-      publishing_api_has_fields_for_document("manual", [manual_content_item], [:content_id])
-      publishing_api_has_fields_for_document("manual_section", section_content_items.map { |section| { content_id: section["content_id"] } }, [:content_id])
-
-      content_items = [manual_content_item] + section_content_items
-
-      content_items.each do |payload|
-        publishing_api_has_item(payload)
-      end
 
       links = [manual_links] + section_links
 
       links.each do |link_set|
         publishing_api_has_links(link_set)
         link_set['links']['organisations'].each do |organisation|
-          organisation = { content_id: organisation, base_path: "/government/organisations/#{organisation}" }
+          organisation = {
+            content_id: organisation,
+            base_path: "/government/organisations/#{organisation}",
+            title: 'Government Digital Service'
+          }
           publishing_api_has_item(organisation)
         end
       end
@@ -220,6 +49,7 @@ RSpec.feature "Viewing a Manual", type: :feature do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("A Manual")
+      expect(page).to have_content("Government Digital Service")
 
       click_link "A Manual"
 
@@ -230,212 +60,30 @@ RSpec.feature "Viewing a Manual", type: :feature do
   end
 
   context 'as a CMA editor' do
-    def manual_content_item
-      {
-        "base_path" => "/guidance/a-cma-manual",
-        "content_id" => "b1dc075f-d946-4bcb-a5eb-941f8c8188cf",
-        "description" => "A CMA manual description",
-        "details" => {
-          "body" => "A CMA manual body",
-          "child_section_groups" => [
-            {
-              "title" => "Contents",
-              "child_sections" => [
-                {
-                  "title" => "First section",
-                  "description" => "This is a CMA manual's first section",
-                  "base_path" => "/guidance/first-section"
-                },
-                {
-                  "title" => "Second section",
-                  "description" => "This is a CMA manual's second section",
-                  "base_path" => "/guidance/second-section"
-                },
-              ]
-            }
-          ],
-          "change_notes" => [
-            {
-              "base_path" => "/guidance/a-cma-manual/first-section",
-              "title" => "First section",
-              "change_note" => "New section added.",
-              "published_at" => "2015-12-23T14:38:51+00:00"
-            },
-            {
-              "base_path" => "/guidance/a-cma-manual/second-section",
-              "title" => "Second section",
-              "change_note" => "New section added.",
-              "published_at" => "2015-12-23T14:38:51+00:00"
-            },
-          ],
-          "organisations" => [
-            {
-              "title" => "Competition and Markets Authority",
-              "abbreviation" => "CMA",
-              "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority"
-            }
-          ]
-        },
-        "format" => "manual",
-        "locale" => "en",
-        "public_updated_at" => "2016-02-02T12:28:41.000Z",
-        "publishing_app" => "specialist-publisher",
-        "redirects" => [],
-        "rendering_app" => "manuals-frontend",
-        "routes" => [
-          {
-            "path" => "/guidance/a-cma-manual",
-            "type" => "exact"
-          },
-          {
-            "path" => "/guidance/a-cma-manual/updates",
-            "type" => "exact"
-          }
-        ],
-        "title" => "A CMA Manual",
-        "analytics_identifier" => nil,
-        "phase" => "live",
-        "update_type" => "major",
-        "need_ids" => [],
-        "publication_state" => "live",
-        "live_version" => 2,
-        "version" => 2
-      }
-    end
-
-    def manual_links
-      {
-        "content_id" => "b1dc075f-d946-4bcb-a5eb-941f8c8188cf",
+    let(:manual_content_item) { Payloads.manual_content_item(title: "A CMA Manual") }
+    let(:manual_links) {
+      Payloads.manual_links(
         "links" => {
-          "sections" => [
-            "f12895fc-58d8-417a-a762-2a5fb2266d63",
-            "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          ],
-          "organisations" => [
-            "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-          ]
+          "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
         }
-      }
-    end
-
-    def section_content_items
-      [
-        {
-          "base_path" => "/guidance/a-cma-manual/first-section",
-          "content_id" => "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          "description" => "This is a CMA manual's first section",
-          "details" => {
-            "body" => "First section body",
-            "organisations" => [
-              {
-                "title" => "Goverment Digital Service",
-                "abbreviation" => "DVSA",
-                "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-              }
-            ]
-          },
-          "format" => "manual_section",
-          "locale" => "en",
-          "public_updated_at" => "2016-02-02T12:28:41.000Z",
-          "publishing_app" => "specialist-publisher",
-          "redirects" => [],
-          "rendering_app" => "manuals-frontend",
-          "routes" => [
-            {
-              "path" => "/guidance/a-cma-manual/first-section",
-              "type" => "exact"
-            }
-          ],
-          "title" => "First section",
-          "analytics_identifier" => nil,
-          "phase" => "live",
-          "update_type" => "major",
-          "need_ids" => [],
-          "publication_state" => "live",
-          "live_version" => 2,
-          "version" => 2
-        },
-        {
-          "base_path" => "/guidance/a-cma-manual/second-section",
-          "content_id" => "f12895fc-58d8-417a-a762-2a5fb2266d63",
-          "description" => "This is a CMA manual's second section",
-          "details" => {
-            "body" => "Second section body",
-            "organisations" => [
-              {
-                "title" => "Goverment Digital Service",
-                "abbreviation" => "DVSA",
-                "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-              }
-            ]
-          },
-          "format" => "manual_section",
-          "locale" => "en",
-          "public_updated_at" => "2016-02-02T12:28:41.000Z",
-          "publishing_app" => "specialist-publisher",
-          "redirects" => [],
-          "rendering_app" => "manuals-frontend",
-          "routes" => [
-            {
-              "path" => "/guidance/a-cma-manual/second-section",
-              "type" => "exact"
-            }
-          ],
-          "title" => "Second section",
-          "analytics_identifier" => nil,
-          "phase" => "live",
-          "update_type" => "major",
-          "need_ids" => [],
-          "publication_state" => "live",
-          "live_version" => 2,
-          "version" => 2
-        },
-      ]
-    end
-
-    def section_links
-      [
-        {
-          "content_id" => "7df32e1b-d92c-4e63-8c74-7922c408cfd5",
-          "links" => {
-            "manual" => [
-              "b1dc075f-d946-4bcb-a5eb-941f8c8188cf"
-            ],
-            "organisations" => [
-              "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-            ]
-          }
-        },
-        {
-          "content_id" => "f12895fc-58d8-417a-a762-2a5fb2266d63",
-          "links" => {
-            "manual" => [
-              "b1dc075f-d946-4bcb-a5eb-941f8c8188cf"
-            ],
-            "organisations" => [
-              "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-            ]
-          }
-        }
-      ]
-    end
+      )
+    }
 
     before do
       log_in_as_editor(:cma_editor)
-
-      publishing_api_has_fields_for_document("manual", [manual_content_item], [:content_id])
-      publishing_api_has_fields_for_document("manual_section", section_content_items.map { |section| { content_id: section["content_id"] } }, [:content_id])
-
-      content_items = [manual_content_item] + section_content_items
-
-      content_items.each do |payload|
-        publishing_api_has_item(payload)
-      end
 
       links = [manual_links] + section_links
 
       links.each do |link_set|
         publishing_api_has_links(link_set)
+        link_set['links']['organisations'].each do |organisation|
+          organisation = {
+            content_id: organisation,
+            base_path: "/government/organisations/#{organisation}",
+            title: 'Competition And Markets Authority'
+          }
+          publishing_api_has_item(organisation)
+        end
       end
     end
 
@@ -444,6 +92,7 @@ RSpec.feature "Viewing a Manual", type: :feature do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("A CMA Manual")
+      expect(page).to_not have_content("Competition And Markets Authority")
 
       click_link "A CMA Manual"
 

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -208,6 +208,10 @@ RSpec.feature "Viewing a Manual", type: :feature do
 
       links.each do |link_set|
         publishing_api_has_links(link_set)
+        link_set['links']['organisations'].each do |organisation|
+          organisation = { content_id: organisation, base_path: "/government/organisations/#{organisation}" }
+          publishing_api_has_item(organisation)
+        end
       end
     end
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
   factory :gds_editor, parent: :user do
     organisation_slug "government-digital-service"
     organisation_content_id "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    permissions %w(signin gds_editor)
   end
 
   factory :cma_editor, parent: :user do

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -8,46 +8,39 @@ RSpec.describe Manual do
         "content_id" => "b1dc075f-d946-4bcb-a5eb-941f8c8188cf",
         "description" => "A manual description",
         "details" => {
-        "body" => "A manual body",
-        "child_section_groups" => [
-          {
-        "title" => "Contents",
-        "child_sections" => [
-          {
-        "title" => "First section",
-        "description" => "This is a manual's first section",
-        "base_path" => "/guidance/a-manual/first-section"
-      },
-          {
-          "title" => "Second section",
-          "description" => "This is a manual's second section",
-          "base_path" => "/guidance/a-manual/second-section"
+          "body" => "A manual body",
+          "child_section_groups" => [
+            {
+              "title" => "Contents",
+              "child_sections" => [
+                {
+                  "title" => "First section",
+                  "description" => "This is a manual's first section",
+                  "base_path" => "/guidance/a-manual/first-section"
+                },
+                {
+                  "title" => "Second section",
+                  "description" => "This is a manual's second section",
+                  "base_path" => "/guidance/a-manual/second-section"
+                },
+              ]
+            }
+          ],
+          "change_notes" => [
+            {
+              "base_path" => "/guidance/a-manual/first-section",
+              "title" => "First section",
+              "change_note" => "New section added.",
+              "published_at" => "2015-12-23T14:38:51+00:00"
+            },
+            {
+              "base_path" => "/guidance/a-manual/second-section",
+              "title" => "Second section",
+              "change_note" => "New section added.",
+              "published_at" => "2015-12-23T14:38:51+00:00"
+            },
+          ]
         },
-      ]
-      }
-      ],
-        "change_notes" => [
-          {
-        "base_path" => "/guidance/a-manual/first-section",
-        "title" => "First section",
-        "change_note" => "New section added.",
-        "published_at" => "2015-12-23T14:38:51+00:00"
-      },
-          {
-          "base_path" => "/guidance/a-manual/second-section",
-          "title" => "Second section",
-          "change_note" => "New section added.",
-          "published_at" => "2015-12-23T14:38:51+00:00"
-        },
-      ],
-      "organisations" => [
-        {
-        "title" => "Goverment Digital Service",
-        "abbreviation" => "GDS",
-        "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-      }
-      ]
-      },
         "format" => "manual",
         "locale" => "en",
         "public_updated_at" => "2016-02-02T12:28:41.000Z",
@@ -56,14 +49,14 @@ RSpec.describe Manual do
         "rendering_app" => "manuals-frontend",
         "routes" => [
           {
-        "path" => "/guidance/a-manual",
-        "type" => "exact"
-      },
+            "path" => "/guidance/a-manual",
+            "type" => "exact"
+          },
           {
-          "path" => "/guidance/a-manual/updates",
-          "type" => "exact"
-        }
-      ],
+            "path" => "/guidance/a-manual/updates",
+            "type" => "exact"
+          }
+        ],
         "title" => "A Manual",
         "analytics_identifier" => nil,
         "phase" => "live",
@@ -76,9 +69,13 @@ RSpec.describe Manual do
     end
 
     let(:test_content_id) { SecureRandom.uuid }
+    let(:organisations_content_id) { SecureRandom.uuid }
+    let(:current_user) { double(User, organisations_content_id: organisations_content_id) }
+
     before do
       publishing_api_has_fields_for_document("manual", [manual_content_item], [:content_id])
       stub_publishing_api_put_content(test_content_id, {})
+      stub_publishing_api_patch_links(test_content_id, {})
     end
 
     it "should put content to publishing-api" do
@@ -98,21 +95,32 @@ RSpec.describe Manual do
         title: "title",
         description: "summary",
         details: {
-        body: "body",
-        child_section_groups: [],
-        change_notes: [],
-        organisations: [] },
+          body: "body",
+          child_section_groups: [],
+          change_notes: [],
+        },
         routes: [
           {
-        path: test_path,
-        type: "exact" }]
+            path: test_path,
+            type: "exact"
+          }
+        ]
       }
 
       manual = Manual.new(test_params)
       manual.base_path = test_path
+      manual.organisation_content_ids = [organisations_content_id]
+
+      expected_links_params = {
+        links: {
+        organisations: manual.organisation_content_ids
+        }
+      }
+
       expect(manual.save).to eq(true)
 
       assert_publishing_api_put_content(manual.content_id, request_json_includes(expected_params))
+      assert_publishing_api_patch_links(manual.content_id, request_json_includes(expected_links_params))
     end
   end
 end

--- a/spec/presenters/manual_links_presenter_spec.rb
+++ b/spec/presenters/manual_links_presenter_spec.rb
@@ -2,13 +2,11 @@ require 'rails_helper'
 
 describe ManualLinksPresenter do
   let(:manual) {
-    Manual.new({
-      body: 'test body content for manual',
+    Manual.new(body: 'test body content for manual',
       summary: 'test manual summary',
       title: 'test manual title',
       content_id: SecureRandom.uuid,
-      organisation_content_ids: organisation_content_id
-    })
+      organisation_content_ids: organisation_content_id)
   }
 
   let(:content_id) { manual.content_id }

--- a/spec/presenters/manual_links_presenter_spec.rb
+++ b/spec/presenters/manual_links_presenter_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe ManualLinksPresenter do
+  let(:manual) {
+    Manual.new({
+      body: 'test body content for manual',
+      summary: 'test manual summary',
+      title: 'test manual title',
+      content_id: SecureRandom.uuid,
+      organisation_content_ids: organisation_content_id
+    })
+  }
+
+  let(:content_id) { manual.content_id }
+  let(:organisation_content_id) { SecureRandom.uuid }
+
+  let(:manual_links_presenter) { described_class.new(manual) }
+
+  describe "#to_json" do
+    let(:presented_data) { manual_links_presenter.to_json }
+    it "renders the correct data" do
+      expect(presented_data[:content_id]).to eq(content_id)
+      expect(presented_data[:links][:organisations]).to eq(manual.organisation_content_ids)
+    end
+  end
+end

--- a/spec/presenters/manual_presenter_spec.rb
+++ b/spec/presenters/manual_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe ManualPresenter do
+  let(:manual) {
+    Manual.new({
+      body: 'test body content for manual',
+      summary: 'test manual summary',
+      title: 'test manual title',
+      content_id: SecureRandom.uuid
+    })
+  }
+
+  let(:content_id) { manual.content_id }
+  let(:manual_presenter) { ManualPresenter.new(manual) }
+
+  before do
+    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe "#to_json" do
+    let(:presented_data) { manual_presenter.to_json }
+    it "renders the correct data" do
+      expect(presented_data[:base_path]).to eq("/guidance/test-manual-title")
+      expect(presented_data[:details][:body]).to eq('test body content for manual')
+      expect(presented_data[:content_id]).to eq(content_id)
+      expect(presented_data[:title]).to eq('test manual title')
+      expect(presented_data[:public_updated_at]).to eq("2015-12-03T16:59:13+00:00")
+      expect(presented_data[:description]).to eq('test manual summary')
+    end
+
+  end
+end
+

--- a/spec/presenters/manual_presenter_spec.rb
+++ b/spec/presenters/manual_presenter_spec.rb
@@ -2,12 +2,10 @@ require 'rails_helper'
 
 describe ManualPresenter do
   let(:manual) {
-    Manual.new({
-      body: 'test body content for manual',
+    Manual.new(body: 'test body content for manual',
       summary: 'test manual summary',
       title: 'test manual title',
-      content_id: SecureRandom.uuid
-    })
+      content_id: SecureRandom.uuid)
   }
 
   let(:content_id) { manual.content_id }
@@ -31,7 +29,5 @@ describe ManualPresenter do
       expect(presented_data[:public_updated_at]).to eq("2015-12-03T16:59:13+00:00")
       expect(presented_data[:description]).to eq('test manual summary')
     end
-
   end
 end
-

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -80,23 +80,6 @@ module Payloads
       "description" => "A manual description",
       "details" => {
         "body" => "A manual body",
-        "child_section_groups" => [
-          {
-            "title" => "Contents",
-            "child_sections" => [
-              {
-                "title" => "First section",
-                "description" => "This is a manual's first section",
-                "base_path" => "/guidance/a-manual/first-section"
-              },
-              {
-                "title" => "Second section",
-                "description" => "This is a manual's second section",
-                "base_path" => "/guidance/a-manual/second-section"
-              },
-            ]
-          }
-        ],
         "change_notes" => [
           {
             "base_path" => "/guidance/a-manual/first-section",
@@ -110,13 +93,6 @@ module Payloads
             "change_note" => "New section added.",
             "published_at" => "2015-12-23T14:38:51+00:00"
           },
-        ],
-        "organisations" => [
-          {
-            "title" => "Goverment Digital Service",
-            "abbreviation" => "GDS",
-            "web_url" => "https://www.gov.uk/government/organisations/government-digital-service"
-          }
         ]
       },
       "format" => "manual",
@@ -158,7 +134,7 @@ module Payloads
           "af07d5a5-df63-4ddc-9383-6a666845ebe9"
         ]
       }
-    }.merge(attr)
+    }.deep_merge(attr)
   end
 
   def self.section_content_items


### PR DESCRIPTION
- On manual create, add current_users organisation_content_id to manuals links hash;
- Not currently adding organisation_content_id to section links hash because you can access it from parent manual??
- [Trello Card](https://trello.com/c/Bao9TpZk/20-manuals-index-page-needs-to-filter-by-organisation)