### PR TITLE
Move specialist document titles into the document model, simplify ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,33 +26,15 @@ private
   end
 
   def current_format
-    document_types.fetch(params.fetch(:document_type, nil), nil)
+    @current_format ||= document_types.detect { |format| format.document_type == document_type }
   end
 
   def formats_user_can_access
-    document_types.select { |_, v| policy(v.klass).index? }
+    document_types.select { |format| policy(format).index? }
   end
 
-  # This Struct is for the document_types method below
-  FormatStruct = Struct.new(:klass, :document_type, :format_name, :title, :organisations)
-
   def document_types
-    # For each format that follows the standard naming convention, this
-    # method takes the model class and generates a FormatStructure.
-    #
-    # eg GdsReport will become this:
-    #
-    # {
-    #   "gds-reports" => FormatStruct.new(
-    #     klass: GdsReports, # This is the class name of the model
-    #     document_type: "gds-reports", # This is internally used for building urls
-    #     format_name: "gds_report", # This is used for fetching the params of the format
-    #     title: "GDS Report", # Rendered as the format name to the User, taken from GdsReport.title
-    #     organisations: ["a-content-id"], # Content IDs for the Orgs fetched from the schema
-    #   )
-    # }
-
-    document_classes = [
+    [
       AaibReport,
       CmaCase,
       CountrysideStewardshipGrant,
@@ -66,22 +48,5 @@ private
       TaxTribunalDecision,
       VehicleRecallsAndFaultsAlert,
     ]
-
-    document_classes.map { |document_class|
-      title = document_class.title
-      {
-        title.downcase.parameterize.pluralize => FormatStruct.new(
-          document_class,
-          title.downcase.parameterize.pluralize,
-          document_class.to_s.underscore,
-          title,
-          document_class.organisations,
-        )
-      }
-    }.reduce({}, :merge)
-  end
-
-  def document_klass
-    current_format.klass
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,48 +38,44 @@ private
 
   def document_types
     # For each format that follows the standard naming convention, this
-    # method takes the title and name of the model class of each format
-    # like this:
+    # method takes the model class and generates a FormatStructure.
     #
-    # data = {
-    #   "GDS Report" => GdsReport
-    # }
-    #
-    # which will become this:
+    # eg GdsReport will become this:
     #
     # {
     #   "gds-reports" => FormatStruct.new(
     #     klass: GdsReports, # This is the class name of the model
     #     document_type: "gds-reports", # This is internally used for building urls
     #     format_name: "gds_report", # This is used for fetching the params of the format
-    #     title: "GDS Report", # Rendered as the format name to the User
+    #     title: "GDS Report", # Rendered as the format name to the User, taken from GdsReport.title
     #     organisations: ["a-content-id"], # Content IDs for the Orgs fetched from the schema
     #   )
     # }
 
-    data = {
-      "AAIB Report" => AaibReport,
-      "CMA Case" => CmaCase,
-      "Countryside Stewardship Grant" => CountrysideStewardshipGrant,
-      "Drug Safety Update" => DrugSafetyUpdate,
-      "EAT Decisions" => EmploymentAppealTribunalDecision,
-      "ESI Fund" => EsiFund,
-      "ET Decisions" => EmploymentTribunalDecision,
-      "MAIB Report" => MaibReport,
-      "Medical Safety Alert" => MedicalSafetyAlert,
-      "RAIB Report" => RaibReport,
-      "Tax Tribunal Decision" => TaxTribunalDecision,
-      "Vehicle Recalls and Faults Alert" => VehicleRecallsAndFaultsAlert,
-    }
+    document_classes = [
+      AaibReport,
+      CmaCase,
+      CountrysideStewardshipGrant,
+      DrugSafetyUpdate,
+      EmploymentAppealTribunalDecision,
+      EsiFund,
+      EmploymentTribunalDecision,
+      MaibReport,
+      MedicalSafetyAlert,
+      RaibReport,
+      TaxTribunalDecision,
+      VehicleRecallsAndFaultsAlert,
+    ]
 
-    data.map { |k, v|
+    document_classes.map { |document_class|
+      title = document_class.title
       {
-        k.downcase.parameterize.pluralize => FormatStruct.new(
-          v,
-          k.downcase.parameterize.pluralize,
-          v.to_s.underscore,
-          k,
-          v.organisations,
+        title.downcase.parameterize.pluralize => FormatStruct.new(
+          document_class,
+          title.downcase.parameterize.pluralize,
+          document_class.to_s.underscore,
+          title,
+          document_class.organisations,
         )
       }
     }.reduce({}, :merge)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -40,7 +40,7 @@ class AttachmentsController < ApplicationController
 private
 
   def fetch_document
-    document_klass.find(params[:document_content_id]).tap do |document|
+    current_format.find(params[:document_content_id]).tap do |document|
       document.update_type = "minor"
     end
   rescue Document::RecordNotFound => e

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -12,7 +12,7 @@ class DocumentsController < ApplicationController
 
   def check_authorisation
     if current_format
-      authorize document_klass
+      authorize current_format
     else
       flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
       redirect_to manuals_path
@@ -22,16 +22,16 @@ class DocumentsController < ApplicationController
   def index
     page = filtered_page_param(params[:page])
     per_page = filtered_per_page_param(params[:per_page])
-    @response = document_klass.all(page, per_page)
+    @response = current_format.all(page, per_page)
     @paged_documents = PaginationPresenter.new(@response, per_page)
   end
 
   def new
-    @document = document_klass.new
+    @document = current_format.new
   end
 
   def create
-    @document = document_klass.new(
+    @document = current_format.new(
       filtered_params(params[current_format.format_name])
     )
 
@@ -103,7 +103,7 @@ private
   end
 
   def fetch_document
-    @document = document_klass.find(params[:content_id])
+    @document = current_format.find(params[:content_id])
   rescue Document::RecordNotFound => e
     flash[:danger] = "Document not found"
     redirect_to documents_path(document_type: document_type)

--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -21,4 +21,8 @@ class AaibReport < Document
   def self.publishing_api_document_type
     "aaib_report"
   end
+
+  def self.title
+    "AAIB Report"
+  end
 end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -23,4 +23,8 @@ class CmaCase < Document
   def self.publishing_api_document_type
     "cma_case"
   end
+
+  def self.title
+    "CMA Case"
+  end
 end

--- a/app/models/countryside_stewardship_grant.rb
+++ b/app/models/countryside_stewardship_grant.rb
@@ -15,4 +15,8 @@ class CountrysideStewardshipGrant < Document
   def self.publishing_api_document_type
     "countryside_stewardship_grant"
   end
+
+  def self.title
+    "Countryside Stewardship Grant"
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -250,6 +250,14 @@ class Document
     self.attachments.detect { |attachment| attachment.content_id == attachment_content_id }
   end
 
+  def self.document_type
+    title.downcase.parameterize.pluralize
+  end
+
+  def self.format_name
+    to_s.underscore
+  end
+
 private
 
   def self.attachments(payload)

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -32,4 +32,8 @@ class DrugSafetyUpdate < Document
   def self.publishing_api_document_type
     "drug_safety_update"
   end
+
+  def self.title
+    "Drug Safety Update"
+  end
 end

--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -21,4 +21,8 @@ class EmploymentAppealTribunalDecision < Document
   def self.publishing_api_document_type
     "employment_appeal_tribunal_decision"
   end
+
+  def self.title
+    "EAT Decision"
+  end
 end

--- a/app/models/employment_tribunal_decision.rb
+++ b/app/models/employment_tribunal_decision.rb
@@ -19,4 +19,8 @@ class EmploymentTribunalDecision < Document
   def self.publishing_api_document_type
     "employment_tribunal_decision"
   end
+
+  def self.title
+    "ET Decision"
+  end
 end

--- a/app/models/esi_fund.rb
+++ b/app/models/esi_fund.rb
@@ -18,4 +18,8 @@ class EsiFund < Document
   def self.publishing_api_document_type
     "esi_fund"
   end
+
+  def self.title
+    "ESI Fund"
+  end
 end

--- a/app/models/maib_report.rb
+++ b/app/models/maib_report.rb
@@ -16,4 +16,8 @@ class MaibReport < Document
   def self.publishing_api_document_type
     "maib_report"
   end
+
+  def self.title
+    "MAIB Report"
+  end
 end

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -17,4 +17,8 @@ class MedicalSafetyAlert < Document
   def self.publishing_api_document_type
     "medical_safety_alert"
   end
+
+  def self.title
+    "Medical Safety Alert"
+  end
 end

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -16,4 +16,8 @@ class RaibReport < Document
   def self.publishing_api_document_type
     "raib_report"
   end
+
+  def self.title
+    "RAIB Report"
+  end
 end

--- a/app/models/tax_tribunal_decision.rb
+++ b/app/models/tax_tribunal_decision.rb
@@ -17,4 +17,8 @@ class TaxTribunalDecision < Document
   def self.publishing_api_document_type
     "tax_tribunal_decision"
   end
+
+  def self.title
+    "Tax Tribunal Decision"
+  end
 end

--- a/app/models/vehicle_recalls_and_faults_alert.rb
+++ b/app/models/vehicle_recalls_and_faults_alert.rb
@@ -26,6 +26,10 @@ class VehicleRecallsAndFaultsAlert < Document
     "vehicle_recalls_and_faults_alert"
   end
 
+  def self.title
+    "Vehicle Recalls and Faults Alert"
+  end
+
 private
 
   def build_dates

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
       <ul class="dropdown-menu" role="menu">
   <% end %>
 
-  <% formats_user_can_access.each do |key, value| %>
-    <li><%= link_to value.title.pluralize, documents_path(key) %></li>
+  <% formats_user_can_access.each do |format| %>
+    <li><%= link_to format.title.pluralize, documents_path(format.document_type) %></li>
   <% end %>
 
   <% if current_user.gds_editor? %>

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Document do
+  class MyDocumentType < Document
+    def self.title
+      "My Document Type"
+    end
+  end
+
+  it "has a document_type for building URLs" do
+    expect(MyDocumentType.document_type).to eq("my-document-types")
+  end
+
+  it "has a format_name for fetching params of the format" do
+    expect(MyDocumentType.format_name).to eq("my_document_type")
+  end
+end


### PR DESCRIPTION
This means that more of the format-specific logic lives in the document
model, not centrally.

This PR also includes:
- a correction to 2 document format titles (EAT Decisions, ET decisions) from plural to singular, to fit the pattern of the other formats.
- a simplification of `ApplicationController` to reduce unnecessary indirection
