### PR TITLE
Create a script to delete duplicate drafts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", :path => "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "28.0.1"
+  gem "gds-api-adapters", "30.2.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
@@ -99,7 +99,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (28.0.1)
+    gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -380,7 +380,7 @@ DEPENDENCIES
   faraday (= 0.9.0)
   fetchable (= 1.0.0)
   foreman (= 0.74.0)
-  gds-api-adapters (= 28.0.1)
+  gds-api-adapters (= 30.2.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.11.0)
   govspeak (= 3.1.0)

--- a/bin/delete_duplicate_drafts
+++ b/bin/delete_duplicate_drafts
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+
+require "duplicate_draft_deleter"
+
+DuplicateDraftDeleter.new.call

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -1,0 +1,39 @@
+require "gds_api/publishing_api_v2"
+
+class DuplicateDraftDeleter
+  def call
+    duplicated_editions_not_in_publishing_api = duplicated_editions.reject {|data| in_publishing_api?(data[:content_id]) }
+
+    puts "The following #{duplicated_editions_not_in_publishing_api.count} unpublished drafts are being deleted:"
+    duplicated_editions_not_in_publishing_api.each do |data|
+      puts [data[:slug], data[:content_id], data[:state], data[:created_at]].join(",")
+      edition = SpecialistDocumentEdition.where(document_id: data[:content_id]).first
+      edition.delete
+    end
+  end
+
+private
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find("publishing-api"),
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
+    )
+  end
+
+  def in_publishing_api?(content_id)
+    publishing_api.get_content(content_id).present?
+  end
+
+  def duplicated_editions
+    slug_hash = {}
+    SpecialistDocumentEdition.all.each do |edition|
+      slug_hash[edition.slug] ||= {}
+      slug_hash[edition.slug][edition.document_id] ||= {state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.document_id, slug: edition.slug}
+      slug_hash[edition.slug][edition.document_id][:editions] += 1
+    end
+
+    slug_hash.reject! { |_slug, documents| documents.size == 1 }
+    slug_hash.values.map(&:values).flatten(1)
+  end
+end

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+require "duplicate_draft_deleter"
+require "gds_api/test_helpers/publishing_api_v2"
+
+describe DuplicateDraftDeleter do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  it "deletes duplicate editions that aren't present in Publishing API" do
+    original_content_id = SecureRandom.uuid
+    edition = FactoryGirl.create(:specialist_document_edition,
+      slug: "cma-cases/a-case",
+      document_id: original_content_id,
+      document_type: "cma_case",
+    )
+    publishing_api_has_item(content_id: original_content_id)
+
+    duplicate_content_id = SecureRandom.uuid
+    duplicate_edition = FactoryGirl.create(:specialist_document_edition,
+      slug: "cma-cases/a-case",
+      document_id: duplicate_content_id,
+      document_type: "cma_case",
+    )
+    publishing_api_does_not_have_item(duplicate_content_id)
+
+    expected_output = /The following 1 unpublished drafts are being deleted.*#{duplicate_content_id}/m
+    expect { DuplicateDraftDeleter.new.call }.to output(expected_output).to_stdout
+
+    expect(SpecialistDocumentEdition.where(document_id: original_content_id)).to be_present
+    expect(SpecialistDocumentEdition.where(document_id: duplicate_content_id)).to_not be_present
+  end
+
+  it "leaves non-duplicated editions alone" do
+    content_id = SecureRandom.uuid
+    edition = FactoryGirl.create(:specialist_document_edition,
+      document_id: content_id,
+    )
+
+    another_content_id = SecureRandom.uuid
+    edition = FactoryGirl.create(:specialist_document_edition,
+      document_id: another_content_id,
+    )
+
+    expect { DuplicateDraftDeleter.new.call }.to output.to_stdout
+
+    expect(SpecialistDocumentEdition.where(document_id: content_id)).to be_present
+    expect(SpecialistDocumentEdition.where(document_id: another_content_id)).to be_present
+  end
+end


### PR DESCRIPTION
There is a bug that causes duplicate draft editions to be created in the SP database. These duplicates are rejected from the Publishing API but cause confusion for publishers, because they suddenly see many identical drafts that they are unable to delete.

We are not fixing the underlying issue because this app will be replaced very shortly; we want to remove duplicates to improve the user experience for publishers and to make republishing to Publishing API possible.

The script works by finding slugs with multiple editions, and then deletes those editions that aren't present in Publishing API.