### PR TITLE
Only allow GDS Editors (managing editors) to publish documents

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,8 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   before_action :fetch_document, only: [:edit, :show, :publish, :update]
-  before_action :permitted?, if: :document_type
+  before_action :permitted?, if: :document_type, except: :publish
+  before_action :publish_permitted?, if: :document_type, only: :publish
 
   def index
     page = filtered_page_param(params[:page])
@@ -140,6 +141,15 @@ private
       redirect_to manuals_path
     else
       flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
+      redirect_to manuals_path
+    end
+  end
+
+  def publish_permitted?
+    if current_user.gds_editor?
+      true
+    else
+      flash[:danger] = "Please contact your organisation's managing editor to publish this document."
       redirect_to manuals_path
     end
   end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -86,15 +86,17 @@
       <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>
     </div>
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Publish document</h3>
+    <% if current_user.gds_editor? %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Publish document</h3>
+        </div>
+        <div class="panel-body">
+          <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
+            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+          <% end %>
+        </div>
       </div>
-      <div class="panel-body">
-        <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
-          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
-        <% end %>
-      </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
   end
 
   before do
-    log_in_as_editor(:cma_editor)
+    log_in_as_editor(:gds_editor)
 
     publishing_api_has_content([cma_case, minor_update_item], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
     publishing_api_has_content([cma_org_content_item], document_type: 'organisation', fields: [:base_path, :content_id])
@@ -121,5 +121,23 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     assert_publishing_api_publish(content_id)
 
     assert_not_requested(:post, Plek.current.find('email-alert-api') + "/notifications")
+  end
+
+  context "a regular CMA editor" do
+    it "shouldn't be able to publish anything" do
+      log_in_as_editor(:cma_editor)
+
+      publishing_api_has_item(minor_update_item)
+
+      visit "/cma-cases"
+      expect(page.status_code).to eq(200)
+
+      click_link "Minor Update Case"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Minor Update Case")
+
+      expect(page).not_to have_button("Publish")
+    end
   end
 end


### PR DESCRIPTION
- This only adds a test that CMA editors (ie normal editors, non-managing editors) can't publish documents,
  because there are already tests
  (https://github.com/alphagov/specialist-publisher-rebuild/blob/master/spec/features/access_control_spec.rb,
  https://github.com/alphagov/specialist-publisher-rebuild/blob/master/spec/features/creating_a_cma_case_spec.rb)
  that check that departmental editors can access and edit their own
  department's documents.
