### PR TITLE
Preview/public website link improvements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,14 +3,6 @@ module ApplicationHelper
     form.object.facet_options(facet)
   end
 
-  def content_preview_url(document)
-    Plek.current.find("draft-origin") + document.base_path
-  end
-
-  def published_document_path(document)
-    Plek.current.find("website-root") + document.base_path
-  end
-
   def state(document)
     state = document.publication_state == "live" ? "published" : document.publication_state
 

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,21 @@
+module UrlHelper
+  def preview_draft_link_for(document)
+    link_to "Preview draft", draft_url_for(document)
+  end
+
+  def view_on_website_link_for(document)
+    link_to "View on website", public_url_for(document)
+  end
+
+  def public_url_for(document)
+    URI.join("#{Plek.new.website_uri.scheme}://#{Plek.new.website_uri.host}", document.base_path, cachebust_query_string).to_s
+  end
+
+  def draft_url_for(document)
+    URI.join(Plek.current.find("draft-origin"), document.base_path, cachebust_query_string).to_s
+  end
+
+  def cachebust_query_string
+    "?cachebust=#{Time.zone.now.getutc.to_i}"
+  end
+end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -3,7 +3,7 @@
   <li class='active'><%= @document.title %></li>
 <% end %>
 
-<%= render partial: "shared/title", locals: { document: @document, public_url: published_document_path(@document) } %>
+<%= render partial: "shared/title", locals: { document: @document } %>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -3,7 +3,7 @@
   <li class='active'><%= @manual.title %></li>
 <% end %>
 
-<%= render partial: "shared/title", locals: { document: @manual, public_url: url_for_public_manual(@manual) } %>
+<%= render partial: "shared/title", locals: { document: @manual } %>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -4,10 +4,10 @@
       <%= document.base_path %>
     </li>
     <% if document.published? %>
-      <li><%= link_to "View on website", public_url %></li>
+      <li><%= view_on_website_link_for(document) %></li>
     <% end %>
     <% if document.draft? || document.redrafted? %>
-      <li><%= link_to "Preview draft", content_preview_url(document) %></li>
+      <li><%= preview_draft_link_for(document) %></li>
     <% end %>
   </li>
 </h1>

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe UrlHelper, type: :helper do
+  describe "#view_on_website_link_for" do
+    it "returns document's public link" do
+      manual = Manual.new.tap { |doc| doc.base_path = "/guidance/abc" }
+      expect(helper.view_on_website_link_for(manual)).to match(%r{<a href="http(s)?://www.(dev|test).gov.uk/guidance/abc\?cachebust=\d+?">View on website</a>})
+    end
+  end
+
+  describe "#preview_draft_link_for" do
+    it "returns document's draft link" do
+      manual = Manual.new.tap { |doc| doc.base_path = "/guidance/abc" }
+      expect(helper.preview_draft_link_for(manual)).to match(%r{<a href="http(s)?://draft-origin.(dev|test).gov.uk/guidance/abc\?cachebust=\d+?">Preview draft</a>})
+    end
+  end
+end


### PR DESCRIPTION
Currently, the "View on website" URL is broken on integration (as it points to `https://website-root.integration.publishing.service.gov.uk`). This PR:
- fixes the public website link
- moves the link generation logic into a tested helper
- adds cache-busting to links to prevent stale content being served (Whitehall has [similar functionality](https://github.com/alphagov/whitehall/blob/master/app/helpers/admin/url_options_helper.rb))
