### PR TITLE
Fix document_type and schema_name for finders and finder_signup pages

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -1,7 +1,8 @@
 class FinderContentItemPresenter < Struct.new(:metadata, :schema, :timestamp)
   def exportable_attributes
     {
-      "format" => format,
+      "schema_name" => "finder",
+      "document_type" => "finder",
       "content_id" => content_id,
       "title" => title,
       "description" => description,
@@ -50,10 +51,6 @@ private
       facets: schema.fetch("facets", []),
       default_order: metadata.fetch("default_order", nil),
     }.reject {|_, value| value.nil?}
-  end
-
-  def format
-    "finder"
   end
 
   def related

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -1,7 +1,8 @@
 class FinderSignupContentItemPresenter < Struct.new(:metadata, :timestamp)
   def exportable_attributes
     {
-      "format" => format,
+      "schema_name" => "finder_email_signup",
+      "document_type" => "finder_email_signup",
       "content_id" => content_id,
       "title" => title,
       "description" => description,
@@ -34,10 +35,6 @@ private
 
   def description
     metadata.fetch("signup_copy", nil)
-  end
-
-  def format
-    "finder_email_signup"
   end
 
   def related


### PR DESCRIPTION
`format` is now [deprecated]( https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+41%3A+Separate+document+type+from+format).