### PR TITLE
Refactor pre-production finder feature flag code

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,4 +28,10 @@ module SpecialistPublisher
 
     config.autoload_paths << Rails.root.join('lib')
   end
+
+  mattr_accessor :publish_pre_production_finders
+
+  def self.should_publish_pre_production_finders?
+    publish_pre_production_finders.present?
+  end
 end

--- a/config/initializers/publish_pre_production_finders_feature_flag.rb
+++ b/config/initializers/publish_pre_production_finders_feature_flag.rb
@@ -1,1 +1,1 @@
-SpecialistPublisher::Application.config.publish_pre_production_finders = ENV["PUBLISH_PRE_PRODUCTION_FINDERS"].present?
+SpecialistPublisher.publish_pre_production_finders = ENV["PUBLISH_PRE_PRODUCTION_FINDERS"].present?

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -30,15 +30,11 @@ private
   end
 
   def should_publish_in_this_environment?(finder)
-    !pre_production?(finder) || should_publish_pre_production_finders?
+    !pre_production?(finder) || SpecialistPublisher.should_publish_pre_production_finders?
   end
 
   def pre_production?(finder)
     finder[:file]["pre_production"] == true
-  end
-
-  def should_publish_pre_production_finders?
-    SpecialistPublisher::Application.config.publish_pre_production_finders
   end
 
   def export_finder(finder)

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -22,15 +22,11 @@ private
   attr_reader :schemas, :logger
 
   def should_publish_in_this_environment?(schema)
-    !pre_production?(schema) || should_publish_pre_production_finders?
+    !pre_production?(schema) || SpecialistPublisher.should_publish_pre_production_finders?
   end
 
   def pre_production?(schema)
     schema[:file]["pre_production"] == true
-  end
-
-  def should_publish_pre_production_finders?
-    SpecialistPublisher::Application.config.publish_pre_production_finders
   end
 
   def export_finder(schema)

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -152,15 +152,13 @@ RSpec.describe PublishingApiFinderPublisher do
 
       context "and the app is configured to publish pre-production finders" do
         before do
-          SpecialistPublisher::Application.config
-            .publish_pre_production_finders = true
+          SpecialistPublisher.publish_pre_production_finders = true
 
           stub_publishing_api_publish(content_id, {})
         end
 
         after do
-          SpecialistPublisher::Application.config
-            .publish_pre_production_finders = false
+          SpecialistPublisher.publish_pre_production_finders = false
         end
 
         it "publishes finder" do

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -124,13 +124,11 @@ RSpec.describe RummagerFinderPublisher do
 
       context "and the app is configured to publish pre-production finders" do
         before do
-          SpecialistPublisher::Application.config
-            .publish_pre_production_finders = true
+          SpecialistPublisher.publish_pre_production_finders = true
         end
 
         after do
-          SpecialistPublisher::Application.config
-            .publish_pre_production_finders = false
+          SpecialistPublisher.publish_pre_production_finders = false
         end
 
         it "publishes finder" do


### PR DESCRIPTION
This change moves the feature flag to an explicit `SpecialistPublisher`
module, where it's more explicitly defined. The new location is shorter,
meaning it can be referenced directly, without helper methods.
