### PR TITLE
Push unit tests down to document specs

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -39,4 +39,67 @@ FactoryGirl.define do
     organisation_slug "department-for-international-development"
     organisation_content_id "db994552-7644-404d-a770-a2fe659c661f"
   end
+
+  sequence :content_id do |_|
+    SecureRandom.uuid
+  end
+
+  factory :document, class: Hash do
+    content_id
+    base_path "/a/b"
+    title "Example document"
+    description "This is the summary of example document"
+    schema_name "specialist_document"
+    publishing_app "specialist-publisher"
+    rendering_app "specialist-frontend"
+    locale "en"
+    phase "live"
+    redirects []
+    update_type "major"
+    public_updated_at "2015-11-16T11:53:30"
+    updated_at "2015-11-15T11:53:30"
+    publication_state "draft"
+    routes {
+      [
+        {
+          "path" => base_path,
+          "type" => "exact",
+        }
+      ]
+    }
+
+    details { default_details }
+
+    transient do
+      default_details {
+        {
+          "body" => [
+            {
+              "content_type" => "text/govspeak",
+              "content" => "## Header" + ("\r\n\r\nThis is the long body of an example document" * 10)
+            },
+            {
+              "content_type" => "text/html",
+              "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example document</p>\n" * 10)
+            }
+          ],
+          "headers" => [{
+            "text" => "Header",
+            "level" => 2,
+            "id" => "header",
+          }],
+          "metadata" => default_metadata,
+          "max_cache_time" => 10,
+          "change_history" => [],
+        }
+      }
+      default_metadata { {} }
+    end
+
+    initialize_with {
+      merged_details = default_details.deep_stringify_keys.deep_merge(details.deep_stringify_keys)
+      attributes.merge(details: merged_details)
+    }
+    to_create(&:deep_stringify_keys!)
+  end
 end

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -64,26 +64,4 @@ RSpec.describe AaibReport do
       expect(aaib_report.to_json).to be_valid_against_schema('specialist_document')
     end
   end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    let(:aaib_report) { described_class.find(aaib_reports[0]["content_id"]) }
-
-    it "notifies Airbrake and returns false if publishing-api does not return status 200" do
-      expect(Airbrake).to receive(:notify)
-      stub_publishing_api_publish(aaib_reports[0]["content_id"], {}, status: 503)
-      stub_any_rummager_post_with_queueing_enabled
-      expect(aaib_report.publish!).to eq(false)
-    end
-
-    it "notifies Airbrake and returns false if rummager does not return status 200" do
-      expect(Airbrake).to receive(:notify)
-      stub_publishing_api_publish(aaib_reports[0]["content_id"], {})
-      stub_request(:post, %r{#{Plek.new.find('search')}/documents}).to_return(status: 503)
-      expect(aaib_report.publish!).to eq(false)
-    end
-  end
 end

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe AaibReport do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example AAIB Report 0",
-      "description" => "This is the summary of example AAIB Report 0",
-      "link" => "/aaib-reports/example-aaib-report-0",
-      "indexable_content" => "Header " + (["This is the long body of an example AAIB Report"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "date_of_occurrence" => "2015-10-10",
-    }
-  }
-
   let(:aaib_reports) { 10.times.map { |n| aaib_report_content_item(n) } }
 
   before do
@@ -82,15 +71,6 @@ RSpec.describe AaibReport do
     end
 
     let(:aaib_report) { described_class.find(aaib_reports[0]["content_id"]) }
-
-    it "publishes the AAIB Report" do
-      stub_publishing_api_publish(aaib_reports[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-      expect(aaib_report.publish!).to eq(true)
-
-      assert_publishing_api_publish(aaib_report.content_id)
-      assert_rummager_posted_item(indexable_attributes)
-    end
 
     it "notifies Airbrake and returns false if publishing-api does not return status 200" do
       expect(Airbrake).to receive(:notify)

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -25,19 +25,6 @@ RSpec.describe AaibReport do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns a AAIB Report" do
-      content_id = aaib_reports[0]["content_id"]
-      aaib_report = described_class.find(content_id)
-
-      expect(aaib_report.base_path).to            eq(aaib_reports[0]["base_path"])
-      expect(aaib_report.title).to                eq(aaib_reports[0]["title"])
-      expect(aaib_report.summary).to              eq(aaib_reports[0]["description"])
-      expect(aaib_report.body).to                 eq(aaib_reports[0]["details"]["body"][0]["content"])
-      expect(aaib_report.date_of_occurrence).to   eq(aaib_reports[0]["details"]["metadata"]["date_of_occurrence"])
-    end
-  end
-
   describe "#save!" do
     it "saves the AAIB Report" do
       stub_any_publishing_api_put_content

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe AaibReport do
-  def aaib_report_content_item(n)
-    Payloads.aaib_report_content_item(
-      "base_path" => "/aaib-reports/example-aaib-report-#{n}",
-      "title" => "Example AAIB Report #{n}",
-      "description" => "This is the summary of example AAIB Report #{n}",
-      "routes" => [
-        {
-          "path" => "/aaib-reports/example-aaib-report-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:aaib_reports) { 10.times.map { |n| aaib_report_content_item(n) } }
-
-  before do
-    aaib_reports.each do |aaib_report|
-      publishing_api_has_item(aaib_report)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the AAIB Report" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      aaib_report = aaib_reports[0]
-
-      aaib_report.delete("publication_state")
-      aaib_report.delete("updated_at")
-      aaib_report.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      aaib_report["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(aaib_report["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(aaib_report))
-      expect(aaib_report.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.aaib_report_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -46,37 +46,6 @@ RSpec.describe CmaCase do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context ".find" do
-    it "returns a CMA Case" do
-      content_id = cma_cases[0]["content_id"]
-      cma_case = described_class.find(content_id)
-
-      expect(cma_case.base_path).to     eq(cma_cases[0]["base_path"])
-      expect(cma_case.title).to         eq(cma_cases[0]["title"])
-      expect(cma_case.summary).to       eq(cma_cases[0]["description"])
-      expect(cma_case.body).to          eq(cma_cases[0]["details"]["body"][0]["content"])
-      expect(cma_case.opened_date).to   eq(cma_cases[0]["details"]["metadata"]["opened_date"])
-      expect(cma_case.closed_date).to   eq(cma_cases[0]["details"]["metadata"]["closed_date"])
-      expect(cma_case.case_type).to     eq(cma_cases[0]["details"]["metadata"]["case_type"])
-      expect(cma_case.case_state).to    eq(cma_cases[0]["details"]["metadata"]["case_state"])
-      expect(cma_case.market_sector).to eq(cma_cases[0]["details"]["metadata"]["market_sector"])
-      expect(cma_case.outcome_type).to  eq(cma_cases[0]["details"]["metadata"]["outcome_type"])
-    end
-
-    it "should be able backward compatible for a single string representation of body in payload" do
-      simple_cma_case_payload = Payloads.cma_case_content_item("details" => { "body" => "single string body" })
-      publishing_api_has_item(simple_cma_case_payload)
-
-      content_id = simple_cma_case_payload["content_id"]
-      cma_case = described_class.find(content_id)
-
-      expect(simple_cma_case_payload["details"]["body"].class).to eq(String)
-      expect(cma_case.body.class).to eq(String)
-
-      expect(cma_case.body).to eq(simple_cma_case_payload["details"]["body"])
-    end
-  end
-
   describe "#save! without attachments" do
     it "saves the CMA Case" do
       stub_any_publishing_api_put_content

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -15,36 +15,7 @@ RSpec.describe CmaCase do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example CMA Case 0",
-      "description" => "This is the summary of example CMA case 0",
-      "link" => "/cma-cases/example-cma-case-0",
-      "indexable_content" => "Header " + (["This is the long body of an example CMA case"] * 10).join(" "),
-      "public_timestamp" => "2015-12-03T16:59:13+00:00",
-      "opened_date" => "2014-01-01",
-      "closed_date" => nil,
-      "case_type" => "ca98-and-civil-cartels",
-      "case_state" => "open",
-      "market_sector" => ["energy"],
-      "outcome_type" => nil
-    }
-  }
-
   let(:cma_cases) { 10.times.map { |n| cma_case_content_item(n) } }
-
-  let(:email_alert_payload) do
-    {
-      "tags" => {
-        "format" => "cma_case",
-        "opened_date" => "2014-01-01",
-        "case_type" => "ca98-and-civil-cartels",
-        "case_state" => "open",
-        "market_sector" => ["energy"]
-      },
-      "document_type" => "cma_case"
-    }
-  end
 
   before do
     cma_cases[1]["details"].merge!(
@@ -157,24 +128,6 @@ RSpec.describe CmaCase do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(cma_case))
       expect(cma_case.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the CMA Case" do
-      stub_publishing_api_publish(cma_cases[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      c = described_class.find(cma_cases[0]["content_id"])
-      expect(c.publish!).to eq(true)
-
-      assert_publishing_api_publish(c.content_id)
-      assert_rummager_posted_item(indexable_attributes)
-      assert_email_alert_sent(email_alert_payload)
     end
   end
 

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe CmaCase do
-  def cma_case_content_item(n)
-    Payloads.cma_case_content_item(
-      "base_path" => "/cma-cases/example-cma-case-#{n}",
-      "title" => "Example CMA Case #{n}",
-      "description" => "This is the summary of example CMA case #{n}",
-      "routes" => [
-        {
-          "path" => "/cma-cases/example-cma-case-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:cma_cases) { 10.times.map { |n| cma_case_content_item(n) } }
-
-  before do
-    cma_cases.each do |cma_case|
-      publishing_api_has_item(cma_case)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save! without attachments" do
-    it "saves the CMA Case" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      cma_case = cma_cases[0]
-
-      cma_case.delete("publication_state")
-      cma_case.delete("updated_at")
-      cma_case.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      cma_case["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(cma_case["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(cma_case))
-      expect(cma_case.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.cma_case_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -18,27 +18,6 @@ RSpec.describe CmaCase do
   let(:cma_cases) { 10.times.map { |n| cma_case_content_item(n) } }
 
   before do
-    cma_cases[1]["details"].merge!(
-      "attachments" => [
-        {
-          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-          "content_type" => "application/jpeg",
-          "title" => "asylum report image title",
-          "created_at" => "2015-12-18T10:12:26+00:00",
-          "updated_at" => "2015-12-18T10:12:26+00:00"
-        },
-        {
-          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-          "content_type" => "application/pdf",
-          "title" => "asylum report pdf title",
-          "created_at" => "2015-12-18T10:12:26+00:00",
-          "updated_at" => "2015-12-18T10:12:26+00:00"
-        }
-      ]
-    )
-
     cma_cases.each do |cma_case|
       publishing_api_has_item(cma_case)
     end
@@ -70,43 +49,6 @@ RSpec.describe CmaCase do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(cma_case))
       expect(cma_case.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#save! with attachments" do
-    it "saves the CMA Case" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      cma_case = cma_cases[1]
-
-      cma_case.delete("publication_state")
-      cma_case.delete("updated_at")
-      cma_case.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      cma_case["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(cma_case["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(cma_case))
-      expect(cma_case.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#find_attachment" do
-    it "finds attachment object inside the document object" do
-      document = described_class.find(cma_cases[1]["content_id"])
-      attachment_content_id = document.attachments[0].content_id
-
-      attachment = document.find_attachment(attachment_content_id)
-      expect(attachment).to eq(document.attachments[0])
     end
   end
 end

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -25,18 +25,6 @@ RSpec.describe CountrysideStewardshipGrant do
     Timecop.freeze("2015-12-18 10:12:26 UTC")
   end
 
-  describe ".find" do
-    it "returns a Countryside Stewardship Grant" do
-      content_id = countryside_stewardship_grants[0]["content_id"]
-      countryside_stewardship_grant = described_class.find(content_id)
-
-      expect(countryside_stewardship_grant.base_path).to eq(countryside_stewardship_grants[0]["base_path"])
-      expect(countryside_stewardship_grant.title).to eq(countryside_stewardship_grants[0]["title"])
-      expect(countryside_stewardship_grant.summary).to eq(countryside_stewardship_grants[0]["description"])
-      expect(countryside_stewardship_grant.body).to eq(countryside_stewardship_grants[0]["details"]["body"][0]["content"])
-    end
-  end
-
   describe "#save!" do
     it "saves the Countryside Stewardship Grant" do
       stub_any_publishing_api_put_content

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -15,16 +15,6 @@ RSpec.describe CountrysideStewardshipGrant do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Countryside Stewardship Grant 0",
-      "description" => "This is the summary of example Countryside Stewardship Grant 0",
-      "link" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Countryside Stewardship Grant"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-    }
-  }
-
   let(:countryside_stewardship_grants) { 10.times.map { |n| countryside_stewardship_grant_content_item(n) } }
 
   before do
@@ -71,23 +61,6 @@ RSpec.describe CountrysideStewardshipGrant do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(countryside_stewardship_grant))
       expect(countryside_stewardship_grant.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Countryside Stewardship Grant" do
-      stub_publishing_api_publish(countryside_stewardship_grants[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      countryside_stewardship_grant = described_class.find(countryside_stewardship_grants[0]["content_id"])
-      expect(countryside_stewardship_grant.publish!).to eq(true)
-
-      assert_publishing_api_publish(countryside_stewardship_grant.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe CountrysideStewardshipGrant do
-  def countryside_stewardship_grant_content_item(n)
-    Payloads.countryside_stewardship_grant_content_item(
-      "base_path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-#{n}",
-      "title" => "Example Countryside Stewardship Grant #{n}",
-      "description" => "This is the summary of example Countryside Stewardship Grant #{n}",
-      "routes" => [
-        {
-          "path" => "/countryside-stewardship-grants/example-countryside-stewardship-grant-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:countryside_stewardship_grants) { 10.times.map { |n| countryside_stewardship_grant_content_item(n) } }
-
-  before do
-    countryside_stewardship_grants.each do |countryside_stewardship_grant|
-      publishing_api_has_item(countryside_stewardship_grant)
-    end
-
-    Timecop.freeze("2015-12-18 10:12:26 UTC")
-  end
-
-  describe "#save!" do
-    it "saves the Countryside Stewardship Grant" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      countryside_stewardship_grant = countryside_stewardship_grants[0]
-
-      countryside_stewardship_grant.delete("publication_state")
-      countryside_stewardship_grant.delete("updated_at")
-      countryside_stewardship_grant.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      countryside_stewardship_grant["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(countryside_stewardship_grant["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(countryside_stewardship_grant))
-      expect(countryside_stewardship_grant.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.countryside_stewardship_grant_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -189,4 +189,18 @@ RSpec.describe Document do
     document.delete("publication_state")
     document
   end
+
+  describe ".find" do
+    it "returns a document" do
+      publishing_api_has_item(payload)
+
+      found_document = MyDocumentType.find(document.content_id)
+
+      expect(found_document.base_path).to eq(payload["base_path"])
+      expect(found_document.title).to     eq(payload["title"])
+      expect(found_document.summary).to   eq(payload["description"])
+      expect(found_document.body).to      eq(payload["details"]["body"][0]["content"])
+      expect(found_document.field3).to    eq(payload["details"]["metadata"]["field3"])
+    end
+  end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -140,6 +140,22 @@ RSpec.describe Document do
     end
   end
 
+  context "unsuccessful #publish!" do
+    it "notifies Airbrake and returns false if publishing-api does not return status 200" do
+      expect(Airbrake).to receive(:notify)
+      stub_publishing_api_publish(document.content_id, {}, status: 503)
+      stub_any_rummager_post_with_queueing_enabled
+      expect(document.publish!).to eq(false)
+    end
+
+    it "notifies Airbrake and returns false if rummager does not return status 200" do
+      expect(Airbrake).to receive(:notify)
+      stub_publishing_api_publish(document.content_id, {})
+      stub_request(:post, %r{#{Plek.new.find('search')}/documents}).to_return(status: 503)
+      expect(document.publish!).to eq(false)
+    end
+  end
+
   describe "#save!" do
     before do
       publishing_api_has_item(payload)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -184,12 +184,6 @@ RSpec.describe Document do
     end
   end
 
-  def write_payload(document)
-    document.delete("updated_at")
-    document.delete("publication_state")
-    document
-  end
-
   describe ".find" do
     it "returns a document" do
       publishing_api_has_item(payload)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -169,17 +169,7 @@ RSpec.describe Document do
       c = MyDocumentType.find(payload["content_id"])
       expect(c.save!).to eq(true)
 
-      expected_payload = write_payload(payload.deep_stringify_keys).deep_merge(
-        "public_updated_at" => "2015-12-18T10:12:26+00:00",
-        "details" => {
-          "change_history" => [
-            {
-              "public_timestamp" => "2015-12-18T10:12:26+00:00",
-              "note" => "First published.",
-            }
-          ]
-        }
-      )
+      expected_payload = saved_for_the_first_time(write_payload(payload.deep_stringify_keys))
       assert_publishing_api_put_content(c.content_id, expected_payload)
     end
   end

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -35,18 +35,6 @@ RSpec.describe DrugSafetyUpdate do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns a Drug Safety Update" do
-      content_id = drug_safety_updates[0]["content_id"]
-      drug_safety_update = described_class.find(content_id)
-
-      expect(drug_safety_update.base_path).to            eq(drug_safety_updates[0]["base_path"])
-      expect(drug_safety_update.title).to                eq(drug_safety_updates[0]["title"])
-      expect(drug_safety_update.summary).to              eq(drug_safety_updates[0]["description"])
-      expect(drug_safety_update.body).to                 eq(drug_safety_updates[0]["details"]["body"][0]["content"])
-    end
-  end
-
   describe "#save!" do
     it "saves the Drug Safety Update" do
       stub_any_publishing_api_put_content

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -15,20 +15,6 @@ RSpec.describe EmploymentAppealTribunalDecision do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Employment Appeal Tribunal Decision 0",
-      "description" => "This is the summary of example Employment Appeal Tribunal Decision 0",
-      "link" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Employment Appeal Tribunal Decision"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "tribunal_decision_categories" => ["age-discrimination"],
-      "tribunal_decision_decision_date" => "2015-07-30",
-      "tribunal_decision_landmark" => "landmark",
-      "tribunal_decision_sub_categories" => ["contract-of-employment-apprenticeship"],
-    }
-  }
-
   let(:employment_appeal_tribunal_decisions) { 10.times.map { |n| employment_appeal_tribunal_decision_content_item(n) } }
 
   before do
@@ -79,23 +65,6 @@ RSpec.describe EmploymentAppealTribunalDecision do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(employment_appeal_tribunal_decision))
       expect(employment_appeal_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Employment Appeal Tribunal Decision" do
-      stub_publishing_api_publish(employment_appeal_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      employment_appeal_tribunal_decision = described_class.find(employment_appeal_tribunal_decisions[0]["content_id"])
-      expect(employment_appeal_tribunal_decision.publish!).to eq(true)
-
-      assert_publishing_api_publish(employment_appeal_tribunal_decision.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe EmploymentAppealTribunalDecision do
-  def employment_appeal_tribunal_decision_content_item(n)
-    Payloads.employment_appeal_tribunal_decision_content_item(
-      "base_path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-#{n}",
-      "title" => "Example Employment Appeal Tribunal Decision #{n}",
-      "description" => "This is the summary of example Employment Appeal Tribunal Decision #{n}",
-      "routes" => [
-        {
-          "path" => "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:employment_appeal_tribunal_decisions) { 10.times.map { |n| employment_appeal_tribunal_decision_content_item(n) } }
-
-  before do
-    employment_appeal_tribunal_decisions.each do |decision|
-      publishing_api_has_item(decision)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the Employment Appeal Tribunal Decision" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      employment_appeal_tribunal_decision = employment_appeal_tribunal_decisions[0]
-
-      employment_appeal_tribunal_decision.delete("publication_state")
-      employment_appeal_tribunal_decision.delete("updated_at")
-      employment_appeal_tribunal_decision.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      employment_appeal_tribunal_decision["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(employment_appeal_tribunal_decision["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(employment_appeal_tribunal_decision))
-      expect(employment_appeal_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.employment_appeal_tribunal_decision_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -25,22 +25,6 @@ RSpec.describe EmploymentAppealTribunalDecision do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns an Employment Appeal Tribunal Decision" do
-      content_id = employment_appeal_tribunal_decisions[0]["content_id"]
-      employment_appeal_tribunal_decision = described_class.find(content_id)
-
-      expect(employment_appeal_tribunal_decision.base_path).to                          eq(employment_appeal_tribunal_decisions[0]["base_path"])
-      expect(employment_appeal_tribunal_decision.title).to                              eq(employment_appeal_tribunal_decisions[0]["title"])
-      expect(employment_appeal_tribunal_decision.summary).to                            eq(employment_appeal_tribunal_decisions[0]["description"])
-      expect(employment_appeal_tribunal_decision.body).to                               eq(employment_appeal_tribunal_decisions[0]["details"]["body"][0]["content"])
-      expect(employment_appeal_tribunal_decision.tribunal_decision_categories).to       eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_categories"])
-      expect(employment_appeal_tribunal_decision.tribunal_decision_decision_date).to    eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])
-      expect(employment_appeal_tribunal_decision.tribunal_decision_landmark).to         eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_landmark"])
-      expect(employment_appeal_tribunal_decision.tribunal_decision_sub_categories).to eq(employment_appeal_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_sub_categories"])
-    end
-  end
-
   describe "#save!" do
     it "saves the Employment Appeal Tribunal Decision" do
       stub_any_publishing_api_put_content

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -15,19 +15,6 @@ RSpec.describe EmploymentTribunalDecision do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Employment Tribunal Decision 0",
-      "description" => "This is the summary of example Employment Tribunal Decision 0",
-      "link" => "/employment-tribunal-decisions/example-employment-tribunal-decision-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Employment Tribunal Decision"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "tribunal_decision_categories" => ["age-discrimination"],
-      "tribunal_decision_country" => "england-and-wales",
-      "tribunal_decision_decision_date" => "2015-07-30",
-    }
-  }
-
   let(:employment_tribunal_decisions) { 10.times.map { |n| employment_tribunal_decision_content_item(n) } }
 
   before do
@@ -77,23 +64,6 @@ RSpec.describe EmploymentTribunalDecision do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(employment_tribunal_decision))
       expect(employment_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Employment Tribunal Decision" do
-      stub_publishing_api_publish(employment_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      employment_tribunal_decision = described_class.find(employment_tribunal_decisions[0]["content_id"])
-      expect(employment_tribunal_decision.publish!).to eq(true)
-
-      assert_publishing_api_publish(employment_tribunal_decision.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe EmploymentTribunalDecision do
-  def employment_tribunal_decision_content_item(n)
-    Payloads.employment_tribunal_decision_content_item(
-      "base_path" => "/employment-tribunal-decisions/example-employment-tribunal-decision-#{n}",
-      "title" => "Example Employment Tribunal Decision #{n}",
-      "description" => "This is the summary of example Employment Tribunal Decision #{n}",
-      "routes" => [
-        {
-          "path" => "/employment-tribunal-decisions/example-employment-tribunal-decision-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:employment_tribunal_decisions) { 10.times.map { |n| employment_tribunal_decision_content_item(n) } }
-
-  before do
-    employment_tribunal_decisions.each do |decision|
-      publishing_api_has_item(decision)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the Employment Tribunal Decision" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      employment_tribunal_decision = employment_tribunal_decisions[0]
-
-      employment_tribunal_decision.delete("publication_state")
-      employment_tribunal_decision.delete("updated_at")
-      employment_tribunal_decision.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      employment_tribunal_decision["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(employment_tribunal_decision["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(employment_tribunal_decision))
-      expect(employment_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.employment_tribunal_decision_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -25,21 +25,6 @@ RSpec.describe EmploymentTribunalDecision do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns an Employment Tribunal Decision" do
-      content_id = employment_tribunal_decisions[0]["content_id"]
-      employment_tribunal_decision = described_class.find(content_id)
-
-      expect(employment_tribunal_decision.base_path).to                        eq(employment_tribunal_decisions[0]["base_path"])
-      expect(employment_tribunal_decision.title).to                            eq(employment_tribunal_decisions[0]["title"])
-      expect(employment_tribunal_decision.summary).to                          eq(employment_tribunal_decisions[0]["description"])
-      expect(employment_tribunal_decision.body).to                             eq(employment_tribunal_decisions[0]["details"]["body"][0]["content"])
-      expect(employment_tribunal_decision.tribunal_decision_categories).to     eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_categories"])
-      expect(employment_tribunal_decision.tribunal_decision_country).to        eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_country"])
-      expect(employment_tribunal_decision.tribunal_decision_decision_date).to  eq(employment_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])
-    end
-  end
-
   describe "#save!" do
     it "saves the Employment Tribunal Decision" do
       stub_any_publishing_api_put_content

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -15,21 +15,6 @@ RSpec.describe EsiFund do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example ESI Fund 0",
-      "description" => "This is the summary of example ESI Fund 0",
-      "link" => "/european-structural-investment-funds/example-esi-fund-0",
-      "indexable_content" => "Header " + (["This is the long body of an example ESI Fund"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "fund_state" => nil,
-      "fund_type" => nil,
-      "location" => nil,
-      "funding_source" => nil,
-      "closing_date" => "2016-01-01",
-    }
-  }
-
   let(:esi_funds) { 10.times.map { |n| esi_fund_content_item(n) } }
 
   before do
@@ -77,23 +62,6 @@ RSpec.describe EsiFund do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(esi_fund))
       expect(esi_fund.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the ESI Fund" do
-      stub_publishing_api_publish(esi_funds[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      esi_fund = described_class.find(esi_funds[0]["content_id"])
-      expect(esi_fund.publish!).to eq(true)
-
-      assert_publishing_api_publish(esi_fund.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -25,19 +25,6 @@ RSpec.describe EsiFund do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context ".find" do
-    it "returns an ESI Fund" do
-      content_id = esi_funds[0]["content_id"]
-      esi_fund = described_class.find(content_id)
-
-      expect(esi_fund.base_path).to            eq(esi_funds[0]["base_path"])
-      expect(esi_fund.title).to                eq(esi_funds[0]["title"])
-      expect(esi_fund.summary).to              eq(esi_funds[0]["description"])
-      expect(esi_fund.body).to                 eq(esi_funds[0]["details"]["body"][0]["content"])
-      expect(esi_fund.closing_date).to         eq(esi_funds[0]["details"]['metadata']["closing_date"])
-    end
-  end
-
   describe "#save!" do
     it "saves the ESI Fund" do
       stub_any_publishing_api_put_content

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe EsiFund do
-  def esi_fund_content_item(n)
-    Payloads.esi_fund_content_item(
-      "base_path" => "/european-structural-investment-funds/example-esi-fund-#{n}",
-      "title" => "Example ESI Fund #{n}",
-      "description" => "This is the summary of example ESI Fund #{n}",
-      "routes" => [
-        {
-          "path" => "/european-structural-investment-funds/example-esi-fund-#{n}",
-          "type" => "exact",
-        },
-      ]
-    )
-  end
-
-  let(:esi_funds) { 10.times.map { |n| esi_fund_content_item(n) } }
-
-  before do
-    esi_funds.each do |esi_fund|
-      publishing_api_has_item(esi_fund)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the ESI Fund" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      esi_fund = esi_funds[0]
-
-      esi_fund.delete("publication_state")
-      esi_fund.delete("updated_at")
-      esi_fund.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      esi_fund["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(esi_fund["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(esi_fund))
-      expect(esi_fund.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.esi_fund_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -25,19 +25,6 @@ RSpec.describe MaibReport do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context ".find" do
-    it "returns a MAIB Report" do
-      content_id = maib_reports[0]["content_id"]
-      maib_report = described_class.find(content_id)
-
-      expect(maib_report.base_path).to            eq(maib_reports[0]["base_path"])
-      expect(maib_report.title).to                eq(maib_reports[0]["title"])
-      expect(maib_report.summary).to              eq(maib_reports[0]["description"])
-      expect(maib_report.body).to                 eq(maib_reports[0]["details"]["body"][0]["content"])
-      expect(maib_report.date_of_occurrence).to   eq(maib_reports[0]["details"]["metadata"]["date_of_occurrence"])
-    end
-  end
-
   describe "#save!" do
     it "saves the MAIB Report" do
       stub_any_publishing_api_put_content

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe MaibReport do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example MAIB Report 0",
-      "description" => "This is the summary of example MAIB Report 0",
-      "link" => "/maib-reports/example-maib-report-0",
-      "indexable_content" => "Header " + (["This is the long body of an example MAIB Report"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "date_of_occurrence" => "2015-10-10",
-    }
-  }
-
   let(:maib_reports) { 10.times.map { |n| maib_report_content_item(n) } }
 
   before do
@@ -73,23 +62,6 @@ RSpec.describe MaibReport do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(maib_report))
       expect(maib_report.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the MAIB Report" do
-      stub_publishing_api_publish(maib_reports[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      maib_report = described_class.find(maib_reports[0]["content_id"])
-      expect(maib_report.publish!).to eq(true)
-
-      assert_publishing_api_publish(maib_report.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe MaibReport do
-  def maib_report_content_item(n)
-    Payloads.maib_report_content_item(
-      "base_path" => "/maib-reports/example-maib-report-#{n}",
-      "title" => "Example MAIB Report #{n}",
-      "description" => "This is the summary of example MAIB Report #{n}",
-      "routes" => [
-        {
-          "path" => "/maib-reports/example-maib-report-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:maib_reports) { 10.times.map { |n| maib_report_content_item(n) } }
-
-  before do
-    maib_reports.each do |maib_report|
-      publishing_api_has_item(maib_report)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the MAIB Report" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      maib_report = maib_reports[0]
-
-      maib_report.delete("publication_state")
-      maib_report.delete("updated_at")
-      maib_report.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      maib_report["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(maib_report["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(maib_report))
-      expect(maib_report.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.maib_report_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -1,67 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe MedicalSafetyAlert do
-  def medical_safety_alert_content_item(n)
-    Payloads.medical_safety_alert_content_item(
-      "base_path" => "/drug-device-alerts/example-medical-safety-alert-#{n}",
-      "title" => "Example Medical Safety Alert #{n}",
-      "description" => "This is the summary of example Medical Safety Alert #{n}",
-      "routes" => [
-        {
-          "path" => "/drug-device-alerts/example-medical-safety-alert-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:medical_safety_alerts) { 10.times.map { |n| medical_safety_alert_content_item(n) } }
-
-  before do
-    medical_safety_alerts.each do |medical_safety_alert|
-      publishing_api_has_item(medical_safety_alert)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe ".find" do
-    it "returns a Medical Safety Alert" do
-      content_id = medical_safety_alerts[0]["content_id"]
-      medical_safety_alert = described_class.find(content_id)
-
-      expect(medical_safety_alert.base_path).to            eq(medical_safety_alerts[0]["base_path"])
-      expect(medical_safety_alert.title).to                eq(medical_safety_alerts[0]["title"])
-      expect(medical_safety_alert.summary).to              eq(medical_safety_alerts[0]["description"])
-      expect(medical_safety_alert.body).to                 eq(medical_safety_alerts[0]["details"]["body"][0]["content"])
-      expect(medical_safety_alert.alert_type).to           eq(medical_safety_alerts[0]["details"]["metadata"]["alert_type"])
-    end
-  end
-
-  describe "#save!" do
-    it "saves the Medical Safety Alert" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      medical_safety_alert = medical_safety_alerts[0]
-
-      medical_safety_alert.delete("publication_state")
-      medical_safety_alert.delete("updated_at")
-      medical_safety_alert.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      medical_safety_alert["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(medical_safety_alert["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(medical_safety_alert))
-      expect(medical_safety_alert.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.medical_safety_alert_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -15,18 +15,6 @@ RSpec.describe MedicalSafetyAlert do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Medical Safety Alert 0",
-      "description" => "This is the summary of example Medical Safety Alert 0",
-      "link" => "/drug-device-alerts/example-medical-safety-alert-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Medical Safety Alert"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "alert_type" => "company-led-drugs",
-      "issued_date" => "2016-02-01",
-    }
-  }
-
   let(:medical_safety_alerts) { 10.times.map { |n| medical_safety_alert_content_item(n) } }
 
   before do
@@ -74,23 +62,6 @@ RSpec.describe MedicalSafetyAlert do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(medical_safety_alert))
       expect(medical_safety_alert.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Medical Safety Alert" do
-      stub_publishing_api_publish(medical_safety_alerts[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      medical_safety_alert = described_class.find(medical_safety_alerts[0]["content_id"])
-      expect(medical_safety_alert.publish!).to eq(true)
-
-      assert_publishing_api_publish(medical_safety_alert.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe RaibReport do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example RAIB Report 0",
-      "description" => "This is the summary of example RAIB Report 0",
-      "link" => "/raib-reports/example-raib-report-0",
-      "indexable_content" => "Header " + (["This is the long body of an example RAIB Report"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "date_of_occurrence" => "2015-10-10",
-    }
-  }
-
   let(:raib_reports) { 10.times.map { |n| raib_report_content_item(n) } }
 
   before do
@@ -73,23 +62,6 @@ RSpec.describe RaibReport do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(raib_report))
       expect(raib_report.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the RAIB Report" do
-      stub_publishing_api_publish(raib_reports[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      raib_report = described_class.find(raib_reports[0]["content_id"])
-      expect(raib_report.publish!).to eq(true)
-
-      assert_publishing_api_publish(raib_report.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe RaibReport do
-  def raib_report_content_item(n)
-    Payloads.raib_report_content_item(
-      "base_path" => "/raib-reports/example-raib-report-#{n}",
-      "title" => "Example RAIB Report #{n}",
-      "description" => "This is the summary of example RAIB Report #{n}",
-      "routes" => [
-        {
-          "path" => "/raib-reports/example-raib-report-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:raib_reports) { 10.times.map { |n| raib_report_content_item(n) } }
-
-  before do
-    raib_reports.each do |raib_report|
-      publishing_api_has_item(raib_report)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the RAIB Report" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      raib_report = raib_reports[0]
-
-      raib_report.delete("publication_state")
-      raib_report.delete("updated_at")
-      raib_report.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      raib_report["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(raib_report["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(raib_report))
-      expect(raib_report.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.raib_report_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -25,19 +25,6 @@ RSpec.describe RaibReport do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  context ".find" do
-    it "returns a AAIB Report" do
-      content_id = raib_reports[0]["content_id"]
-      raib_report = described_class.find(content_id)
-
-      expect(raib_report.base_path).to            eq(raib_reports[0]["base_path"])
-      expect(raib_report.title).to                eq(raib_reports[0]["title"])
-      expect(raib_report.summary).to              eq(raib_reports[0]["description"])
-      expect(raib_report.body).to                 eq(raib_reports[0]["details"]["body"][0]["content"])
-      expect(raib_report.date_of_occurrence).to   eq(raib_reports[0]["details"]["metadata"]["date_of_occurrence"])
-    end
-  end
-
   describe "#save!" do
     it "saves the RAIB Report" do
       stub_any_publishing_api_put_content

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -25,21 +25,6 @@ RSpec.describe TaxTribunalDecision do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns an Tax Tribunal Decision" do
-      content_id = tax_tribunal_decisions[0]["content_id"]
-      tax_tribunal_decision = described_class.find(content_id)
-
-      expect(tax_tribunal_decision.base_path).to                        eq(tax_tribunal_decisions[0]["base_path"])
-      expect(tax_tribunal_decision.title).to                            eq(tax_tribunal_decisions[0]["title"])
-      expect(tax_tribunal_decision.summary).to                          eq(tax_tribunal_decisions[0]["description"])
-      expect(tax_tribunal_decision.body).to                             eq(tax_tribunal_decisions[0]["details"]["body"][0]["content"])
-      expect(tax_tribunal_decision.tribunal_decision_category).to       eq(tax_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_category"])
-      expect(tax_tribunal_decision.tribunal_decision_decision_date).to  eq(tax_tribunal_decisions[0]["details"]["metadata"]["tribunal_decision_decision_date"])
-    end
-  end
-
-
   describe "#save!" do
     it "saves the Tax Tribunal Decision" do
       stub_any_publishing_api_put_content

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -15,18 +15,6 @@ RSpec.describe TaxTribunalDecision do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Tax Tribunal Decision 0",
-      "description" => "This is the summary of example Tax Tribunal Decision 0",
-      "link" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Tax Tribunal Decision"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "tribunal_decision_category" => "banking",
-      "tribunal_decision_decision_date" => "2015-07-30",
-    }
-  }
-
   let(:tax_tribunal_decisions) { 10.times.map { |n| tax_tribunal_decision_content_item(n) } }
 
   before do
@@ -76,23 +64,6 @@ RSpec.describe TaxTribunalDecision do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(tax_tribunal_decision))
       expect(tax_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Tax Tribunal Decision" do
-      stub_publishing_api_publish(tax_tribunal_decisions[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      tax_tribunal_decision = described_class.find(tax_tribunal_decisions[0]["content_id"])
-      expect(tax_tribunal_decision.publish!).to eq(true)
-
-      assert_publishing_api_publish(tax_tribunal_decision.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -1,54 +1,7 @@
-require "rails_helper"
+require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe TaxTribunalDecision do
-  def tax_tribunal_decision_content_item(n)
-    Payloads.tax_tribunal_decision_content_item(
-      "base_path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-#{n}",
-      "title" => "Example Tax Tribunal Decision #{n}",
-      "description" => "This is the summary of example Tax Tribunal Decision #{n}",
-      "routes" => [
-        {
-          "path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:tax_tribunal_decisions) { 10.times.map { |n| tax_tribunal_decision_content_item(n) } }
-
-  before do
-    tax_tribunal_decisions.each do |decision|
-      publishing_api_has_item(decision)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the Tax Tribunal Decision" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      tax_tribunal_decision = tax_tribunal_decisions[0]
-
-      tax_tribunal_decision.delete("publication_state")
-      tax_tribunal_decision.delete("updated_at")
-      tax_tribunal_decision.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      tax_tribunal_decision["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(tax_tribunal_decision["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(tax_tribunal_decision))
-      expect(tax_tribunal_decision.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.tax_tribunal_decision_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -1,0 +1,33 @@
+RSpec.shared_examples "it saves payloads that are valid against the 'specialist_document' schema" do
+  describe "#save!" do
+    it "saves a valid document" do
+      publishing_api_has_item(payload)
+      Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+
+      instance = described_class.find(payload["content_id"])
+      expect(instance.save!).to eq(true)
+
+      expected_payload_sent_to_publishing_api = saved_for_the_first_time(write_payload(payload))
+
+      assert_publishing_api_put_content(instance.content_id, expected_payload_sent_to_publishing_api)
+      expect(expected_payload_sent_to_publishing_api.to_json).to be_valid_against_schema('specialist_document')
+    end
+
+    def saved_for_the_first_time(document)
+      timestamp = Time.now.to_datetime.rfc3339
+      document.deep_merge(
+        "public_updated_at" => timestamp,
+        "details" => {
+          "change_history" => [
+            {
+              "public_timestamp" => timestamp,
+              "note" => "First published.",
+            }
+          ]
+        }
+      )
+    end
+  end
+end

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -14,20 +14,5 @@ RSpec.shared_examples "it saves payloads that are valid against the 'specialist_
       assert_publishing_api_put_content(instance.content_id, expected_payload_sent_to_publishing_api)
       expect(expected_payload_sent_to_publishing_api.to_json).to be_valid_against_schema('specialist_document')
     end
-
-    def saved_for_the_first_time(document)
-      timestamp = Time.now.to_datetime.rfc3339
-      document.deep_merge(
-        "public_updated_at" => timestamp,
-        "details" => {
-          "change_history" => [
-            {
-              "public_timestamp" => timestamp,
-              "note" => "First published.",
-            }
-          ]
-        }
-      )
-    end
   end
 end

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -15,19 +15,6 @@ RSpec.describe VehicleRecallsAndFaultsAlert do
     )
   end
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Vehicle Recalls And Faults 0",
-      "description" => "This is the summary of example Vehicle Recalls And Faults 0",
-      "link" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Vehicle Recalls And Faults"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
-      "alert_issue_date" => "2015-04-28",
-      "build_start_date" => "2015-04-28",
-      "build_end_date" => "2015-06-28",
-    }
-  }
-
   let(:vehicle_recalls_and_faults) { 10.times.map { |n| vehicle_recalls_and_faults_alert_content_item(n) } }
 
   before do
@@ -77,23 +64,6 @@ RSpec.describe VehicleRecallsAndFaultsAlert do
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(vehicle_recall_and_fault))
       expect(vehicle_recall_and_fault.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    before do
-      email_alert_api_accepts_alert
-    end
-
-    it "publishes the Vehicle Recall and Fault" do
-      stub_publishing_api_publish(vehicle_recalls_and_faults[0]["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
-
-      vehicle_recall_and_fault = described_class.find(vehicle_recalls_and_faults[0]["content_id"])
-      expect(vehicle_recall_and_fault.publish!).to eq(true)
-
-      assert_publishing_api_publish(vehicle_recall_and_fault.content_id)
-      assert_rummager_posted_item(indexable_attributes)
     end
   end
 end

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -1,54 +1,7 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe VehicleRecallsAndFaultsAlert do
-  def vehicle_recalls_and_faults_alert_content_item(n)
-    Payloads.vehicle_recalls_and_faults_alert_content_item(
-      "base_path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-#{n}",
-      "title" => "Example Vehicle Recalls And Faults #{n}",
-      "description" => "This is the summary of example Vehicle Recalls And Faults #{n}",
-      "routes" => [
-        {
-          "path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
-
-  let(:vehicle_recalls_and_faults) { 10.times.map { |n| vehicle_recalls_and_faults_alert_content_item(n) } }
-
-  before do
-    vehicle_recalls_and_faults.each do |vehicle|
-      publishing_api_has_item(vehicle)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save!" do
-    it "saves the Vehicle Recall and Fault" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      vehicle_recall_and_fault = vehicle_recalls_and_faults[0]
-
-      vehicle_recall_and_fault.delete("publication_state")
-      vehicle_recall_and_fault.delete("updated_at")
-      vehicle_recall_and_fault.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      vehicle_recall_and_fault["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(vehicle_recall_and_fault["content_id"])
-      expect(c.save!).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(vehicle_recall_and_fault))
-      expect(vehicle_recall_and_fault.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
+  let(:payload) { Payloads.vehicle_recalls_and_faults_alert_content_item }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 end

--- a/spec/models/vehicle_recalls_and_faults_alert_spec.rb
+++ b/spec/models/vehicle_recalls_and_faults_alert_spec.rb
@@ -25,21 +25,6 @@ RSpec.describe VehicleRecallsAndFaultsAlert do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe ".find" do
-    it "returns a Vehicle Recall and Fault" do
-      content_id = vehicle_recalls_and_faults[0]["content_id"]
-      vehicle_recall_and_fault = described_class.find(content_id)
-
-      expect(vehicle_recall_and_fault.base_path).to            eq(vehicle_recalls_and_faults[0]["base_path"])
-      expect(vehicle_recall_and_fault.title).to                eq(vehicle_recalls_and_faults[0]["title"])
-      expect(vehicle_recall_and_fault.summary).to              eq(vehicle_recalls_and_faults[0]["description"])
-      expect(vehicle_recall_and_fault.body).to                 eq(vehicle_recalls_and_faults[0]["details"]["body"][0]["content"])
-      expect(vehicle_recall_and_fault.alert_issue_date).to     eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["alert_issue_date"])
-      expect(vehicle_recall_and_fault.build_start_date).to     eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["build_start_date"])
-      expect(vehicle_recall_and_fault.build_end_date).to       eq(vehicle_recalls_and_faults[0]["details"]["metadata"]["build_end_date"])
-    end
-  end
-
   describe "#save!" do
     it "saves the Vehicle Recall and Fault" do
       stub_any_publishing_api_put_content

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,4 +63,10 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
+
+  def write_payload(document)
+    document.delete("updated_at")
+    document.delete("publication_state")
+    document
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,10 +63,4 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
-
-  def write_payload(document)
-    document.delete("updated_at")
-    document.delete("publication_state")
-    document
-  end
 end

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -303,7 +303,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.employment_tribunal_decision_content_item(attrs)
+  def self.employment_tribunal_decision_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/employment-tribunal-decisions/example-employment-tribunal-decision",
@@ -354,7 +354,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.esi_fund_content_item(attrs)
+  def self.esi_fund_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/european-structural-investment-funds/example-esi-fund",
@@ -403,7 +403,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.maib_report_content_item(attrs)
+  def self.maib_report_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/maib-reports/example-maib-report",
@@ -527,7 +527,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.raib_report_content_item(attrs)
+  def self.raib_report_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/raib-reports/example-raib-report",
@@ -575,7 +575,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.tax_tribunal_decision_content_item(attrs)
+  def self.tax_tribunal_decision_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/tax-and-chancery-tribunal-decisions/example-tax-tribunal-decision",
@@ -625,7 +625,7 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.vehicle_recalls_and_faults_alert_content_item(attrs)
+  def self.vehicle_recalls_and_faults_alert_content_item(attrs = {})
     {
       "content_id" => SecureRandom.uuid,
       "base_path" => "/vehicle-recalls-faults/example-vehicle-recalls-and-faults",

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -1,0 +1,24 @@
+module PublishingApiHelpers
+  def write_payload(document)
+    document.delete("updated_at")
+    document.delete("publication_state")
+    document
+  end
+
+  def saved_for_the_first_time(document)
+    timestamp = Time.now.to_datetime.rfc3339
+    document.deep_merge(
+      "public_updated_at" => timestamp,
+      "details" => {
+        "change_history" => [
+          {
+            "public_timestamp" => timestamp,
+            "note" => "First published.",
+          }
+        ]
+      }
+    )
+  end
+end
+
+RSpec.configuration.include PublishingApiHelpers


### PR DESCRIPTION
Supersedes https://github.com/alphagov/specialist-publisher-rebuild/pull/759

The document model specs have a lot of duplication between them; however the models themselves (except `DrugSafetyUpdate`) don't actually contain the logic under test – the `Document` class does.

This PR moves the specs into `document_spec` and slims the specs down to a single shared spec. The shared spec checks that saving sends an appropriate payload to Publishing API, which is valid against the content schema. This step isn't possible to test in `document_spec`, because there isn't a schema to validate against for the dummy document subclass used in document specs.

Out of scope here (will look to do these on subsequent PRs):
- converting the `Payloads` module to use FactoryGirl
- tidying up `drug_safety_update_spec`
