### PR TITLE
Add a healthcheck specific to this application

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
+  get '/rebuild-healthcheck', to: proc { [200, {}, ['OK']] }
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe "healthcheck path", type: :request do
     expect(response.status).to eq(200)
     expect(response.body).to eq("OK")
   end
+
+  it "should respond with 'OK'" do
+    get "/rebuild-healthcheck"
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq("OK")
+  end
 end


### PR DESCRIPTION
When the "frankenstein" app is running in production with
both v1 and v2, it will be useful to check that the
routing to v2 is working correctly. We will add this rule
to the Nginx config, too.
