### PR TITLE
Don't check for specific success status code when pushing to Publishing API and Rummager

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -207,13 +207,12 @@ class Document
       presented_links = DocumentLinksPresenter.new(self)
 
       begin
-        item_request = publishing_api.put_content(self.content_id, presented_document.to_json)
-        links_request = publishing_api.patch_links(self.content_id, presented_links.to_json)
+        publishing_api.put_content(self.content_id, presented_document.to_json)
+        publishing_api.patch_links(self.content_id, presented_links.to_json)
 
-        item_request.code == 200 && links_request.code == 200
+        true
       rescue GdsApi::HTTPErrorResponse => e
         Airbrake.notify(e)
-
         false
       end
     else
@@ -228,8 +227,8 @@ class Document
 
     begin
       update_type = self.update_type || 'major'
-      publish_request = publishing_api.publish(content_id, update_type)
-      rummager_request = rummager.add_document(
+      publishing_api.publish(content_id, update_type)
+      rummager.add_document(
         search_document_type,
         base_path,
         indexable_document.to_json,
@@ -239,7 +238,7 @@ class Document
         email_alert_api.send_alert(EmailAlertPresenter.new(self).to_json)
       end
 
-      publish_request.code == 200 && rummager_request.code == 200
+      true
     rescue GdsApi::HTTPErrorResponse => e
       Airbrake.notify(e)
       false

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -15,15 +15,14 @@ class DrugSafetyUpdate < Document
 
     begin
       update_type = self.update_type || 'major'
-      publish_request = publishing_api.publish(content_id, update_type)
-      rummager_request = rummager.add_document(
+      publishing_api.publish(content_id, update_type)
+      rummager.add_document(
         search_document_type,
         base_path,
         indexable_document.to_json,
       )
 
-      publish_request.code == 200 && rummager_request.code == 200
-
+      true
     rescue GdsApi::HTTPErrorResponse => e
       Airbrake.notify(e)
     end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -187,10 +187,10 @@ class Manual
       presented_manual = ManualPresenter.new(self)
       presented_links = ManualLinksPresenter.new(self)
       begin
-        item_request = publishing_api.put_content(self.content_id, presented_manual.to_json)
-        links_request = publishing_api.patch_links(self.content_id, presented_links.to_json)
+        publishing_api.put_content(self.content_id, presented_manual.to_json)
+        publishing_api.patch_links(self.content_id, presented_links.to_json)
 
-        item_request.code == 200 && links_request.code == 200
+        true
       rescue GdsApi::HTTPErrorResponse => e
         Airbrake.notify(e)
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -112,11 +112,11 @@ class Section
     if section_ids.include?(self.content_id)
       true
     else
-      manual_link_request = publishing_api.patch_links(
+      publishing_api.patch_links(
         self.manual_content_id,
         links: { sections: section_ids << self.content_id }
       )
-      manual_link_request.code == 200
+      true
     end
   end
 
@@ -133,9 +133,9 @@ class Section
 
       presented_section_links = { links: { manual: [self.manual_content_id] } }
       begin
-        item_request = publishing_api.put_content(self.content_id, presented_section)
-        section_link_request = publishing_api.patch_links(self.content_id, presented_section_links)
-        item_request.code == 200 && update_manual_links && section_link_request.code == 200
+        publishing_api.put_content(self.content_id, presented_section)
+        publishing_api.patch_links(self.content_id, presented_section_links)
+        update_manual_links
       rescue GdsApi::HTTPErrorResponse => e
         Airbrake.notify(e)
         false

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     publishing_api_has_item(cma_case)
 
     stub_publishing_api_publish(content_id, {})
-    stub_any_rummager_post
+    stub_any_rummager_post_with_queueing_enabled
     email_alert_api_accepts_alert
   end
 

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -140,7 +140,7 @@ describe AaibReport do
 
     it "publishes the AAIB Report" do
       stub_publishing_api_publish(aaib_reports[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       expect(aaib_report.publish!).to eq(true)
 
       assert_publishing_api_publish(aaib_report.content_id)
@@ -150,7 +150,7 @@ describe AaibReport do
     it "notifies Airbrake and returns false if publishing-api does not return status 200" do
       expect(Airbrake).to receive(:notify)
       stub_publishing_api_publish(aaib_reports[0]["content_id"], {}, status: 503)
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       expect(aaib_report.publish!).to eq(false)
     end
 

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe CmaCase do
 
     it "publishes the CMA Case" do
       stub_publishing_api_publish(cma_cases[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [cma_org_content_item],
         document_type: 'organisation',

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -127,7 +127,7 @@ describe CountrysideStewardshipGrant do
 
     it "publishes the Countryside Stewardship Grant" do
       stub_publishing_api_publish(countryside_stewardship_grants[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         countryside_stewardship_grant_org_content_items,
         document_type: 'organisation',

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -130,7 +130,7 @@ describe EmploymentAppealTribunalDecision do
 
     it "publishes the Employment Appeal Tribunal Decision" do
       stub_publishing_api_publish(employment_appeal_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [employment_appeal_tribunal_decision_org_content_item],
         document_type: 'organisation',

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -128,7 +128,7 @@ describe EmploymentTribunalDecision do
 
     it "publishes the Employment Tribunal Decision" do
       stub_publishing_api_publish(employment_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [employment_tribunal_decision_org_content_item],
         document_type: 'organisation',

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -143,7 +143,7 @@ describe EsiFund do
 
     it "publishes the ESI Fund" do
       stub_publishing_api_publish(esi_funds[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         esi_fund_org_content_items,
         document_type: 'organisation',

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -125,7 +125,7 @@ describe MaibReport do
 
     it "publishes the MAIB Report" do
       stub_publishing_api_publish(maib_reports[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [maib_org_content_item],
         document_type: 'organisation',

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -125,7 +125,7 @@ describe MedicalSafetyAlert do
 
     it "publishes the Medical Safety Alert" do
       stub_publishing_api_publish(medical_safety_alerts[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [mhra_org_content_item],
         document_type: 'organisation',

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -125,7 +125,7 @@ describe RaibReport do
 
     it "publishes the RAIB Report" do
       stub_publishing_api_publish(raib_reports[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [raib_org_content_item],
         document_type: 'organisation',

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -128,7 +128,7 @@ describe TaxTribunalDecision do
 
     it "publishes the Tax Tribunal Decision" do
       stub_publishing_api_publish(tax_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [tax_tribunal_decision_org_content_item],
         document_type: 'organisation',

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -127,7 +127,7 @@ describe VehicleRecallsAndFaultsAlert do
 
     it "publishes the Vehicle Recall and Fault" do
       stub_publishing_api_publish(vehicle_recalls_and_faults[0]["content_id"], {})
-      stub_any_rummager_post
+      stub_any_rummager_post_with_queueing_enabled
       publishing_api_has_content(
         [vehicle_recalls_and_faults_alert_org_content_item],
         document_type: 'organisation',


### PR DESCRIPTION
As of https://github.com/alphagov/rummager/commit/805647a49d3a530338657bbfd6cb2ff1f432550d, synchronous publishing with Rummager has been removed, so always returns a 202 on success. This commit updates the checks in the publish methods as well as the test helpers to stub rummager. Presumably these were put in place for the development environment where synchronous rummager publishing was enabled.

We update the `publish!` method for drug safety updates in a separate PR (https://github.com/alphagov/specialist-publisher-rebuild/pull/727)
