### PR TITLE
Publishing api rake task with govspeak and html

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -18,20 +18,7 @@ class SpecialistDocumentPublishingAPIFormatter
       update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,
-      details: {
-        metadata: metadata,
-        change_history: change_history,
-        body: [
-          {
-            content_type: "text/html",
-            content: rendered_document.attributes[:body]
-          },
-          {
-            content_type: "text/govspeak",
-            content: specialist_document.body
-          }
-        ]
-      }.merge(headers),
+      details: details,
       routes: [
         path: base_path,
         type: "exact"
@@ -44,6 +31,46 @@ class SpecialistDocumentPublishingAPIFormatter
   end
 
   private
+
+  def details
+    {
+      metadata: metadata,
+      change_history: change_history,
+      body: [
+        {
+          content_type: "text/html",
+          content: rendered_document.attributes.fetch(:body)
+        },
+        {
+          content_type: "text/govspeak",
+          content: specialist_document.attributes.fetch(:body)
+        }
+      ]
+    }.tap do |details_hash|
+      details_hash[:attachments] = attachments if specialist_document.attachments.present?
+    end.merge(headers)
+  end
+
+  def attachments
+    specialist_document.attachments.map{|attachment| attachment_json_builder(attachment.attributes) }
+  end
+
+  def build_content_type(file_url)
+    return unless file_url
+    extname = File.extname(file_url).delete(".")
+    "application/#{extname}"
+  end
+
+  def attachment_json_builder(attributes)
+    {
+      content_id: attributes.fetch("content_id", SecureRandom.uuid),
+      title: attributes.fetch("title", nil),
+      url: attributes.fetch("file_url", nil),
+      updated_at: attributes.fetch("updated_at", nil),
+      created_at: attributes.fetch("created_at", nil),
+      content_type: build_content_type(attributes.fetch("file_url", nil))
+    }
+  end
 
   def rendered_document
     @rendered_document ||= specialist_document_renderer.call(specialist_document)

--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -21,7 +21,16 @@ class SpecialistDocumentPublishingAPIFormatter
       details: {
         metadata: metadata,
         change_history: change_history,
-        body: rendered_document.attributes[:body]
+        body: [
+          {
+            content_type: "text/html",
+            content: rendered_document.attributes[:body]
+          },
+          {
+            content_type: "text/govspeak",
+            content: specialist_document.body
+          }
+        ]
       }.merge(headers),
       routes: [
         path: base_path,

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -66,7 +66,16 @@ private
 
   def details_data
     {
-      body: rendered_manual_attributes.fetch(:body),
+      body: [
+        {
+          content_type: "text/govspeak",
+          content: manual.attributes.fetch(:body)
+        },
+        {
+          content_type: "text/html",
+          content: rendered_manual_attributes.fetch(:body)
+        }
+      ],
       child_section_groups: [
         {
           title: "Contents",

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -63,9 +63,32 @@ private
       organisations: [
         organisation_info
       ],
+    }.tap do |details_hash|
+      details_hash[:attachments] = attachments if document.attachments.present?
+    end
+  end
+
+  def attachments
+    document.attachments.map{|attachment| attachment_json_builder(attachment.attributes) }
+  end
+
+  def build_content_type(file_url)
+    return unless file_url
+    extname = File.extname(file_url).delete(".")
+    "application/#{extname}"
+  end
+
+  def attachment_json_builder(attributes)
+    {
+      content_id: attributes.fetch("content_id", SecureRandom.uuid),
+      title: attributes.fetch("title", nil),
+      url: attributes.fetch("file_url", nil),
+      updated_at: attributes.fetch("updated_at", nil),
+      created_at: attributes.fetch("created_at", nil),
+      content_type: build_content_type(attributes.fetch("file_url", nil))
     }
   end
-  
+
   def update_type
     document.minor_update? ? "minor" : "major"
   end

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -36,15 +36,7 @@ private
           type: "exact",
         }
       ],
-      details: {
-        body: rendered_document_attributes.fetch(:body),
-        manual: {
-          base_path: "/#{manual.attributes.fetch(:slug)}",
-        },
-        organisations: [
-          organisation_info
-        ],
-      },
+      details: details,
       locale: "en",
       links: {
         organisations: [organisation.details.content_id],
@@ -53,6 +45,27 @@ private
     }
   end
 
+  def details
+    {
+      body: [
+        {
+          content_type: "text/govspeak",
+          content: document.attributes.fetch(:body)
+        },
+        {
+          content_type: "text/html",
+          content: rendered_document_attributes.fetch(:body)
+        }
+      ],
+      manual: {
+        base_path: "/#{manual.attributes.fetch(:slug)}",
+      },
+      organisations: [
+        organisation_info
+      ],
+    }
+  end
+  
   def update_type
     document.minor_update? ? "minor" : "major"
   end

--- a/app/lib/cli_manual_section_remover.rb
+++ b/app/lib/cli_manual_section_remover.rb
@@ -30,7 +30,7 @@ private
   end
 
   def user_confirmed?
-    user_response == "Yes"
+    user_response == "y"
   end
 
   def user_response
@@ -42,7 +42,7 @@ private
 ### PLEASE CONFIRM -------------------------------------
 You want to remove the section '#{section.title}' from the manual '#{manual.title}'.
 This manual was last edited at #{manual.updated_at} and belongs to #{manual.organisation_slug}.
-Type 'Yes' to proceed and remove this manual section or type anything else to exit:
+Type 'y' to proceed and remove this manual section or type anything else to exit:
     )
   end
 

--- a/bin/delete_duplicate_draft_manuals_and_draft_manual_sections
+++ b/bin/delete_duplicate_draft_manuals_and_draft_manual_sections
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+
+["c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e c23dc478-cd8f-437b-aba2-2cee9aed60e2", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e ecce885d-7225-4fd4-b23f-da0d0eee9849", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 0e52e6b8-8d81-4f9f-a139-4af7acc5ec71", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 1be90806-e94d-4ece-a40f-c040b21ea7d0", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 97f16fee-0eff-452e-aecc-d0c55126f328", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 9c12c55e-00aa-4417-8c6b-a1314cf1fff7","c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e f3030447-158a-4821-906b-7e25027ac742", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 911e7471-0760-4bf0-a113-e833e7dca042", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e f97c7969-3ccc-42b1-bc03-c270e08c15a2", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 7f0447b6-d3e4-4716-8527-dbbb3104a0a3", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e 6cada3f6-8e45-45cb-8a39-e9e70fbfdafa", "39e0c495-64b3-48c3-8905-30ee4c46867c 70ed29bc-f267-4828-b94c-2dba63a498ef", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e ae86a4be-3bc5-4d53-b4ed-df4f73fa8a91", "c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e e59f0d99-5566-4b9e-bcc5-dd26c8686664"].each do |i|
+  `yes | govuk_setenv specialist-publisher /var/apps/specialist-publisher/bin/remove_draft_manual_section  #{i} `
+end
+
+["/guidance/the-guide-to-cross-compliance-in-england-2016 555b57c0-8efb-487a-9316-955bd1e9b534", "/guidance/the-guide-to-cross-compliance-in-england-2016 0d1f1847-eb37-435b-bb4b-3a26155cb78a", "/guidance/the-guide-to-cross-compliance-in-england-2016 c3f1a2a8-923a-4dca-88f2-40cb04811513", "/guidance/the-guide-to-cross-compliance-in-england-2016 ef8b87d2-5f5c-4963-b38c-e65779aabe42", "/guidance/the-guide-to-cross-compliance-in-england-2016 79036b22-e4c1-4075-90b0-68cea2563e65", "/guidance/the-guide-to-cross-compliance-in-england-2016 d7915dbc-4522-498c-97c1-1177eefd9413", "/guidance/the-guide-to-cross-compliance-in-england-2016 63caeb1f-4f9d-4ec7-befb-bdfec56c1f36", "guidance/tax-tribunal-lead-case-appeals fde8c754-f620-4f56-a009-5088b0607a93", "/guidance/tax-tribunal-lead-case-appeals 9b0a9757-91ab-46e0-8cf3-0c138f652130", "/guidance/tax-tribunal-lead-case-appeals 480aa64a-e711-4c0b-91fc-3f0344ac6b60", "/guidance/test 1da6b4ac-47fd-4ab8-9078-297dcb568d58"].each do |i|
+  `yes | govuk_setenv specialist-publisher /var/apps/specialist-publisher/bin/delete_draft_manual #{i} `
+end
+
+
+
+
+
+
+
+
+

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -48,10 +48,10 @@ private
     log "Manual to be deleted: #{manual_record.slug}"
     log "Organisation: #{manual_record.organisation_slug}"
     log "This manual has #{number_of_sections} sections, and was last edited at #{manual_record.updated_at}"
-    log "Type 'Yes' to proceed and delete this manual or anything else to exit:"
+    log "Type 'y' to proceed and delete this manual or anything else to exit:"
 
     response = stdin.gets
-    unless response.strip.downcase == "yes"
+    unless response.strip.downcase == "y"
       raise "Quitting"
     end
   end

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -84,8 +84,15 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
 
       it { should be_valid_against_schema("specialist_document") }
 
-      it "should convert the body from govspeak to html" do
-        expect(presented["details"]["body"]).to eq(%{<h2 id="heading-2">Heading 2</h2>\n\n<p>Paragraph</p>\n})
+      it "should store both govspeak and html in the body" do
+        expect(presented["details"]["body"]).to eq([{
+                                                      "content_type"=>"text/html",
+                                                      "content"=>"<h2 id=\"heading-2\">Heading 2</h2>\n\n<p>Paragraph</p>\n"
+                                                    },
+                                                    {
+                                                      "content_type"=>"text/govspeak",
+                                                      "content"=>"## Heading 2\n\nParagraph"
+                                                    }])
       end
     end
 

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -15,7 +15,7 @@ describe ManualPublishingAPIExporter do
   }
 
   let(:export_recipent) { double(:export_recipent, call: nil) }
-  let(:manual_renderer) { ->(_) { double(:rendered_manual, attributes: manual_attributes) } }
+  let(:manual_renderer) { ->(_) { double(:rendered_manual, attributes: rendered_manual_attributes) } }
 
   let(:manual) {
     double(
@@ -56,6 +56,17 @@ describe ManualPublishingAPIExporter do
   }
 
   let(:manual_attributes) {
+    {
+      title: "My first manual",
+      summary: "This is my first manual",
+      body: "#Some heading\nmanual body",
+      slug: "guidance/my-first-manual",
+      updated_at: Time.new(2013, 12, 31, 12, 0, 0),
+      organisation_slug: "cabinet-office",
+    }
+  }
+
+  let(:rendered_manual_attributes) {
     {
       title: "My first manual",
       summary: "This is my first manual",
@@ -128,7 +139,14 @@ describe ManualPublishingAPIExporter do
       "/guidance/my-first-manual",
       hash_including(
         details: {
-          body: "<h1>Some heading</h1>\nmanual body",
+          body: [
+            {
+              :content_type=>"text/govspeak",
+              :content=>"#Some heading\nmanual body"
+            },
+            {:content_type=>"text/html",
+             :content=>"<h1>Some heading</h1>\nmanual body"}
+          ],
           child_section_groups: [
             {
               title: "Contents",

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -38,12 +38,28 @@ describe ManualSectionPublishingAPIExporter do
 
   let(:manual_slug) { "guidance/my-first-manual" }
 
+  let(:attachments) { [double("Attachment", attributes: {
+                         'content_id' => "0aa1aa33-36b9-4677-a643-52b9034a1c32",
+                         'file_url' => "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/introduction-section-image.jpg",
+                         'title' => "introduction section image",
+                         'created_at' => "2015-02-11T13:45:00.000+00:00",
+                         'updated_at' => "2015-02-13T13:45:00.000+00:00"
+                       }),
+                       double("Attachment", attributes: {
+                         'content_id' => "130d2b69-e32f-437f-9caa-89a4246fbe39",
+                         'file_url' => "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/introduction-section-pdf.pdf",
+                         'title' => "introduction section pdf",
+                         'created_at' => "2015-02-11T13:45:00.000+00:00",
+                         'updated_at' => "2015-02-13T13:45:00.000+00:00"
+                       })] }
+
   let(:document) {
     double(
       :document,
       id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
       attributes: {:body => "##Some heading\nmanual section body"},
+      attachments: attachments
     )
   }
 
@@ -91,7 +107,35 @@ describe ManualSectionPublishingAPIExporter do
       "/guidance/my-first-manual/first-section",
       hash_including(
         details: {
-          body: "<h1>Some heading</h1>\nsection body",
+          body:
+            [
+              {
+                :content_type=>"text/govspeak",
+                :content=>"##Some heading\nmanual section body"
+              },
+              {
+                :content_type=>"text/html",
+                :content=>"<h1>Some heading</h1>\nmanual section body"
+              }
+            ],
+          attachments: [
+            {
+              content_id: "0aa1aa33-36b9-4677-a643-52b9034a1c32",
+              url: "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/introduction-section-image.jpg",
+              title: "introduction section image",
+              content_type: 'application/jpg',
+              created_at: "2015-02-11T13:45:00.000+00:00",
+              updated_at: "2015-02-13T13:45:00.000+00:00"
+            },
+            {
+              content_id: "130d2b69-e32f-437f-9caa-89a4246fbe39",
+              url: "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/introduction-section-pdf.pdf",
+              title: "introduction section pdf",
+              content_type: 'application/pdf',
+              created_at: "2015-02-11T13:45:00.000+00:00",
+              updated_at: "2015-02-13T13:45:00.000+00:00"
+            }
+          ],
           manual: {
             base_path: "/guidance/my-first-manual",
           },

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -43,6 +43,7 @@ describe ManualSectionPublishingAPIExporter do
       :document,
       id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
+      attributes: {:body => "##Some heading\nmanual section body"},
     )
   }
 
@@ -51,7 +52,7 @@ describe ManualSectionPublishingAPIExporter do
       title: "Document title",
       summary: "This is the first section",
       slug: "guidance/my-first-manual/first-section",
-      body: "<h1>Some heading</h1>\nsection body",
+      body: "<h1>Some heading</h1>\nmanual section body",
       updated_at: Time.new(2013, 12, 31, 12, 0, 0),
     }
   }


### PR DESCRIPTION
- In V2 we are storing both govspeak and html inside publishing_api for the body field.
- Two rake tasks:  publishing_api:draft:publish_manuals & publishing_api:publish_documents_as_placeholders that are porting over V1 data to publishing-api have been updated to send both govspeak and html in the body field.
- V2 now stores attachments nested inside details hash for specialist_document and manual_sections. Rake task been updated to build attachment payload and send inside details hash.
- The rake tasks are not currently running. Refer to comments about specific errors on the [Trello card](https://trello.com/c/3TVLuEPC/14-import-all-the-old-specialist-publisher-documents-into-the-new-version-of-specialist-publisher). I have spoken to @tuzz, he mentioned about prioritising this [Trello Card](https://trello.com/c/1wLclYR2/668-improve-efficiency-of-content-item-presenter) to improve the efficient of publishing-api when it is hit with multiple put requests.
- [Trello Card](https://trello.com/c/3TVLuEPC/14-import-all-the-old-specialist-publisher-documents-into-the-new-version-of-specialist-publisher)