### PR TITLE
Publish button permissions on manuals

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -197,6 +197,10 @@ class Manual
     end
   end
 
+  def can_be_published?
+    sections.any?
+  end
+
 private
 
   def publishing_api

--- a/app/policies/manual_policy.rb
+++ b/app/policies/manual_policy.rb
@@ -9,6 +9,10 @@ class ManualPolicy < ApplicationPolicy
   alias_method :update?, :index?
   alias_method :show?, :index?
 
+  def publish?
+    gds_editor || departmental_editor
+  end
+
   class Scope
     attr_reader :user, :scope
 

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -69,7 +69,7 @@
       <%= link_to 'Edit manual', edit_manual_path(@manual.content_id), class: 'btn btn-success' %>
     </div>
 
-    <% if @manual.can_be_published? %>
+    <% if policy(@manual).publish? && @manual.can_be_published? %>
       <%= form_tag(publish_manual_path(@manual.content_id), method: :post, class: 'well') do %>
         <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
       <% end -%>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -69,7 +69,7 @@
       <%= link_to 'Edit manual', edit_manual_path(@manual.content_id), class: 'btn btn-success' %>
     </div>
 
-    <% if @manual.sections.any? %>
+    <% if @manual.can_be_published? %>
       <%= form_tag(publish_manual_path(@manual.content_id), method: :post, class: 'well') do %>
         <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
       <% end -%>

--- a/spec/features/publishing_a_manual_spec.rb
+++ b/spec/features/publishing_a_manual_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+RSpec.feature "Publishing a Manual", type: :feature do
+  let(:manual_content_item) { Payloads.manual_content_item }
+  let(:manual_links) { Payloads.manual_links }
+  let(:manual_organisation_content_id) { manual_links["links"]["organisations"].first }
+  let(:section_content_items) { Payloads.section_content_items }
+  let(:section_links) { Payloads.section_links }
+  let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
+  before do
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
+    publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: 10000)
+
+    content_items = [manual_content_item] + section_content_items
+
+    content_items.each do |payload|
+      publishing_api_has_item(payload)
+    end
+
+    links = [manual_links] + section_links
+
+    links.each do |link_set|
+      publishing_api_has_links(link_set)
+      link_set['links']['organisations'].each do |organisation|
+        organisation = { content_id: organisation, base_path: "/government/organisations/#{organisation}" }
+        publishing_api_has_item(organisation)
+      end
+    end
+  end
+
+  scenario "GDS editors see a Publish button" do
+    log_in_as_editor(:gds_editor)
+
+    visit "/manuals"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("A Manual")
+
+    click_link "A Manual"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("First section")
+    expect(page).to have_content("Second section")
+
+    expect(page).to have_selector(:button, 'Publish')
+
+    # the publishing itself hasn't been implemented yet
+  end
+
+  scenario "writers don't see a Publish button" do
+    log_in_as FactoryGirl.create(:writer, organisation_content_id: manual_organisation_content_id)
+
+    visit "/manuals"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("A Manual")
+
+    click_link "A Manual"
+
+    expect(page).not_to have_selector(:button, 'Publish')
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   end
 
-  factory :cma_writer, parent: :editor do
+  factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug "competition-and-markets-authority"
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
     permissions %w(signin)


### PR DESCRIPTION
Writers should not see the publish button (since they can't publish) but other roles can.

Note that publishing itself doesn't actually work yet. I'm raising this PR as a counterpart to https://github.com/alphagov/specialist-publisher-rebuild/pull/749 so that we don't forget permissions later.

There's slightly different behaviour between manuals and documents (this is carried across from Specialist Publisher v1), namely:
- writers don't see any button for manuals
- writers are told "You don't have permission to publish this document" for specialist documents
