### PR TITLE
Change wording of live publication state

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
   end
 
   def state(document)
-    state = document.publication_state
+    state = document.live? ? "published" : document.publication_state
 
     if document.draft?
       classes = "label label-primary"

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
         "publication_state" => "draft",
       )
     end
+    ten_example_cases[1]["publication_state"] = "published"
     ten_example_cases << cma_case_with_attachments
   }
 
@@ -39,7 +40,9 @@ RSpec.feature "Viewing a specific case", type: :feature do
     expect(page).to have_content("Example CMA Case 0")
     expect(page).to have_content("Example CMA Case 1")
     expect(page).to have_content("Example CMA Case 2")
-
+    within(".document-list li.document:nth-child(2)") do
+      expect(page).to have_content("published")
+    end
     click_link "Example CMA Case 0"
 
     expect(page.status_code).to eq(200)


### PR DESCRIPTION
Changes publication state label to display 'published' instead of 'live'. This was to remain consistent with v1 Specialist Publisher and also felt slightly more descriptive.

[Trello](https://trello.com/c/OneSeP43/78-wording-inconsistencies-between-sp-and-spr-small)
