### PR TITLE
Disable RSpec monkey-patching

### DIFF
--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe UrlHelper, type: :helper do
+RSpec.describe UrlHelper, type: :helper do
   describe "#view_on_website_link_for" do
     it "returns document's public link" do
       manual = Manual.new.tap { |doc| doc.base_path = "/guidance/abc" }

--- a/spec/lib/publishing_api_finder_loader_spec.rb
+++ b/spec/lib/publishing_api_finder_loader_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "publishing_api_finder_loader"
 
-describe PublishingApiFinderLoader do
+RSpec.describe PublishingApiFinderLoader do
   before do
     expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w{
       lib/documents/schemas/format-1.json

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "publishing_api_finder_publisher"
 
-describe PublishingApiFinderPublisher do
+RSpec.describe PublishingApiFinderPublisher do
   describe "#call" do
     def make_file(base_path, overrides = {})
       underscore_name = base_path.sub("/", "")

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "rummager_finder_publisher"
 
-describe RummagerFinderPublisher do
+RSpec.describe RummagerFinderPublisher do
   let(:rummager) { double(:rummager) }
 
   let(:test_logger) { Logger.new(nil) }

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AaibReport do
+RSpec.describe AaibReport do
   def aaib_report_content_item(n)
     Payloads.aaib_report_content_item(
       "base_path" => "/aaib-reports/example-aaib-report-#{n}",

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Attachment do
+RSpec.describe Attachment do
   describe "#new" do
     let(:attachment) {
       Attachment.new(

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CountrysideStewardshipGrant do
+RSpec.describe CountrysideStewardshipGrant do
   def countryside_stewardship_grant_content_item(n)
     Payloads.countryside_stewardship_grant_content_item(
       "base_path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-#{n}",

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Document do
+RSpec.describe Document do
   class MyDocumentType < Document
     def self.title
       "My Document Type"

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DrugSafetyUpdate do
+RSpec.describe DrugSafetyUpdate do
   def drug_safety_update_content_item(n)
     Payloads.drug_safety_update_content_item(
       "base_path" => "/drug-safety-update/example-drug-safety-update-#{n}",

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EmploymentAppealTribunalDecision do
+RSpec.describe EmploymentAppealTribunalDecision do
   def employment_appeal_tribunal_decision_content_item(n)
     Payloads.employment_appeal_tribunal_decision_content_item(
       "base_path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-#{n}",

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EmploymentTribunalDecision do
+RSpec.describe EmploymentTribunalDecision do
   def employment_tribunal_decision_content_item(n)
     Payloads.employment_tribunal_decision_content_item(
       "base_path" => "/employment-tribunal-decisions/example-employment-tribunal-decision-#{n}",

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EsiFund do
+RSpec.describe EsiFund do
   def esi_fund_content_item(n)
     Payloads.esi_fund_content_item(
       "base_path" => "/european-structural-investment-funds/example-esi-fund-#{n}",

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MaibReport do
+RSpec.describe MaibReport do
   def maib_report_content_item(n)
     Payloads.maib_report_content_item(
       "base_path" => "/maib-reports/example-maib-report-#{n}",

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MedicalSafetyAlert do
+RSpec.describe MedicalSafetyAlert do
   def medical_safety_alert_content_item(n)
     Payloads.medical_safety_alert_content_item(
       "base_path" => "/drug-device-alerts/example-medical-safety-alert-#{n}",

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RaibReport do
+RSpec.describe RaibReport do
   def raib_report_content_item(n)
     Payloads.raib_report_content_item(
       "base_path" => "/raib-reports/example-raib-report-#{n}",

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe TaxTribunalDecision do
+RSpec.describe TaxTribunalDecision do
   def tax_tribunal_decision_content_item(n)
     Payloads.tax_tribunal_decision_content_item(
       "base_path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-#{n}",

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VehicleRecallsAndFaultsAlert do
+RSpec.describe VehicleRecallsAndFaultsAlert do
   def vehicle_recalls_and_faults_alert_content_item(n)
     Payloads.vehicle_recalls_and_faults_alert_content_item(
       "base_path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-#{n}",

--- a/spec/policies/document_policy_spec.rb
+++ b/spec/policies/document_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DocumentPolicy do
+RSpec.describe DocumentPolicy do
   let(:allowed_organisation_id) { 'department-of-serious-business' }
   let(:not_allowed_organisation_id) { 'ministry-of-funk' }
   let(:gds_editor) { User.new(permissions: %w(signin gds_editor)) }

--- a/spec/policies/manual_policy_spec.rb
+++ b/spec/policies/manual_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ManualPolicy do
+RSpec.describe ManualPolicy do
   permissions :index?, :show?, :new?, :create?, :edit?, :update? do
     it 'grants access to all user' do
       expect(described_class).to permit(User.new, :manual)

--- a/spec/presenters/attachment_presenter_spec.rb
+++ b/spec/presenters/attachment_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe AttachmentPresenter do
+RSpec.describe AttachmentPresenter do
   let(:content_id) { SecureRandom.uuid }
   let(:attachment) {
     Attachment.new(url: 'path/to/file/in/asset/manger',

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DocumentPresenter do
+RSpec.describe DocumentPresenter do
   let(:cma_case) { Payloads.cma_case_content_item }
   let(:content_item_with_rendered_body) {
     cma_case.deep_merge!("details" => {

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EmailAlertPresenter do
+RSpec.describe EmailAlertPresenter do
   let(:cma_case_payload) { Payloads.cma_case_content_item }
   let(:medical_safety_payload) { Payloads.medical_safety_alert_content_item }
   let(:cma_case_redrafted_payload) { Payloads.cma_case_content_item("publication_state" => "redrafted") }

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe GovspeakPresenter do
+RSpec.describe GovspeakPresenter do
   it "should render html and Govspeak when a Govspeak string is provided" do
     input_govspeak = "^callout test^"
     rendered_html = "\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>callout test</p>\n</div>\n"

--- a/spec/presenters/manual_links_presenter_spec.rb
+++ b/spec/presenters/manual_links_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ManualLinksPresenter do
+RSpec.describe ManualLinksPresenter do
   let(:manual) {
     Manual.new(body: 'test body content for manual',
       summary: 'test manual summary',

--- a/spec/presenters/manual_presenter_spec.rb
+++ b/spec/presenters/manual_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ManualPresenter do
+RSpec.describe ManualPresenter do
   let(:manual) {
     Manual.new(body: 'test body content for manual',
       summary: 'test manual summary',

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SearchPresenter do
+RSpec.describe SearchPresenter do
   subject(:presenter) { SearchPresenter.new(document) }
 
   context 'a complete document is given' do

--- a/spec/presenters/section_presenter_spec.rb
+++ b/spec/presenters/section_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe SectionPresenter do
+RSpec.describe SectionPresenter do
   let(:manual_content_id) { SecureRandom.uuid }
   let(:manual_base_path) { "/guidance/content-design" }
   let(:content_id) { SecureRandom.uuid }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ require 'gds_api/test_helpers/email_alert_api'
 require 'pundit/rspec'
 
 RSpec.configure do |config|
-  # config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
It is usually discouraged to monkey patch RSpec methods
into Object. This change enables the RSpec option that
disables monkey patching. More information here:

http://rspec.info/blog/2013/07/the-plan-for-rspec-3/#zero-monkey-patching-mode

Happy to discuss this change if people prefer to use things
like `describe` without the prefixed `RSpec` constant.
