### PR TITLE
Fix some style/presentation issues on specialist documents

### DIFF
--- a/app/assets/stylesheets/_document-index.scss
+++ b/app/assets/stylesheets/_document-index.scss
@@ -1,0 +1,19 @@
+.metadata-list {
+  width:100%;
+
+  dt {
+    float: left;
+    clear: both;
+    width:30%;
+  }
+  dd {
+    float: right;
+    width:70%;
+  }
+}
+
+.body-pre {
+  max-height: 500px;
+  overflow: scroll;
+  word-break: break-word;
+}

--- a/app/assets/stylesheets/_govspeak_help.scss
+++ b/app/assets/stylesheets/_govspeak_help.scss
@@ -1,0 +1,9 @@
+.govspeak-help {
+  h3 {
+    font-size: 19px;
+    margin-top: 0;
+  }
+  a {
+    cursor: pointer;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import 'document-list';
 @import 'header';
 @import "govspeak_help";
+@import 'document-index';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,4 +24,5 @@
 @import 'govuk_admin_template';
 @import 'forms';
 @import 'document-list';
-@import 'header'
+@import 'header';
+@import "govspeak_help";

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,7 +30,7 @@ class DocumentsController < ApplicationController
     if @document.valid?
       if @document.save!
         flash[:success] = "Created #{@document.title}"
-        redirect_to documents_path(current_format.document_type)
+        redirect_to document_path(current_format.document_type, @document.content_id)
       else
         flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
         render :new
@@ -55,7 +55,7 @@ class DocumentsController < ApplicationController
     if @document.valid?
       if @document.save!
         flash[:success] = "Updated #{@document.title}"
-        redirect_to documents_path(current_format.document_type)
+        redirect_to document_path(current_format.document_type, @document.content_id)
       else
         flash.now[:danger] = "There was an error updating #{@document.title}. Please try again later."
         render :edit
@@ -69,11 +69,10 @@ class DocumentsController < ApplicationController
   def publish
     if @document.publish!
       flash[:success] = "Published #{@document.title}"
-      redirect_to documents_path(current_format.document_type)
     else
       flash[:danger] = "There was an error publishing #{@document.title}. Please try again later."
-      redirect_to document_path(current_format.document_type, params[:content_id])
     end
+    redirect_to document_path(current_format.document_type, params[:content_id])
   end
 
 private

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -28,6 +28,10 @@ class Manual
     end
   end
 
+  def published?
+    live? || redrafted?
+  end
+
   def updated_at
     @updated_at ||= Time.zone.now
   end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,17 +1,25 @@
+<% content_for :breadcrumbs do %>
+  <li><%= link_to "Your documents", documents_path(current_format.document_type) %></li>
+  <li><%= link_to @document.title, document_path(document_type: params[:document_type], content_id: @document.content_id) %></li>
+  <li class='active'>Edit document</li>
+<% end %>
+
 <h2>Editing <%= @document.title %></h2>
 
-<div class="col-md-8">
-  <%= form_for @document, url: document_path(document_type: params[:document_type], content_id: @document.content_id), method: :put do |f| %>
-    <%= render partial: "shared/form_fields", locals: { f: f } %>
+<div class="row">
+  <div class="col-md-8">
+    <%= form_for @document, url: document_path(document_type: params[:document_type], content_id: @document.content_id), method: :put do |f| %>
+      <%= render partial: "shared/form_fields", locals: { f: f } %>
 
-    <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
+      <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
 
-    <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
+      <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
 
-    <div class="actions">
-      <button name="save" class="btn btn-success">Save as draft</button>
-    </div>
-  <% end %>
+      <div class="actions">
+        <button name="save" class="btn btn-success">Save as draft</button>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render partial: 'attachments/attachment_links' %>
 </div>
-
-<%= render partial: 'attachments/attachment_links' %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,15 +1,22 @@
+<% content_for :breadcrumbs do %>
+  <li><%= link_to "Your documents", documents_path(current_format.document_type) %></li>
+  <li class='active'>New document</li>
+<% end %>
+
 <h2>New <%= current_format.title.singularize %></h2>
 
-<div class="col-md-8">
-  <%= form_for @document, url: documents_path(params[:document_type]) do |f| %>
-    <%= render partial: "shared/form_fields", locals: { f: f } %>
+<div class="row">
+  <div class="col-md-8">
+    <%= form_for @document, url: documents_path(params[:document_type]) do |f| %>
+      <%= render partial: "shared/form_fields", locals: { f: f } %>
 
-    <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
+      <%= render partial: "metadata_fields/#{params[:document_type].underscore}", locals: { f: f } %>
 
-    <div class="actions">
-      <button name="save" class="btn btn-success">Save as draft</button>
-    </div>
-  <% end %>
+      <div class="actions">
+        <button name="save" class="btn btn-success">Save as draft</button>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render partial: 'attachments/attachment_links' %>
 </div>
-
-<%= render partial: 'attachments/attachment_links' %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -42,6 +42,45 @@
 
 <div class="row">
   <div class="col-md-8">
+    <%
+      truncate_at_size = 5
+      attachments = @document.attachments || []
+    %>
+    <h2 class="add-bottom-margin">
+      <%= number_with_delimiter(attachments.size) %> <%= 'attachment'.pluralize(attachments.size) %>
+    </h2>
+    <% if attachments.any? %>
+      <table class="table table-bordered table-striped add-bottom-margin" data-module="toggle">
+        <thead>
+          <tr class="table-header">
+            <th>Title</th>
+            <th>Created</th>
+            <th>Last&nbsp;updated</th>
+          </tr>
+        </thead>
+        <% attachments.each_with_index do | attachment, i | %>
+          <% if i == truncate_at_size - 1 %>
+            <tr class="table-header">
+              <td colspan="3" class="js-toggle-target text-center">
+                <strong><a href="#expand-table" class="js-toggle">…and <%= attachments.size - (truncate_at_size - 1) %> more</a></strong>
+              </td>
+            </tr>
+          <% end %>
+          <tr <% if i > truncate_at_size - 2 %>class="js-toggle-target if-js-hide"<% end %>>
+            <td><%= attachment.title %></td>
+            <td><%= attachment.created_at.to_date.to_s(:govuk_date) %></td>
+            <td><%= attachment.updated_at.to_date.to_s(:govuk_date) %></td>
+          </tr>
+        <% end %>
+      </table>
+    <% else %>
+      <p class='no-content-message'>This document doesn’t have any attachments</p>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-8">
     <h2>Actions</h2>
     <div class="well">
       <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,4 +43,4 @@
 <% end %>
 
 <%# use the govuk_admin_foundation layout %>
-<%= render :template => 'layouts/govuk_admin_template' %>
+<%= render :template => 'layouts/govuk_admin_template'%>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -3,10 +3,10 @@
     <li title='<% if !document.live? %>When published this document will appear at this URL<% end %>'>
       <%= document.base_path %>
     </li>
-    <% if document.live? %>
+    <% if document.published? %>
       <li><%= link_to "View on website", public_url %></li>
     <% end %>
-    <% if document.draft? %>
+    <% if document.draft? || document.redrafted? %>
       <li><%= link_to "Preview draft", content_preview_url(document) %></li>
     <% end %>
   </li>

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 require 'pathname'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -344,6 +344,32 @@ module Payloads
     }.deep_merge(attrs)
   end
 
+  def self.cma_case_with_attachments(attrs = {})
+    attachments = {
+      "details" => {
+        "attachments" => [
+          {
+            "content_id" => "0aa1aa33-36b9-4677-a643-52b9034a1c32",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-image.jpg",
+            "content_type" => "application/jpg",
+            "title" => "example cma case image",
+            "created_at" => "2015-02-11T13:45:00.000+00:00",
+            "updated_at" => "2015-02-13T13:45:00.000+00:00"
+          },
+          {
+            "content_id" => "130d2b69-e32f-437f-9caa-89a4246fbe39",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-pdf.pdf",
+            "content_type" => "application/pdf",
+            "title" => "example cma case pdf",
+            "created_at" => "2015-02-11T13:45:00.000+00:00",
+            "updated_at" => "2015-02-13T13:45:00.000+00:00"
+          }
+        ]
+      } }.deep_merge(attrs)
+
+    cma_case_content_item(attachments)
+  end
+
   def self.medical_safety_alert_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,


### PR DESCRIPTION
Add missing styles and container divs, breadcrumbs on form pages, attachments summary on show page.

This was originally raised on the original Specialist Publisher repository: https://github.com/alphagov/specialist-publisher/pull/696
