### PR TITLE
Republish for draft documents

### DIFF
--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -32,6 +32,12 @@ class AbstractSpecialistDocumentObserversRegistry
     ]
   end
 
+  def draft_republication
+    [
+      publishing_api_exporter,
+    ]
+  end
+
   def withdrawal
     [
       publishing_api_withdrawer,

--- a/app/services/abstract_document_service_registry.rb
+++ b/app/services/abstract_document_service_registry.rb
@@ -75,7 +75,8 @@ class AbstractDocumentServiceRegistry
   def republish(document_id)
     RepublishDocumentService.new(
       document_repository: document_repository,
-      listeners: observers.republication,
+      published_listeners: observers.republication,
+      draft_listeners: observers.draft_republication,
       document_id: document_id,
     )
   end

--- a/app/services/republish_document_service.rb
+++ b/app/services/republish_document_service.rb
@@ -1,23 +1,34 @@
 class RepublishDocumentService
-  def initialize(document_repository:, listeners: [], document_id:)
+  def initialize(document_repository:, published_listeners: [], draft_listeners: [], document_id:)
     @document_repository = document_repository
-    @listeners = listeners
+    @published_listeners = published_listeners
+    @draft_listeners = draft_listeners
     @document_id = document_id
   end
 
   def call
     if document.published?
-      notify_listeners
+      notify_published_listeners
+    elsif  document.draft?
+      notify_draft_listeners
     end
 
     document
   end
 
 private
-  attr_reader :document_repository, :listeners, :document_id
+  attr_reader :document_repository, :published_listeners, :draft_listeners, :document_id
 
-  def notify_listeners
+  def notify_listeners(listeners)
     listeners.each { |l| l.call(document) }
+  end
+
+  def notify_draft_listeners
+    notify_listeners(draft_listeners)
+  end
+
+  def notify_published_listeners
+    notify_listeners(published_listeners)
   end
 
   def document

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -2,28 +2,82 @@ require "spec_helper"
 require "sidekiq/testing"
 
 RSpec.describe "Republishing documents", type: :feature do
+  let(:public_timestamp) { "2016-05-11 10:56:07" }
+  let(:publishing_api_fields) do
+    {
+      content_id: @document.document_id,
+      schema_name: "specialist_document",
+      document_type: @document.document_type,
+      publishing_app: "specialist-publisher",
+      rendering_app: "specialist-frontend",
+      title: @document.title,
+      description: @document.summary,
+      update_type: "major",
+      locale: "en",
+      public_updated_at: "2016-05-11T10:56:07+00:00",
+      details: {"metadata" => {"opened_date" => "2013-04-20", # These nested hashes use Strings as keys because Symbols gives a false negative in the request_json_matching matcher.
+                               "market_sector" => "some-market-sector",
+                               "case_type" => "a-case-type",
+                               "case_state" => "open",
+                               "document_type" => @document.document_type},
+                "change_history" => [],
+                "body" => [{"content_type" => "text/html",
+                            "content" => "<p>My body</p>\n"},
+                           {"content_type" => "text/govspeak",
+                            "content" => "My body"}],
+                "max_cache_time" => 10,
+      },
+      routes: [{"path" => "/" + @document.slug,
+                "type" => "exact"}]
+    }
+  end
+
+  let(:rummager_fields) do
+    {
+      title: @document.title,
+      description: @document.summary,
+      link: "/" + @document.slug,
+      indexable_content: @document.body,
+      organisations: ["air-accidents-investigation-branch"],
+      public_timestamp: public_timestamp,
+      aircraft_category: nil,
+      report_type: nil,
+      date_of_occurrence: nil,
+      location: nil,
+      aircraft_type: nil,
+      registration: nil
+    }
+  end
+
+  before do
+    Timecop.freeze(public_timestamp)
+  end
+
+  after do
+    Timecop.return
+  end
+
   context "for drafts" do
     before do
-      create(:specialist_document_edition,
+      @document = create(:specialist_document_edition,
         document_type: "aaib_report",
         state: "draft",
         slug: "a/b",
       )
     end
 
-    it "should NOT push to Publishing API" do
+    it "should push to Publishing API as draft-content" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
 
       assert_publishing_api_put_item("/a/b", {}, 0)
-      assert_publishing_api_put_draft_item("/a/b", {}, 0)
+      assert_publishing_api_put_draft_item("/a/b", request_json_matching(publishing_api_fields))
       expect(fake_rummager).not_to have_received(:add_document)
+                                 .with(@document.document_type, "/a/b", hash_including(rummager_fields))
     end
   end
 
   context "for published documents" do
-    let(:public_timestamp) { "2016-05-11 10:56:07" }
     before do
-      Timecop.freeze(public_timestamp)
       @document = create(:specialist_document_edition,
                          document_type: "aaib_report",
                          state: "published",
@@ -31,49 +85,7 @@ RSpec.describe "Republishing documents", type: :feature do
       )
     end
 
-    after do
-      Timecop.return
-    end
-
     it "should push to Publishing API as content" do
-      publishing_api_fields = {
-        content_id: @document.document_id,
-        schema_name: "specialist_document",
-        document_type: @document.document_type,
-        publishing_app: "specialist-publisher",
-        rendering_app: "specialist-frontend",
-        title: @document.title,
-        description: @document.summary,
-        update_type: "major",
-        locale: "en",
-        public_updated_at: "2016-05-11T10:56:07+00:00",
-        details: {"metadata" => {"opened_date" => "2013-04-20", # These nested hashes use Strings as keys because Symbols gives a false negative in the request_json_matching matcher.
-                                 "market_sector" => "some-market-sector",
-                                 "case_type" => "a-case-type",
-                                 "case_state" => "open",
-                                 "document_type" => @document.document_type},
-                  "change_history" => [],
-                  "body" => [{"content_type" => "text/html",
-                              "content" => "<p>My body</p>\n"},
-                             {"content_type" => "text/govspeak",
-                              "content" => "My body"}],
-                  "max_cache_time" => 10},
-        routes: [{"path" => "/" + @document.slug,
-                  "type" => "exact"}]}
-
-      rummager_fields = {title: @document.title,
-                         description: @document.summary,
-                         link: "/" + @document.slug,
-                         indexable_content: @document.body,
-                         organisations: ["air-accidents-investigation-branch"],
-                         public_timestamp: public_timestamp,
-                         aircraft_category: nil,
-                         report_type: nil,
-                         date_of_occurrence: nil,
-                         location: nil,
-                         aircraft_type: nil,
-                         registration: nil}
-
       SpecialistPublisher.document_services("aaib_report").republish_all.call
       assert_publishing_api_put_item("/c/d", request_json_matching(publishing_api_fields))
       expect(fake_rummager).to have_received(:add_document)


### PR DESCRIPTION
Following #714 this opens up the republish action to also work on documents with a publication state `draft`