### PR TITLE
Display 'published' for live specialist-documents on index page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
   end
 
   def state(document)
-    state = document.live? ? "published" : document.publication_state
+    state = document.publication_state == "live" ? "published" : document.publication_state
 
     if document.draft?
       classes = "label label-primary"

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
         "publication_state" => "draft",
       )
     end
-    ten_example_cases[1]["publication_state"] = "published"
+    ten_example_cases[1]["publication_state"] = "live"
     ten_example_cases << cma_case_with_attachments
   }
 


### PR DESCRIPTION
Paired with @Rosa-Fox 
Previous fix for the show page calls `document#live?` in the `state` helper
method. However, the index page loads OpenStruct objects instead of
Document objects and will always return nil for `document#live?`.

Before:
![pubstate_before](https://cloud.githubusercontent.com/assets/3989823/14743699/cc4671fa-089a-11e6-904b-cd0795fbe88b.png)

After:
![publishstate_after](https://cloud.githubusercontent.com/assets/3989823/14743703/d148c8d8-089a-11e6-9fac-6bfd5c863fec.png)
