### PR TITLE
Use single select UI for asylum support tribunal sub-category

### DIFF
--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -17,7 +17,7 @@ private
       tribunal_decision_landmark: entity.tribunal_decision_landmark,
       tribunal_decision_landmark_name: expand_value(:tribunal_decision_landmark).first,
       tribunal_decision_reference_number: entity.tribunal_decision_reference_number,
-      tribunal_decision_sub_category: entity.tribunal_decision_sub_category.first,
+      tribunal_decision_sub_category: entity.tribunal_decision_sub_category,
       tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category).first,
     }
   end

--- a/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
+++ b/app/models/validators/tribunal_decision_sub_category_relates_to_parent_validator.rb
@@ -29,9 +29,7 @@ class TribunalDecisionSubCategoryRelatesToParentValidator < ActiveModel::EachVal
   end
 
   def validate_sub_category(validator, attribute, sub_category)
-    if sub_category.size > 1
-      validator.errors.add attribute, "change to a single sub-category"
-    elsif !prefixed_by_parent_category?(sub_category.first, validator)
+    if !prefixed_by_parent_category?(sub_category, validator)
       message = if category_has_sub_categories?(validator)
                   "change to be a sub-category of '#{category_label(validator)}' or change category"
                 else

--- a/app/views/asylum_support_decisions/_form.html.erb
+++ b/app/views/asylum_support_decisions/_form.html.erb
@@ -4,8 +4,8 @@
     <%= render partial: "shared/form_fields", locals: { f: f } %>
     <%= render partial: "shared/form_preview" %>
 
-    <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
-    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category" }, { class: "select2", multiple: true, data: { placeholder: "Select sub-category when relevant" } } %>
+    <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category", prompt: "Select category" }, { class: 'form-control' } %>
+    <%= f.select :tribunal_decision_sub_category, f.object.facet_options(:tribunal_decision_sub_category), { label: "Sub-category", prompt: "Select sub-category" }, { class: "form-control" } %>
     <%= f.select :tribunal_decision_judges, f.object.facet_options(:tribunal_decision_judges), { label: "Judges" }, { class: 'select2', multiple: true, data: { placeholder: 'Select judges' } } %>
     <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
     <%= f.text_field :tribunal_decision_reference_number, label: "Reference number", placeholder: '', class: 'form-control' %>

--- a/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/asylum_support_decision_indexable_formatter_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "formatters/aaib_report_indexable_formatter"
 
 RSpec.describe AsylumSupportDecisionIndexableFormatter do
-  let(:sub_category) { [double] }
+  let(:sub_category) { double }
   let(:document) {
     double(
       :asylum_support_decision,

--- a/spec/models/validators/asylum_support_decision_validator_spec.rb
+++ b/spec/models/validators/asylum_support_decision_validator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AsylumSupportDecisionValidator do
 
     context "when sub_category matches alternate prefix for parent category" do
       let(:category) { "section-95-support-for-asylum-seekers" }
-      let(:sub_category) { ["section-95-jurisdiction"] }
+      let(:sub_category) { "section-95-jurisdiction" }
 
       it "returns an empty error hash" do
         errors = validatable.errors.messages

--- a/spec/support/shared/tribunal_decision_indexable_formatter_examples.rb
+++ b/spec/support/shared/tribunal_decision_indexable_formatter_examples.rb
@@ -1,18 +1,18 @@
 RSpec.shared_examples_for "a tribunal decision indexable formatter" do
 
   context "with sub_category" do
-    let(:sub_category) { [double] }
+    let(:sub_category) { double }
     it "sends single sub_category for indexing" do
       attributes = formatter.indexable_attributes
-      expect(attributes[:tribunal_decision_sub_category]).to eq(sub_category.first)
+      expect(attributes[:tribunal_decision_sub_category]).to eq(sub_category)
     end
   end
 
   context "without sub_category" do
-    let(:sub_category) { [] }
+    let(:sub_category) { "" }
     it "sends blank for indexing" do
       attributes = formatter.indexable_attributes
-      expect(attributes[:tribunal_decision_sub_category]).to eq(nil)
+      expect(attributes[:tribunal_decision_sub_category]).to eq("")
     end
   end
 

--- a/spec/support/shared/tribunal_decision_sub_category_relates_to_parent_validator_examples.rb
+++ b/spec/support/shared/tribunal_decision_sub_category_relates_to_parent_validator_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
 
     context "when sub_category not provided" do
       let(:category) { "category-name" }
-      let(:sub_category) { [] }
+      let(:sub_category) { "" }
 
       context "and parent category has no sub-categories" do
         before do
@@ -41,22 +41,9 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
       end
     end
 
-    context "when sub_category has two values" do
-      let(:category) { "category-name" }
-      let(:sub_category) { %w[category-name-sub-category-1 category-name-sub-category-2] }
-
-      it "returns error for sub_category" do
-        validatable.valid?
-        errors = validatable.errors.messages
-        expect(errors).to eq({
-          tribunal_decision_sub_category: ["change to a single sub-category"]
-        })
-      end
-    end
-
     context "when sub_category does not match category" do
       let(:category) { "category-name" }
-      let(:sub_category) { ["non-matching-sub-category"] }
+      let(:sub_category) { "non-matching-sub-category" }
 
       context "and relevant sub_categories exist" do
         before do
@@ -91,7 +78,7 @@ RSpec.shared_examples_for "tribunal decision sub_category validator" do
 
     context "when sub_category matches category" do
       let(:category) { "category-name" }
-      let(:sub_category) { ["category-name-subcategory-name"] }
+      let(:sub_category) { "category-name-subcategory-name" }
 
       it "returns an empty error hash" do
         validatable.valid?


### PR DESCRIPTION
Replace multiple select UI with a single select UI for asylum support tribunal decisions sub-category. This is to match schema validations which require at most one sub-category be present.

Change tribunal decision validator to work with single value sub-category.

Provide prompt text for decision category and sub-category selects.