### PR TITLE
Don't use MONGO_URI env var in development

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   clients:
     default:
-      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost/specialist_publisher_rebuild_development' %>
+      uri: mongodb://localhost/specialist_publisher_rebuild_development
       options:
         write:
           w: 1


### PR DESCRIPTION
Without this change, the app connects to different databases, depending
on whether it's started through `bowler` or through `bundle exec rails s`,
which was causing grief.

/cc @tahb @rgarner 
