### PR TITLE
Revert "Only allow GDS Editors (managing editors) to publish documents"

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,8 +6,7 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   before_action :fetch_document, only: [:edit, :show, :publish, :update]
-  before_action :permitted?, if: :document_type, except: :publish
-  before_action :publish_permitted?, if: :document_type, only: :publish
+  before_action :permitted?, if: :document_type
 
   def index
     page = filtered_page_param(params[:page])
@@ -141,15 +140,6 @@ private
       redirect_to manuals_path
     else
       flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
-      redirect_to manuals_path
-    end
-  end
-
-  def publish_permitted?
-    if current_user.gds_editor?
-      true
-    else
-      flash[:danger] = "Please contact your organisation's managing editor to publish this document."
       redirect_to manuals_path
     end
   end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -86,17 +86,15 @@
       <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>
     </div>
 
-    <% if current_user.gds_editor? %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Publish document</h3>
-        </div>
-        <div class="panel-body">
-          <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
-            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
-          <% end %>
-        </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Publish document</h3>
       </div>
-    <% end %>
+      <div class="panel-body">
+        <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
+          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
   end
 
   before do
-    log_in_as_editor(:gds_editor)
+    log_in_as_editor(:cma_editor)
 
     publishing_api_has_content([cma_case, minor_update_item], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
     publishing_api_has_content([cma_org_content_item], document_type: 'organisation', fields: [:base_path, :content_id])
@@ -121,23 +121,5 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     assert_publishing_api_publish(content_id)
 
     assert_not_requested(:post, Plek.current.find('email-alert-api') + "/notifications")
-  end
-
-  context "a regular CMA editor" do
-    it "shouldn't be able to publish anything" do
-      log_in_as_editor(:cma_editor)
-
-      publishing_api_has_item(minor_update_item)
-
-      visit "/cma-cases"
-      expect(page.status_code).to eq(200)
-
-      click_link "Minor Update Case"
-
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content("Minor Update Case")
-
-      expect(page).not_to have_button("Publish")
-    end
   end
 end


### PR DESCRIPTION
Reverts alphagov/specialist-publisher-rebuild#719 because having these changes is confusing the issue of making https://trello.com/c/DEDYI3iV/47-permission-levels-for-different-editors-in-specialist-documents correct: to allow all editors in a department to do everything to their department's documents. This diff doesn't help. SP doesn't have the same workflow as other publishing apps (no concept currently of managing editors, for example), and the team will work more on the story to make it clearer what is required.
