### PR TITLE
Display bulk_published label value

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,6 +33,10 @@ class Document
     end
   end
 
+  def bulk_published
+    @bulk_published || false
+  end
+
   def base_path
     @base_path ||= "#{finder_schema.base_path}/#{title.parameterize}"
   end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -46,6 +46,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Created Example CMA Case")
+    expect(page).to have_content('Bulk published false')
   end
 
   scenario "with no data" do

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 RSpec.feature "Editing a published CMA case", type: :feature do
   let(:published_cma_case) {
     Payloads.cma_case_content_item("details" => {
+      "metadata" => {
+        "bulk_published" => true,
+      },
       "attachments" => [
         {
           "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
@@ -91,6 +94,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Minor update title")
+    expect(page).to have_content('Bulk published true')
   end
 
   scenario "with a major update" do
@@ -129,6 +133,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Updated Major update title")
+    expect(page).to have_content('Bulk published true')
   end
 
   scenario "adding an attachment" do

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -7,6 +7,16 @@ RSpec.feature "Viewing a specific case", type: :feature do
       "title" => "CMA Case With Attachment"
     )
   }
+  let(:cma_case_bulk_published) {
+    Payloads.cma_case_with_attachments(
+      "title" => "Bulk published CMA Case",
+      "details" => {
+        "metadata" => {
+          "bulk_published" => true,
+        }
+      }
+    )
+  }
   let(:cma_cases) {
     ten_example_cases = 10.times.collect do |n|
       Payloads.cma_case_content_item(
@@ -23,6 +33,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
     end
     ten_example_cases[1]["publication_state"] = "live"
     ten_example_cases << cma_case_with_attachments
+    ten_example_cases << cma_case_bulk_published
   }
 
   let(:page_number) { 1 }
@@ -44,7 +55,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
 
       expect(page.status_code).to eq(200)
-      expect(page).to have_selector('li.document', count: 11)
+      expect(page).to have_selector('li.document', count: 12)
       expect(page).to have_content("Example CMA Case 0")
       expect(page).to have_content("Example CMA Case 1")
       expect(page).to have_content("Example CMA Case 2")
@@ -84,6 +95,13 @@ RSpec.feature "Viewing a specific case", type: :feature do
 
     expect(page.current_path).to eq("/cma-cases")
     expect(page).to have_content("Document not found")
+  end
+
+  scenario "the document has been bulk published" do
+    visit "/cma-cases"
+    expect(page).to have_content("Bulk published CMA Case")
+    click_link "Bulk published CMA Case"
+    expect(page).to have_content("Bulk published true")
   end
 
   scenario "Viewing attachments on a document" do


### PR DESCRIPTION
Displays an associated boolean value alongside `bulk_published` labels for all formats.

Tests check that:
- the correct labels display.
- publishing a new edition of a document will not change the `bulk_published` field.

Please note - functionality to bulk publish documents has not yet been implemented within specialist-publisher-rebuild

[Trello](https://trello.com/c/GMrhLspk/79-missing-bulk-publication-field-for-specialist-documents-small)
