### PR TITLE
Notify user if #publish method is unsuccessful

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -238,6 +238,7 @@ class Document
       publish_request.code == 200 && rummager_request.code == 200
     rescue GdsApi::HTTPErrorResponse => e
       Airbrake.notify(e)
+      false
     end
   end
 


### PR DESCRIPTION
- Previously #publish was returning true even is an error was raised;
- The meant users was being falsely notified that their documents had been successfully published; 
- #publish now explicitly returns false if an error is raised;
- Users are correctly informed if their documents have been successfully published or not;
- (Trello Card)[https://trello.com/c/q38HWZOz/73-users-not-being-notified-if-specialist-document-is-not-successfully-published-or-indexed-by-rummager]
