### PR TITLE
Queue republish_all jobs

### DIFF
--- a/app/services/abstract_document_service_registry.rb
+++ b/app/services/abstract_document_service_registry.rb
@@ -84,7 +84,7 @@ class AbstractDocumentServiceRegistry
   def republish_all
     -> {
       document_repository.all.each do |document|
-        republish(document.id).call
+        RepublishDocumentWorker.perform_async(document.id, document.document_type)
       end
     }
   end

--- a/app/workers/republish_document_worker.rb
+++ b/app/workers/republish_document_worker.rb
@@ -1,0 +1,15 @@
+class RepublishDocumentWorker
+  include Sidekiq::Worker
+
+  sidekiq_options(
+    # This is required to retry in the case of a FailedToPublishError
+    retry: 25,
+    backtrace: true,
+    queue: "bulk_republishing",
+  )
+
+  def perform(document_id, type)
+    services = SpecialistPublisher.document_services(type)
+    services.republish(document_id).call
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,1 +1,4 @@
 :concurrency:  2
+:queues:
+  - ["bulk_republishing", 1]
+  - ["default", 5]

--- a/spec/workers/republish_document_worker_spec.rb
+++ b/spec/workers/republish_document_worker_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+require "sidekiq/testing"
+
+RSpec.describe RepublishDocumentWorker do
+  it "place job in bulk republishing queue" do
+    Sidekiq::Testing.fake! do
+      RepublishDocumentWorker.perform_async("1", "doc_type")
+      expect(RepublishDocumentWorker.jobs.size).to eq(1)
+      expect(RepublishDocumentWorker.jobs.first.fetch("queue")).to eq("bulk_republishing")
+    end
+  end
+end


### PR DESCRIPTION
Due to the large amount of documents, it is useful to speed up the
republish_all action by sending each document to be republished to a
queue.