### PR TITLE
Use a different email template for Medical Safety alerts

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -14,9 +14,19 @@ class EmailAlertPresenter
     }.merge(extra_options)
   end
 
+private
+
   def body
+    if document.publishing_api_document_type == "medical_safety_alert"
+      standard_body("email_alerts/medical_safety_alerts/publication")
+    else
+      standard_body("email_alerts/publication")
+    end
+  end
+
+  def standard_body(template_path)
     view_renderer.render(
-      template: "email_alerts/publication",
+      template: template_path,
       formats: ["html"],
       locals:   {
         document_title: document.title,
@@ -26,8 +36,6 @@ class EmailAlertPresenter
       }
     )
   end
-
-private
 
   def extra_options
     {

--- a/app/views/email_alerts/medical_safety_alerts/publication.html.erb
+++ b/app/views/email_alerts/medical_safety_alerts/publication.html.erb
@@ -1,0 +1,45 @@
+<table id="govuk-email-content" style="max-width: 580px; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+  <tr>
+    <td style="border-collapse: collapse; padding: 0 0 0 15px;">
+      <h1 style="color: #0B0C0C !important; font-family: sans-serif; font-weight: 700; font-size: 30px; line-height: 1.111111111; margin: 15px 0; padding: 15px 0;">
+        Documents
+      </h1>
+
+      <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+        <strong>
+          <%= document_title %>
+        </strong>
+      </p>
+
+      <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+        <%= document_summary %>
+      </p>
+
+      <% if document_change_note.present? %>
+          <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+            Update: <%= document_change_note %>
+          </p>
+      <% end %>
+
+      <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+        For further information on this updated document:
+      </p>
+
+      <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+        <%= link_to document_url, document_url, style: "color: #005EA5; text-decoration: underline;" %>
+      </p>
+
+      <table class="separator" style="width: 100%; height: 1px; line-height: 1px; font-size: 1px; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+          <td style="border-top-style: solid; border-top-color: #bfc1c3; height: 1px; line-height: 1px; font-size: 1px; width: 100%; border-collapse: collapse; background: none; margin: 20px 0px 0px; padding: 0 0 20px 15px; border-width: 1px 0 0;">
+          </td>
+        </tr>
+      </table>
+
+      <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
+        This is an automatically generated email, enquiries should be sent to:
+        <a href="mailto:email.support@mhra.gsi.gov.uk" style="color: #005EA5;">email.support@mhra.gsi.gov.uk</a>
+      </p>
+    </td>
+  </tr>
+</table>

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -1,24 +1,46 @@
 require 'spec_helper'
 
 describe EmailAlertPresenter do
-  let(:document) { Payloads.cma_case_content_item }
+  let(:cma_case_payload) { Payloads.cma_case_content_item }
+  let(:medical_safety_payload) { Payloads.medical_safety_alert_content_item }
+
   describe "#to_json" do
-    before do
-      publishing_api_has_item(document)
+    context "any finders document" do
+      before do
+        publishing_api_has_item(cma_case_payload)
+      end
+
+      it "has correct information" do
+        cma_case = CmaCase.find(cma_case_payload["content_id"])
+        email_alert_presenter = EmailAlertPresenter.new(cma_case)
+        presented_data = email_alert_presenter.to_json
+
+        expect(presented_data[:subject]).to include(cma_case_payload["title"])
+        expect(presented_data[:body]).to include(cma_case_payload["description"])
+        expect(presented_data[:body]).to include(cma_case_payload["title"])
+        expect(presented_data[:links]).to eq(topics: [cma_case_payload["content_id"]])
+        expect(presented_data[:document_type]).to eq("cma_case")
+        expect(presented_data[:footer]).to include("SUBSCRIBER_PREFERENCES_URL")
+        expect(presented_data[:header]).to include("govuk-email-header")
+      end
     end
 
-    it "has correct information" do
-      cma_case = CmaCase.find(document["content_id"])
-      email_alert_presenter = EmailAlertPresenter.new(cma_case)
-      presented_data = email_alert_presenter.to_json
+    context "Medical Safety Alerts documents" do
+      let(:mhra_email_address) { "email.support@mhra.gsi.gov.uk" }
 
-      expect(presented_data[:subject]).to include(document["title"])
-      expect(presented_data[:body]).to include(document["description"])
-      expect(presented_data[:body]).to include(document["title"])
-      expect(presented_data[:links]).to eq(topics: [document["content_id"]])
-      expect(presented_data[:document_type]).to eq("cma_case")
-      expect(presented_data[:footer]).to include("SUBSCRIBER_PREFERENCES_URL")
-      expect(presented_data[:header]).to include("govuk-email-header")
+      before do
+        publishing_api_has_item(medical_safety_payload)
+      end
+
+      it "should use template that contains the email address of MHRA" do
+        medical_safety_alert = MedicalSafetyAlert.find(medical_safety_payload["content_id"])
+        email_alert_presenter = EmailAlertPresenter.new(medical_safety_alert)
+        presented_data = email_alert_presenter.to_json
+
+        expect(presented_data[:body]).to include(mhra_email_address)
+        expect(presented_data[:links]).to eq(topics: [medical_safety_payload["content_id"]])
+        expect(presented_data[:document_type]).to eq("medical_safety_alert")
+      end
     end
   end
 end

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -39,6 +39,40 @@ module Payloads
     }.deep_merge(attrs)
   end
 
+  def self.medical_safety_alert_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/drug-device-alerts/example-medical-safety-alert",
+      "title" => "Example Medical Safety Alert",
+      "description" => "This is the summary of example Medical Safety Alert",
+      "document_type" => "medical_safety_alert",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10),
+        "metadata" => {
+          "alert_type" => "company-led-drugs",
+          "issued_date" => "2016-02-01",
+          "document_type" => "medical_safety_alert"
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/drug-device-alerts/example-medical-safety-alert",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
   def self.manual_content_item(attr = {})
     {
       "base_path" => "/guidance/a-manual",


### PR DESCRIPTION
This is a copy of an existing feature on master branch where the alerts
related to MHRA uses an extended version of the normal email template
that includes the email address for enquiries specific to MHRA

The [email template] (https://github.com/alphagov/specialist-publisher/compare/phase-two...bespoke-email-template-for-MHRA?expand=1#diff-e78c009b4f63deea5e92d20cc1bcd218) is taken from [master branch](https://github.com/alphagov/specialist-publisher/blob/master/app/views/email_alerts/medical_safety_alerts/publication.html.erb)