### PR TITLE
Run Rubocop as part of Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:lint]


### PR DESCRIPTION
Given that the Rubocop linter will fail a build on CI, adding this to `bundle exec rake` will notify us of errors earlier and remove the need to remember to run a seperate command each time.
