### PR TITLE
Remove publish button for published specialist documents

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -91,8 +91,14 @@
         <h3 class="panel-title">Publish document</h3>
       </div>
       <div class="panel-body">
-        <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
-          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+        <% if @document.live? %>
+          <p class="remove-bottom-margin">
+            There are no changes to publish.
+          </p>
+        <% else %>
+          <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
+            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
This was to remain consistent with v1 Specialist Publisher. If a specialist document has been published then the user will not see a 'Publish' button and will see a message instead.

[Trello](https://trello.com/c/7fCjj5MV/87-published-document-should-not-have-a-publish-button-small)

Before:
<img width="800" alt="publish_button_before" src="https://cloud.githubusercontent.com/assets/5963488/14746558/1f0047b0-08a8-11e6-993f-e16c297e4a09.png">

After:
<img width="780" alt="publish_button_after" src="https://cloud.githubusercontent.com/assets/5963488/14746577/2bd8a374-08a8-11e6-8c20-1c765a27545d.png">
