### PR TITLE
Ensure headers navigation is rendered for specialist-documents

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -41,6 +41,19 @@ private
       change_history: change_history
     }.tap do |details_hash|
       details_hash[:attachments] = attachments if document.attachments
+      details_hash[:headers] = headers if !headers.empty?
+    end
+  end
+
+  def headers
+    headers = Govspeak::Document.new(document.body).structured_headers
+    remove_empty_headers(headers.map(&:to_h))
+  end
+
+  def remove_empty_headers(headers)
+    headers.each do |header|
+      header.delete_if { |k, v| k == :headers && v.empty? }
+      remove_empty_headers(header[:headers]) if header.has_key?(:headers)
     end
   end
 

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -24,6 +24,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example AAIB Report</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "date_of_occurrence" => "2015-10-10",
           "document_type" => "aaib_report"
@@ -66,6 +71,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Employment Appeal Tribunal Decision</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "tribunal_decision_categories" => ["age-discrimination"],
           "tribunal_decision_decision_date" => "2015-07-30",
@@ -110,6 +120,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example CMA case</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "opened_date" => "2014-01-01",
           "case_type" => "ca98-and-civil-cartels",
@@ -160,6 +175,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Countryside Stewardship Grant</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "document_type" => "countryside_stewardship_grant"
         },
@@ -201,6 +221,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Drug Safety Update</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "document_type" => "drug_safety_update",
         },
@@ -242,6 +267,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Employment Tribunal Decision</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "tribunal_decision_categories" => ["age-discrimination"],
           "tribunal_decision_country" => "england-and-wales",
@@ -286,6 +316,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example ESI Fund</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "closing_date" => "2016-01-01",
           "document_type" => "esi_fund",
@@ -328,6 +363,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example MAIB Report</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "date_of_occurrence" => "2015-10-10",
           "document_type" => "maib_report"
@@ -395,6 +435,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Medical Safety Alert</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "alert_type" => "company-led-drugs",
           "issued_date" => "2016-02-01",
@@ -438,6 +483,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example RAIB Report</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "date_of_occurrence" => "2015-10-10",
           "document_type" => "raib_report"
@@ -479,6 +529,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Tax Tribunal Decision</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "tribunal_decision_category" => "banking",
           "tribunal_decision_decision_date" => "2015-07-30",
@@ -522,6 +577,11 @@ module Payloads
             "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Vehicle Recalls And Faults</p>\n" * 10)
           }
         ],
+        "headers" => [{
+          "text" => "Header",
+          "level" => 2,
+          "id" => "header",
+        }],
         "metadata" => {
           "alert_issue_date" => "2015-04-28",
           "build_start_date" => "2015-04-28",


### PR DESCRIPTION
Headers data is now sent to the publishing-api to ensure that headers navigation renders on specialist-frontend.

Paired with @davidbasalla.

`remove_empty_headers` method has been implemented to match specifications within content schema which enforce that ‘headers’ values must not be empty (https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document/publisher/details.json#L72). Previously the GovSpeak `structured_headers` method was generating a key `headers` which would be an empty array unless it contained a nested header, causing contract tests to fail.

[Trello](https://trello.com/c/RO6QRqw9/96-headings-missing-on-specialist-documents-medium)
