### PR TITLE
Use pundit gem for authorisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jquery-rails', '~> 3.1.4'
 gem 'select2-rails', '~> 4.0.0'
 gem "kaminari"
 gem 'bootstrap-kaminari-views', '0.0.5'
-
+gem 'pundit'
 # GDS managed dependencies
 gem 'plek', '~> 1.10'
 gem 'gds-sso', '11.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -343,6 +345,7 @@ DEPENDENCIES
   mongoid (= 5.0.1)
   plek (~> 1.10)
   pry
+  pundit
   rails (= 4.2.6)
   rspec-rails (~> 3.3)
   sass-rails (~> 4.0.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,22 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
+  include Pundit
 
   before_filter :require_signin_permission!
 
   helper_method :current_format
   helper_method :formats_user_can_access
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
 private
+
+  def user_not_authorized
+    flash[:danger] = "You aren't permitted to access #{current_format.title.pluralize}. If you feel you've reached this in error, contact your SPOC."
+    redirect_to manuals_path
+  end
+
 
   def document_type
     params[:document_type]

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -20,6 +20,10 @@ class Document
     :public_updated_at,
   ]
 
+  def self.policy_class
+    DocumentPolicy
+  end
+
   def initialize(params = {}, format_specific_fields = [])
     @content_id = params.fetch(:content_id, SecureRandom.uuid)
     @format_specific_fields = format_specific_fields

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -1,0 +1,38 @@
+class DocumentPolicy
+  attr_reader :user, :document_class
+
+  def initialize(user, document_class)
+    @user = user
+    @document_class = document_class
+  end
+
+  def user_organisation_owns_document_type?
+    document_class.organisations.include?(user.organisation_content_id)
+  end
+
+  def departmental_editor
+    user_organisation_owns_document_type? && user.permissions.include?('editor')
+  end
+
+  def writer
+    user_organisation_owns_document_type?
+  end
+
+  def gds_editor
+    user.gds_editor?
+  end
+
+  def index?
+    gds_editor || departmental_editor || writer
+  end
+
+  alias_method :new?, :index?
+  alias_method :create?, :index?
+  alias_method :edit?, :index?
+  alias_method :update?, :index?
+  alias_method :show?, :index?
+
+  def publish?
+    gds_editor || departmental_editor
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -19,12 +19,12 @@ FactoryGirl.define do
     permissions %w(signin gds_editor)
   end
 
-  factory :cma_editor, parent: :user do
+  factory :cma_editor, parent: :editor do
     organisation_slug "competition-and-markets-authority"
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   end
 
-  factory :aaib_editor, parent: :user do
+  factory :aaib_editor, parent: :editor do
     organisation_slug "air-accidents-investigation-branch"
     organisation_content_id "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
   end


### PR DESCRIPTION
We wanted to use this gem because it allows us to format authorisation
levels in policies objects, which might be an improvement on readability
of permission rules.

This commit replaces the original "permitted?" method used in DocumentController with Pundit code.

Another benefit is that we are moving away from using the "helper methods" in application controller (#formats_user_can_access) and it helps clean up the code some more.
