### PR TITLE
Update finder org access to be more like SPv1

### DIFF
--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -8,7 +8,9 @@
   "filter": {
     "document_type": "countryside_stewardship_grant"
   },
-  "organisations": ["d3ce4ba7-bc75-46b4-89d9-38cb3240376d", "de4e9dc6-cca4-43af-a594-682023b84d6c", "8bf5624b-dec2-44fa-9b6c-daed166333a5"],
+  "organisations": [
+    "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
+  ],
   "related": [
     "5bdde33c-c200-4245-925b-8d5dcd075546",
     "975ad786-7d28-4189-b635-961395e19954"

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -10,6 +10,8 @@
   },
   "show_summaries": true,
   "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "caeb418c-d11c-4352-92e9-47b21289f696"
   ],
   "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -10,6 +10,8 @@
   },
   "show_summaries": true,
   "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "8bb37087-a5a7-4493-8afe-900b36ebc927"
   ],
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -12,7 +12,12 @@
   "default_order": "-closing_date",
   "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
-  "organisations": ["2e7868a8-38f5-4ff6-b62f-9a15d1c22d28", "de4e9dc6-cca4-43af-a594-682023b84d6c", "569a9ee5-c195-4b7f-b9dc-edc17a09113f", "b548a09f-8b35-4104-89f4-f1a40bf3136d" ],
+  "organisations": [
+    "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+    "de4e9dc6-cca4-43af-a594-682023b84d6c",
+    "e8fae147-6232-4163-a3f1-1c15b755a8a4",
+    "b548a09f-8b35-4104-89f4-f1a40bf3136d"
+  ],
   "subscription_list_title_prefix": {
     "singular": "European Structural and Investment Fund",
     "plural": "European Structural and Investment Funds"

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -11,6 +11,8 @@
   "default_order": "-tribunal_decision_decision_date",
   "show_summaries": true,
   "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "1a68b2cc-eb52-4528-8989-429f710da00f"
   ],
   "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",

--- a/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
+++ b/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
@@ -8,6 +8,9 @@
   "filter": {
     "document_type": "vehicle_recalls_and_faults_alert"
   },
+  "organisations": [
+    "d39237a5-678b-4bb5-a372-eb2cb036933d"
+  ],
   "document_noun": "alert",
   "facets": [
     {


### PR DESCRIPTION
In this app, the organisation lists in the [finder schemas](https://github.com/alphagov/specialist-publisher-rebuild/tree/master/lib/documents/schemas) determine which publishers (from which org)
can see and edit particular finders.

In Specialist Publisher v1, this info is not in 1, but two places:
- the [finder metadata files](https://github.com/alphagov/specialist-publisher/tree/master/finders/metadata)
- the [permission checker](https://github.com/alphagov/specialist-publisher/blob/master/app/lib/permission_checker.rb)
  which actually controls whether publishers from specific orgs can edit those document types

In V1, the organisation lists in those two places went out of sync with time.
When finders were migrated across to this app, the (outdated) metadata orgs from V1 were used to create the schemas. Instead, the orgs in the permission checker are really the source of truth for access.

This commit makes brings the org lists in line with the permission checker in V1.

Before this change:

```
aaib_reports
v2 schema:      air-accidents-investigation-branch
v1 permissions: air-accidents-investigation-branch
v1 schema:      air-accidents-investigation-branch

cma_cases
v2 schema:      competition-and-markets-authority
v1 permissions: competition-and-markets-authority
v1 schema:      competition-and-markets-authority

countryside_stewardship_grants
v2 schema:      department-for-environment-food-rural-affairs, forestry-commission, natural-england
v1 permissions: natural-england
v1 schema:      department-for-environment-food-rural-affairs, forestry-commission, natural-england

dfid_research_outputs
v2 schema:      department-for-international-development
v1 permissions:
v1 schema:

drug_safety_updates
v2 schema:      medicines-and-healthcare-products-regulatory-agency
v1 permissions: medicines-and-healthcare-products-regulatory-agency
v1 schema:      medicines-and-healthcare-products-regulatory-agency

employment_appeal_tribunal_decisions
v2 schema:      employment-appeal-tribunal
v1 permissions: employment-appeal-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 schema:      employment-appeal-tribunal

employment_tribunal_decisions
v2 schema:      employment-tribunal
v1 permissions: employment-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 schema:      employment-tribunal

esi_funds
v2 schema:      department-for-business-innovation-skills, department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions
v1 permissions: department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions, rural-payments-agency
v1 schema:      department-for-business-innovation-skills, department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions

maib_reports
v2 schema:      marine-accident-investigation-branch
v1 permissions: marine-accident-investigation-branch
v1 schema:      marine-accident-investigation-branch

medical_safety_alerts
v2 schema:      medicines-and-healthcare-products-regulatory-agency
v1 permissions: medicines-and-healthcare-products-regulatory-agency
v1 schema:      medicines-and-healthcare-products-regulatory-agency

raib_reports
v2 schema:      rail-accident-investigation-branch
v1 permissions: rail-accident-investigation-branch
v1 schema:      rail-accident-investigation-branch

tax_tribunal_decisions
v2 schema:      upper-tribunal-tax-and-chancery-chamber
v1 permissions: hm-courts-and-tribunals-service, ministry-of-justice, upper-tribunal-tax-and-chancery-chamber
v1 schema:      upper-tribunal-tax-and-chancery-chamber

vehicle_recalls_and_faults_alerts
v2 schema:
v1 permissions: driver-and-vehicle-standards-agency
v1 schema:
```

After the change:

```
aaib_reports
v2 schema:      air-accidents-investigation-branch
v1 permissions: air-accidents-investigation-branch
v1 schema:      air-accidents-investigation-branch

cma_cases
v2 schema:      competition-and-markets-authority
v1 permissions: competition-and-markets-authority
v1 schema:      competition-and-markets-authority

countryside_stewardship_grants
v2 schema:      natural-england
v1 permissions: natural-england
v1 schema:      department-for-environment-food-rural-affairs, forestry-commission, natural-england

dfid_research_outputs
v2 schema:      department-for-international-development
v1 permissions:
v1 schema:

drug_safety_updates
v2 schema:      medicines-and-healthcare-products-regulatory-agency
v1 permissions: medicines-and-healthcare-products-regulatory-agency
v1 schema:      medicines-and-healthcare-products-regulatory-agency

employment_appeal_tribunal_decisions
v2 schema:      employment-appeal-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 permissions: employment-appeal-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 schema:      employment-appeal-tribunal

employment_tribunal_decisions
v2 schema:      employment-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 permissions: employment-tribunal, hm-courts-and-tribunals-service, ministry-of-justice
v1 schema:      employment-tribunal

esi_funds
v2 schema:      department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions, rural-payments-agency
v1 permissions: department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions, rural-payments-agency
v1 schema:      department-for-business-innovation-skills, department-for-communities-and-local-government, department-for-environment-food-rural-affairs, department-for-work-pensions

maib_reports
v2 schema:      marine-accident-investigation-branch
v1 permissions: marine-accident-investigation-branch
v1 schema:      marine-accident-investigation-branch

medical_safety_alerts
v2 schema:      medicines-and-healthcare-products-regulatory-agency
v1 permissions: medicines-and-healthcare-products-regulatory-agency
v1 schema:      medicines-and-healthcare-products-regulatory-agency

raib_reports
v2 schema:      rail-accident-investigation-branch
v1 permissions: rail-accident-investigation-branch
v1 schema:      rail-accident-investigation-branch

tax_tribunal_decisions
v2 schema:      hm-courts-and-tribunals-service, ministry-of-justice, upper-tribunal-tax-and-chancery-chamber
v1 permissions: hm-courts-and-tribunals-service, ministry-of-justice, upper-tribunal-tax-and-chancery-chamber
v1 schema:      upper-tribunal-tax-and-chancery-chamber

vehicle_recalls_and_faults_alerts
v2 schema:      driver-and-vehicle-standards-agency
v1 permissions: driver-and-vehicle-standards-agency
v1 schema:
```

We need to make sure that we avoid the same trap for the remaining document types that need to be ported.

[Trello](https://trello.com/c/DEDYI3iV/47-permission-levels-for-different-editors-in-specialist-documents)
