### PR TITLE
Consistent error messages

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,3 +1,15 @@
+.elements-error-summary {
+  border: 5px solid #b10e1e;
+  padding: 15px;
+  color: #b10e1e;
+  font-weight: bold;
+
+  h4 {
+    margin-top: 0;
+    color: black;
+  }
+}
+
 form {
 
   .select2 {
@@ -9,7 +21,7 @@ form {
   }
 
   .elements-error {
-    border-left: 3px solid #b10e1e;
+    border-left: 5px solid #b10e1e;
     padding-left: 15px;
 
     label {
@@ -22,7 +34,8 @@ form {
     }
 
     input, textarea {
-      border-width: 3px;
+      border-width: 2px;
+      border-radius: 0;
       border-color: #b10e1e;
     }
 

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -8,6 +8,26 @@ form {
     height: 50px;
   }
 
+  .elements-error {
+    border-left: 3px solid #b10e1e;
+    padding-left: 15px;
+
+    label {
+      color: black;
+    }
+
+    .elements-error-message {
+      color: #b10e1e;
+      font-weight: bold;
+    }
+
+    input, textarea {
+      border-width: 3px;
+      border-color: #b10e1e;
+    }
+
+  }
+
   .error-list {
     h2 {
       font-weight: bold;

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,7 +1,9 @@
+$elements-red: #b10e1e;
+
 .elements-error-summary {
-  border: 5px solid #b10e1e;
+  border: 5px solid $elements-red;
   padding: 15px;
-  color: #b10e1e;
+  color: $elements-red;
   font-weight: bold;
 
   h4 {
@@ -21,7 +23,7 @@ form {
   }
 
   .elements-error {
-    border-left: 5px solid #b10e1e;
+    border-left: 5px solid $elements-red;
     padding-left: 15px;
 
     label {
@@ -29,14 +31,14 @@ form {
     }
 
     .elements-error-message {
-      color: #b10e1e;
+      color: $elements-red;
       font-weight: bold;
     }
 
     input, textarea {
       border-width: 2px;
       border-radius: 0;
-      border-color: #b10e1e;
+      border-color: $elements-red;
     }
 
   }

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -43,7 +43,7 @@ class DocumentsController < ApplicationController
         render :new
       end
     else
-      flash.now[:danger] = document_error_messages
+      flash.now[:errors] = document_error_messages
       render :new, status: 422
     end
   end
@@ -87,14 +87,12 @@ private
   def document_error_messages
     document_errors = @document.errors.messages
     heading = content_tag(
-      :p,
+      :h4,
       %{
-        There #{document_errors.length > 1 ? 'were' : 'was'} the following
-        #{document_errors.length > 1 ? 'errors' : 'error'} with your
-        #{current_format.title.singularize}:
+        Please fix the following errors
       }
     )
-    errors = content_tag :ul do
+    errors = content_tag :ul, class: "list-unstyled remove-bottom-margin" do
       @document.errors.full_messages.map { |e| content_tag(:li, e) }.join('').html_safe
     end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -68,7 +68,7 @@ class DocumentsController < ApplicationController
         render :edit
       end
     else
-      flash.now[:danger] = document_error_messages
+      flash.now[:errors] = document_error_messages
       render :edit, status: 422
     end
   end
@@ -85,7 +85,7 @@ class DocumentsController < ApplicationController
 private
 
   def document_error_messages
-    document_errors = @document.errors.messages
+    @document.errors.messages
     heading = content_tag(
       :h4,
       %{

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,9 @@
+module ErrorsHelper
+  def field_has_errors(document, field)
+    field_errors(document, field).any?
+  end
+
+  def field_errors(document, field)
+    document.errors.full_messages_for(field)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,11 @@
 <% end %>
 
 <% content_for :content do %>
+  <% if flash[:errors].present? %>
+    <div class="elements-error-summary add-bottom-margin">
+      <%= flash[:errors] %>
+    </div>
+  <% end %>
   <%= render partial: 'shared/breadcrumbs' %>
   <%= yield %>
   <script>

--- a/app/views/metadata_fields/_aaib_reports.html.erb
+++ b/app/views/metadata_fields/_aaib_reports.html.erb
@@ -1,24 +1,34 @@
-<div class="form-group">
-  <%= f.label :date_of_occurrence %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
   <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :aircraft_type %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :aircraft_type } do %>
   <%= f.text_field :aircraft_type, class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :registration %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :registration } do %>
   <%= f.text_field :registration, class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :location %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :location } do %>
   <%= f.text_field :location, class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :aircraft_category %>
-  <%= f.select :aircraft_category, f.object.facet_options(:aircraft_category), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select an Aircraft category'} } %>
-</div>
-<div class="form-group">
-  <%= f.label :report_type %>
-  <%= f.select :report_type, f.object.facet_options(:report_type), {}, { class: 'form-control' } %>
-</div>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :aircraft_category } do %>
+  <%= f.select :aircraft_category,
+      f.object.facet_options(:aircraft_category),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select an Aircraft category'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :report_type } do %>
+  <%= f.select :report_type,
+      f.object.facet_options(:report_type),
+      {},
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_cma_cases.html.erb
+++ b/app/views/metadata_fields/_cma_cases.html.erb
@@ -1,24 +1,37 @@
-<div class="form-group">
-  <%= f.label :opened_date %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :opened_date } do %>
   <%= f.text_field :opened_date, placeholder: '2012-04-23', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :closed_date %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :closed_date } do %>
   <%= f.text_field :closed_date, placeholder: '2013-10-19', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :case_type %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :case_type } do %>
   <%= f.select :case_type, facet_options(f, :case_type), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :case_state %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :case_state } do %>
   <%= f.select :case_state, facet_options(f, :case_state), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :market_sector %>
-  <%= f.select :market_sector, facet_options(f, :market_sector), {}, { class: 'select2 form-control', multiple: true, data: { placeholder: 'Select a market sector' } } %>
-</div>
-<div class="form-group">
-  <%= f.label :outcome_type %>
-  <%= f.select :outcome_type, facet_options(f, :outcome_type), { include_blank: true }, { class: 'form-control' } %>
-</div>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :market_sector } do %>
+  <%= f.select :market_sector,
+      facet_options(f, :market_sector),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a market sector'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :outcome_type } do %>
+  <%= f.select :outcome_type,
+      facet_options(f, :outcome_type),
+      {
+        include_blank: true
+      },
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
+++ b/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
@@ -1,39 +1,43 @@
-<div class="form-group">
-  <%= f.label :grant_type %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :grant_type } do %>
   <%= f.select :grant_type, f.object.facet_options(:grant_type), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :land_use %>
-  <%= f.select :land_use,
-      f.object.facet_options(:land_use),
-      {},
-      {
-        class: 'select2 form-control',
-        multiple: true, data: {placeholder: 'Select a location'}
-      }
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :land_use } do %>
+<%= f.select :land_use,
+    f.object.facet_options(:land_use),
+    {},
+    {
+      class: 'select2 form-control',
+      multiple: true, data: {placeholder: 'Select a location'}
+    }
   %>
-</div>
-<div class="form-group">
-  <%= f.label :tiers_or_standalone_items %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tiers_or_standalone_items } do %>
   <%= f.select :tiers_or_standalone_items,
       f.object.facet_options(:tiers_or_standalone_items),
       {},
       {
         class: 'select2 form-control',
         multiple: true,
-        data: {placeholder: 'Select a Tier or Standalone Item'}
+        data:
+        {
+          placeholder: 'Select a Tier or Standalone Item'
+        }
       }
   %>
-</div>
-<div class="form-group">
-  <%= f.label :funding_amount %>
-  <%= f.select :funding_amount,
-      f.object.facet_options(:funding_amount),
-      { label: 'Funding (per unit per year)'},
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :funding_amount } do %>
+<%= f.select :funding_amount,
+    f.object.facet_options(:funding_amount),
+    {
+      label: 'Funding (per unit per year)'
+    },
+    {
+      class: 'select2 form-control',
+      multiple: true,
+      data:
       {
-        class: 'select2 form-control',
-        multiple: true,
-        data: {placeholder: 'Select a level of funding (per unit per year) '}
+        placeholder: 'Select a level of funding (per unit per year) '
       }
+    }
   %>
-</div>
+<% end %>

--- a/app/views/metadata_fields/_drug_safety_updates.html.erb
+++ b/app/views/metadata_fields/_drug_safety_updates.html.erb
@@ -1,4 +1,14 @@
-<div class="form-group">
-  <%= f.label :therapeutic_area %>
-  <%= f.select :therapeutic_area, f.object.facet_options(:therapeutic_area), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select a Therapeutic area'} } %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :therapeutic_area } do %>
+  <%= f.select :therapeutic_area,
+      f.object.facet_options(:therapeutic_area),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a Therapeutic area'
+        }
+      }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_eat_decisions.html.erb
+++ b/app/views/metadata_fields/_eat_decisions.html.erb
@@ -1,20 +1,45 @@
-<div class="form-group">
-  <%= f.label :tribunal_decision_categories %>
-  <%= f.select :tribunal_decision_categories, f.object.facet_options(:tribunal_decision_categories), { label: "Category" }, { class: 'select2', multiple: true, data: { placeholder: 'Select category' } } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_sub_categories %>
-  <%= f.select :tribunal_decision_sub_categories, f.object.facet_options(:tribunal_decision_sub_categories), { label: "Sub-category" }, { class: 'select2 form-control', multiple: true, data: { placeholder: 'Select sub-category' } } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_landmark %>
-  <%= f.select :tribunal_decision_landmark, f.object.facet_options(:tribunal_decision_landmark), { label: "Landmark" }, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_decision_date %>
-  <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-07-30', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :hidden_indexable_content %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_categories } do %>
+  <%= f.select :tribunal_decision_categories,
+      f.object.facet_options(:tribunal_decision_categories),
+      { label: "Category" },
+      {
+        class: 'select2',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select category'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_sub_categories } do %>
+  <%= f.select :tribunal_decision_sub_categories,
+      f.object.facet_options(:tribunal_decision_sub_categories),
+      { label: "Sub-category" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select sub-category'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_landmark } do %>
+  <%= f.select :tribunal_decision_landmark,
+      f.object.facet_options(:tribunal_decision_landmark),
+      { label: "Landmark" },
+      { class: 'form-control' }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
+  <%= f.text_field :tribunal_decision_decision_date,
+      label: "Decision date",
+      placeholder: '2015-07-30',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
   <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
-</div>
+<% end %>

--- a/app/views/metadata_fields/_esi_funds.html.erb
+++ b/app/views/metadata_fields/_esi_funds.html.erb
@@ -1,20 +1,46 @@
-<div class="form-group">
-  <%= f.label :fund_state %>
-  <%= f.select :fund_state, f.object.facet_options(:fund_state), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :fund_type %>
-  <%= f.select :fund_type, f.object.facet_options(:fund_type), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select a fund type'} } %>
-  </div>
-<div class="form-group">
-  <%= f.label :location %>
-  <%= f.select :location, f.object.facet_options(:location), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select a location'} } %>
-</div>
-<div class="form-group">
-  <%= f.label :funding_source %>
-  <%= f.select :funding_source, f.object.facet_options(:funding_source), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select a source'} } %>
-</div>
-<div class="form-group">
-  <%= f.label :closing_date %>
-  <%= f.text_field :closing_date, placeholder: '2018-10-19', class: 'form-control' %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :fund_state } do %>
+  <%= f.select :fund_state,
+      f.object.facet_options(:fund_state),
+      {},
+      { class: 'form-control' }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :fund_type } do %>
+  <%= f.select :fund_type,
+      f.object.facet_options(:fund_type),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {placeholder: 'Select a fund type'}
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :location } do %>
+  <%= f.select :location,
+      f.object.facet_options(:location),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {placeholder: 'Select a location'}
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :funding_source } do %>
+  <%= f.select :funding_source,
+      f.object.facet_options(:funding_source),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {placeholder: 'Select a source'}
+      }
+    %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :closing_date } do %>
+  <%= f.text_field :closing_date,
+      placeholder: '2018-10-19',
+      class: 'form-control'
+  %>
+<% end %>

--- a/app/views/metadata_fields/_et_decisions.html.erb
+++ b/app/views/metadata_fields/_et_decisions.html.erb
@@ -1,16 +1,31 @@
-<div class="form-group">
-  <%= f.label :tribunal_decision_country %>
-  <%= f.select :tribunal_decision_country, f.object.facet_options(:tribunal_decision_country), { label: "Country" }, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_categories %>
-  <%= f.select :tribunal_decision_categories, f.object.facet_options(:tribunal_decision_categories), { label: "Jurisdiction code" }, { class: 'select2 form-control', multiple: true, data: { placeholder: '' } } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_decision_date %>
-  <%= f.text_field :tribunal_decision_decision_date, label: "Decision date", placeholder: '2015-07-30', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :hidden_indexable_content %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_country } do %>
+  <%= f.select :tribunal_decision_country,
+      f.object.facet_options(:tribunal_decision_country),
+      { label: "Country" },
+      { class: 'form-control' }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_categories } do %>
+  <%= f.select :tribunal_decision_categories,
+      f.object.facet_options(:tribunal_decision_categories),
+      { label: "Jurisdiction code" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: ''
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
+  <%= f.text_field :tribunal_decision_decision_date,
+      label: "Decision date",
+      placeholder: '2015-07-30',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
   <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
-</div>
+<% end %>

--- a/app/views/metadata_fields/_maib_reports.html.erb
+++ b/app/views/metadata_fields/_maib_reports.html.erb
@@ -1,12 +1,26 @@
-<div class="form-group">
-  <%= f.label :date_of_occurrence %>
-  <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :vessel_type %>
-  <%= f.select :vessel_type, f.object.facet_options(:vessel_type), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select a Vessel type'} } %>
-</div>
-<div class="form-group">
-  <%= f.label :report_type %>
-  <%= f.select :report_type, f.object.facet_options(:report_type), {}, { class: 'form-control' } %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
+  <%= f.text_field :date_of_occurrence,
+      placeholder: '2012-04-23',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :vessel_type } do %>
+  <%= f.select :vessel_type,
+      f.object.facet_options(:vessel_type),
+      {},
+      {
+        class: 'select2',
+        multiple: true,
+        data: {placeholder: 'Select a Vessel type'}
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :report_type } do %>
+  <%= f.select :report_type,
+      f.object.facet_options(:report_type),
+      {},
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_medical_safety_alerts.html.erb
+++ b/app/views/metadata_fields/_medical_safety_alerts.html.erb
@@ -1,6 +1,31 @@
-<%= f.label :alert_type %>
-<%= f.select :alert_type, f.object.facet_options(:alert_type), { include_blank: true }, { class: 'form-control' } %>
-<%= f.label :medical_specialism %>
-<%= f.select :medical_specialism, f.object.facet_options(:medical_specialism), {}, { class: 'select2', multiple: true, data: { placeholder: 'Select a Medical specialism' } } %>
-<%= f.label :issued_date %>
-<%= f.text_field :issued_date, placeholder: '2012-04-23', class: 'form-control' %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :alert_type } do %>
+  <%= f.select :alert_type,
+      f.object.facet_options(:alert_type),
+      {
+        include_blank: true
+      },
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :medical_specialism } do %>
+  <%= f.select :medical_specialism,
+      f.object.facet_options(:medical_specialism),
+      {},
+      {
+        class: 'select2',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a Medical specialism'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :issued_date } do %>
+  <%= f.text_field :issued_date,
+      placeholder: '2012-04-23',
+      class: 'form-control'
+  %>
+<% end %>

--- a/app/views/metadata_fields/_raib_reports.html.erb
+++ b/app/views/metadata_fields/_raib_reports.html.erb
@@ -1,12 +1,27 @@
-<div class="form-group">
-  <%= f.label :date_of_occurrence %>
-  <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :railway_type %>
-  <%= f.select :railway_type, f.object.facet_options(:railway_type), {}, { class: 'select2 form-control', multiple: true, data: {placeholder: 'Select a Railway type'} } %>
-</div>
-<div class="form-group">
-  <%= f.label :report_type %>
-  <%= f.select :report_type, f.object.facet_options(:report_type), {}, { class: 'form-control' } %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
+  <%= f.text_field :date_of_occurrence,
+      placeholder: '2012-04-23',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :railway_type } do %>
+  <%= f.select :railway_type,
+      f.object.facet_options(:railway_type),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a Railway type'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :report_type } do %>
+  <%= f.select :report_type,
+      f.object.facet_options(:report_type),
+      {},
+      { class: 'form-control' }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
@@ -1,12 +1,19 @@
-<div class="form-group">
-  <%= f.label :tribunal_decision_category %>
-  <%= f.select :tribunal_decision_category, f.object.facet_options(:tribunal_decision_category), { label: "Category" }, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :tribunal_decision_decision_date %>
-  <%= f.text_field :tribunal_decision_decision_date, label: "Release date", placeholder: '2015-07-30', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :hidden_indexable_content %>
-  <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_category } do %>
+  <%= f.select :tribunal_decision_category,
+      f.object.facet_options(:tribunal_decision_category),
+      { label: "Category" },
+      { class: 'form-control' }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
+  <%= f.text_field :tribunal_decision_decision_date,
+      label: "Release date",
+      placeholder: '2015-07-30',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
+  <%= f.text_area :hidden_indexable_content,
+      class: 'form-control'
+  %>
+<% end %>

--- a/app/views/metadata_fields/_vehicle_recalls_and_faults_alerts.html.erb
+++ b/app/views/metadata_fields/_vehicle_recalls_and_faults_alerts.html.erb
@@ -1,32 +1,61 @@
-<div class="form-group">
-  <%= f.label :fault_type %>
-  <%= f.select :fault_type, f.object.facet_options(:fault_type), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :alert_issue_date %>
-  <%= f.text_field :alert_issue_date, placeholder: Date.today.to_s, class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :faulty_item_type %>
-  <%= f.select :faulty_item_type, f.object.facet_options(:faulty_item_type), { label: "Item type" }, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :manufacturer %>
-  <%= f.select :manufacturer, f.object.facet_options(:manufacturer), {}, { class: 'form-control' } %>
-</div>
-<div class="form-group">
-  <%= f.label :faulty_item_model %>
-  <%= f.text_field :faulty_item_model, placeholder: 'A80', class: 'form-control', label: "Model" %>
-</div>
-<div class="form-group">
-  <%= f.label :serial_number %>
-  <%= f.text_field :serial_number, placeholder: 'XX YY 12345 - XX YY 22345', class: 'form-control', label: "Serial number/Vehicle ID" %>
-</div>
-<div class="form-group">
-  <%= f.label :build_start_date %>
-  <%= f.text_field :build_start_date, placeholder: '2014-07-12', class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :build_end_date %>
-  <%= f.text_field :build_end_date, placeholder: '2014-10-15', class: 'form-control' %>
-</div>
+<%= render layout: "shared/form_group", locals: { f: f, field: :fault_type} do %>
+  <%= f.select :fault_type,
+      f.object.facet_options(:fault_type),
+      {},
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :alert_issue_date} do %>
+  <%= f.text_field :alert_issue_date,
+      placeholder: Date.today.to_s,
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :faulty_item_type} do %>
+  <%= f.select :faulty_item_type,
+      f.object.facet_options(:faulty_item_type),
+      {
+        label: "Item type"
+      },
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :manufacturer} do %>
+  <%= f.select :manufacturer,
+      f.object.facet_options(:manufacturer),
+      {},
+      {
+        class: 'form-control'
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :faulty_item_model} do %>
+  <%= f.text_field :faulty_item_model,
+      placeholder: 'A80',
+      class: 'form-control',
+      label: "Model"
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :serial_number} do %>
+  <%= f.text_field :serial_number,
+      placeholder: 'XX YY 12345 - XX YY 22345',
+      class: 'form-control',
+      label: "Serial number/Vehicle ID"
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :build_start_date} do %>
+  <%= f.text_field :build_start_date,
+      placeholder: '2014-07-12',
+      class: 'form-control'
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :build_end_date} do %>
+    <%= f.text_field :build_end_date,
+        placeholder: '2014-10-15',
+        class: 'form-control'
+    %>
+<% end %>

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,5 +1,11 @@
-<div class="form-group">
-  <%= f.label :title %>
+<div class="form-group <%= 'elements-error' if @document.errors.full_messages_for(:title).any? %>">
+  <%= f.label :title do %>
+    <%= :title.to_s.humanize %>
+    <% @document.errors.full_messages_for(:title).each do |msg| %>
+      <br />
+      <span class="elements-error-message add-label-margin"><%= msg %></span>
+    <% end %>
+  <% end %>
   <%= f.text_field :title, class: 'form-control' %>
 </div>
 <div class="form-group">

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,11 +1,11 @@
-<%= render layout: "shared/form_group", locals: { f: f, sym: :title } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :title } do %>
   <%= f.text_field :title, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, sym: :summary } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :summary } do %>
   <%= f.text_area :summary, class: 'form-control short-textarea' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, sym: :body } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :body } do %>
   <%= f.text_area :body, rows: 20, class: 'form-control' %>
 <% end %>

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,18 +1,11 @@
-<div class="form-group <%= 'elements-error' if @document.errors.full_messages_for(:title).any? %>">
-  <%= f.label :title do %>
-    <%= :title.to_s.humanize %>
-    <% @document.errors.full_messages_for(:title).each do |msg| %>
-      <br />
-      <span class="elements-error-message add-label-margin"><%= msg %></span>
-    <% end %>
-  <% end %>
+<%= render layout: "shared/form_group", locals: { f: f, sym: :title } do %>
   <%= f.text_field :title, class: 'form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :summary %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, sym: :summary } do %>
   <%= f.text_area :summary, class: 'form-control short-textarea' %>
-</div>
-<div class="form-group">
-  <%= f.label :body %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, sym: :body } do %>
   <%= f.text_area :body, rows: 20, class: 'form-control' %>
-</div>
+<% end %>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,0 +1,10 @@
+<div class="form-group <%= 'elements-error' if @document.errors.full_messages_for(sym).any? %>">
+  <%= f.label sym do %>
+    <%= sym.to_s.humanize %>
+    <% @document.errors.full_messages_for(sym).each do |msg| %>
+      <br />
+      <span class="elements-error-message add-label-margin"><%= msg %></span>
+    <% end %>
+  <% end %>
+  <%= yield %>
+</div>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,7 +1,7 @@
-<div class="form-group <%= 'elements-error' if @document.errors.full_messages_for(sym).any? %>">
+<div class="form-group <%= 'elements-error' if field_has_errors(@document, sym) %>">
   <%= f.label sym do %>
     <%= sym.to_s.humanize %>
-    <% @document.errors.full_messages_for(sym).each do |msg| %>
+    <% field_errors(@document, sym).each do |msg| %>
       <br />
       <span class="elements-error-message add-label-margin"><%= msg %></span>
     <% end %>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,7 +1,7 @@
-<div class="form-group <%= 'elements-error' if field_has_errors(@document, sym) %>">
-  <%= f.label sym do %>
-    <%= sym.to_s.humanize %>
-    <% field_errors(@document, sym).each do |msg| %>
+<div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
+  <%= f.label field do %>
+    <%= field.to_s.humanize %>
+    <% field_errors(@document, field).each do |msg| %>
       <br />
       <span class="elements-error-message add-label-margin"><%= msg %></span>
     <% end %>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -56,6 +56,11 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     expect(page.status_code).to eq(422)
 
+    expect(page).to have_css('.elements-error-summary')
+    expect(page).to have_css('.form-group.elements-error')
+    expect(page).to have_css('.elements-error-message')
+
+    expect(page).to have_content("Please fix the following errors")
     expect(page).to have_content("Title can't be blank")
     expect(page).to have_content("Summary can't be blank")
     expect(page).to have_content("Body can't be blank")
@@ -75,6 +80,10 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     expect(page.status_code).to eq(422)
 
+    expect(page).to have_css('.elements-error-summary')
+    expect(page).to have_css('.elements-error-message')
+
+    expect(page).to have_content("Please fix the following errors")
     expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
     expect(page).to have_content("Body cannot include invalid Govspeak")
   end

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -112,9 +112,13 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
 
     click_button "Save as draft"
 
+    expect(page).to have_css('.elements-error-summary')
+    expect(page).to have_css('.elements-error-message')
+
     expect(@changed_json["content_id"]).to eq(content_id)
     expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
     expect(page).to have_content("Body cannot include invalid Govspeak")
+    expect(page).to have_content("Please fix the following errors")
 
     expect(page.status_code).to eq(422)
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/SSLDHS0j/81-consistent-error-message-styling-and-wording-small)

Paired with @fofr on this.

Restyle and reword error messages.
- Reword error messages to keep consistent with v1
- Restyle error messages in the style of [govuk-elements](http://govuk-elements.herokuapp.com/errors/#example-ni-number)

V2 error messages before:

![v2-before](https://cloud.githubusercontent.com/assets/5963488/15253632/1580f4d0-192b-11e6-8193-54eff1cb9128.png)

V2 error messages after:

![v2-after](https://cloud.githubusercontent.com/assets/5963488/15253648/292f9ebe-192b-11e6-9b1f-7e57b1b75490.png)
