### PR TITLE
Remove wrong code climate badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Code Climate](https://codeclimate.com/github/alphagov/specialist-publisher.png)](https://codeclimate.com/github/alphagov/specialist-publisher)
-
 # Specialist publisher
 
 ## Purpose


### PR DESCRIPTION
- the CC badge points at the old repo (specialist-publisher)
- on review it seems that it doesn't provide extra value to our team except for a pretty picture.
