### PR TITLE
Remove redunand test mongoid config

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -13,7 +13,3 @@ test:
       options:
         write:
           w: 1
-        # In the test environment we lower the retries and retry interval to
-        # low amounts for fast failures.
-        max_retries: 1
-        retry_interval: 0


### PR DESCRIPTION
This silences the following warnings during test runs:

```
W, [2016-04-12T14:14:36.334219 #26791]  WARN -- : MONGODB | Unsupported client option 'max_retries'. It will be ignored.
W, [2016-04-12T14:14:36.334368 #26791]  WARN -- : MONGODB | Unsupported client option 'retry_interval'. It will be ignored.
```
