### PR TITLE
Switching back to using tags in email alert payload

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -25,16 +25,9 @@ private
   end
 
   def tags
-    { format: document.publishing_api_document_type }.deep_merge(metadata)
-  end
-
-  def metadata
-    merged_fields = document.format_specific_fields.map { |f|
-      {
-        f => document.send(f)
-      }
-    }.reduce({}, :merge)
-    merged_fields.reject { |_k, v| v.blank? }
+    {
+      format: document.publishing_api_document_type
+    }.deep_merge(document.format_specific_metadata.reject { |_k, v| v.blank? })
   end
 
   def standard_body(template_path)

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -9,7 +9,7 @@ class EmailAlertPresenter
     {
       subject: document.title + " updated",
       body: body,
-      links: { topics: [document.content_id] },
+      tags: tags,
       document_type: document.publishing_api_document_type,
     }.merge(extra_options)
   end
@@ -22,6 +22,19 @@ private
     else
       standard_body("email_alerts/publication")
     end
+  end
+
+  def tags
+    { format: document.publishing_api_document_type }.deep_merge(metadata)
+  end
+
+  def metadata
+    merged_fields = document.format_specific_fields.map { |f|
+      {
+        f => document.send(f)
+      }
+    }.reduce({}, :merge)
+    merged_fields.reject { |_k, v| v.blank? }
   end
 
   def standard_body(template_path)

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -68,8 +68,12 @@ RSpec.describe CmaCase do
 
   let(:email_alert_payload) do
     {
-      "links" => {
-        "topics" => [cma_cases[0]["content_id"]]
+      "tags" => {
+        "format" => "cma_case",
+        "opened_date" => "2014-01-01",
+        "case_type" => "ca98-and-civil-cartels",
+        "case_state" => "open",
+        "market_sector" => ["energy"]
       },
       "document_type" => "cma_case"
     }

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -18,8 +18,9 @@ describe EmailAlertPresenter do
         expect(presented_data[:subject]).to include(cma_case_payload["title"])
         expect(presented_data[:body]).to include(cma_case_payload["description"])
         expect(presented_data[:body]).to include(cma_case_payload["title"])
-        expect(presented_data[:links]).to eq(topics: [cma_case_payload["content_id"]])
-        expect(presented_data[:document_type]).to eq("cma_case")
+        expect(presented_data[:tags][:format]).to eq(cma_case_payload["document_type"])
+        expect(presented_data[:tags][:case_type]).to eq(cma_case_payload["details"]["metadata"]["case_type"])
+        expect(presented_data[:document_type]).to eq(cma_case_payload["document_type"])
         expect(presented_data[:footer]).to include("SUBSCRIBER_PREFERENCES_URL")
         expect(presented_data[:header]).to include("govuk-email-header")
       end
@@ -38,7 +39,6 @@ describe EmailAlertPresenter do
         presented_data = email_alert_presenter.to_json
 
         expect(presented_data[:body]).to include(mhra_email_address)
-        expect(presented_data[:links]).to eq(topics: [medical_safety_payload["content_id"]])
         expect(presented_data[:document_type]).to eq("medical_safety_alert")
       end
     end


### PR DESCRIPTION
[TRELLO](https://trello.com/c/ploRXLJV)
As of now email-alert-api does not support a way without using "tags" to get a
multi-document subscriber list (subscribed to all /cma-cases changes as
opposed to one specific document as seen with travel advise publisher's
usage) from content-ids/links.

Leaving links intact because a.) it doesn't affect the payload in initial testing, b.) tags are being deprecated and we hope to use just links in the future.

I have tested this change in payload format by using 

```
curl -X POST -H "Content-Type: application/json" -d <actual payload> https://email-alert-api.integration.publishing.service.gov.uk/notifications
```

The payload where marked <actual payload> in the above example is as follow with the HTML replaced with <shortened> (but for context the actual html string was used). Focus is on the `"tags"` attribute

```
{"subject": "test with b", "body": "<shortened>", "links": {"topic": ["e033acc7-9034-4f01-90f4-ca6a49952194"]}, "tags": {"format": "cma_case", "opened_date": "2016-04-10", "case_type": "ca98-and-civil-cartels", "case_state": "open", "market_sector":["something"]}, "document_type": "cma_case", "header": "<shortened>", "footer": "<shortened>"}
```

In the Tech Debt session of email-alert-api govuk docs, regarding the new links architechure, one of the future goals is "Resolving how specialist document alerts would work alongside such an architecture"
Reference: https://gov-uk.atlassian.net/wiki/display/TECH/Email+Alert+API
