### PR TITLE
Update countryside stewardship grants finder

### DIFF
--- a/finders/metadata/countryside-stewardship-grants.json
+++ b/finders/metadata/countryside-stewardship-grants.json
@@ -10,7 +10,8 @@
   },
   "organisations": ["d3ce4ba7-bc75-46b4-89d9-38cb3240376d", "de4e9dc6-cca4-43af-a594-682023b84d6c", "8bf5624b-dec2-44fa-9b6c-daed166333a5"],
   "related": [
-    "c763d9e0-3228-4fde-9b30-a4f69f656468",
-    "6f6d6f3e-be96-48bb-8ba8-c5bce6cc6922"
-  ]
+    "5bdde33c-c200-4245-925b-8d5dcd075546",
+    "975ad786-7d28-4189-b635-961395e19954"
+  ],
+  "summary": "<p>Find options, supplements and capital items to include in your application for Countryside Stewardship. For agreements that started on 1 January 2016 refer to the <a href=\"government/publications/countryside-stewardship-manual-and-grants-1-january-2016-agreements\">earlier version</a>.</p>"
 }


### PR DESCRIPTION
Change the related links and add a summary.  This change request came from Natural England, see: https://trello.com/c/LtlnThLN/356-content-changes-to-countryside-stewardship-grants-finder-2

(See alphagov/specialist-publisher-rebuild#718 which does the same to the rebuild)