### PR TITLE
Add document republishing spec

### DIFF
--- a/features/support/gds_sso_helpers.rb
+++ b/features/support/gds_sso_helpers.rb
@@ -2,9 +2,10 @@ require "warden/test/helpers"
 
 module GdsSsoHelpers
   include Warden::Test::Helpers
+  include FactoryGirl::Syntax::Methods
 
   def login_as(user_type)
-    user = FactoryGirl.create(user_type.to_sym)
+    user = create(user_type.to_sym)
     GDS::SSO.test_user = user
     super(user) # warden
   end

--- a/spec/controllers/aaib_reports_controller_spec.rb
+++ b/spec/controllers/aaib_reports_controller_spec.rb
@@ -46,8 +46,7 @@ describe AaibReportsController, type: :controller do
     before do
       login_as_stub_user
       allow_any_instance_of(PermissionChecker).to receive(:can_edit?).and_return(true)
-      @edition = FactoryGirl.create(
-        :specialist_document_edition,
+      @edition = create(:specialist_document_edition,
         document_id: "document-id-1",
         document_type: "aaib_report",
         updated_at: 2.days.ago

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
   }
 
   let(:edition) {
-    FactoryGirl.create(
-      :specialist_document_edition,
+    create(:specialist_document_edition,
       document_id: SecureRandom.uuid,
       document_type: "cma_case",
       updated_at: 2.days.ago,
@@ -192,9 +191,9 @@ END_OF_GOVSPEAK
     context "in draft state" do
       let(:state) { "draft" }
 
-      let!(:cma_editor) { FactoryGirl.create(:cma_editor) }
-      let!(:aaib_editor) { FactoryGirl.create(:aaib_editor) }
-      let!(:gds_editor) { FactoryGirl.create(:gds_editor) }
+      let!(:cma_editor) { create(:cma_editor) }
+      let!(:aaib_editor) { create(:aaib_editor) }
+      let!(:gds_editor) { create(:gds_editor) }
 
       it "includes an access_limited hash" do
         expect(presented).to include("access_limited")

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe "Republishing documents", type: :feature do
       )
     end
 
-    it "should NOT push to Publishing API as draft-content" do
+    it "should NOT push to Publishing API" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
 
       assert_publishing_api_put("http://publishing-api.dev.gov.uk/draft-content/a/b", {}, 0)
+      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/a/b", {}, 0)
       expect(fake_rummager).not_to have_received(:add_document)
     end
   end
@@ -41,5 +42,24 @@ RSpec.describe "Republishing documents", type: :feature do
       expect(fake_rummager).to have_received(:add_document)
                                  .with(@document.document_type, "/c/d", hash_including(rummager_fields))
     end
+  end
+
+  context "for withdrawn documents" do
+    before do
+      create(:specialist_document_edition,
+             document_type: "aaib_report",
+             state: "archived",
+             slug: "e/f",
+      )
+    end
+
+    it "should NOT push to Publishing API" do
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+
+      assert_publishing_api_put("http://publishing-api.dev.gov.uk/draft-content/e/f", {}, 0)
+      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/e/f", {}, 0)
+      expect(fake_rummager).not_to have_received(:add_document)
+    end
+
   end
 end

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "sidekiq/testing"
+
+RSpec.describe "Republishing documents", type: :feature do
+  context "for drafts" do
+    before do
+      create(:specialist_document_edition,
+        document_type: "aaib_report",
+        state: "draft",
+        slug: "a/b",
+      )
+    end
+
+    it "should NOT push to Publishing API as draft-content" do
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+
+      assert_publishing_api_put("http://publishing-api.dev.gov.uk/draft-content/a/b", {}, 0)
+      expect(fake_rummager).not_to have_received(:add_document)
+    end
+  end
+
+  context "for published documents" do
+    before do
+      @document = create(:specialist_document_edition,
+        document_type: "aaib_report",
+        state: "published",
+        slug: "c/d",
+      )
+    end
+
+    it "should push to Publishing API as content" do
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+
+      rummager_fields = {title: @document.title,
+       description: @document.summary,
+       link: "/" + @document.slug,
+       indexable_content: @document.body,
+       organisations: ["air-accidents-investigation-branch"]}
+
+      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/c/d")
+      expect(fake_rummager).to have_received(:add_document)
+                                 .with(@document.document_type, "/c/d", hash_including(rummager_fields))
+    end
+  end
+end

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Republishing documents", type: :feature do
     it "should NOT push to Publishing API" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
 
-      assert_publishing_api_put("http://publishing-api.dev.gov.uk/draft-content/a/b", {}, 0)
-      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/a/b", {}, 0)
+      assert_publishing_api_put_item("/a/b", {}, 0)
+      assert_publishing_api_put_draft_item("/a/b", {}, 0)
       expect(fake_rummager).not_to have_received(:add_document)
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe "Republishing documents", type: :feature do
        indexable_content: @document.body,
        organisations: ["air-accidents-investigation-branch"]}
 
-      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/c/d")
+      assert_publishing_api_put_item("/c/d")
       expect(fake_rummager).to have_received(:add_document)
                                  .with(@document.document_type, "/c/d", hash_including(rummager_fields))
     end
@@ -56,8 +56,8 @@ RSpec.describe "Republishing documents", type: :feature do
     it "should NOT push to Publishing API" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
 
-      assert_publishing_api_put("http://publishing-api.dev.gov.uk/draft-content/e/f", {}, 0)
-      assert_publishing_api_put("http://publishing-api.dev.gov.uk/content/e/f", {}, 0)
+      assert_publishing_api_put_item("/e/f", {}, 0)
+      assert_publishing_api_put_draft_item("/e/f", {}, 0)
       expect(fake_rummager).not_to have_received(:add_document)
     end
 

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "sidekiq/testing"
 
-RSpec.describe "Saving invalid documents", type: :feature do
+RSpec.describe "Republishing manuals", type: :feature do
   before do
     Sidekiq::Testing.inline!
     login_as(:generic_editor)

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -70,7 +70,7 @@ describe SpecialistDocumentRepository do
       @edition_1, @edition_2 = [2, 1].map do |n|
         document_id = "document-id-#{n}"
 
-        edition = FactoryGirl.create(:specialist_document_edition,
+        edition = create(:specialist_document_edition,
                             document_id: document_id,
                             document_type: document_type,
                             updated_at: n.days.ago)

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -88,6 +88,7 @@ FactoryGirl.define do
     summary "My summary"
     body "My body"
     document_type "cma_case"
+    document_id "document-id-1"
     extra_fields do
       {
         opened_date: "2013-04-20",


### PR DESCRIPTION
Add test to expose how `AbstractDocumentServiceRegistry#republish_all` work differently for documents with state `published`, `draft`, `archived` (aka withdrawn).