### PR TITLE
Fix jenkins schema testing

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.alphagov.co.uk
+export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
 export CONTEXT_MESSAGE="Verify specialist-publisher-rebuild against content schemas"
 env


### PR DESCRIPTION
This probably fixes persistent errors on ci:

https://ci.dev.publishing.service.gov.uk/job/govuk_specialist-publisher-rebuild_schema_tests/50/console

This app should not be setting `GOVUK_APP_DOMAIN` in jenkins at all - it’s using a really old pattern here. See this for example: https://github.com/alphagov/collections-publisher/pull/128/commits/fbd02be7adc9ce616b537efc408a1c8a7e37fbc9
