### PR TITLE
Change draft label colour for document index

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   def state(document)
     state = document.publication_state == "live" ? "published" : document.publication_state
 
-    if document.draft?
+    if document.publication_state == "draft"
       classes = "label label-primary"
     else
       classes = "label label-default"

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -34,8 +34,19 @@ RSpec.feature "Searching and filtering", type: :feature do
       expect(page).to have_content("Example CMA Case 0")
       expect(page).to have_content("Example CMA Case 1")
       expect(page).to have_content("Example CMA Case 2")
+    end
+
+    scenario "viewing the publication state on the index page" do
+      visit "/cma-cases"
+
       within(".document-list li.document:nth-child(2)") do
+        expect(page).to have_css(".label-default")
         expect(page).to have_content("published")
+      end
+
+      within(".document-list li.document:nth-child(3)") do
+        expect(page).to have_css(".label-primary")
+        expect(page).to have_content("draft")
       end
     end
 


### PR DESCRIPTION
worked with @Rosa-Fox and @brenetic 

The code was there to change the colour but because the index controller
passes OStruct instead of document objects to the view,
`Document#draft?` in the ApplicationHelper was returning nil and assigned the wrong style-class to the element.

[Trello](https://trello.com/c/gug9gFfl/125-draft-label-is-different-colour-in-v2-to-v1-small)
