### PR TITLE
Editing manual sections

### DIFF
--- a/app/controllers/manual_sections_controller.rb
+++ b/app/controllers/manual_sections_controller.rb
@@ -17,10 +17,7 @@ class ManualSectionsController < ApplicationController
   end
 
   def create
-    section_data = params["section"]
-    section_data["manual_content_id"] = params["manual_content_id"]
-
-    @section = Section.new(section_data)
+    @section = Section.new(section_params.merge(manual_content_id: params[:manual_content_id]))
 
     if @section.save
       flash[:success] = "Created #{@section.title}"
@@ -37,16 +34,19 @@ class ManualSectionsController < ApplicationController
 
   def update
     @section = Section.find(content_id: params[:content_id], manual_content_id: params[:manual_content_id])
-    params[:section].each do |k, v|
-      @section.public_send(:"#{k}=", v)
-    end
 
-    if @section.save
+    if @section.update_attributes(section_params)
       flash[:success] = "#{@section.title} has been updated"
       redirect_to manual_section_path(@section.manual.content_id, @section.content_id)
     else
       flash.now[:danger] = "There was an error updating #{@section.title}. Please try again later."
       render :edit
     end
+  end
+
+private
+
+  def section_params
+    params.require(:section).permit(:title, :summary, :body)
   end
 end

--- a/app/controllers/manual_sections_controller.rb
+++ b/app/controllers/manual_sections_controller.rb
@@ -32,5 +32,21 @@ class ManualSectionsController < ApplicationController
   end
 
   def edit
+    @section = Section.find(content_id: params[:content_id], manual_content_id: params[:manual_content_id])
+  end
+
+  def update
+    @section = Section.find(content_id: params[:content_id], manual_content_id: params[:manual_content_id])
+    params[:section].each do |k, v|
+      @section.public_send(:"#{k}=", v)
+    end
+
+    if @section.save
+      flash[:success] = "#{@section.title} has been updated"
+      redirect_to manual_section_path(@section.manual.content_id, @section.content_id)
+    else
+      flash.now[:danger] = "There was an error updating #{@section.title}. Please try again later."
+      render :edit
+    end
   end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -29,13 +29,7 @@ class ManualsController < ApplicationController
   def update
     @manual = Manual.find(content_id: params[:content_id])
 
-    manual_content = params["manual"]
-
-    @manual.title = manual_content["title"]
-    @manual.summary = manual_content["summary"]
-    @manual.body = manual_content["body"]
-
-    if @manual.save
+    if @manual.update_attributes(manual_params)
       flash[:success] = "#{@manual.title} has been updated"
       redirect_to manual_path(@manual.content_id)
     else
@@ -45,7 +39,7 @@ class ManualsController < ApplicationController
   end
 
   def create
-    @manual = Manual.new(params["manual"])
+    @manual = Manual.new(manual_params)
 
     if @manual.save
       flash[:success] = "Created #{@manual.title}"
@@ -54,5 +48,11 @@ class ManualsController < ApplicationController
       flash.now[:danger] = "There was an error creating #{@manual.title}. Please try again later."
       render :new
     end
+  end
+
+private
+
+  def manual_params
+    params.require(:manual).permit(:title, :summary, :body)
   end
 end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -163,6 +163,13 @@ class Manual
   end
   private_class_method :content_ids
 
+  def update_attributes(new_attributes)
+    new_attributes.each do |attribute, value|
+      public_send(:"#{attribute}=", value)
+    end
+    save
+  end
+
   def save
     if self.valid?
       presented_manual = ManualPresenter.new(self)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -117,6 +117,13 @@ class Section
     end
   end
 
+  def update_attributes(new_attributes)
+    new_attributes.each do |attribute, value|
+      public_send(:"#{attribute}=", value)
+    end
+    save
+  end
+
   def save
     if self.valid?
       presented_section = SectionPresenter.new(self).to_json

--- a/app/views/manual_sections/_form.html.erb
+++ b/app/views/manual_sections/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-8">
-    <%= form_for section, url: manual_sections_path do |f| %>
+    <%= form_for section, url: url, method: method do |f| %>
       <%= render partial: "shared/form_errors", locals: { object: section } %>
       <%= f.label :title %>
       <%= f.text_field :title, class: 'form-control' %>

--- a/app/views/manual_sections/edit.html.erb
+++ b/app/views/manual_sections/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :breadcrumbs do %>
+  <li><%= link_to "Your manuals", manuals_path %></li>
+  <li><%= link_to @section.manual.title, manual_path(@section.manual_content_id) %></li>
+  <li class='active'>Edit section</li>
+<% end %>
+
+<h1 class="page-header">Edit section</h1>
+
+<%= render 'form', section: @section, url: {action: "update"}, method: :put %>

--- a/app/views/manual_sections/new.html.erb
+++ b/app/views/manual_sections/new.html.erb
@@ -5,4 +5,4 @@
 
 <h1 class="page-header">Add section</h1>
 
-<%= render 'form', section: @section %>
+<%= render 'form', section: @section, url: {action: 'create'}, method: 'post' %>

--- a/app/views/manual_sections/show.html.erb
+++ b/app/views/manual_sections/show.html.erb
@@ -15,6 +15,15 @@
   </div>
 </div>
 
+<% if @section.body.present? %>
+  <div class="row">
+    <div class=" col-md-8">
+      <h2>Body</h2>
+      <pre class="body-pre add-bottom-margin"><%= @section.body %></pre>
+    </div>
+  </div>
+<% end %>
+
 <div class="actions">
   <%= link_to("Edit section", edit_manual_section_path(manual_content_id: @section.manual.content_id, content_id: @section.content_id), class: 'action-link') %>
 </div>

--- a/spec/features/editing_a_manual_section_spec.rb
+++ b/spec/features/editing_a_manual_section_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "editing a manual section" do
       click_link 'Edit section'
 
       expect(page.status_code).to eq(200)
-      
+
       fill_in "Title", with: "My updated first section"
 
       fill_in "Summary", with: "Updated summary of first section"

--- a/spec/features/editing_a_manual_section_spec.rb
+++ b/spec/features/editing_a_manual_section_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.feature "editing a manual section" do
+  context 'as a GDS editor' do
+    let(:manual) { Payloads.manual_content_item }
+    let(:manual_links) { Payloads.manual_links }
+    let(:sections) { Payloads.section_content_items }
+    let(:sections_links) { Payloads.section_links }
+
+    let(:manual_content_id) { manual['content_id'] }
+
+    let(:section_content_id) { sections.first['content_id'] }
+
+    before do
+      log_in_as_editor(:gds_editor)
+
+      publishing_api_has_item(manual)
+      publishing_api_has_links(manual_links)
+
+      sections.each { |section| publishing_api_has_item(section) }
+      sections_links.each { |section_links| publishing_api_has_links(section_links) }
+
+      stub_publishing_api_put_content(section_content_id, {})
+      stub_publishing_api_patch_links(section_content_id, {})
+    end
+
+    scenario 'editing a section of a manual' do
+      visit manual_path(manual_content_id)
+      click_link 'First section'
+      click_link 'Edit section'
+
+      expect(page.status_code).to eq(200)
+      
+      fill_in "Title", with: "My updated first section"
+
+      fill_in "Summary", with: "Updated summary of first section"
+
+      fill_in "Body", with: "The updated body of my first section."
+
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("My updated first section has been updated")
+
+      expected_json = request_json_includes(
+        'title' => 'My updated first section',
+        'description' => 'Updated summary of first section',
+        'details' => {
+          'body' => 'The updated body of my first section.',
+          'manual' => {
+            'base_path' => '/guidance/a-manual'
+          },
+          'organisations' => []
+        }
+      )
+      assert_publishing_api_put_content(section_content_id, expected_json)
+    end
+  end
+end

--- a/spec/features/viewing_a_manual_section_spec.rb
+++ b/spec/features/viewing_a_manual_section_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "Viewing a Manual and its Sections", type: :feature do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("This is a manual's first section")
+      expect(page).to have_content("First section body")
     end
 
     scenario "requesting a Section with the wrong content id" do


### PR DESCRIPTION
- Users can edit manual_section content; 
- We have added body field to the section show page;
[Trello Card](https://trello.com/c/3F0sXPVn/44-add-ability-to-edit-manual-sections)
