### PR TITLE
Schema tests: make GitHub message reflect the app repo

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -2,7 +2,7 @@
 export DISPLAY=:99
 export GOVUK_APP_DOMAIN=test.alphagov.co.uk
 export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
-export CONTEXT_MESSAGE="Verify specialist-publisher against content schemas"
+export CONTEXT_MESSAGE="Verify specialist-publisher-rebuild against content schemas"
 env
 
 function github_status {


### PR DESCRIPTION
Currently the message is clashing with the Specialist Publisher v1
schema tests.

/cc @christophwong 
