### PR TITLE
Fix root path

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -174,7 +174,7 @@ class Manual
   end
 
   def self.max_numbers_of_manuals
-    10000
+    10
   end
 
   def update_attributes(new_attributes)

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Access control", type: :feature do
   before do
     publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
     publishing_api_has_content([], hash_including(document_type: AaibReport.document_type))
-    publishing_api_has_content([], document_type: 'manual', fields: manual_fields, per_page: 10000)
+    publishing_api_has_content([], document_type: 'manual', fields: manual_fields, per_page: Manual.max_numbers_of_manuals)
   end
 
   context "as a CMA Editor" do
@@ -70,7 +70,7 @@ RSpec.feature "Access control", type: :feature do
       publishing_api_has_item(manual_content_item_1)
       publishing_api_has_item(manual_content_item_2)
 
-      publishing_api_has_content([manual_content_item_1, manual_content_item_2], document_type: 'manual', fields: manual_fields, per_page: 10000)
+      publishing_api_has_content([manual_content_item_1, manual_content_item_2], document_type: 'manual', fields: manual_fields, per_page: Manual.max_numbers_of_manuals)
 
       [manual_links_1, manual_links_2].each do |link_set|
         publishing_api_has_links(link_set)

--- a/spec/features/creating_a_manual_spec.rb
+++ b/spec/features/creating_a_manual_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Creating a Manual", type: :feature do
     before do
       log_in_as_editor(:gds_editor)
       #make manual content items... before they just needed ids now needs other fields1
-      publishing_api_has_content([], document_type: "manual", fields: fields, per_page: 10000)
+      publishing_api_has_content([], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
 
       stub_publishing_api_put_content(test_content_id, {})
       stub_publishing_api_patch_links(test_content_id, {})

--- a/spec/features/editing_a_manual_spec.rb
+++ b/spec/features/editing_a_manual_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'editing a manual' do
 
   before do
     log_in_as_editor(:gds_editor)
-    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
     publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: [:content_id])
     stub_publishing_api_put_content(manual_content_item["content_id"], {})
     stub_publishing_api_patch_links(manual_content_item["content_id"], {})

--- a/spec/features/publishing_a_manual_spec.rb
+++ b/spec/features/publishing_a_manual_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "Publishing a Manual", type: :feature do
   let(:section_links) { Payloads.section_links }
   let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
   before do
-    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
-    publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: 10000)
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
+    publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: Manual.max_numbers_of_manuals)
 
     content_items = [manual_content_item] + section_content_items
 

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
   context 'when logged in as a GDS editor' do
     let(:fields) { %i(content_id base_path description details public_updated_at publication_state title update_type) }
     before do
-      publishing_api_has_content([], document_type: 'manual', fields: fields, per_page: 10000)
+      publishing_api_has_content([], document_type: 'manual', fields: fields, per_page: Manual.max_numbers_of_manuals)
       log_in_as_editor(:gds_editor)
     end
 

--- a/spec/features/viewing_a_manual_section_spec.rb
+++ b/spec/features/viewing_a_manual_section_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Viewing a Manual and its Sections", type: :feature do
     before do
       log_in_as_editor(:gds_editor)
 
-      publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
-      publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: 10000)
+      publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
+      publishing_api_has_content(section_content_items.map { |section| { content_id: section["content_id"] } }, document_type: "manual_section", fields: fields, per_page: Manual.max_numbers_of_manuals)
 
       content_items = [manual_content_item] + section_content_items
 

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Viewing a Manual", type: :feature do
   let(:fields) { %i[content_id description title details public_updated_at publication_state base_path update_type] }
 
   before do
-    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: 10000)
+    publishing_api_has_content([manual_content_item], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
     publishing_api_has_content(
       section_content_items.map do |section|
         {

--- a/spec/features/visiting_the_app_spec.rb
+++ b/spec/features/visiting_the_app_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Visiting the app", type: :feature do
 
   before do
     log_in_as_editor(:cma_editor)
-    publishing_api_has_content([], document_type: "manual", fields: fields, per_page: 10000)
+    publishing_api_has_content([], document_type: "manual", fields: fields, per_page: Manual.max_numbers_of_manuals)
   end
 
   scenario "visiting / should redirect to manuals" do

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -123,4 +123,8 @@ RSpec.describe Manual do
       assert_publishing_api_patch_links(manual.content_id, request_json_includes(expected_links_params))
     end
   end
+
+  it "should have max number per page set" do
+    expect(Manual.max_numbers_of_manuals).to eq(10)
+  end
 end


### PR DESCRIPTION
The root path redirects to manuals#index. However, this action makes a lot of api calls and currently times-out on integration, making product review quite troublesome.
Seeing that it is not in high priority to work on the manuals controller, this is a quick work around to lower the number of manuals loaded on the index page so to avoid the 504 errors from happening.

Alternative takes:
1. I've considered changing the root path so it redirects to a specialist-document endpoint. However, there isn't a document type that is open to all user (across different permissions), making it a bad choice as the root page.
1. Also, I attempted to create a stub-landing-page. This breaks some integration tests regarding what the index (root) page should display.
