### PR TITLE
Document#save! should raise an exception on failure

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -35,10 +35,11 @@ class DocumentsController < ApplicationController
     )
 
     if @document.valid?
-      if @document.save!
+      begin
+        @document.save!
         flash[:success] = "Created #{@document.title}"
         redirect_to document_path(current_format.slug, @document.content_id)
-      else
+      rescue Document::RecordNotSaved
         flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
         render :new
       end
@@ -60,10 +61,11 @@ class DocumentsController < ApplicationController
     end
 
     if @document.valid?
-      if @document.save!
+      begin
+        @document.save!
         flash[:success] = "Updated #{@document.title}"
         redirect_to document_path(current_format.slug, @document.content_id)
-      else
+      rescue Document::RecordNotSaved
         flash.now[:danger] = "There was an error updating #{@document.title}. Please try again later."
         render :edit
       end

--- a/app/models/attachment_uploader.rb
+++ b/app/models/attachment_uploader.rb
@@ -7,7 +7,8 @@ class AttachmentUploader
     attachment.url = file_url(attachment.file)
     add_attachment(document, attachment) unless attachment.changed?
     document.save!
-  rescue GdsApi::BaseError => e
+    true
+  rescue Document::RecordNotSaved => e
     Airbrake.notify(e)
     false
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -206,10 +206,12 @@ class Document
       presented_document = DocumentPresenter.new(self)
       presented_links = DocumentLinksPresenter.new(self)
 
-      handle_remote_error do
+      success = handle_remote_error do
         Services.publishing_api.put_content(self.content_id, presented_document.to_json)
         Services.publishing_api.patch_links(self.content_id, presented_links.to_json)
       end
+
+      raise RecordNotSaved unless success
     else
       raise RecordNotSaved
     end

--- a/spec/models/attachment_uploader_spec.rb
+++ b/spec/models/attachment_uploader_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe AttachmentUploader do
 
       context 'publisher raises an error' do
         before do
-          allow(service).to receive(:create_asset).and_raise(GdsApi::BaseError)
+          allow(service).to receive(:create_asset).and_raise(Document::RecordNotSaved)
         end
 
         it 'returns false' do
@@ -181,7 +181,7 @@ RSpec.describe AttachmentUploader do
 
       context 'publisher raises an error' do
         before do
-          allow(service).to receive(:create_asset).and_raise(GdsApi::BaseError)
+          allow(service).to receive(:create_asset).and_raise(Document::RecordNotSaved)
         end
 
         it 'returns false' do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -167,10 +167,16 @@ RSpec.describe Document do
       stub_any_publishing_api_patch_links
 
       c = MyDocumentType.find(payload["content_id"])
-      expect(c.save!).to eq(true)
+      c.save!
 
       expected_payload = saved_for_the_first_time(write_payload(payload.deep_stringify_keys))
       assert_publishing_api_put_content(c.content_id, expected_payload)
+    end
+
+    it "notifies Airbrake and raises an error if any of the Publishing API calls fail" do
+      expect(Airbrake).to receive(:notify)
+      publishing_api_isnt_available
+      expect { document.save! }.to raise_error(Document::RecordNotSaved)
     end
   end
 

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DrugSafetyUpdate do
       )
 
       c = described_class.find(drug_safety_update["content_id"])
-      expect(c.save!).to eq(true)
+      c.save!
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(drug_safety_update))
       expect(drug_safety_update.to_json).to be_valid_against_schema('specialist_document')

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "it saves payloads that are valid against the 'specialist_
       stub_any_publishing_api_patch_links
 
       instance = described_class.find(payload["content_id"])
-      expect(instance.save!).to eq(true)
+      instance.save!
 
       expected_payload_sent_to_publishing_api = saved_for_the_first_time(write_payload(payload))
 


### PR DESCRIPTION
(this is a fix for an issue raised by @rgarner on [another PR](https://github.com/alphagov/specialist-publisher-rebuild/pull/766#discussion_r64013689))

Prior to this fix, the `save!` method didn't raise an exception
if there was a failure from one of the remote calls. This is a bit misleading
because it breaks the ActiveRecord convention around bang methods ie `method!`
usually raises exceptions on failure, whereas `method` returns false
on failure.

I've not added a specific message to the exception in `save!` because this code will be revisited shortly (for the offloading of remote calls onto a queue).
