### PR TITLE
Stop sending organisations to Rummager, add a SearchPresenter spec

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -11,25 +11,17 @@ class SearchPresenter
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,
-      organisations: organisation_slugs,
+      # FIXME: This line was dependent on a method called #organisation_slugs,
+      # which in turn used publishing_api.get_content to map org content_ids to
+      # organisation slugs. It was stubbed in many places in spec/, but that method
+      # call always returned a blank list in the real world.
+      organisations: [],
       public_timestamp: document.public_updated_at.to_datetime.rfc3339,
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }
   end
 
   def indexable_content
     document.body
-  end
-
-  def organisation_slugs
-    response = publishing_api.get_linkables(document_type: "organisation")
-
-    organisations = response.select do |organisation|
-      document.organisations.include?(organisation["content_id"])
-    end
-
-    organisations.map do |org|
-      org["base_path"].gsub("/government/organisations/", "").gsub("/courts-tribunals/", "")
-    end
   end
 
 private

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -21,10 +21,15 @@ class SearchPresenter
   end
 
   def organisation_slugs
-    response = publishing_api.get_content_items(document_type: "organisation", fields: [:content_id, :base_path])
+    response = publishing_api.get_linkables(document_type: "organisation")
 
-    orgs = response.results.select { |o| document.organisations.include?(o["content_id"]) }
-    orgs.map { |o| o["base_path"].gsub("/government/organisations/", "") }.map { |o| o.gsub("/courts-tribunals/", "") }
+    organisations = response.select do |organisation|
+      document.organisations.include?(organisation["content_id"])
+    end
+
+    organisations.map do |org|
+      org["base_path"].gsub("/government/organisations/", "").gsub("/courts-tribunals/", "")
+    end
   end
 
 private

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -11,11 +11,6 @@ class SearchPresenter
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,
-      # FIXME: This line was dependent on a method called #organisation_slugs,
-      # which in turn used publishing_api.get_content to map org content_ids to
-      # organisation slugs. It was stubbed in many places in spec/, but that method
-      # call always returned a blank list in the real world.
-      organisations: [],
       public_timestamp: document.public_updated_at.to_datetime.rfc3339,
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }
   end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -1,36 +1,6 @@
 require 'spec_helper'
 
 RSpec.feature "Publishing a CMA case", type: :feature do
-  def cma_org_content_item
-    {
-      "base_path" => "/government/organisations/competition-and-markets-authority",
-      "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-      "title" => "Competition and Markets Authority",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-10-26T09:21:17.645Z",
-      "public_updated_at" => "2015-03-10T16:23:14.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "D550",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-            "title" => "Competition and Markets Authority",
-            "base_path" => "/government/organisations/competition-and-markets-authority",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
-            "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  end
-
   def indexable_attributes
     {
       "title" => "Example CMA Case",
@@ -44,7 +14,6 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "case_state" => "open",
       "market_sector" => ["energy"],
       "outcome_type" => nil,
-      "organisations" => ["competition-and-markets-authority"],
     }
   end
 
@@ -86,7 +55,6 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     log_in_as_editor(:cma_editor)
 
     publishing_api_has_content([cma_case, minor_update_item, live_item, withdrawn_item], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
-    publishing_api_has_linkables([cma_org_content_item], document_type: 'organisation')
 
     publishing_api_has_item(cma_case)
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     log_in_as_editor(:cma_editor)
 
     publishing_api_has_content([cma_case, minor_update_item, live_item, withdrawn_item], document_type: CmaCase.publishing_api_document_type, fields: fields, page: page_number, per_page: per_page)
-    publishing_api_has_content([cma_org_content_item], document_type: 'organisation', fields: [:base_path, :content_id])
+    publishing_api_has_linkables([cma_org_content_item], document_type: 'organisation')
 
     publishing_api_has_item(cma_case)
 

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -15,36 +15,6 @@ describe AaibReport do
     )
   end
 
-  let(:aaib_org_content_item) {
-    {
-      "base_path" => "/government/organisations/air-accidents-investigation-branch",
-      "content_id" => "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
-      "title" => "Air Accidents Investigation Branch",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "OT248",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
-            "title" => "Air Accidents Investigation Branch",
-            "base_path" => "/government/organisations/air-accidents-investigation-branch",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/air-accidents-investigation-branch",
-            "web_url" => "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example AAIB Report 0",
@@ -53,7 +23,6 @@ describe AaibReport do
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example AAIB Report" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
-      "organisations" => ["air-accidents-investigation-branch"],
     }
   }
 
@@ -129,10 +98,6 @@ describe AaibReport do
   describe "#publish!" do
     before do
       email_alert_api_accepts_alert
-      publishing_api_has_linkables(
-        [aaib_org_content_item],
-        document_type: 'organisation'
-      )
     end
 
     let(:aaib_report) { described_class.find(aaib_reports[0]["content_id"]) }

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -129,10 +129,9 @@ describe AaibReport do
   describe "#publish!" do
     before do
       email_alert_api_accepts_alert
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [aaib_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
     end
 

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -221,10 +221,9 @@ RSpec.describe CmaCase do
     it "publishes the CMA Case" do
       stub_publishing_api_publish(cma_cases[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [cma_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       c = described_class.find(cma_cases[0]["content_id"])

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -15,36 +15,6 @@ RSpec.describe CmaCase do
     )
   end
 
-  let(:cma_org_content_item) {
-    {
-      "base_path" => "/government/organisations/competition-and-markets-authority",
-      "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-      "title" => "Competition and Markets Authority",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-10-26T09:21:17.645Z",
-      "public_updated_at" => "2015-03-10T16:23:14.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "D550",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-            "title" => "Competition and Markets Authority",
-            "base_path" => "/government/organisations/competition-and-markets-authority",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
-            "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example CMA Case 0",
@@ -57,8 +27,7 @@ RSpec.describe CmaCase do
       "case_type" => "ca98-and-civil-cartels",
       "case_state" => "open",
       "market_sector" => ["energy"],
-      "outcome_type" => nil,
-      "organisations" => ["competition-and-markets-authority"],
+      "outcome_type" => nil
     }
   }
 
@@ -221,10 +190,6 @@ RSpec.describe CmaCase do
     it "publishes the CMA Case" do
       stub_publishing_api_publish(cma_cases[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [cma_org_content_item],
-        document_type: 'organisation'
-      )
 
       c = described_class.find(cma_cases[0]["content_id"])
       expect(c.publish!).to eq(true)

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -15,41 +15,6 @@ describe CountrysideStewardshipGrant do
     )
   end
 
-  let(:countryside_stewardship_grant_org_content_items) {
-    [
-      {
-        "content_id" => "d3ce4ba7-bc75-46b4-89d9-38cb3240376d",
-        "title" => "Natural England",
-        "base_path" => "/government/organisations/natural-england",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/natural-england",
-        "web_url" => "https://www.gov.uk/government/organisations/natural-england",
-        "locale" => "en",
-        "analytics_identifier" => "PB202"
-      },
-      {
-        "content_id" => "de4e9dc6-cca4-43af-a594-682023b84d6c",
-        "title" => "Department for Environment, Food & Rural Affairs",
-        "base_path" => "/government/organisations/department-for-environment-food-rural-affairs",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
-        "web_url" => "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
-        "locale" => "en",
-        "analytics_identifier" => "D7"
-      },
-      {
-        "content_id" => "8bf5624b-dec2-44fa-9b6c-daed166333a5",
-        "title" => "Forestry Commission",
-        "base_path" => "/government/organisations/forestry-commission",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/forestry-commission",
-        "web_url" => "https://www.gov.uk/government/organisations/forestry-commission",
-        "locale" => "en",
-        "analytics_identifier" => "D85"
-      },
-    ]
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Countryside Stewardship Grant 0",
@@ -57,7 +22,6 @@ describe CountrysideStewardshipGrant do
       "link" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-0",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Countryside Stewardship Grant" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "organisations" => ["natural-england", "department-for-environment-food-rural-affairs", "forestry-commission"],
     }
   }
 
@@ -128,10 +92,6 @@ describe CountrysideStewardshipGrant do
     it "publishes the Countryside Stewardship Grant" do
       stub_publishing_api_publish(countryside_stewardship_grants[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        countryside_stewardship_grant_org_content_items,
-        document_type: 'organisation'
-      )
 
       countryside_stewardship_grant = described_class.find(countryside_stewardship_grants[0]["content_id"])
       expect(countryside_stewardship_grant.publish!).to eq(true)

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -128,10 +128,9 @@ describe CountrysideStewardshipGrant do
     it "publishes the Countryside Stewardship Grant" do
       stub_publishing_api_publish(countryside_stewardship_grants[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         countryside_stewardship_grant_org_content_items,
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       countryside_stewardship_grant = described_class.find(countryside_stewardship_grants[0]["content_id"])

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -15,36 +15,6 @@ describe DrugSafetyUpdate do
     )
   end
 
-  let(:drug_safety_update_org_content_item) {
-    {
-      "base_path" => "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-      "content_id" => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
-      "title" => "Medicines and Healthcare products Regulatory Agency",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "A63",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
-            "title" => "Medicines and Healthcare products Regulatory Agency",
-            "base_path" => "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "web_url" => "https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Drug Safety Update 0",
@@ -52,7 +22,6 @@ describe DrugSafetyUpdate do
       "link" => "/drug-safety-update/example-drug-safety-update-0",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Drug Safety Update" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "organisations" => ["medicines-and-healthcare-products-regulatory-agency"],
     }
   }
 
@@ -136,11 +105,6 @@ describe DrugSafetyUpdate do
 
       publishing_api_has_item(unpublished_drug_safety_update_content_item)
       publishing_api_has_item(published_drug_safety_update_content_item)
-
-      publishing_api_has_linkables(
-        [drug_safety_update_org_content_item],
-        document_type: 'organisation'
-      )
     end
 
     let(:drug_safety_update) { described_class.find(drug_safety_updates[0]["content_id"]) }

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -137,10 +137,9 @@ describe DrugSafetyUpdate do
       publishing_api_has_item(unpublished_drug_safety_update_content_item)
       publishing_api_has_item(published_drug_safety_update_content_item)
 
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [drug_safety_update_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
     end
 

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -131,10 +131,9 @@ describe EmploymentAppealTribunalDecision do
     it "publishes the Employment Appeal Tribunal Decision" do
       stub_publishing_api_publish(employment_appeal_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [employment_appeal_tribunal_decision_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       employment_appeal_tribunal_decision = described_class.find(employment_appeal_tribunal_decisions[0]["content_id"])

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -15,36 +15,6 @@ describe EmploymentAppealTribunalDecision do
     )
   end
 
-  let(:employment_appeal_tribunal_decision_org_content_item) {
-    {
-      "base_path" => "/courts-tribunals/employment-appeal-tribunal",
-      "content_id" => "caeb418c-d11c-4352-92e9-47b21289f696",
-      "title" => "Employment Appeal Tribunal",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "CO1134",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "975cf540-6e64-40e3-b62a-df655a8c99ef",
-            "title" => "Employment appeal tribunal decisions",
-            "base_path" => "/employment-appeal-tribunal-decisions",
-            "description" => nil,
-            "api_url" => "https://www-origin.integration.publishing.service.gov.uk/api/content/employment-appeal-tribunal-decisions",
-            "web_url" => "https://www-origin.integration.publishing.service.gov.uk/employment-appeal-tribunal-decisions",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Employment Appeal Tribunal Decision 0",
@@ -56,7 +26,6 @@ describe EmploymentAppealTribunalDecision do
       "tribunal_decision_decision_date" => "2015-07-30",
       "tribunal_decision_landmark" => "landmark",
       "tribunal_decision_sub_categories" => ["contract-of-employment-apprenticeship"],
-      "organisations" => ["employment-appeal-tribunal"],
     }
   }
 
@@ -131,10 +100,6 @@ describe EmploymentAppealTribunalDecision do
     it "publishes the Employment Appeal Tribunal Decision" do
       stub_publishing_api_publish(employment_appeal_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [employment_appeal_tribunal_decision_org_content_item],
-        document_type: 'organisation'
-      )
 
       employment_appeal_tribunal_decision = described_class.find(employment_appeal_tribunal_decisions[0]["content_id"])
       expect(employment_appeal_tribunal_decision.publish!).to eq(true)

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -129,10 +129,9 @@ describe EmploymentTribunalDecision do
     it "publishes the Employment Tribunal Decision" do
       stub_publishing_api_publish(employment_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [employment_tribunal_decision_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       employment_tribunal_decision = described_class.find(employment_tribunal_decisions[0]["content_id"])

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -15,36 +15,6 @@ describe EmploymentTribunalDecision do
     )
   end
 
-  let(:employment_tribunal_decision_org_content_item) {
-    {
-      "base_path" => "/courts-tribunals/employment-tribunal",
-      "content_id" => "8bb37087-a5a7-4493-8afe-900b36ebc927",
-      "title" => "Employment Tribunal",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "CO1133",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
-            "title" => "Employment tribunal decisions",
-            "base_path" => "/employment-tribunal-decisions",
-            "description" => nil,
-            "api_url" => "https://www-origin.integration.publishing.service.gov.uk/api/content/employment-tribunal-decisions",
-            "web_url" => "https://www-origin.integration.publishing.service.gov.uk/employment-tribunal-decisions",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Employment Tribunal Decision 0",
@@ -55,7 +25,6 @@ describe EmploymentTribunalDecision do
       "tribunal_decision_categories" => ["age-discrimination"],
       "tribunal_decision_country" => "england-and-wales",
       "tribunal_decision_decision_date" => "2015-07-30",
-      "organisations" => ["employment-tribunal"],
     }
   }
 
@@ -129,10 +98,6 @@ describe EmploymentTribunalDecision do
     it "publishes the Employment Tribunal Decision" do
       stub_publishing_api_publish(employment_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [employment_tribunal_decision_org_content_item],
-        document_type: 'organisation'
-      )
 
       employment_tribunal_decision = described_class.find(employment_tribunal_decisions[0]["content_id"])
       expect(employment_tribunal_decision.publish!).to eq(true)

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -144,11 +144,7 @@ describe EsiFund do
     it "publishes the ESI Fund" do
       stub_publishing_api_publish(esi_funds[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
-        esi_fund_org_content_items,
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
-      )
+      publishing_api_has_linkables(esi_fund_org_content_items, document_type: 'organisation')
 
       esi_fund = described_class.find(esi_funds[0]["content_id"])
       expect(esi_fund.publish!).to eq(true)

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -15,51 +15,6 @@ describe EsiFund do
     )
   end
 
-  let(:esi_fund_org_content_items) {
-    [
-      {
-        "content_id" => "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
-        "title" => "Department for Communities and Local Government",
-        "base_path" => "/government/organisations/department-for-communities-and-local-government",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
-        "web_url" => "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
-        "locale" => "en",
-        "analytics_identifier" => "D4"
-      },
-      {
-        "content_id" => "de4e9dc6-cca4-43af-a594-682023b84d6c",
-        "title" => "Department for Environment, Food & Rural Affairs",
-        "base_path" => "/government/organisations/department-for-environment-food-rural-affairs",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
-        "web_url" => "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
-        "locale" => "en",
-        "analytics_identifier" => "D7"
-      },
-      {
-        "content_id" => "569a9ee5-c195-4b7f-b9dc-edc17a09113f",
-        "title" => "Department for Business, Innovation & Skills",
-        "base_path" => "/government/organisations/department-for-business-innovation-skills",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/department-for-business-innovation-skills",
-        "web_url" => "https://www.gov.uk/government/organisations/department-for-business-innovation-skills",
-        "locale" => "en",
-        "analytics_identifier" => "D3"
-      },
-      {
-        "content_id" => "b548a09f-8b35-4104-89f4-f1a40bf3136d",
-        "title" => "Department for Work and Pensions",
-        "base_path" => "/government/organisations/department-for-work-pensions",
-        "description" => nil,
-        "api_url" => "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
-        "web_url" => "https://www.gov.uk/government/organisations/department-for-work-pensions",
-        "locale" => "en",
-        "analytics_identifier" => "D10"
-      }
-    ]
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example ESI Fund 0",
@@ -72,7 +27,6 @@ describe EsiFund do
       "location" => nil,
       "funding_source" => nil,
       "closing_date" => "2016-01-01",
-      "organisations" => ["department-for-communities-and-local-government", "department-for-environment-food-rural-affairs", "department-for-business-innovation-skills", "department-for-work-pensions"],
     }
   }
 
@@ -144,7 +98,6 @@ describe EsiFund do
     it "publishes the ESI Fund" do
       stub_publishing_api_publish(esi_funds[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(esi_fund_org_content_items, document_type: 'organisation')
 
       esi_fund = described_class.find(esi_funds[0]["content_id"])
       expect(esi_fund.publish!).to eq(true)

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -15,37 +15,6 @@ describe MaibReport do
     )
   end
 
-  let(:maib_org_content_item) {
-    {
-      "base_path" => "/government/organisations/marine-accident-investigation-branch",
-      "content_id" => "9c66b9a3-1e6a-48e8-974d-2a5635f84679",
-      "title" => "Marine Accident Investigation Branch",
-      "format" => "redirect",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-10-27T11:47:43.454Z",
-      "public_updated_at" => "2014-12-19T14:16:32.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => nil,
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "9c66b9a3-1e6a-48e8-974d-2a5635f84679",
-            "title" => "Marine Accident Investigation Branch",
-            "base_path" => "/government/organisations/marine-accident-investigation-branch",
-            "description" => "nil",
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/marine-accident-investigation-branch",
-            "web_url" => "https://www.gov.uk/government/organisations/marine-accident-investigation-branch",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {
-      }
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example MAIB Report 0",
@@ -54,7 +23,6 @@ describe MaibReport do
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example MAIB Report" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
-      "organisations" => ["marine-accident-investigation-branch"],
     }
   }
 
@@ -126,10 +94,6 @@ describe MaibReport do
     it "publishes the MAIB Report" do
       stub_publishing_api_publish(maib_reports[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [maib_org_content_item],
-        document_type: 'organisation'
-      )
 
       maib_report = described_class.find(maib_reports[0]["content_id"])
       expect(maib_report.publish!).to eq(true)

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -126,10 +126,9 @@ describe MaibReport do
     it "publishes the MAIB Report" do
       stub_publishing_api_publish(maib_reports[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [maib_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       maib_report = described_class.find(maib_reports[0]["content_id"])

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -15,36 +15,6 @@ describe MedicalSafetyAlert do
     )
   end
 
-  let(:mhra_org_content_item) {
-    {
-      "base_path" => "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-      "content_id" => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
-      "title" => "Medicines and Healthcare products Regulatory Agency",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-12-01T15:51:43.521Z",
-      "public_updated_at" => "2015-06-29T14:33:29.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "EA63",
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
-            "title" => "Medicines and Healthcare products Regulatory Agency",
-            "base_path" => "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "web_url" => "https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Medical Safety Alert 0",
@@ -52,7 +22,6 @@ describe MedicalSafetyAlert do
       "link" => "/drug-device-alerts/example-medical-safety-alert-0",
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "organisations" => ["medicines-and-healthcare-products-regulatory-agency"],
       "alert_type" => "company-led-drugs",
       "issued_date" => "2016-02-01",
     }
@@ -126,10 +95,6 @@ describe MedicalSafetyAlert do
     it "publishes the Medical Safety Alert" do
       stub_publishing_api_publish(medical_safety_alerts[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [mhra_org_content_item],
-        document_type: 'organisation'
-      )
 
       medical_safety_alert = described_class.find(medical_safety_alerts[0]["content_id"])
       expect(medical_safety_alert.publish!).to eq(true)

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -126,10 +126,9 @@ describe MedicalSafetyAlert do
     it "publishes the Medical Safety Alert" do
       stub_publishing_api_publish(medical_safety_alerts[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [mhra_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       medical_safety_alert = described_class.find(medical_safety_alerts[0]["content_id"])

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -126,10 +126,9 @@ describe RaibReport do
     it "publishes the RAIB Report" do
       stub_publishing_api_publish(raib_reports[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [raib_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       raib_report = described_class.find(raib_reports[0]["content_id"])

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -15,37 +15,6 @@ describe RaibReport do
     )
   end
 
-  let(:raib_org_content_item) {
-    {
-      "base_path" => "/government/organisations/rail-accidents-investigation-branch",
-      "content_id" => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
-      "title" => "Rail Accident Investigation Branch",
-      "format" => "redirect",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-10-27T11:47:43.454Z",
-      "public_updated_at" => "2014-12-19T14:16:32.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => nil,
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "c4c1bd4d-f252-43f1-91cf-a8cfdd526097",
-            "title" => "Rail Accident Investigation Branch",
-            "base_path" => "/government/organisations/rail-accidents-investigation-branch",
-            "description" => "nil",
-            "api_url" => "https://www.gov.uk/api/content/government/organisations/air-accidents-investigation-branch",
-            "web_url" => "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {
-      }
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example RAIB Report 0",
@@ -54,7 +23,6 @@ describe RaibReport do
       "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example RAIB Report" * 10),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
-      "organisations" => ["rail-accidents-investigation-branch"],
     }
   }
 
@@ -126,10 +94,6 @@ describe RaibReport do
     it "publishes the RAIB Report" do
       stub_publishing_api_publish(raib_reports[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [raib_org_content_item],
-        document_type: 'organisation'
-      )
 
       raib_report = described_class.find(raib_reports[0]["content_id"])
       expect(raib_report.publish!).to eq(true)

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -129,10 +129,9 @@ describe TaxTribunalDecision do
     it "publishes the Tax Tribunal Decision" do
       stub_publishing_api_publish(tax_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [tax_tribunal_decision_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       tax_tribunal_decision = described_class.find(tax_tribunal_decisions[0]["content_id"])

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -15,37 +15,6 @@ describe TaxTribunalDecision do
     )
   end
 
-  let(:tax_tribunal_decision_org_content_item) {
-    {
-      "base_path" => "/courts-tribunals/upper-tribunal-tax-and-chancery-chamber",
-      "content_id" => "1a68b2cc-eb52-4528-8989-429f710da00f",
-      "title" => "Upper Tribunal (Tax and Chancery Chamber)",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => "CO1133",
-      "links" => {
-        "available_translations" => [
-          {
-
-            "title" => "Upper Tribunal (Tax and Chancery Chamber)",
-            "base_path" => "/courts-tribunals/upper-tribunal-tax-and-chancery-chamber",
-            "description" => nil,
-            "api_url" => "https://www-origin.integration.publishing.service.gov.uk/api/content/courts-tribunals/upper-tribunal-tax-and-chancery-chamber",
-            "web_url" => "https://www-origin.integration.publishing.service.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber",
-            "locale" => "en",
-            "analytics_identifier" => "PB1140",
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {},
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Tax Tribunal Decision 0",
@@ -55,7 +24,6 @@ describe TaxTribunalDecision do
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "tribunal_decision_category" => "banking",
       "tribunal_decision_decision_date" => "2015-07-30",
-      "organisations" => ["upper-tribunal-tax-and-chancery-chamber"]
     }
   }
 
@@ -129,10 +97,6 @@ describe TaxTribunalDecision do
     it "publishes the Tax Tribunal Decision" do
       stub_publishing_api_publish(tax_tribunal_decisions[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [tax_tribunal_decision_org_content_item],
-        document_type: 'organisation'
-      )
 
       tax_tribunal_decision = described_class.find(tax_tribunal_decisions[0]["content_id"])
       expect(tax_tribunal_decision.publish!).to eq(true)

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -128,10 +128,9 @@ describe VehicleRecallsAndFaultsAlert do
     it "publishes the Vehicle Recall and Fault" do
       stub_publishing_api_publish(vehicle_recalls_and_faults[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_content(
+      publishing_api_has_linkables(
         [vehicle_recalls_and_faults_alert_org_content_item],
-        document_type: 'organisation',
-        fields: [:base_path, :content_id]
+        document_type: 'organisation'
       )
 
       vehicle_recall_and_fault = described_class.find(vehicle_recalls_and_faults[0]["content_id"])

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -15,36 +15,6 @@ describe VehicleRecallsAndFaultsAlert do
     )
   end
 
-  let(:vehicle_recalls_and_faults_alert_org_content_item) {
-    {
-      "base_path" => "/vehicle-recalls-faults",
-      "content_id" => "76290530-743e-4a8c-8752-04ebee25f64a",
-      "title" => "Vehicle recalls and faults",
-      "format" => "placeholder_organisation",
-      "need_ids" => [],
-      "locale" => "en",
-      "updated_at" => "2015-08-20T10:26:56.082Z",
-      "public_updated_at" => "2015-04-15T10:04:28.000+00:00",
-      "phase" => "live",
-      "analytics_identifier" => nil,
-      "links" => {
-        "available_translations" => [
-          {
-            "content_id" => "76290530-743e-4a8c-8752-04ebee25f64a",
-            "title" => "Vehicle recalls and faults",
-            "base_path" => "/vehicle-recalls-faults",
-            "description" => nil,
-            "api_url" => "https://www.gov.uk/api/content/vehicle-recalls-faults",
-            "web_url" => "https://www.gov.uk/vehicle-recalls-faults",
-            "locale" => "en"
-          }
-        ]
-      },
-      "description" => nil,
-      "details" => {}
-    }
-  }
-
   let(:indexable_attributes) {
     {
       "title" => "Example Vehicle Recalls And Faults 0",
@@ -128,10 +98,6 @@ describe VehicleRecallsAndFaultsAlert do
     it "publishes the Vehicle Recall and Fault" do
       stub_publishing_api_publish(vehicle_recalls_and_faults[0]["content_id"], {})
       stub_any_rummager_post_with_queueing_enabled
-      publishing_api_has_linkables(
-        [vehicle_recalls_and_faults_alert_org_content_item],
-        document_type: 'organisation'
-      )
 
       vehicle_recall_and_fault = described_class.find(vehicle_recalls_and_faults[0]["content_id"])
       expect(vehicle_recall_and_fault.publish!).to eq(true)

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe SearchPresenter do
+  subject(:presenter) { SearchPresenter.new(document) }
+
+  let(:aaib_content_id) { "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4" }
+  let(:court)           { "b0bdfcf3-2763-4002-961e-a0b2d7825038" }
+
+  let(:organisations) {
+    [
+      { "content_id" => aaib_content_id,
+        "base_path"  => "/government/organisations/air-accidents-investigation-branch" },
+      { "content_id" => "0398096c-6742-4cf3-934a-09fa70309beb",
+        "base_path"  =>
+          "/government/organisations/inquiry-into-the-supervision-of-the-bank-of-credit-and-commerce-international" },
+      { "content_id" => court,
+        "base_path"  => "/courts-tribunals/administrative-court" }
+    ]
+  }
+
+  before do
+    publishing_api_has_linkables(organisations, document_type: 'organisation')
+  end
+
+  context 'a complete document is given' do
+    let(:document) do
+      double(
+        'Document',
+        title:                    'A Title',
+        summary:                  'A summary',
+        base_path:                '/some-finder/a-title',
+        organisations:            [aaib_content_id, court],
+        public_updated_at:        Time.now,
+        body:                     '## A Title',
+        format_specific_metadata: { country: ['GB'], blank_value: '' }
+      )
+    end
+
+    describe '#indexable_content' do
+      it 'indexes the body alone' do
+        expect(presenter.indexable_content).to eql('## A Title')
+      end
+    end
+
+    describe '#to_json' do
+      subject(:json) { presenter.to_json }
+
+      it 'has values that are present' do
+        expect(json[:title]).to eql('A Title')
+        expect(json[:link]).to eql(document.base_path)
+      end
+
+      it 'includes format-specific metadata' do
+        expect(json[:country]).to eql(['GB'])
+      end
+
+      it 'does not include blank values' do
+        expect { json.fetch(:blank_value) }.to raise_error(KeyError)
+      end
+    end
+
+    describe '#organisations_slugs' do
+      subject(:organisation_slugs) { presenter.organisation_slugs }
+
+      it 'gets slugs with a content-id in the document\'s organisations' do
+        expect(organisation_slugs).to eql(
+          %w(air-accidents-investigation-branch administrative-court))
+      end
+    end
+  end
+end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -3,25 +3,6 @@ require 'spec_helper'
 describe SearchPresenter do
   subject(:presenter) { SearchPresenter.new(document) }
 
-  let(:aaib_content_id) { "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4" }
-  let(:court)           { "b0bdfcf3-2763-4002-961e-a0b2d7825038" }
-
-  let(:organisations) {
-    [
-      { "content_id" => aaib_content_id,
-        "base_path"  => "/government/organisations/air-accidents-investigation-branch" },
-      { "content_id" => "0398096c-6742-4cf3-934a-09fa70309beb",
-        "base_path"  =>
-          "/government/organisations/inquiry-into-the-supervision-of-the-bank-of-credit-and-commerce-international" },
-      { "content_id" => court,
-        "base_path"  => "/courts-tribunals/administrative-court" }
-    ]
-  }
-
-  before do
-    publishing_api_has_linkables(organisations, document_type: 'organisation')
-  end
-
   context 'a complete document is given' do
     let(:document) do
       double(
@@ -29,7 +10,6 @@ describe SearchPresenter do
         title:                    'A Title',
         summary:                  'A summary',
         base_path:                '/some-finder/a-title',
-        organisations:            [aaib_content_id, court],
         public_updated_at:        Time.now,
         body:                     '## A Title',
         format_specific_metadata: { country: ['GB'], blank_value: '' }
@@ -57,15 +37,9 @@ describe SearchPresenter do
       it 'does not include blank values' do
         expect { json.fetch(:blank_value) }.to raise_error(KeyError)
       end
-    end
 
-    describe '#organisations_slugs' do
-      subject(:organisation_slugs) { presenter.organisation_slugs }
-
-      it 'gets slugs with a content-id in the document\'s organisations' do
-        expect(organisation_slugs).to eql(
-          %w(air-accidents-investigation-branch administrative-court))
-      end
+      # This needs thought.
+      it 'prepares organisation details *somehow*'
     end
   end
 end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -37,9 +37,6 @@ describe SearchPresenter do
       it 'does not include blank values' do
         expect { json.fetch(:blank_value) }.to raise_error(KeyError)
       end
-
-      # This needs thought.
-      it 'prepares organisation details *somehow*'
     end
   end
 end


### PR DESCRIPTION
A retrievable-by-author-only restriction in the publishing-api (thanks @tuzz):
https://github.com/alphagov/publishing-api/blob/master/app/controllers/v2/content_items_controller.rb#L64-L68

means that `get_content_items` always returned an empty organisations
list. This means that Rummager never got to relate indexable content to organisation
slugs.

@danielroseman pointed out we could use `get_linkables`
instead, so we stubbed that and added tests for everything else (there was no
 spec for `SearchPresenter`).

Subsequently, @tijmenb pointed out that this will shortly not be necessary,
since 'rummager will start looking up the organisations in the
publishing-api soon-ish'.

As a result, we removed the misleading specs and assertions and left an obvious
placeholder in the `SearchPresenter` spec from which to address this at a time 
when upstream work is complete – but the `get_linkables` commit remains here should
we subsequently need to use it.

Then we removed even that placeholder. We'll wait for Rummager.
