### PR TITLE
Cache specialist documents for maximum 10 seconds

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -46,7 +46,8 @@ class SpecialistDocumentPublishingAPIFormatter
           content_type: "text/govspeak",
           content: specialist_document.attributes.fetch(:body)
         }
-      ]
+      ],
+      max_cache_time: 10,
     }
     details_hash[:attachments] = attachments if specialist_document.attachments.present?
     details_hash.merge(headers)

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -76,6 +76,10 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
       expect(presented).to be_valid_against_schema("specialist_document")
     end
 
+    it "should include a short cache time" do
+      expect(presented["details"]["max_cache_time"]).to eq 10
+    end
+
     it "should include the relevant metadata in the details hash" do
       fields = %w(case_type case_state market_sector opened_date document_type)
       expect(presented["details"]["metadata"].keys).to eq(fields)

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe "Republishing documents", type: :feature do
                   "body" => [{"content_type" => "text/html",
                               "content" => "<p>My body</p>\n"},
                              {"content_type" => "text/govspeak",
-                              "content" => "My body"}]},
+                              "content" => "My body"}],
+                  "max_cache_time" => 10},
         routes: [{"path" => "/" + @document.slug,
                   "type" => "exact"}]}
 


### PR DESCRIPTION
We needed to ensure that specialist documents had a short enough cache time so
that recipients of alert emails would see current content if they looked at
the website.  This change adds the `max_cache_time` onto the details hash so
that it matches the work done in the [specialist-publisher-rebuild](https://github.com/alphagov/specialist-publisher-rebuild/pull/751).

We have set the cache time to 10 seconds as this matches what was originally
done in [Travel Advice Publisher](https://github.com/alphagov/travel-advice-publisher/pull/126).

[Trello card](https://trello.com/c/WGlWkWT5/70-reduce-cache-on-specialist-publisher-medium)