### PR TITLE
Send text to Rummager for Specialist Publisher bodies

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -22,8 +22,4 @@ class SearchPresenter
 private
 
   attr_reader :document
-
-  def publishing_api
-    @publishing_api ||= Services.publishing_api
-  end
 end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -16,7 +16,7 @@ class SearchPresenter
   end
 
   def indexable_content
-    document.body
+    Govspeak::Document.new(document.body).to_text
   end
 
 private

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       "title" => "Example CMA Case",
       "description" => "This is the summary of an example CMA case",
       "link" => "/cma-cases/example-cma-case",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example CMA case"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "opened_date" => "2014-01-01",
       "closed_date" => nil,

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AaibReport do
       "title" => "Example AAIB Report 0",
       "description" => "This is the summary of example AAIB Report 0",
       "link" => "/aaib-reports/example-aaib-report-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example AAIB Report" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example AAIB Report"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
     }

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CmaCase do
       "title" => "Example CMA Case 0",
       "description" => "This is the summary of example CMA case 0",
       "link" => "/cma-cases/example-cma-case-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example CMA case" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example CMA case"] * 10).join(" "),
       "public_timestamp" => "2015-12-03T16:59:13+00:00",
       "opened_date" => "2014-01-01",
       "closed_date" => nil,

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CountrysideStewardshipGrant do
       "title" => "Example Countryside Stewardship Grant 0",
       "description" => "This is the summary of example Countryside Stewardship Grant 0",
       "link" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Countryside Stewardship Grant" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Countryside Stewardship Grant"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
     }
   }

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DrugSafetyUpdate do
       "title" => "Example Drug Safety Update 0",
       "description" => "This is the summary of an example Drug Safety Update 0",
       "link" => "/drug-safety-update/example-drug-safety-update-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Drug Safety Update" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Drug Safety Update"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
     }
   }

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe EmploymentAppealTribunalDecision do
       "title" => "Example Employment Appeal Tribunal Decision 0",
       "description" => "This is the summary of example Employment Appeal Tribunal Decision 0",
       "link" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Appeal Tribunal Decision" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Employment Appeal Tribunal Decision"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "tribunal_decision_categories" => ["age-discrimination"],
       "tribunal_decision_decision_date" => "2015-07-30",

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe EmploymentTribunalDecision do
       "title" => "Example Employment Tribunal Decision 0",
       "description" => "This is the summary of example Employment Tribunal Decision 0",
       "link" => "/employment-tribunal-decisions/example-employment-tribunal-decision-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Employment Tribunal Decision" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Employment Tribunal Decision"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "tribunal_decision_categories" => ["age-discrimination"],
       "tribunal_decision_country" => "england-and-wales",

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe EsiFund do
       "title" => "Example ESI Fund 0",
       "description" => "This is the summary of example ESI Fund 0",
       "link" => "/european-structural-investment-funds/example-esi-fund-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example ESI Fund" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example ESI Fund"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "fund_state" => nil,
       "fund_type" => nil,

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe MaibReport do
       "title" => "Example MAIB Report 0",
       "description" => "This is the summary of example MAIB Report 0",
       "link" => "/maib-reports/example-maib-report-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example MAIB Report" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example MAIB Report"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
     }

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe MedicalSafetyAlert do
       "title" => "Example Medical Safety Alert 0",
       "description" => "This is the summary of example Medical Safety Alert 0",
       "link" => "/drug-device-alerts/example-medical-safety-alert-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Medical Safety Alert" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Medical Safety Alert"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "alert_type" => "company-led-drugs",
       "issued_date" => "2016-02-01",

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RaibReport do
       "title" => "Example RAIB Report 0",
       "description" => "This is the summary of example RAIB Report 0",
       "link" => "/raib-reports/example-raib-report-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example RAIB Report" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example RAIB Report"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "date_of_occurrence" => "2015-10-10",
     }

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TaxTribunalDecision do
       "title" => "Example Tax Tribunal Decision 0",
       "description" => "This is the summary of example Tax Tribunal Decision 0",
       "link" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Tax Tribunal Decision" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Tax Tribunal Decision"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "tribunal_decision_category" => "banking",
       "tribunal_decision_decision_date" => "2015-07-30",

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe VehicleRecallsAndFaultsAlert do
       "title" => "Example Vehicle Recalls And Faults 0",
       "description" => "This is the summary of example Vehicle Recalls And Faults 0",
       "link" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-0",
-      "indexable_content" => "## Header" + ("\r\n\r\nThis is the long body of an example Vehicle Recalls And Faults" * 10),
+      "indexable_content" => "Header " + (["This is the long body of an example Vehicle Recalls And Faults"] * 10).join(" "),
       "public_timestamp" => "2015-11-16T11:53:30+00:00",
       "alert_issue_date" => "2015-04-28",
       "build_start_date" => "2015-04-28",

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SearchPresenter do
 
     describe '#indexable_content' do
       it 'indexes the body alone' do
-        expect(presenter.indexable_content).to eql('## A Title')
+        expect(presenter.indexable_content).to eql('A Title')
       end
     end
 


### PR DESCRIPTION
Before this change, the app was sending Govspeak to Rummager as the document body. This isn't quite right, it's better to send text (like [Whitehall does](https://github.com/alphagov/whitehall/blob/89573063e31af11bf664c588ca560dd980e05c68/app/models/about_page.rb#L25), for instance).

(hat tip to @tijmenb)
