### PR TITLE
Publish button permissions for specialist documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -257,6 +257,10 @@ class Document
     to_s.underscore
   end
 
+  def can_be_published?
+    !live?
+  end
+
 private
 
   def self.attachments(payload)

--- a/app/views/documents/_publish_panel.html.erb
+++ b/app/views/documents/_publish_panel.html.erb
@@ -3,7 +3,11 @@
     <h3 class="panel-title">Publish document</h3>
   </div>
   <div class="panel-body">
-    <% if @document.can_be_published? %>
+    <% if !policy(@document).publish? %>
+      <p class="remove-bottom-margin">
+        You don’t have permission to publish this document.
+      </p>
+    <% elsif @document.can_be_published? %>
       <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
         <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
       <% end %>

--- a/app/views/documents/_publish_panel.html.erb
+++ b/app/views/documents/_publish_panel.html.erb
@@ -3,14 +3,14 @@
     <h3 class="panel-title">Publish document</h3>
   </div>
   <div class="panel-body">
-    <% if @document.live? %>
-      <p class="remove-bottom-margin">
-        There are no changes to publish.
-      </p>
-    <% else %>
+    <% if @document.can_be_published? %>
       <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
         <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
       <% end %>
+    <% else %>
+      <p class="remove-bottom-margin">
+        There are no changes to publish.
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/_publish_panel.html.erb
+++ b/app/views/documents/_publish_panel.html.erb
@@ -1,0 +1,16 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Publish document</h3>
+  </div>
+  <div class="panel-body">
+    <% if @document.live? %>
+      <p class="remove-bottom-margin">
+        There are no changes to publish.
+      </p>
+    <% else %>
+      <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
+        <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -88,21 +88,6 @@
       <%= link_to "Edit document", edit_document_path(current_format.document_type, @document.content_id), class: "btn btn-success" %>
     </div>
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Publish document</h3>
-      </div>
-      <div class="panel-body">
-        <% if @document.live? %>
-          <p class="remove-bottom-margin">
-            There are no changes to publish.
-          </p>
-        <% else %>
-          <%= form_tag(publish_document_path(current_format.document_type, @document.content_id), method: :post) do %>
-            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: 'publish_panel' %>
   </div>
 </div>

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -150,6 +150,18 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     expect(page).to have_content("There are no changes to publish.")
   end
 
+  scenario "writers don't see a publish button" do
+    log_in_as_editor(:cma_writer)
+
+    publishing_api_has_item(minor_update_item)
+
+    visit "/cma-cases"
+    click_link "Minor Update Case"
+
+    expect(page).not_to have_selector(:button, 'Publish')
+    expect(page).to have_content("You don’t have permission to publish this document.")
+  end
+
   scenario "when content item is withdrawn, there will be a publish button" do
     publishing_api_has_item(withdrawn_item)
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -24,6 +24,12 @@ FactoryGirl.define do
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   end
 
+  factory :cma_writer, parent: :editor do
+    organisation_slug "competition-and-markets-authority"
+    organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+    permissions %w(signin)
+  end
+
   factory :aaib_editor, parent: :editor do
     organisation_slug "air-accidents-investigation-branch"
     organisation_content_id "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"


### PR DESCRIPTION
This PR hides the Publish button from specialist document writers (these users aren't allowed to publish anyway).

![image](https://cloud.githubusercontent.com/assets/23801/15115691/1cc52670-15f8-11e6-9e0b-ae9cdaa5b213.png)
