### PR TITLE
Fix email text

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -7,7 +7,7 @@ class EmailAlertPresenter
 
   def to_json
     {
-      subject: document.title + " updated",
+      subject: subject,
       body: body,
       tags: tags,
       document_type: document.publishing_api_document_type,
@@ -39,8 +39,55 @@ private
         document_summary: document.summary,
         document_url: File.join(Plek.current.website_root, document.base_path),
         document_change_note: document.change_note,
+        document_org_title: org_title[document.publishing_api_document_type],
+        document_noun: document_noun[document.publishing_api_document_type],
+        updated_or_published: updated_or_published,
       }
     )
+  end
+
+  def org_title
+    {
+      "aaib_report" => "Air Accidents Investigation Branch reports",
+      "cma_case" => "Competition and Markets Authority cases",
+      "countryside_stewardship_grant" => "Countryside Stewardship Grants",
+      "employment_appeal_tribunal_decision" => "Employment appeal tribunal decisions",
+      "employment_tribunal_decision" => "Employment tribunal decisions",
+      "esi_fund" => "European Structural and Investment Funds",
+      "maib_report" => "Marine Accident Investigation Branch reports",
+      "medical_safety_alert" => "Alerts and recalls for drugs and medical devices",
+      "raib_report" => "Rail Accident Investigation Branch reports",
+      "tax_tribunal_decision" => "Upper Tribunal (Tax and Chancery Chamber)",
+      "vehicle_recalls_and_faults_alert" => "Vehicle recalls and faults",
+    }
+  end
+
+  def document_noun
+    {
+      "aaib_report" => "report",
+      "cma_case" => "case",
+      "countryside_stewardship_grant" => "grant",
+      "employment_appeal_tribunal_decision" => "decision",
+      "employment_tribunal_decision" => "decision",
+      "esi_fund" => "fund",
+      "maib_report" => "report",
+      "medical_safety_alert" => "alert",
+      "raib_report" => "report",
+      "tax_tribunal_decision" => "decision",
+      "vehicle_recalls_and_faults_alert" => "alert",
+    }
+  end
+
+  def subject
+    redrafted? ? document.title + " updated" : document.title
+  end
+
+  def updated_or_published
+    redrafted? ? "updated" : "published"
+  end
+
+  def redrafted?
+    document.publication_state == "redrafted"
   end
 
   def extra_options

--- a/app/views/email_alerts/medical_safety_alerts/publication.html.erb
+++ b/app/views/email_alerts/medical_safety_alerts/publication.html.erb
@@ -2,7 +2,7 @@
   <tr>
     <td style="border-collapse: collapse; padding: 0 0 0 15px;">
       <h1 style="color: #0B0C0C !important; font-family: sans-serif; font-weight: 700; font-size: 30px; line-height: 1.111111111; margin: 15px 0; padding: 15px 0;">
-        Documents
+        <%= document_org_title %>
       </h1>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
@@ -22,7 +22,7 @@
       <% end %>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
-        For further information on this updated document:
+        For further information on this <%= updated_or_published %> <%= document_noun %>:
       </p>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">

--- a/app/views/email_alerts/publication.html.erb
+++ b/app/views/email_alerts/publication.html.erb
@@ -2,7 +2,7 @@
   <tr>
     <td style="border-collapse: collapse; padding: 0 0 0 15px;">
       <h1 style="color: #0B0C0C !important; font-family: sans-serif; font-weight: 700; font-size: 30px; line-height: 1.111111111; margin: 15px 0; padding: 15px 0;">
-        Documents
+        <%= document_org_title %>
       </h1>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
@@ -22,7 +22,7 @@
       <% end %>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
-      For further information on this updated document:
+      For further information on this <%= updated_or_published %> <%= document_noun %>:
       </p>
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
@@ -31,4 +31,3 @@
     </td>
   </tr>
 </table>
-

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe EmailAlertPresenter do
   let(:cma_case_payload) { Payloads.cma_case_content_item }
   let(:medical_safety_payload) { Payloads.medical_safety_alert_content_item }
+  let(:cma_case_redrafted_payload) { Payloads.cma_case_content_item("publication_state" => "redrafted") }
 
   describe "#to_json" do
     context "any finders document" do
       before do
         publishing_api_has_item(cma_case_payload)
+        publishing_api_has_item(cma_case_redrafted_payload)
       end
 
       it "has correct information" do
@@ -15,9 +17,17 @@ describe EmailAlertPresenter do
         email_alert_presenter = EmailAlertPresenter.new(cma_case)
         presented_data = email_alert_presenter.to_json
 
+        redrafted_cma_case = CmaCase.find(cma_case_redrafted_payload["content_id"])
+        email_alert_presenter_redrafted = EmailAlertPresenter.new(redrafted_cma_case)
+        presented_data_redrafted = email_alert_presenter_redrafted.to_json
+
         expect(presented_data[:subject]).to include(cma_case_payload["title"])
+        expect(presented_data[:subject]).not_to include("updated")
+        expect(presented_data_redrafted[:subject]).to include("updated")
         expect(presented_data[:body]).to include(cma_case_payload["description"])
         expect(presented_data[:body]).to include(cma_case_payload["title"])
+        expect(presented_data[:body]).to include("For further information on this published case")
+        expect(presented_data_redrafted[:body]).to include("For further information on this updated case")
         expect(presented_data[:tags][:format]).to eq(cma_case_payload["document_type"])
         expect(presented_data[:tags][:case_type]).to eq(cma_case_payload["details"]["metadata"]["case_type"])
         expect(presented_data[:document_type]).to eq(cma_case_payload["document_type"])


### PR DESCRIPTION
[Trello](https://trello.com/c/1QTTPUR1/106-emails-sent-for-new-content-make-clear-that-the-content-is-new-and-not-updated-small)
- Subject now only appends the text 'updated' if a document has actually been updated (previously it was also displaying when a document was 1st published)
- Name of the organisation displays within the H1 as opposed to "Documents" which was previously hard-coded into the h1 in V2
- 'Further information' paragraph dynamically informs the user if the document is published or updated aka 'For further information on this published case:' as opposed to 'For further information on this updated document' which was previously hardcoded into v2

This is an email from V1 (which this PR aims to replicate): 

![v1-create-new-document](https://cloud.githubusercontent.com/assets/5963488/15179147/f52768c8-1771-11e6-8f9d-39cc0a3d934b.png)

This is how a V2 email looked before this PR:

![v2-create-new-document](https://cloud.githubusercontent.com/assets/5963488/15179166/12885ada-1772-11e6-9ad1-5150151426d4.png)

This is what a V2 email looks (with the changes from this PR) when a document is 1st published:

![v2-published-subject-line](https://cloud.githubusercontent.com/assets/5963488/15179193/344323e4-1772-11e6-9e1d-273728763a37.png)

![v2-published-email](https://cloud.githubusercontent.com/assets/5963488/15179200/3c477b58-1772-11e6-891f-9e35cc1e90a4.png)

This is what a V2 email looks (with the changes from this PR) when a document is updated:

![v2-updated-subject-line](https://cloud.githubusercontent.com/assets/5963488/15179212/52bf2868-1772-11e6-98b4-7b67ee534000.png)

![v2-updated-email](https://cloud.githubusercontent.com/assets/5963488/15179219/5ab1279c-1772-11e6-8a09-133573007d72.png)

Currently email information is set for all formats (except `drug-safety-updates` which are sent out manually each month). This may change to only being set for certain formats at a later date. This decision will be made after further investigation into email alert behaviour, which is detailed on this [Trello card](https://trello.com/c/S3PiWkE8/123-discovery-email-1-day).

Currently there are 2 commits on this PR, which I am planning to squash together after review. Originally I defined the text in the models, but then switched to using hashes within the `email_alert_presenter`. Please let me know which way is preferable. I prefer the hash version but can revert back if preferred.
