### PR TITLE
Don't read from MONGO_URI in development

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   clients:
     default:
-      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost/govuk_content_development' %>
+      uri: mongodb://localhost/govuk_content_development
       options:
         write:
           w: 1


### PR DESCRIPTION
This puts back the change from #744, which was regressed in #768.
Without this, the app behaves differently depending on whether it's
started using `./startup.sh` or using Bowler.
