### PR TITLE
Add worker to publish specialist documents in background

### DIFF
--- a/app/workers/publish_specialist_document_worker.rb
+++ b/app/workers/publish_specialist_document_worker.rb
@@ -1,0 +1,87 @@
+class PublishSpecialistDocumentWorker
+  include Sidekiq::Worker
+  attr_reader :logger
+
+  def initialize
+    @logger = Logger.new(STDOUT)
+  end
+  sidekiq_options(
+    # This is required to retry in the case of a FailedToPublishError
+    retry: 25,
+    backtrace: true,
+  )
+
+  def perform(edition_id)
+    log_queue_length
+    edition = specialist_document_editions.find(edition_id)
+    document = factory(edition.document_type).call(edition.document_id, [edition])
+
+    rendered_document = formatter.new(
+      document,
+      specialist_document_renderer: renderer,
+      publication_logs: PublicationLog
+    )
+
+    exporter.new(
+        publishing_api,
+        rendered_document,
+        document.draft?
+    ).call
+  rescue => error
+    log_error(error)
+    requeue_task(edition_id, error)
+  end
+
+  private
+  def log_queue_length
+    logger.info("Sidekiq queue length: #{Sidekiq::Queue.new.size}")
+  end
+
+  def specialist_document_editions
+    SpecialistDocumentEdition
+  end
+
+  def formatter
+    SpecialistDocumentPublishingAPIFormatter
+  end
+
+  def publishing_api
+    SpecialistPublisherWiring.get(:publishing_api)
+  end
+
+  def renderer
+    SpecialistPublisherWiring.get(:specialist_document_renderer)
+  end
+
+  def exporter
+    SpecialistDocumentPublishingAPIExporter
+  end
+
+  def factory(type)
+    entity_factories.public_send("#{type}_factory")
+  end
+
+  def entity_factories
+    SpecialistPublisherWiring.get(:validatable_document_factories)
+  end
+
+  def requeue_task(edition_id, error)
+    # Raise a FailedToPublishError in order for Sidekiq to catch and requeue it
+    # This is more meaningful when viewing retries in the queue than an error thrown
+    # further down the stack!
+    raise FailedToPublishError.new("Failed to publish specialist document with id: #{edition_id}", error)
+  end
+
+  def log_error(error)
+    Airbrake.notify(error)
+  end
+
+  class FailedToPublishError < StandardError
+    attr_reader :original_exception
+
+    def initialize(message, original_exception = nil)
+      super(message)
+      @original_exception = original_exception
+    end
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -24,7 +24,6 @@ namespace :publishing_api do
     SpecialistPublisher.document_types.each do |type|
       SpecialistDocumentBulkExporter.new(
         type,
-        formatter: MigrationSpecialistDocumentPublishingAPIFormatter,
         logger: Logger.new(STDOUT)
       ).call
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"
 require "webmock/rspec"
+require "gds_api/test_helpers/publishing_api"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -43,6 +44,8 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  config.include(GdsApi::TestHelpers::PublishingApi)
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/workers/publish_specialist_document_worker_spec.rb
+++ b/spec/workers/publish_specialist_document_worker_spec.rb
@@ -1,0 +1,35 @@
+require "sidekiq/testing"
+require "spec_helper"
+Sidekiq::Testing.inline!
+
+RSpec.describe "Publish specialist document worker" do
+  let(:subject) { PublishSpecialistDocumentWorker }
+
+  let!(:edition1) {
+    FactoryGirl.create(
+      :specialist_document_edition,
+      document_id: SecureRandom.uuid,
+      document_type: "cma_case",
+      updated_at: 2.days.ago,
+      title: "Original title",
+      body: "",
+      state: "published",
+      slug: "specialist-document-1"
+    )
+  }
+
+  it "should PUT specialist document payload to publishing-api" do
+    stub_default_publishing_api_put
+    worker = subject.new
+    worker.perform(edition1.id.to_s)
+    assert_publishing_api_put_item("/specialist-document-1")
+  end
+
+  it "should log response to Airbrake and requeue task if publishing-api does not return http status 200" do
+    publishing_api_isnt_available
+    expect(Airbrake).to receive(:notify)
+    worker = subject.new
+    expect {worker.perform(edition1.id.to_s)}.to raise_error(PublishSpecialistDocumentWorker::FailedToPublishError)
+  end
+
+end


### PR DESCRIPTION
- publishing_api:publish_documents_as_placeholders rake task queries mongoDB and returns over 14k editions. For each edition, it was synchronously sending the edition payload to publishing-api. The connection to MongoDB was timing out after around 3000 editions causing the rake task to fail;
- To solve this, the request to publishing-api was extracted into an asynchronous background sidekiq worker;
- [Trello Card](https://trello.com/c/3TVLuEPC/14-import-all-the-old-specialist-publisher-documents-into-the-new-version-of-specialist-publisher)