### PR TITLE
Add the current release SHA to the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,5 +42,7 @@
   </script>
 <% end %>
 
+<% content_for :footer_version, CURRENT_RELEASE_SHA %>
+
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template'%>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,0 +1,7 @@
+revision_file = File.join(Rails.root, "REVISION")
+if File.exist?(revision_file)
+  revision = File.read(revision_file).strip
+  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
+else
+  CURRENT_RELEASE_SHA = "development"
+end


### PR DESCRIPTION
This helps debug the version of the app that's deployed, and brings
this app in line with other publishing apps on the stack.

![image](https://cloud.githubusercontent.com/assets/23801/15050792/9ca3260c-12ed-11e6-83f5-2ff8eeb16569.png)
