### PR TITLE
Seed a new user for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ $ ./startup.sh
 ```
 If you are using the GDS development virtual machine then the application will be available on the host at https://specialist-publisher-rebuild.dev.gov.uk/
 
+### Populate development database
+
+In order to quickly get your local database into working order run `$ bundle exec rake db:seed`.
+
+Currently this:
+* creates a default user record with basic permissions that allows you to log in and create a new document
+
 ### Notes on Mock User while running the application on development environment
 
 In the development environment, a mock user is created automatically by the gds-sso gem.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+if Rails.env.development?
+  # Setup a mock user
+  User.create(name: "Test user", permissions: ["signin", "gds_editor"])
+end


### PR DESCRIPTION
In order to get up and running in development as quickly as possible without having to run the console and remember what permissions are required each time, we add this into `rake db:seed`.
