### PR TITLE
[DO NOT MERGE] Unpublish special doc

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
-  before_action :fetch_document, only: [:edit, :show, :publish, :update]
+  before_action :fetch_document, only: [:edit, :show, :publish, :update, :withdraw]
   before_action :permitted?, if: :document_type
 
   def index
@@ -72,6 +72,16 @@ class DocumentsController < ApplicationController
       redirect_to documents_path(current_format.document_type)
     else
       flash[:danger] = "There was an error publishing #{@document.title}. Please try again later."
+      redirect_to document_path(current_format.document_type, params[:content_id])
+    end
+  end
+
+  def withdraw
+    if @document.withdraw!
+      flash[:success] = "Withdrawn #{@document.title}"
+      redirect_to document_path(current_format.document_type, params[:content_id])
+    else
+      flash[:danger] = "There was an error withdrawing #{@document.title}. Please try again later."
       redirect_to document_path(current_format.document_type, params[:content_id])
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -225,6 +225,22 @@ class Document
     end
   end
 
+  def withdraw!
+    gone_content_id = SecureRandom.uuid
+    presented_document = WithdrawPresenter.new(gone_content_id, self.base_path)
+
+    begin
+      item_request = publishing_api.put_content(gone_content_id, presented_document.to_json)
+      publish_request = publishing_api.publish(gone_content_id, update_type)
+
+      item_request.code == 200 && publish_request.code == 200
+    rescue GdsApi::HTTPErrorResponse => e
+      Airbrake.notify(e)
+
+      false
+    end
+  end
+
   def find_attachment(attachment_content_id)
     self.attachments.detect { |attachment| attachment.content_id == attachment_content_id }
   end

--- a/app/presenters/withdraw_presenter.rb
+++ b/app/presenters/withdraw_presenter.rb
@@ -10,6 +10,7 @@ class WithdrawPresenter
       base_path: base_path,
       document_type: "gone",
       schema_name: "gone",
+      format: "gone",
       publishing_app: "specialist-publisher",
       routes: [
         {

--- a/app/presenters/withdraw_presenter.rb
+++ b/app/presenters/withdraw_presenter.rb
@@ -1,0 +1,26 @@
+class WithdrawPresenter
+  def initialize(content_id, base_path)
+    @content_id = content_id
+    @base_path = base_path
+  end
+
+  def to_json
+    {
+      content_id: content_id,
+      base_path: base_path,
+      document_type: "gone",
+      schema_name: "gone",
+      publishing_app: "specialist-publisher",
+      routes: [
+        {
+          path: base_path,
+          type: "exact",
+        }
+      ]
+    }
+  end
+
+private
+
+  attr_reader :content_id, :base_path
+end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -57,5 +57,17 @@
         <% end %>
       </div>
     </div>
+
+    <%= form_tag(withdraw_document_path(current_format.document_type, @document.content_id), method: :post, class: 'panel panel-default') do %>
+        <div class="panel-heading">
+          <div class="panel-title">
+            Withdraw document
+          </div>
+        </div>
+        <div class="panel-body">
+          <p>The document will be removed from the site. It will still be possible to edit the document and publish a new version.</p>
+          <button name="submit" class="btn btn-warning" data-module="confirm" data-message="Are you sure you want to withdraw this document?">Withdraw document</button>
+        </div>
+    <% end %>
   </div>
 </div>

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.feature 'Unpublishing a CMA case', type: :feature do
+  let(:cma_content_id) { 'c1b89646-bb11-487b-971a-4603bdd95b1d' }
+  let(:gone_content_id) { '44c3e7d3-2ec8-429f-bf5d-45c3125cd8ae' }
+
+  let(:published_cma_case) { Payloads.cma_case_content_item('content_id' => cma_content_id) }
+  let(:expected_withdraw_payload) do
+    {
+      content_id: gone_content_id,
+      base_path: published_cma_case['base_path'],
+      schema_name: 'gone',
+      document_type: 'gone',
+      publishing_app: 'specialist-publisher',
+      routes: [{
+        path: published_cma_case['base_path'],
+        type: 'exact'
+               }]
+    }
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    stub_any_publishing_api_put_content
+    stub_publishing_api_publish(gone_content_id, {})
+
+    allow(SecureRandom).to receive(:uuid).and_return(gone_content_id)
+
+    publishing_api_has_item(published_cma_case)
+  end
+
+  scenario 'from the show page' do
+    visit "/cma-cases/#{cma_content_id}"
+
+    click_button "Withdraw document"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Withdrawn Example CMA Case")
+
+    assert_publishing_api_put_content(gone_content_id, expected_withdraw_payload)
+    assert_publishing_api_publish(gone_content_id)
+  end
+end

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Unpublishing a CMA case', type: :feature do
       base_path: published_cma_case['base_path'],
       schema_name: 'gone',
       document_type: 'gone',
+      format: 'gone',
       publishing_app: 'specialist-publisher',
       routes: [{
         path: published_cma_case['base_path'],


### PR DESCRIPTION
This pull request was originally opened on specialist-publisher https://github.com/alphagov/specialist-publisher/pull/695

There was no comment on the original pull request at the time of this migration.

Original comment:
[Trello Card](https://trello.com/c/B0yvF9Vd)
## This is a PR opened to get more comments and is not feature-complete.
## Questions
1. Shall we call it 'withdraw' or 'unpublish' ? 
   - master branch uses withdraw
   - trello card has been updated to call it 'unpublish'
2. By sending a 'gone' format, the document is now lost and unretrievable in publishing-api. I believe this requires an extension of publishing-api. 
