### PR TITLE
Explicitly sort nav menu entries alphabetically

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
       <ul class="dropdown-menu" role="menu">
   <% end %>
 
-  <% formats_user_can_access.each do |format| %>
+  <% formats_user_can_access.sort_by(&:title).each do |format| %>
     <li><%= link_to format.title.pluralize, documents_path(format.document_type) %></li>
   <% end %>
 


### PR DESCRIPTION
This makes the list easier to parse for GDS editors, who see all the formats. Right now the sort order implicitly depends on `ApplicationController#document_types` being sorted alphabetically.

This is the same change as https://github.com/alphagov/specialist-publisher/pull/708
