### PR TITLE
Decrease manual load time

### DIFF
--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -4,11 +4,12 @@ RSpec.feature "Access control", type: :feature do
   let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
   let(:page_number) { 1 }
   let(:per_page) { 50 }
+  let(:manual_fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
 
   before do
     publishing_api_has_content([], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
     publishing_api_has_content([], document_type: AaibReport.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
-    publishing_api_has_content([], document_type: 'manual', fields: [:content_id])
+    publishing_api_has_content([], document_type: 'manual', fields: manual_fields, per_page: 10000)
   end
 
   context "as a CMA Editor" do
@@ -67,12 +68,12 @@ RSpec.feature "Access control", type: :feature do
     let(:manual_links_2) { Payloads.manual_links("content_id" => manual_content_id_2, "links" => { "organisations" => [organisation_user.organisation_content_id] }) }
 
     let(:organisation_user) { FactoryGirl.create(:cma_editor) }
-
+    let(:manual_fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
     before do
       publishing_api_has_item(manual_content_item_1)
       publishing_api_has_item(manual_content_item_2)
 
-      publishing_api_has_content([manual_content_item_1, manual_content_item_2], document_type: 'manual', fields: [:content_id])
+      publishing_api_has_content([manual_content_item_1, manual_content_item_2], document_type: 'manual', fields: manual_fields, per_page: 10000)
 
       [manual_links_1, manual_links_2].each do |link_set|
         publishing_api_has_links(link_set)

--- a/spec/features/creating_a_manual_spec.rb
+++ b/spec/features/creating_a_manual_spec.rb
@@ -33,9 +33,12 @@ RSpec.feature "Creating a Manual", type: :feature do
       }
     end
 
+    let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
+
     before do
       log_in_as_editor(:gds_editor)
-      publishing_api_has_content([], document_type: "manual", fields: [:content_id])
+      #make manual content items... before they just needed ids now needs other fields1
+      publishing_api_has_content([], document_type: "manual", fields: fields, per_page: 10000)
 
       stub_publishing_api_put_content(test_content_id, {})
       stub_publishing_api_patch_links(test_content_id, {})

--- a/spec/features/editing_a_manual_spec.rb
+++ b/spec/features/editing_a_manual_spec.rb
@@ -5,10 +5,11 @@ RSpec.feature 'editing a manual' do
   let(:manual_links) { Payloads.manual_links }
   let(:section_content_items) { Payloads.section_content_items }
   let(:section_links) { Payloads.section_links }
+  let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
 
   before do
     log_in_as_editor(:gds_editor)
-    publishing_api_has_content([manual_content_item], document_type: "manual", fields: [:content_id])
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
     publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: [:content_id])
     stub_publishing_api_put_content(manual_content_item["content_id"], {})
     stub_publishing_api_patch_links(manual_content_item["content_id"], {})

--- a/spec/features/viewing_a_manual_section_spec.rb
+++ b/spec/features/viewing_a_manual_section_spec.rb
@@ -6,12 +6,12 @@ RSpec.feature "Viewing a Manual and its Sections", type: :feature do
     let(:manual_links) { Payloads.manual_links }
     let(:section_content_items) { Payloads.section_content_items }
     let(:section_links) { Payloads.section_links }
-
+    let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
     before do
       log_in_as_editor(:gds_editor)
 
-      publishing_api_has_content([manual_content_item], document_type: "manual", fields: [:content_id])
-      publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: [:content_id])
+      publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
+      publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: 10000)
 
       content_items = [manual_content_item] + section_content_items
 

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -5,9 +5,10 @@ RSpec.feature "Viewing a Manual", type: :feature do
   let(:manual_links) { Payloads.manual_links }
   let(:section_content_items) { Payloads.section_content_items }
   let(:section_links) { Payloads.section_links }
+  let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
 
   before do
-    publishing_api_has_content([manual_content_item], document_type: "manual", fields: [:content_id])
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
     publishing_api_has_content(
       section_content_items.map do |section|
         {


### PR DESCRIPTION
[Trello](https://trello.com/c/Eh0CIc1C/95-speed-up-manuals-load-time)

The `/manuals` page is the home page of specialist-publisher. Currently users are often unable to view the `/manuals` page as there are time-outs in pulling manual data from the publishing-api.

In the previous implementation of manuals#index, `get_content_items` received all manual content items from publishing-api, mapped their ids and then looped over these ids to get each individual content item's attributes. Building all content items is now faster due to requesting the required fields and utilising results from the publishing-api response (basically the results contains all content_item data - links). This eradicates the need to loop over each content_id to build individual manual objects.

Getting links for each content item is still done individually as currently the publishing-api does not support returning all requested links at once.

Unfortunately looping through each content item and fetching links data from the publishing-api is still causing time outs. However this commit is an improvement on the previous implementation which individually fetched data for the attributes of each content item from publishing-api as well as then fetching links data for each content item.
