### PR TITLE
Add a filterable "first_published_at" field

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -10,6 +10,15 @@ class DfidResearchOutput < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  ##
+  # DFID research outputs are always bulk published, because our 'publication'
+  # is just a proxy for a research output PDF. Its date is not important to a
+  # user. Setting this +true+ means that specialist-frontend will never render
+  # the publishing-api +published+ date.
+  def bulk_published
+    true
+  end
+
   def self.title
     'DFID Research Output'
   end

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,7 +1,8 @@
 class DfidResearchOutput < Document
   validates :country, presence: true
+  validates :first_published_at, presence: true, date: true
 
-  FORMAT_SPECIFIC_FIELDS = %i(country)
+  FORMAT_SPECIFIC_FIELDS = %i(country first_published_at)
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
 

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -1,8 +1,10 @@
-<div class="form-group">
-  <%= f.label :country %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :country } do %>
   <%=
     f.select :country, facet_options(f, :country),
       { include_blank: true },
       { class: 'select2', multiple: true, data: { placeholder: 'Select countries' } }
   %>
-</div>
+<% end %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at } do %>
+  <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
+<% end %>

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -823,6 +823,14 @@
           "label": "Zimbabwe"
         }
       ]
+    },
+    {
+      "key": "first_published_at",
+      "name": "First published",
+      "short_name": "First published",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
     }
   ]
 }

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Title", with: title
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
+    fill_in "First published at", with: "2013-01-01"
     select "United Kingdom", from: "Country"
 
     expect(page).to have_css('div.govspeak-help')

--- a/spec/models/dfid_research_output_spec.rb
+++ b/spec/models/dfid_research_output_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe DfidResearchOutput do
+  subject(:output) { DfidResearchOutput.new }
+
+  it 'is always bulk published to hide the publishing-api published date' do
+    expect(output.bulk_published).to be true
+  end
+end


### PR DESCRIPTION
This needs to be separate and distinct from the publishing platform's
 "Published" date field, which is updated in lockstep with major updates
and will not appear when items are `bulk_published`. There is already
 a "first_published_at" field in rummager, so we just use this.

This gives editors the opportunity to enter the real published date
of a research output.
## Related PRs

https://github.com/alphagov/rummager/pull/638
https://github.com/alphagov/dfid-transition/pull/25
## Screenshots

<img width="771" alt="screen shot 2016-05-20 at 16 40 37" src="https://cloud.githubusercontent.com/assets/194511/15433283/a1eb4afa-1ea9-11e6-9cef-61c2adcc89ac.png">

![screen shot 2016-05-20 at 16 56 47](https://cloud.githubusercontent.com/assets/194511/15433846/ea47aec2-1eab-11e6-81c6-35b7da1b3cce.png)

<img width="969" alt="screen shot 2016-05-23 at 12 53 58" src="https://cloud.githubusercontent.com/assets/194511/15469985/883c6cb8-20e5-11e6-9dab-8114c1485573.png">
