### PR TITLE
Wrap remote publishing calls

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -131,10 +131,10 @@ private
   end
 
   def publishing_api
-    @publishing_api ||= SpecialistPublisher.services(:publishing_api)
+    @publishing_api ||= Services.publishing_api
   end
 
   def rummager
-    @rummager ||= SpecialistPublisher.services(:rummager)
+    @rummager ||= Services.rummager
   end
 end

--- a/app/helpers/publishing_helper.rb
+++ b/app/helpers/publishing_helper.rb
@@ -1,0 +1,11 @@
+module PublishingHelper
+  def handle_remote_error(&block)
+    begin
+      block.call
+      true
+    rescue GdsApi::HTTPErrorResponse => e
+      Airbrake.notify(e)
+      false
+    end
+  end
+end

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -13,23 +13,17 @@ class DrugSafetyUpdate < Document
   def publish!
     indexable_document = SearchPresenter.new(self)
 
-    begin
+    handle_remote_error do
       update_type = self.update_type || 'major'
 
       save_first_published_at if not_published?
 
       publishing_api.publish(content_id, update_type)
-      rummager.add_document(
+      Services.rummager.add_document(
         search_document_type,
         base_path,
         indexable_document.to_json,
       )
-
-      true
-    rescue GdsApi::HTTPErrorResponse => e
-      Airbrake.notify(e)
-
-      false
     end
   end
 

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -1,6 +1,8 @@
 class Manual
   include ActiveModel::Model
   include ActiveModel::Validations
+  include PublishingHelper
+
   #publishing-api will return per_page default of 50 items. ALL variable is set to high number to return all manuals until pagination is properly implemented, else user would only see 50 manuals.
 
   attr_accessor :content_id, :base_path, :title, :summary, :body, :publication_state, :update_type
@@ -186,15 +188,9 @@ class Manual
     if self.valid?
       presented_manual = ManualPresenter.new(self)
       presented_links = ManualLinksPresenter.new(self)
-      begin
+      handle_remote_error do
         publishing_api.put_content(self.content_id, presented_manual.to_json)
         publishing_api.patch_links(self.content_id, presented_links.to_json)
-
-        true
-      rescue GdsApi::HTTPErrorResponse => e
-        Airbrake.notify(e)
-
-        false
       end
     else
       false
@@ -208,6 +204,6 @@ private
   end
 
   def self.publishing_api
-    SpecialistPublisher.services(:publishing_api)
+    Services.publishing_api
   end
 end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -32,6 +32,6 @@ private
   attr_reader :document
 
   def publishing_api
-    @publishing_api ||= SpecialistPublisher.services(:publishing_api)
+    @publishing_api ||= Services.publishing_api
   end
 end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -3,6 +3,33 @@ require 'gds_api/rummager'
 require 'gds_api/asset_manager'
 require 'gds_api/email_alert_api'
 
+module Services
+  def self.publishing_api
+    GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+    )
+  end
+
+  def self.rummager
+    GdsApi::Rummager.new(Plek.new.find('search'))
+  end
+
+  def self.asset_api
+    GdsApi::AssetManager.new(
+      Plek.current.find('asset-manager'),
+      bearer_token: ENV['ASSET_MANAGER_BEARER_TOKEN'] || '12345678'
+    )
+  end
+
+  def self.email_alert_api
+    GdsApi::EmailAlertApi.new(
+      Plek.current.find('email-alert-api'),
+      bearer_token: ENV['EMAIL_ALERT_API_BEARER_TOKEN'] || 'example123'
+    )
+  end
+end
+
 module SpecialistPublisher
   def self.register_service(name, service)
     @services ||= {}
@@ -10,8 +37,12 @@ module SpecialistPublisher
     @services[name] = service
   end
 
-  def self.services(name)
-    @services[name] || raise(ServiceNotRegisteredException.new(name))
+  def self.services(name = nil)
+    if name
+      @services[name] || raise(ServiceNotRegisteredException.new(name))
+    else
+      @services
+    end
   end
 
   class ServiceNotRegisteredException < Exception; end

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -76,6 +76,6 @@ private
   end
 
   def publishing_api
-    SpecialistPublisher.services(:publishing_api)
+    Services.publishing_api
   end
 end

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -40,8 +40,7 @@ describe PublishingApiFinderPublisher do
     let(:test_logger) { Logger.new(nil) }
 
     before do
-      allow(SpecialistPublisher).to receive(:services)
-        .with(:publishing_api)
+      allow(Services).to receive(:publishing_api)
         .and_return(publishing_api)
 
       stub_any_publishing_api_put_content

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -119,7 +119,11 @@ RSpec.describe CmaCase do
     end
 
     it "passes query parameter if supplied" do
-      expect(described_class.publishing_api).to receive(:get_content_items)
+      publishing_api = double("publishing-api")
+      allow(Services).to receive(:publishing_api)
+        .and_return(publishing_api)
+
+      expect(publishing_api).to receive(:get_content_items)
         .with(hash_including(q: "foo"))
         .and_return(double(to_ostruct: {}))
       described_class.all(page, per_page, q: "foo")


### PR DESCRIPTION
This helps have more consistent behaviour when pushing data to remote apps
(Publishing API, Rummager, Email Alert API).

/cc @boffbowsh 
