### PR TITLE
Don't set any defaults for Mongoid in production

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -17,7 +17,7 @@ test:
 production:
   clients:
     default:
-      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost/govuk_content_development' %>
+      uri: <%= ENV['MONGODB_URI'] %>
       options:
         write:
           w: majority


### PR DESCRIPTION
This was inadvertently introduced in #768. There's no good reason to
have this default.
