### PR TITLE
Specialist documents: split format => document_type/schema_name in Publishing API payload

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -10,7 +10,8 @@ class SpecialistDocumentPublishingAPIFormatter
   def call
     {
       content_id: specialist_document.id,
-      format: "specialist_document",
+      schema_name: "specialist_document",
+      document_type: specialist_document.document_type,
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
       title: rendered_document.attributes.fetch(:title),

--- a/features/support/document_helpers.rb
+++ b/features/support/document_helpers.rb
@@ -1,5 +1,7 @@
 module DocumentHelpers
   def create_document(type, fields, save: true, publish: false)
+    @document_type = type
+
     visit send(:"new_#{type}_path")
     fill_in_fields(fields)
 
@@ -39,7 +41,8 @@ module DocumentHelpers
     attributes = {
       title: fields[:title],
       description: fields[:summary],
-      format: "specialist_document",
+      schema_name: "specialist_document",
+      document_type: @document_type.to_s,
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
     }


### PR DESCRIPTION
`format` is now deprecated (see https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+41%3A+Separate+document+type+from+format).

Without this change, specialist documents created in this app don't show up in the index in Specialist Publisher Rebuild (because they aren't returned in the index from Publishing API).