### PR TITLE
List the formats alphabetically in navigation drop-down

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,6 +118,10 @@ module ApplicationHelper
     }
   end
 
+  def finders_sorted_by_title
+    finders.sort_by {|_, value| value[:title] }
+  end
+
 private
   def publish_text_hash(document)
     {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
       <ul class="dropdown-menu" role="menu">
   <% end %>
 
-  <% finders.each do |key, value| %>
+  <% finders_sorted_by_title.each do |key, value| %>
     <% if current_user_can_edit?(value[:document_type]) %>
       <li><%= nav_link_to value[:title], "/#{key}" %></li>
     <% end %>


### PR DESCRIPTION
Before this change, the list of finders was almost alphabetical, but not
quite.

Before:
![image](https://cloud.githubusercontent.com/assets/23801/14982905/ce7d1f10-1131-11e6-88a3-f86cde02c88c.png)

After:
![image](https://cloud.githubusercontent.com/assets/23801/14982912/d735af50-1131-11e6-98b0-660a22426d38.png)
