### PR TITLE
Send organisation links to publishing api

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,10 +1,11 @@
 class SpecialistDocumentPublishingAPIFormatter
-  attr_reader :specialist_document, :specialist_document_renderer, :publication_logs
+  attr_reader :specialist_document, :specialist_document_renderer, :publication_logs, :links
 
-  def initialize(specialist_document, specialist_document_renderer:, publication_logs:)
+  def initialize(specialist_document, specialist_document_renderer:, publication_logs:, links: links)
     @specialist_document = specialist_document
     @specialist_document_renderer = specialist_document_renderer
     @publication_logs = publication_logs
+    @links = links
   end
 
   def call
@@ -24,6 +25,7 @@ class SpecialistDocumentPublishingAPIFormatter
         path: base_path,
         type: "exact"
       ],
+      links: links
     }.merge(access_limited)
   end
 

--- a/app/lib/specialist_publisher.rb
+++ b/app/lib/specialist_publisher.rb
@@ -42,6 +42,54 @@ private
     "vehicle_recalls_and_faults_alert" => VehicleRecallsAndFaultsAlertObserversRegistry,
   }.freeze
 
+  ORGANISATIONS = {
+    "aaib_report" => %w(
+      38eb5d8f-2d89-480c-8655-e2e7ac23f8f4
+    ), # air-accidents-investigation-branch
+    "asylum_support_decision" => %w(
+      7141e343-e7bb-483b-920a-c6a5cf8f758c
+    ), # first-tier-tribunal-asylum-support
+    "cma_case" => %w(
+      957eb4ec-089b-4f71-ba2a-dc69ac8919ea
+    ), # competition-and-markets-authority
+    "countryside_stewardship_grant" => %w(
+      8bf5624b-dec2-44fa-9b6c-daed166333a5
+      de4e9dc6-cca4-43af-a594-682023b84d6c
+      d3ce4ba7-bc75-46b4-89d9-38cb3240376d
+    ), # natural-england, department-for-environment-food-rural-affairs, forestry-commission
+    "drug_safety_update" => %w(
+      240f72bd-9a4d-4f39-94d9-77235cadde8e
+    ), # medicines-and-healthcare-products-regulatory-agency
+    "employment_appeal_tribunal_decision" => %w(
+      caeb418c-d11c-4352-92e9-47b21289f696
+    ), # employment-appeal-tribunal
+    "employment_tribunal_decision" => %w(
+      8bb37087-a5a7-4493-8afe-900b36ebc927
+    ), # employment-tribunal
+    "esi_fund" => %w(), # none
+    "international_development_fund" => %w(
+      db994552-7644-404d-a770-a2fe659c661f
+    ), # department-for-international-development
+    "maib_report" => %w(
+      9c66b9a3-1e6a-48e8-974d-2a5635f84679
+    ), # marine-accident-investigation-branch
+    "medical_safety_alert" => %w(
+      240f72bd-9a4d-4f39-94d9-77235cadde8e
+    ), # medicines-and-healthcare-products-regulatory-agency
+    "raib_report" => %w(
+      013872d8-8bbb-4e80-9b79-45c7c5cf9177
+    ), # rail-accident-investigation-branch
+    "tax_tribunal_decision" => %w(
+      1a68b2cc-eb52-4528-8989-429f710da00f
+    ), # upper-tribunal-tax-and-chancery-chamber
+    "utaac_decision" => %w(
+      4c2e325a-2d95-442b-856a-e7fb9f9e3cf8
+    ), # upper-tribunal-administrative-appeals-chamber
+    "vehicle_recalls_and_faults_alert" => %w(
+      d39237a5-678b-4bb5-a372-eb2cb036933d
+    ), # driver-and-vehicle-standards-agency
+  }
+
   def view_adapters
     SpecialistPublisherWiring.get(:view_adapter_registry)
   end
@@ -51,6 +99,6 @@ private
   end
 
   def observer_registry(document_type)
-    OBSERVER_MAP.fetch(document_type).new
+    OBSERVER_MAP.fetch(document_type).new(ORGANISATIONS.fetch(document_type, []))
   end
 end

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -4,6 +4,10 @@ require "publishing_api_withdrawer"
 require "formatters/specialist_document_publishing_api_formatter"
 
 class AbstractSpecialistDocumentObserversRegistry
+  def initialize(organisation_content_ids)
+    @organisation_content_ids = organisation_content_ids
+  end
+
   def creation
     [
       publishing_api_exporter,
@@ -46,12 +50,15 @@ class AbstractSpecialistDocumentObserversRegistry
   end
 
 private
+  attr_reader :organisation_content_ids
+
   def publishing_api_exporter
     ->(document) {
       rendered_document = SpecialistDocumentPublishingAPIFormatter.new(
         document,
         specialist_document_renderer: SpecialistPublisherWiring.get(:specialist_document_renderer),
-        publication_logs: PublicationLog
+        publication_logs: PublicationLog,
+        links: format_links_for_publishing_api(document)
       )
 
       SpecialistDocumentPublishingAPIExporter.new(
@@ -89,6 +96,12 @@ private
 
   def format_document_for_indexing(document)
     raise NotImplementedError
+  end
+
+  def format_links_for_publishing_api(document)
+    {
+      organisations: organisation_content_ids
+    }
   end
 
   def email_alert_api

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
     described_class.new(
       document,
       specialist_document_renderer: specialist_document_renderer,
-      publication_logs: publication_logs
+      publication_logs: publication_logs,
+      links: { "organisations" => ["0aa1aa33-36b9-4677-a643-52b9034a1c33"] }
     )
   }
 
@@ -105,6 +106,10 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
         "created_at" => "2015-02-11T13:45:00.000+00:00",
         "content_type" => "application/jpg",
        }])
+    end
+
+    it "should include a links hash" do
+      expect(presented).to include("links")
     end
 
     context "with a body containing some govspeak" do

--- a/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
+++ b/spec/exporters/specialist_document_publishing_api_exporter_spec.rb
@@ -21,7 +21,8 @@ describe SpecialistDocumentPublishingAPIExporter do
       update_type: "major",
       locale: "en",
       public_updated_at: Time.now,
-      details: {}
+      details: {},
+      links: {"organisations" => ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"]}
     }
   }
 

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe "Republishing documents", type: :feature do
                 "max_cache_time" => 10,
       },
       routes: [{"path" => "/" + @document.slug,
-                "type" => "exact"}]
+                "type" => "exact"}],
+      links: {
+        "organisations" => ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"]
+      }
     }
   end
 


### PR DESCRIPTION
Each type of specialist document has a fixed list of organisations associated with
it. We pass these to rummager already, but not publishing api.

https://trello.com/c/oqjOp8jd/639-specialist-publisher-documents-don-t-have-organisations-in-the-publishing-api