### PR TITLE
Display bulk published field for specialist documents

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -25,6 +25,8 @@
           <% end %>
         <% end %>
       <% end %>
+      <dt>Bulk published</dt>
+      <dd><%= @document.bulk_published %></dd>
       <dt>Publication state</dt>
       <dd><%= state(@document) %></dd>
     </dl>

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -14,6 +14,11 @@ RSpec.feature "Viewing a specific case", type: :feature do
         "description" => "This is the summary of example CMA case #{n}",
         "base_path" => "/cma-cases/example-cma-case-#{n}",
         "publication_state" => "draft",
+        "details" => {
+          "metadata" => {
+            "bulk_published" => false
+          }
+        }
       )
     end
     ten_example_cases[1]["publication_state"] = "live"
@@ -52,6 +57,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
     expect(page).to have_content("2014-01-01")
     expect(page).to have_content("CA98 and civil cartels")
     expect(page).to have_content("Energy")
+    expect(page).to have_content("Bulk published false")
   end
 
   scenario "that doesn't exist" do


### PR DESCRIPTION
Turns out bulk publish is already an attribute on documents, so this just adds some frontend code to display it.
It is shared across all document types, therefore, it follows the pattern of [Publication state](https://github.com/alphagov/specialist-publisher-rebuild/compare/bulk-publish-field-for-specialist-documents?expand=1#diff-7232652c110734708bc642ae5d220644R30) and doesn't use the [humanized_attributes](https://github.com/alphagov/specialist-publisher-rebuild/compare/bulk-publish-field-for-specialist-documents?expand=1#diff-7232652c110734708bc642ae5d220644R18) method like other metadata fields.

Another PR is needed to add the functionality to save/publish a document with bulk-published field
