### PR TITLE
Duplicate deleter: clean up all unknown content IDs

### DIFF
--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -3,11 +3,12 @@ require "gds_api/publishing_api_v2"
 class DuplicateDraftDeleter
   def call
     duplicated_editions_not_in_publishing_api = duplicated_editions.reject {|data| in_publishing_api?(data[:content_id]) }
+    content_ids = duplicated_editions_not_in_publishing_api.map { |data| data[:content_id] }
+    editions_to_delete = SpecialistDocumentEdition.where(:document_id.in => content_ids)
 
-    puts "The following #{duplicated_editions_not_in_publishing_api.count} unpublished drafts are being deleted:"
-    duplicated_editions_not_in_publishing_api.each do |data|
-      puts [data[:slug], data[:content_id], data[:state], data[:created_at]].join(",")
-      edition = SpecialistDocumentEdition.where(document_id: data[:content_id]).first
+    puts "The following #{editions_to_delete.count} editions are unknown to Publishing API and will be deleted:"
+    editions_to_delete.each do |edition|
+      puts [edition[:slug], edition[:document_id], edition[:state], edition[:created_at]].join(",")
       edition.delete
     end
   end

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -11,6 +11,7 @@ describe DuplicateDraftDeleter do
       slug: "cma-cases/a-case",
       document_id: original_content_id,
       document_type: "cma_case",
+      state: "draft",
     )
     publishing_api_has_item(content_id: original_content_id)
 
@@ -19,14 +20,21 @@ describe DuplicateDraftDeleter do
       slug: "cma-cases/a-case",
       document_id: duplicate_content_id,
       document_type: "cma_case",
+      state: "draft",
+    )
+    another_duplicate_edition_with_same_content_id = FactoryGirl.create(:specialist_document_edition,
+      slug: "cma-cases/a-case",
+      document_id: duplicate_content_id,
+      document_type: "cma_case",
+      state: "archived",
     )
     publishing_api_does_not_have_item(duplicate_content_id)
 
-    expected_output = /The following 1 unpublished drafts are being deleted.*#{duplicate_content_id}/m
+    expected_output = /The following 2 editions are unknown to Publishing API and will be deleted:.*#{duplicate_content_id}/m
     expect { DuplicateDraftDeleter.new.call }.to output(expected_output).to_stdout
 
     expect(SpecialistDocumentEdition.where(document_id: original_content_id)).to be_present
-    expect(SpecialistDocumentEdition.where(document_id: duplicate_content_id)).to_not be_present
+    expect(SpecialistDocumentEdition.where(document_id: duplicate_content_id)).to be_empty
   end
 
   it "leaves non-duplicated editions alone" do


### PR DESCRIPTION
This is a follow-up to #706.

Before this change, the duplicate deleter script didn't get rid of
all duplicate editions if there were multiple duplicates with the same
content ID (eg if a publisher archived a duplicate, there would be
one archived edition and one draft edition with the same content ID).

After this change, if a content ID is unknown to Publishing API,
the script will delete all editions with that content ID.

/cc @h-lame 