### PR TITLE
Make publish! report failure for drug safety updates

### DIFF
--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -25,6 +25,7 @@ class DrugSafetyUpdate < Document
       true
     rescue GdsApi::HTTPErrorResponse => e
       Airbrake.notify(e)
+      false
     end
   end
 


### PR DESCRIPTION
If an error is raised while publishing a drug safety update, the
`publish!` method should return false in line with other `Document`
subclasses
