### PR TITLE
Explicitly document what json payload looks like when republishing

### DIFF
--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -21,24 +21,60 @@ RSpec.describe "Republishing documents", type: :feature do
   end
 
   context "for published documents" do
+    let(:public_timestamp) { "2016-05-11 10:56:07" }
     before do
+      Timecop.freeze(public_timestamp)
       @document = create(:specialist_document_edition,
-        document_type: "aaib_report",
-        state: "published",
-        slug: "c/d",
+                         document_type: "aaib_report",
+                         state: "published",
+                         slug: "c/d",
       )
     end
 
+    after do
+      Timecop.return
+    end
+
     it "should push to Publishing API as content" do
-      SpecialistPublisher.document_services("aaib_report").republish_all.call
+      publishing_api_fields = {
+        content_id: @document.document_id,
+        schema_name: "specialist_document",
+        document_type: @document.document_type,
+        publishing_app: "specialist-publisher",
+        rendering_app: "specialist-frontend",
+        title: @document.title,
+        description: @document.summary,
+        update_type: "major",
+        locale: "en",
+        public_updated_at: "2016-05-11T10:56:07+00:00",
+        details: {"metadata" => {"opened_date" => "2013-04-20", # These nested hashes use Strings as keys because Symbols gives a false negative in the request_json_matching matcher.
+                                 "market_sector" => "some-market-sector",
+                                 "case_type" => "a-case-type",
+                                 "case_state" => "open",
+                                 "document_type" => @document.document_type},
+                  "change_history" => [],
+                  "body" => [{"content_type" => "text/html",
+                              "content" => "<p>My body</p>\n"},
+                             {"content_type" => "text/govspeak",
+                              "content" => "My body"}]},
+        routes: [{"path" => "/" + @document.slug,
+                  "type" => "exact"}]}
 
       rummager_fields = {title: @document.title,
-       description: @document.summary,
-       link: "/" + @document.slug,
-       indexable_content: @document.body,
-       organisations: ["air-accidents-investigation-branch"]}
+                         description: @document.summary,
+                         link: "/" + @document.slug,
+                         indexable_content: @document.body,
+                         organisations: ["air-accidents-investigation-branch"],
+                         public_timestamp: public_timestamp,
+                         aircraft_category: nil,
+                         report_type: nil,
+                         date_of_occurrence: nil,
+                         location: nil,
+                         aircraft_type: nil,
+                         registration: nil}
 
-      assert_publishing_api_put_item("/c/d")
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+      assert_publishing_api_put_item("/c/d", request_json_matching(publishing_api_fields))
       expect(fake_rummager).to have_received(:add_document)
                                  .with(@document.document_type, "/c/d", hash_including(rummager_fields))
     end


### PR DESCRIPTION
I intend to add more explicit tests so it is very clear what is sent to publishing api and rummager on a republish action. However there are some helpers that are confusing. As the commented-out lines show, by using `request_json_including` or `request_json_matching` the same data could either fail or pass the test. This seems strange to me because if a json passes a "matching" test, it should logically pass the "including" test.

Secondly, please comment on whether putting the json payload in this test is good readability/clarity or too verbose/messy?