### PR TITLE
Change create document wording

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="sidebar col-md-3">
-    <%= link_to "New #{current_format.title}", new_document_path(current_format.slug), class: 'action-link' %>
+    <%= link_to "Add another #{current_format.title}", new_document_path(current_format.slug), class: 'action-link' %>
     <%= form_tag(documents_path(current_format.slug), method: :get, class: "add-vertical-margins well") do %>
       <%= label_tag "query", "Search" %>
       <%= text_field_tag("query", params[:query], class: "form-control add-bottom-margin") %>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -25,6 +25,13 @@ RSpec.feature "Creating a CMA case", type: :feature do
     publishing_api_has_content([cma_case], hash_including(document_type: CmaCase.document_type))
     publishing_api_has_item(cma_case)
   end
+  scenario "getting to the new document page" do
+    visit "/cma-cases"
+    click_link "Add another CMA Case"
+
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/cma-cases/new")
+  end
 
   scenario "with valid data" do
     visit "/cma-cases/new"


### PR DESCRIPTION
Change "New <document format>" to "Add another <document format>"
[Trello](https://trello.com/c/QG8Y2e2k)

Previously ("New <document forma\t>")
<img width="528" alt="new_dsu" src="https://cloud.githubusercontent.com/assets/3989823/15507614/3fccc9a2-21c4-11e6-8326-226721852d05.png">

Change to  "Add another <document format>"
<img width="388" alt="add another dsu" src="https://cloud.githubusercontent.com/assets/3989823/15507621/475abb84-21c4-11e6-9291-c38e0ed639f9.png">
