### PR TITLE
Render Govspeak on save

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "govuk_frontend_toolkit", "0.44.0"
 if ENV["GOVSPEAK_DEV"]
   gem "govspeak", path: "../govspeak"
 else
-  gem "govspeak", "3.4.0"
+  gem "govspeak", "~> 3.5"
 end
 
 if ENV["API_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,8 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govspeak (3.4.0)
+    govspeak (3.5.2)
+      addressable (~> 2.3.8)
       htmlentities (~> 4)
       kramdown (~> 1.5.0)
       nokogiri (~> 1.5)
@@ -325,7 +326,7 @@ DEPENDENCIES
   foreman (= 0.74.0)
   gds-api-adapters (= 30.0.0)
   gds-sso (= 11.0.0)
-  govspeak (= 3.4.0)
+  govspeak (~> 3.5)
   govuk-content-schema-test-helpers (= 1.4.0)
   govuk-lint
   govuk_admin_template (~> 3.4.0)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -104,12 +104,26 @@ class Document
     end
   end
 
+  def self.extract_body_from_payload(payload)
+    body_attribute = payload['details']['body']
+
+    case
+    when body_attribute.class == Array
+      govspeak_body = body_attribute.detect do |body_hash|
+        body_hash['content_type'] == 'text/govspeak'
+      end
+      govspeak_body['content']
+    when body_attribute.class == String
+      body_attribute
+    end
+  end
+
   def self.from_publishing_api(payload)
     document = self.new(
       content_id: payload['content_id'],
       title: payload['title'],
       summary: payload['description'],
-      body: payload['details']['body'],
+      body: extract_body_from_payload(payload),
       publication_state: payload['publication_state'],
       public_updated_at: payload['public_updated_at']
     )

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -36,7 +36,7 @@ private
 
   def details
     {
-      body: document.body,
+      body: GovspeakPresenter.present(document.body),
       metadata: metadata,
       change_history: change_history
     }.tap do |details_hash|

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -1,0 +1,16 @@
+module GovspeakPresenter
+  class << self
+    def present(govspeak)
+      [
+        { content_type: "text/govspeak", content: govspeak },
+        { content_type: "text/html", content: html(govspeak) }
+      ]
+    end
+
+  private
+
+    def html(govspeak)
+      Govspeak::Document.new(govspeak).to_html
+    end
+  end
+end

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -2,36 +2,17 @@ require 'spec_helper'
 
 describe AaibReport do
   def aaib_report_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.aaib_report_content_item(
       "base_path" => "/aaib-reports/example-aaib-report-#{n}",
       "title" => "Example AAIB Report #{n}",
       "description" => "This is the summary of example AAIB Report #{n}",
-      "document_type" => "aaib_report",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example AAIB Report" * 10),
-        "metadata" => {
-          "date_of_occurrence" => "2015-10-10",
-          "document_type" => "aaib_report"
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/aaib-reports/example-aaib-report-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:aaib_org_content_item) {
@@ -113,7 +94,7 @@ describe AaibReport do
       expect(aaib_report.base_path).to            eq(aaib_reports[0]["base_path"])
       expect(aaib_report.title).to                eq(aaib_reports[0]["title"])
       expect(aaib_report.summary).to              eq(aaib_reports[0]["description"])
-      expect(aaib_report.body).to                 eq(aaib_reports[0]["details"]["body"])
+      expect(aaib_report.body).to                 eq(aaib_reports[0]["details"]["body"][0]["content"])
       expect(aaib_report.date_of_occurrence).to   eq(aaib_reports[0]["details"]["metadata"]["date_of_occurrence"])
     end
   end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -2,39 +2,17 @@ require 'spec_helper'
 
 RSpec.describe CmaCase do
   def cma_case_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.cma_case_content_item(
       "base_path" => "/cma-cases/example-cma-case-#{n}",
       "title" => "Example CMA Case #{n}",
       "description" => "This is the summary of example CMA case #{n}",
-      "document_type" => "cma_case",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/cma-cases/example-cma-case-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:cma_org_content_item) {
@@ -73,7 +51,7 @@ RSpec.describe CmaCase do
       "description" => "This is the summary of example CMA case 0",
       "link" => "/cma-cases/example-cma-case-0",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
+      "public_timestamp" => "2015-12-03T16:59:13+00:00",
       "opened_date" => "2014-01-01",
       "closed_date" => nil,
       "case_type" => "ca98-and-civil-cartels",
@@ -142,7 +120,7 @@ RSpec.describe CmaCase do
       expect(cma_case.base_path).to     eq(cma_cases[0]["base_path"])
       expect(cma_case.title).to         eq(cma_cases[0]["title"])
       expect(cma_case.summary).to       eq(cma_cases[0]["description"])
-      expect(cma_case.body).to          eq(cma_cases[0]["details"]["body"])
+      expect(cma_case.body).to          eq(cma_cases[0]["details"]["body"][0]["content"])
       expect(cma_case.opened_date).to   eq(cma_cases[0]["details"]["metadata"]["opened_date"])
       expect(cma_case.closed_date).to   eq(cma_cases[0]["details"]["metadata"]["closed_date"])
       expect(cma_case.case_type).to     eq(cma_cases[0]["details"]["metadata"]["case_type"])

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe CmaCase do
       expect(cma_case.market_sector).to eq(cma_cases[0]["details"]["metadata"]["market_sector"])
       expect(cma_case.outcome_type).to  eq(cma_cases[0]["details"]["metadata"]["outcome_type"])
     end
+
+    it "should be able backward compatible for a single string representation of body in payload" do
+      simple_cma_case_payload = Payloads.cma_case_content_item("details" => { "body" => "single string body" })
+      publishing_api_has_item(simple_cma_case_payload)
+
+      content_id = simple_cma_case_payload["content_id"]
+      cma_case = described_class.find(content_id)
+
+      expect(simple_cma_case_payload["details"]["body"].class).to eq(String)
+      expect(cma_case.body.class).to eq(String)
+
+      expect(cma_case.body).to eq(simple_cma_case_payload["details"]["body"])
+    end
   end
 
   describe "#save! without attachments" do

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -2,35 +2,17 @@ require 'spec_helper'
 
 describe CountrysideStewardshipGrant do
   def countryside_stewardship_grant_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.countryside_stewardship_grant_content_item(
       "base_path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-#{n}",
       "title" => "Example Countryside Stewardship Grant #{n}",
       "description" => "This is the summary of example Countryside Stewardship Grant #{n}",
-      "document_type" => "countryside_stewardship_grant",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Countryside Stewardship Grant" * 10),
-        "metadata" => {
-          "document_type" => "countryside_stewardship_grant"
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:countryside_stewardship_grant_org_content_items) {
@@ -107,7 +89,7 @@ describe CountrysideStewardshipGrant do
       expect(countryside_stewardship_grant.base_path).to eq(countryside_stewardship_grants[0]["base_path"])
       expect(countryside_stewardship_grant.title).to eq(countryside_stewardship_grants[0]["title"])
       expect(countryside_stewardship_grant.summary).to eq(countryside_stewardship_grants[0]["description"])
-      expect(countryside_stewardship_grant.body).to eq(countryside_stewardship_grants[0]["details"]["body"])
+      expect(countryside_stewardship_grant.body).to eq(countryside_stewardship_grants[0]["details"]["body"][0]["content"])
     end
   end
 

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -2,35 +2,17 @@ require 'spec_helper'
 
 describe DrugSafetyUpdate do
   def drug_safety_update_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.drug_safety_update_content_item(
       "base_path" => "/drug-safety-update/example-drug-safety-update-#{n}",
       "title" => "Example Drug Safety Update #{n}",
       "description" => "This is the summary of an example Drug Safety Update #{n}",
-      "document_type" => "drug_safety_update",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Drug Safety Update" * 10),
-        "metadata" => {
-          "document_type" => "drug_safety_update",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/drug-safety-update/example-drug-safety-update-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:drug_safety_update_org_content_item) {
@@ -102,7 +84,7 @@ describe DrugSafetyUpdate do
       expect(drug_safety_update.base_path).to            eq(drug_safety_updates[0]["base_path"])
       expect(drug_safety_update.title).to                eq(drug_safety_updates[0]["title"])
       expect(drug_safety_update.summary).to              eq(drug_safety_updates[0]["description"])
-      expect(drug_safety_update.body).to                 eq(drug_safety_updates[0]["details"]["body"])
+      expect(drug_safety_update.body).to                 eq(drug_safety_updates[0]["details"]["body"][0]["content"])
     end
   end
 

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -2,39 +2,17 @@ require 'spec_helper'
 
 describe EmploymentAppealTribunalDecision do
   def employment_appeal_tribunal_decision_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.employment_appeal_tribunal_decision_content_item(
       "base_path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-#{n}",
       "title" => "Example Employment Appeal Tribunal Decision #{n}",
       "description" => "This is the summary of example Employment Appeal Tribunal Decision #{n}",
-      "document_type" => "employment_appeal_tribunal_decision",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Appeal Tribunal Decision" * 10),
-        "metadata" => {
-          "tribunal_decision_categories" => ["age-discrimination"],
-          "tribunal_decision_decision_date" => "2015-07-30",
-          "tribunal_decision_landmark" => "landmark",
-          "tribunal_decision_sub_categories" => ["contract-of-employment-apprenticeship"],
-          "document_type" => "employment_appeal_tribunal_decision",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:employment_appeal_tribunal_decision_org_content_item) {
@@ -110,7 +88,7 @@ describe EmploymentAppealTribunalDecision do
       expect(employment_appeal_tribunal_decision.base_path).to                          eq(employment_appeal_tribunal_decisions[0]["base_path"])
       expect(employment_appeal_tribunal_decision.title).to                              eq(employment_appeal_tribunal_decisions[0]["title"])
       expect(employment_appeal_tribunal_decision.summary).to                            eq(employment_appeal_tribunal_decisions[0]["description"])
-      expect(employment_appeal_tribunal_decision.body).to                               eq(employment_appeal_tribunal_decisions[0]["details"]["body"])
+      expect(employment_appeal_tribunal_decision.body).to                               eq(employment_appeal_tribunal_decisions[0]["details"]["body"][0]["content"])
       expect(employment_appeal_tribunal_decision.tribunal_decision_categories).to       eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_categories"])
       expect(employment_appeal_tribunal_decision.tribunal_decision_decision_date).to    eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])
       expect(employment_appeal_tribunal_decision.tribunal_decision_landmark).to         eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_landmark"])

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -2,38 +2,17 @@ require 'spec_helper'
 
 describe EmploymentTribunalDecision do
   def employment_tribunal_decision_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.employment_tribunal_decision_content_item(
       "base_path" => "/employment-tribunal-decisions/example-employment-tribunal-decision-#{n}",
       "title" => "Example Employment Tribunal Decision #{n}",
       "description" => "This is the summary of example Employment Tribunal Decision #{n}",
-      "document_type" => "employment_tribunal_decision",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Tribunal Decision" * 10),
-        "metadata" => {
-          "tribunal_decision_categories" => ["age-discrimination"],
-          "tribunal_decision_country" => "england-and-wales",
-          "tribunal_decision_decision_date" => "2015-07-30",
-          "document_type" => "employment_tribunal_decision",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/employment-tribunal-decisions/example-employment-tribunal-decision-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:employment_tribunal_decision_org_content_item) {
@@ -108,7 +87,7 @@ describe EmploymentTribunalDecision do
       expect(employment_tribunal_decision.base_path).to                        eq(employment_tribunal_decisions[0]["base_path"])
       expect(employment_tribunal_decision.title).to                            eq(employment_tribunal_decisions[0]["title"])
       expect(employment_tribunal_decision.summary).to                          eq(employment_tribunal_decisions[0]["description"])
-      expect(employment_tribunal_decision.body).to                             eq(employment_tribunal_decisions[0]["details"]["body"])
+      expect(employment_tribunal_decision.body).to                             eq(employment_tribunal_decisions[0]["details"]["body"][0]["content"])
       expect(employment_tribunal_decision.tribunal_decision_categories).to     eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_categories"])
       expect(employment_tribunal_decision.tribunal_decision_country).to        eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_country"])
       expect(employment_tribunal_decision.tribunal_decision_decision_date).to  eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -2,36 +2,17 @@ require 'spec_helper'
 
 describe EsiFund do
   def esi_fund_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.esi_fund_content_item(
       "base_path" => "/european-structural-investment-funds/example-esi-fund-#{n}",
       "title" => "Example ESI Fund #{n}",
       "description" => "This is the summary of example ESI Fund #{n}",
-      "document_type" => "esi_fund",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example ESI Fund" * 10),
-        "metadata" => {
-          "closing_date" => "2016-01-01",
-          "document_type" => "esi_fund",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/european-structural-investment-funds/example-esi-fund-#{n}",
           "type" => "exact",
         },
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:esi_fund_org_content_items) {
@@ -123,7 +104,7 @@ describe EsiFund do
       expect(esi_fund.base_path).to            eq(esi_funds[0]["base_path"])
       expect(esi_fund.title).to                eq(esi_funds[0]["title"])
       expect(esi_fund.summary).to              eq(esi_funds[0]["description"])
-      expect(esi_fund.body).to                 eq(esi_funds[0]["details"]["body"])
+      expect(esi_fund.body).to                 eq(esi_funds[0]["details"]["body"][0]["content"])
       expect(esi_fund.closing_date).to         eq(esi_funds[0]["details"]['metadata']["closing_date"])
     end
   end

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -2,35 +2,17 @@ require 'spec_helper'
 
 describe MaibReport do
   def maib_report_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.maib_report_content_item(
       "base_path" => "/maib-reports/example-maib-report-#{n}",
       "title" => "Example MAIB Report #{n}",
       "description" => "This is the summary of example MAIB Report #{n}",
-      "document_type" => "maib_report",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example MAIB Report" * 10),
-        "metadata" => {
-          "date_of_occurrence" => "2015-10-10",
-          "document_type" => "maib_report"
-        },
-      },
       "routes" => [
         {
           "path" => "/maib-reports/example-maib-report-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:maib_org_content_item) {
@@ -104,7 +86,7 @@ describe MaibReport do
       expect(maib_report.base_path).to            eq(maib_reports[0]["base_path"])
       expect(maib_report.title).to                eq(maib_reports[0]["title"])
       expect(maib_report.summary).to              eq(maib_reports[0]["description"])
-      expect(maib_report.body).to                 eq(maib_reports[0]["details"]["body"])
+      expect(maib_report.body).to                 eq(maib_reports[0]["details"]["body"][0]["content"])
       expect(maib_report.date_of_occurrence).to   eq(maib_reports[0]["details"]["metadata"]["date_of_occurrence"])
     end
   end

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -2,37 +2,17 @@ require 'spec_helper'
 
 describe MedicalSafetyAlert do
   def medical_safety_alert_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.medical_safety_alert_content_item(
       "base_path" => "/drug-device-alerts/example-medical-safety-alert-#{n}",
       "title" => "Example Medical Safety Alert #{n}",
       "description" => "This is the summary of example Medical Safety Alert #{n}",
-      "document_type" => "medical_safety_alert",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10),
-        "metadata" => {
-          "alert_type" => "company-led-drugs",
-          "issued_date" => "2016-02-01",
-          "document_type" => "medical_safety_alert"
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/drug-device-alerts/example-medical-safety-alert-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:mhra_org_content_item) {
@@ -106,7 +86,7 @@ describe MedicalSafetyAlert do
       expect(medical_safety_alert.base_path).to            eq(medical_safety_alerts[0]["base_path"])
       expect(medical_safety_alert.title).to                eq(medical_safety_alerts[0]["title"])
       expect(medical_safety_alert.summary).to              eq(medical_safety_alerts[0]["description"])
-      expect(medical_safety_alert.body).to                 eq(medical_safety_alerts[0]["details"]["body"])
+      expect(medical_safety_alert.body).to                 eq(medical_safety_alerts[0]["details"]["body"][0]["content"])
       expect(medical_safety_alert.alert_type).to           eq(medical_safety_alerts[0]["details"]["metadata"]["alert_type"])
     end
   end

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -2,35 +2,17 @@ require 'spec_helper'
 
 describe RaibReport do
   def raib_report_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.raib_report_content_item(
       "base_path" => "/raib-reports/example-raib-report-#{n}",
       "title" => "Example RAIB Report #{n}",
       "description" => "This is the summary of example RAIB Report #{n}",
-      "document_type" => "raib_report",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example RAIB Report" * 10),
-        "metadata" => {
-          "date_of_occurrence" => "2015-10-10",
-          "document_type" => "raib_report"
-        },
-      },
       "routes" => [
         {
           "path" => "/raib-reports/example-raib-report-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:raib_org_content_item) {
@@ -104,7 +86,7 @@ describe RaibReport do
       expect(raib_report.base_path).to            eq(raib_reports[0]["base_path"])
       expect(raib_report.title).to                eq(raib_reports[0]["title"])
       expect(raib_report.summary).to              eq(raib_reports[0]["description"])
-      expect(raib_report.body).to                 eq(raib_reports[0]["details"]["body"])
+      expect(raib_report.body).to                 eq(raib_reports[0]["details"]["body"][0]["content"])
       expect(raib_report.date_of_occurrence).to   eq(raib_reports[0]["details"]["metadata"]["date_of_occurrence"])
     end
   end

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -2,37 +2,17 @@ require "rails_helper"
 
 describe TaxTribunalDecision do
   def tax_tribunal_decision_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.tax_tribunal_decision_content_item(
       "base_path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-#{n}",
       "title" => "Example Tax Tribunal Decision #{n}",
       "description" => "This is the summary of example Tax Tribunal Decision #{n}",
-      "document_type" => "tax_tribunal_decision",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Tax Tribunal Decision" * 10),
-        "metadata" => {
-          "tribunal_decision_category" => "banking",
-          "tribunal_decision_decision_date" => "2015-07-30",
-          "document_type" => "tax_tribunal_decision",
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:tax_tribunal_decision_org_content_item) {
@@ -107,7 +87,7 @@ describe TaxTribunalDecision do
       expect(tax_tribunal_decision.base_path).to                        eq(tax_tribunal_decisions[0]["base_path"])
       expect(tax_tribunal_decision.title).to                            eq(tax_tribunal_decisions[0]["title"])
       expect(tax_tribunal_decision.summary).to                          eq(tax_tribunal_decisions[0]["description"])
-      expect(tax_tribunal_decision.body).to                             eq(tax_tribunal_decisions[0]["details"]["body"])
+      expect(tax_tribunal_decision.body).to                             eq(tax_tribunal_decisions[0]["details"]["body"][0]["content"])
       expect(tax_tribunal_decision.tribunal_decision_category).to       eq(tax_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_category"])
       expect(tax_tribunal_decision.tribunal_decision_decision_date).to  eq(tax_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])
     end

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -2,38 +2,17 @@ require 'spec_helper'
 
 describe VehicleRecallsAndFaultsAlert do
   def vehicle_recalls_and_faults_alert_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
+    Payloads.vehicle_recalls_and_faults_alert_content_item(
       "base_path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-#{n}",
       "title" => "Example Vehicle Recalls And Faults #{n}",
       "description" => "This is the summary of example Vehicle Recalls And Faults #{n}",
-      "document_type" => "vehicle_recalls_and_faults_alert",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Vehicle Recalls And Faults" * 10),
-        "metadata" => {
-          "alert_issue_date" => "2015-04-28",
-          "build_start_date" => "2015-04-28",
-          "build_end_date" => "2015-06-28",
-          "document_type" => "vehicle_recalls_and_faults_alert"
-        },
-        "change_history" => [],
-      },
       "routes" => [
         {
           "path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-#{n}",
           "type" => "exact",
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
+      ]
+    )
   end
 
   let(:vehicle_recalls_and_faults_alert_org_content_item) {
@@ -106,7 +85,7 @@ describe VehicleRecallsAndFaultsAlert do
       expect(vehicle_recall_and_fault.base_path).to            eq(vehicle_recalls_and_faults[0]["base_path"])
       expect(vehicle_recall_and_fault.title).to                eq(vehicle_recalls_and_faults[0]["title"])
       expect(vehicle_recall_and_fault.summary).to              eq(vehicle_recalls_and_faults[0]["description"])
-      expect(vehicle_recall_and_fault.body).to                 eq(vehicle_recalls_and_faults[0]["details"]["body"])
+      expect(vehicle_recall_and_fault.body).to                 eq(vehicle_recalls_and_faults[0]["details"]["body"][0]["content"])
       expect(vehicle_recall_and_fault.alert_issue_date).to     eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["alert_issue_date"])
       expect(vehicle_recall_and_fault.build_start_date).to     eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["build_start_date"])
       expect(vehicle_recall_and_fault.build_end_date).to       eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["build_end_date"])

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -1,51 +1,49 @@
 require 'rails_helper'
 
 describe DocumentPresenter do
-  def cma_case_content_item(n)
-    {
-      "content_id" => SecureRandom.uuid,
-      "base_path" => "/cma-cases/example-cma-case-#{n}",
-      "title" => "Example CMA Case #{n}",
-      "description" => "This is the summary of example CMA case #{n}",
-      "document_type" => "cma_case",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30+00:00",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
-        "metadata" => {
-          "opened_date" => "2014-01-01",
-          "case_type" => "ca98-and-civil-cartels",
-          "case_state" => "open",
-          "market_sector" => ["energy"],
-          "document_type" => "cma_case",
-        },
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-23T14:07:47+00:00",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
+  let(:cma_case) { Payloads.cma_case_content_item }
+  let(:content_item_with_rendered_body) {
+    cma_case.deep_merge!("details" => {
+      "body" => [
         {
-          "path" => "/cma-cases/example-cma-case-#{n}",
-          "type" => "exact",
+          "content_type" => "text/govspeak",
+          "content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10)
+        },
+        {
+          "content_type" => "text/html",
+          "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example CMA case</p>\n" * 10)
         }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }
-  end
+      ]
+    })
+  }
 
-  let(:content_item_without_attachments) { cma_case_content_item(0) }
+  let(:content_item_without_attachments) { cma_case }
 
   let(:content_item_with_attachments) {
-    cma_case_content_item(1).deep_merge!("details" => {
+    cma_case.deep_merge!("details" => {
+     "attachments" => [
+       {
+         "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+         "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+         "content_type" => "application/jpeg",
+         "title" => "asylum report image title",
+         "created_at" => "2015-12-03T16:59:13+00:00",
+         "updated_at" => "2015-12-03T16:59:13+00:00"
+       },
+       {
+         "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+         "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
+         "content_type" => "application/pdf",
+         "title" => "asylum report pdf title",
+         "created_at" => "2015-12-03T16:59:13+00:00",
+         "updated_at" => "2015-12-03T16:59:13+00:00"
+       }
+     ]
+   })
+  }
+
+  let(:content_item_with_rendered_body_and_attachments) {
+    content_item_with_rendered_body.deep_merge!("details" => {
      "attachments" => [
        {
          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
@@ -93,10 +91,10 @@ describe DocumentPresenter do
     end
 
     it "returns a specialist document content item" do
-      presented_data[:details][:change_history] = [{ public_timestamp: "2015-11-23T14:07:47+00:00", note: "First published." }]
-      content_item_without_attachments.delete('publication_state')
+      presented_data[:details][:change_history] = [{ public_timestamp: "2015-12-03T16:59:13+00:00", note: "First published." }]
+      content_item_with_rendered_body.delete('publication_state')
 
-      expect(presented_data).to eq(content_item_without_attachments.to_h.deep_symbolize_keys)
+      expect(presented_data).to eq(content_item_with_rendered_body.to_h.deep_symbolize_keys)
     end
   end
 
@@ -115,10 +113,10 @@ describe DocumentPresenter do
     end
 
     it "returns a specialist document content item" do
-      presented_data[:details][:change_history] = [{ public_timestamp: "2015-11-23T14:07:47+00:00", note: "First published." }]
-      content_item_with_attachments.delete('publication_state')
+      presented_data[:details][:change_history] = [{ public_timestamp: "2015-12-03T16:59:13+00:00", note: "First published." }]
+      content_item_with_rendered_body_and_attachments.delete('publication_state')
 
-      expect(presented_data).to eq(content_item_with_attachments.to_h.deep_symbolize_keys)
+      expect(presented_data).to eq(content_item_with_rendered_body_and_attachments.to_h.deep_symbolize_keys)
     end
   end
 end

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe GovspeakPresenter do
+  it "should render html and Govspeak when a Govspeak string is provided" do
+    input_govspeak = "^callout test^"
+    rendered_html = "\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>callout test</p>\n</div>\n"
+    presented_content = [{ content_type: "text/govspeak", content: input_govspeak },
+                         { content_type: "text/html", content: rendered_html }]
+
+    expect(GovspeakPresenter.present(input_govspeak)).to eq(presented_content)
+  end
+end

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -1,4 +1,91 @@
 module Payloads
+  def self.aaib_report_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/aaib-reports/example-aaib-report",
+      "title" => "Example AAIB Report",
+      "description" => "This is the summary of example AAIB Report",
+      "document_type" => "aaib_report",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example AAIB Report" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example AAIB Report</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "date_of_occurrence" => "2015-10-10",
+          "document_type" => "aaib_report"
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/aaib-reports/example-aaib-report",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.employment_appeal_tribunal_decision_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision",
+      "title" => "Example Employment Appeal Tribunal Decision",
+      "description" => "This is the summary of example Employment Appeal Tribunal Decision",
+      "document_type" => "employment_appeal_tribunal_decision",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Appeal Tribunal Decision" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Employment Appeal Tribunal Decision</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "tribunal_decision_categories" => ["age-discrimination"],
+          "tribunal_decision_decision_date" => "2015-07-30",
+          "tribunal_decision_landmark" => "landmark",
+          "tribunal_decision_sub_categories" => ["contract-of-employment-apprenticeship"],
+          "document_type" => "employment_appeal_tribunal_decision",
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
   def self.cma_case_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
@@ -13,7 +100,16 @@ module Payloads
       "phase" => "live",
       "public_updated_at" => "2015-12-03T16:59:13+00:00",
       "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example CMA case</p>\n" * 10)
+          }
+        ],
         "metadata" => {
           "opened_date" => "2014-01-01",
           "case_type" => "ca98-and-civil-cartels",
@@ -39,6 +135,215 @@ module Payloads
     }.deep_merge(attrs)
   end
 
+  def self.countryside_stewardship_grant_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant",
+      "title" => "Example Countryside Stewardship Grant",
+      "description" => "This is the summary of example Countryside Stewardship Grant",
+      "document_type" => "countryside_stewardship_grant",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Countryside Stewardship Grant" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Countryside Stewardship Grant</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "document_type" => "countryside_stewardship_grant"
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.drug_safety_update_content_item(attrs = {})
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/drug-safety-update/example-drug-safety-update",
+      "title" => "Example Drug Safety Update",
+      "description" => "This is the summary of an example Drug Safety Update",
+      "document_type" => "drug_safety_update",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Drug Safety Update" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Drug Safety Update</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "document_type" => "drug_safety_update",
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/drug-safety-update/example-drug-safety-update",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.employment_tribunal_decision_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/employment-tribunal-decisions/example-employment-tribunal-decision",
+      "title" => "Example Employment Tribunal Decision",
+      "description" => "This is the summary of example Employment Tribunal Decision",
+      "document_type" => "employment_tribunal_decision",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Tribunal Decision" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Employment Tribunal Decision</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "tribunal_decision_categories" => ["age-discrimination"],
+          "tribunal_decision_country" => "england-and-wales",
+          "tribunal_decision_decision_date" => "2015-07-30",
+          "document_type" => "employment_tribunal_decision",
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/employment-tribunal-decisions/example-employment-tribunal-decision",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.esi_fund_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/european-structural-investment-funds/example-esi-fund",
+      "title" => "Example ESI Fund",
+      "description" => "This is the summary of example ESI Fund",
+      "document_type" => "esi_fund",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example ESI Fund" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example ESI Fund</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "closing_date" => "2016-01-01",
+          "document_type" => "esi_fund",
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/european-structural-investment-funds/example-esi-fund",
+          "type" => "exact",
+        },
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.maib_report_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/maib-reports/example-maib-report",
+      "title" => "Example MAIB Report",
+      "description" => "This is the summary of example MAIB Report",
+      "document_type" => "maib_report",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example MAIB Report" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example MAIB Report</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "date_of_occurrence" => "2015-10-10",
+          "document_type" => "maib_report"
+        },
+      },
+      "routes" => [
+        {
+          "path" => "/maib-reports/example-maib-report",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
   def self.medical_safety_alert_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
@@ -54,7 +359,16 @@ module Payloads
       "public_updated_at" => "2015-11-16T11:53:30",
       "publication_state" => "draft",
       "details" => {
-        "body" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10),
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Medical Safety Alert</p>\n" * 10)
+          }
+        ],
         "metadata" => {
           "alert_type" => "company-led-drugs",
           "issued_date" => "2016-02-01",
@@ -65,6 +379,134 @@ module Payloads
       "routes" => [
         {
           "path" => "/drug-device-alerts/example-medical-safety-alert",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.raib_report_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/raib-reports/example-raib-report",
+      "title" => "Example RAIB Report",
+      "description" => "This is the summary of example RAIB Report",
+      "document_type" => "raib_report",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example RAIB Report" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example RAIB Report</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "date_of_occurrence" => "2015-10-10",
+          "document_type" => "raib_report"
+        },
+      },
+      "routes" => [
+        {
+          "path" => "/raib-reports/example-raib-report",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.tax_tribunal_decision_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision",
+      "title" => "Example Tax Tribunal Decision",
+      "description" => "This is the summary of example Tax Tribunal Decision",
+      "document_type" => "tax_tribunal_decision",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Tax Tribunal Decision" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Tax Tribunal Decision</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "tribunal_decision_category" => "banking",
+          "tribunal_decision_decision_date" => "2015-07-30",
+          "document_type" => "tax_tribunal_decision",
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision",
+          "type" => "exact",
+        }
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+    }.deep_merge(attrs)
+  end
+
+  def self.vehicle_recalls_and_faults_alert_content_item(attrs)
+    {
+      "content_id" => SecureRandom.uuid,
+      "base_path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults",
+      "title" => "Example Vehicle Recalls And Faults",
+      "description" => "This is the summary of example Vehicle Recalls And Faults",
+      "document_type" => "vehicle_recalls_and_faults_alert",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "specialist-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "public_updated_at" => "2015-11-16T11:53:30",
+      "publication_state" => "draft",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Vehicle Recalls And Faults" * 10)
+          },
+          {
+            "content_type" => "text/html",
+            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Vehicle Recalls And Faults</p>\n" * 10)
+          }
+        ],
+        "metadata" => {
+          "alert_issue_date" => "2015-04-28",
+          "build_start_date" => "2015-04-28",
+          "build_end_date" => "2015-06-28",
+          "document_type" => "vehicle_recalls_and_faults_alert"
+        },
+        "change_history" => [],
+      },
+      "routes" => [
+        {
+          "path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults",
           "type" => "exact",
         }
       ],


### PR DESCRIPTION
[Trello](https://trello.com/c/y9wLTaUD)
Changing presenters so we send both Govspeak and HTML versions for the body of a specialist-document. This will break until govuk-content-schema is updated.

There was quite a big refactoring so this PR is best checks per commit. I've isolated the changes most directly related to the feature change in separates commits. 