### PR TITLE
Accessing '/' should redirect the user to '/manuals'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 
@@ -24,54 +22,5 @@ Rails.application.routes.draw do
     post :publish, on: :member
   end
 
-  root 'documents#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  root to: redirect("/manuals")
 end

--- a/spec/features/visiting_the_app_spec.rb
+++ b/spec/features/visiting_the_app_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.feature "Visiting the app", type: :feature do
+  let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
+
+  before do
+    log_in_as_editor(:cma_editor)
+    publishing_api_has_content([], document_type: "manual", fields: fields, per_page: 10000)
+  end
+
+  scenario "visiting / should redirect to manuals" do
+    visit "/"
+    expect(page).to have_content("Your manuals (0)")
+  end
+end


### PR DESCRIPTION
This brings the behaviour of this app in line with Specialist Publisher v1.

This commit also removes redundant comments from `routes.rb`.
