### PR TITLE
Remove published_date from DFID research output

### DIFF
--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -823,14 +823,6 @@
           "label": "Zimbabwe"
         }
       ]
-    },
-    {
-      "key": "published_date",
-      "name": "Published",
-      "short_name": "Published",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": false
     }
   ]
 }


### PR DESCRIPTION
This field isn't sent to Rummager and isn't used. The presence of this field is causing [errors in `finder-frontend`](https://errbit.integration.publishing.service.gov.uk/apps/54088b400da115ada0003680/problems/573b3bcd6578635a8d4f0100).

I've tested this on Integration and it seems to fix the errors.

/cc @rgarner
