### PR TITLE
Improve empty result rendering

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -20,8 +20,8 @@ class DocumentsController < ApplicationController
   def index
     page = filtered_page_param(params[:page])
     per_page = filtered_per_page_param(params[:per_page])
-    query = params[:query]
-    @response = current_format.all(page, per_page, q: query)
+    @query = params[:query]
+    @response = current_format.all(page, per_page, q: @query)
     @paged_documents = PaginationPresenter.new(@response, per_page)
   end
 

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,0 +1,9 @@
+<li class="document">
+  <%= link_to document.title, document_path(current_format.document_type, document.content_id), class: 'document-title' %>
+  <ul class="metadata">
+    <li class="text-muted">Updated <%= time_ago_in_words(document.public_updated_at) %> ago</li>
+    <li>
+      <%= state(document) %>
+    </li>
+  </ul>
+</li>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -16,17 +16,7 @@
 
   <div class="col-md-9">
     <ul class="document-list">
-      <% @paged_documents.each do |document| %>
-        <li class="document">
-          <%= link_to document.title, document_path(current_format.document_type, document.content_id), class: 'document-title' %>
-          <ul class="metadata">
-            <li class="text-muted">Updated <%= time_ago_in_words(document.public_updated_at) %> ago</li>
-            <li>
-              <%= state(document) %>
-            </li>
-          </ul>
-        </li>
-      <% end %>
+      <%= render partial: 'document', collection: @paged_documents %>
     </ul>
     <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -22,6 +22,8 @@
       <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
     <% elsif @query %>
       <p class="no-content no-content-bordered">Your search – <%= @query %> – did not match any documents.</p>
+    <% else %>
+      <p class="no-content no-content-bordered">No <%= current_format.title.pluralize %> available.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -15,9 +15,13 @@
   </div>
 
   <div class="col-md-9">
-    <ul class="document-list">
-      <%= render partial: 'document', collection: @paged_documents %>
-    </ul>
-    <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
+    <% if !@paged_documents.empty? %>
+      <ul class="document-list">
+        <%= render partial: 'document', collection: @paged_documents %>
+      </ul>
+      <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
+    <% elsif @query %>
+      <p class="no-content no-content-bordered">Your search – <%= @query %> – did not match any documents.</p>
+    <% end %>
   </div>
 </div>

--- a/spec/features/searching_and_filtering_cma_cases.rb
+++ b/spec/features/searching_and_filtering_cma_cases.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.feature "Searching and filtering", type: :feature do
+  let(:fields) { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
+
+  let(:cma_cases) {
+    ten_example_cases = 10.times.collect do |n|
+      Payloads.cma_case_content_item(
+        "title" => "Example CMA Case #{n}",
+        "description" => "This is the summary of example CMA case #{n}",
+        "base_path" => "/cma-cases/example-cma-case-#{n}",
+        "publication_state" => "draft",
+      )
+    end
+    ten_example_cases[1]["publication_state"] = "live"
+    ten_example_cases
+  }
+
+  let(:page_number) { 1 }
+  let(:per_page) { 50 }
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    publishing_api_has_content(cma_cases, document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
+    publishing_api_has_content([cma_cases.first], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page, q: "0")
+  end
+
+  context "visiting the index" do
+    scenario "viewing the unfiltered items" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector('li.document', count: 10)
+      expect(page).to have_content("Example CMA Case 0")
+      expect(page).to have_content("Example CMA Case 1")
+      expect(page).to have_content("Example CMA Case 2")
+      within(".document-list li.document:nth-child(2)") do
+        expect(page).to have_content("published")
+      end
+    end
+
+    scenario "filtering the items" do
+      visit "/cma-cases"
+      fill_in "Search", with: "0"
+      click_button "Search"
+      expect(page).to have_content("Example CMA Case 0")
+      expect(page).to have_selector('li.document', count: 1)
+    end
+  end
+end

--- a/spec/features/searching_and_filtering_cma_cases.rb
+++ b/spec/features/searching_and_filtering_cma_cases.rb
@@ -23,7 +23,7 @@ RSpec.feature "Searching and filtering", type: :feature do
     log_in_as_editor(:cma_editor)
   end
 
-  context "visiting the index" do
+  context "visiting the index with results" do
     before do
       publishing_api_has_content(cma_cases, document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
     end
@@ -59,6 +59,19 @@ RSpec.feature "Searching and filtering", type: :feature do
       fill_in "Search", with: "abcdef"
       click_button "Search"
       expect(page).to have_content("Your search – abcdef – did not match any documents.")
+    end
+  end
+
+  context "visiting the index with no results" do
+    before do
+      publishing_api_has_content([], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
+    end
+
+    scenario "viewing the unfiltered items" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("No CMA Cases available.")
     end
   end
 end

--- a/spec/features/searching_and_filtering_cma_cases.rb
+++ b/spec/features/searching_and_filtering_cma_cases.rb
@@ -21,12 +21,13 @@ RSpec.feature "Searching and filtering", type: :feature do
 
   before do
     log_in_as_editor(:cma_editor)
-
-    publishing_api_has_content(cma_cases, document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
-    publishing_api_has_content([cma_cases.first], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page, q: "0")
   end
 
   context "visiting the index" do
+    before do
+      publishing_api_has_content(cma_cases, document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
+    end
+
     scenario "viewing the unfiltered items" do
       visit "/cma-cases"
 
@@ -40,12 +41,24 @@ RSpec.feature "Searching and filtering", type: :feature do
       end
     end
 
-    scenario "filtering the items" do
+    scenario "filtering the items with some results returned" do
+      publishing_api_has_content([cma_cases.first], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page, q: "0")
+
       visit "/cma-cases"
+
       fill_in "Search", with: "0"
       click_button "Search"
       expect(page).to have_content("Example CMA Case 0")
       expect(page).to have_selector('li.document', count: 1)
+    end
+
+    scenario "filtering the items with no results returned" do
+      publishing_api_has_content([], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page, q: "abcdef")
+
+      visit "/cma-cases"
+      fill_in "Search", with: "abcdef"
+      click_button "Search"
+      expect(page).to have_content("Your search – abcdef – did not match any documents.")
     end
   end
 end

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -50,29 +50,6 @@ RSpec.feature "Viewing a specific case", type: :feature do
     end
   end
 
-  context "visiting the index" do
-    scenario "viewing the unfiltered items" do
-      visit "/cma-cases"
-
-      expect(page.status_code).to eq(200)
-      expect(page).to have_selector('li.document', count: 12)
-      expect(page).to have_content("Example CMA Case 0")
-      expect(page).to have_content("Example CMA Case 1")
-      expect(page).to have_content("Example CMA Case 2")
-      within(".document-list li.document:nth-child(2)") do
-        expect(page).to have_content("published")
-      end
-    end
-
-    scenario "filtering the items" do
-      visit "/cma-cases"
-      fill_in "Search", with: "0"
-      click_button "Search"
-      expect(page).to have_content("Example CMA Case 0")
-      expect(page).to have_selector('li.document', count: 1)
-    end
-  end
-
   scenario "from the index" do
     visit "/cma-cases"
     click_link "Example CMA Case 0"


### PR DESCRIPTION
A follow up to https://github.com/alphagov/specialist-publisher-rebuild/pull/739.

[Trello](https://trello.com/c/9ijF7QFE/56-search-documents-by-slug-and-title-medium)
## Empty search results page

![image](https://cloud.githubusercontent.com/assets/23801/15072904/f4e19a42-138d-11e6-9b9b-bb821671fc2f.png)
## No documents for that format

![image](https://cloud.githubusercontent.com/assets/23801/15072912/02cc5372-138e-11e6-8c34-93e20d3dd0ec.png)

/cc @fofr 
