### PR TITLE
Fix document_type and schema_name for manuals and manual sections

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -33,7 +33,8 @@ private
   def exportable_attributes
     {
       content_id: manual.id,
-      format: "manual",
+      schema_name: "manual",
+      document_type: "manual",
       title: rendered_manual_attributes.fetch(:title),
       description: rendered_manual_attributes.fetch(:summary),
       public_updated_at: rendered_manual_attributes.fetch(:updated_at).iso8601,

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -23,7 +23,8 @@ private
   def exportable_attributes
     {
       content_id: document.id,
-      format: "manual_section",
+      schema_name: "manual_section",
+      document_type: "manual_section",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),
       public_updated_at: rendered_document_attributes.fetch(:updated_at).iso8601,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -176,7 +176,8 @@ module ManualHelpers
 
   def check_manual_is_published_to_publishing_api(slug, extra_attributes: {}, draft: false)
     attributes = {
-      "format" => "manual",
+      "schema_name" => "manual",
+      "document_type" => "manual",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "specialist-publisher",
     }.merge(extra_attributes)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -190,7 +190,8 @@ module ManualHelpers
 
   def check_manual_document_is_published_to_publishing_api(slug, draft: false)
     attributes = {
-      "format" => "manual_section",
+      "schema_name" => "manual_section",
+      "document_type" => "manual_section",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "specialist-publisher",
     }

--- a/spec/manual_publishing_api_exporter_spec.rb
+++ b/spec/manual_publishing_api_exporter_spec.rb
@@ -111,7 +111,8 @@ describe ManualPublishingAPIExporter do
       "/guidance/my-first-manual",
       hash_including(
         content_id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        format: "manual",
+        schema_name: "manual",
+        document_type: "manual",
         title: "My first manual",
         description: "This is my first manual",
         public_updated_at: Time.new(2013, 12, 31, 12, 0, 0).iso8601,

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -88,7 +88,8 @@ describe ManualSectionPublishingAPIExporter do
       "/guidance/my-first-manual/first-section",
       hash_including(
         content_id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
-        format: "manual_section",
+        schema_name: "manual_section",
+        document_type: "manual_section",
         title: "Document title",
         description: "This is the first section",
         public_updated_at: Time.new(2013, 12, 31, 12, 0, 0).iso8601,


### PR DESCRIPTION
format is now deprecated (see https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+41%3A+Separate+document+type+from+format)