### PR TITLE
Display publishing alerts

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -48,7 +48,9 @@ class DocumentsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @publish_warning = PublishWarningPresenter.new.publish_warning(@document).html_safe
+  end
 
   def edit; end
 

--- a/app/presenters/publish_warning_presenter.rb
+++ b/app/presenters/publish_warning_presenter.rb
@@ -1,0 +1,12 @@
+class PublishWarningPresenter
+  def publish_warning(document)
+    if document.update_type == 'minor'
+      '<p>You are about to publish a <strong>minor edit</strong>.</p>'
+    elsif document.update_type == 'major' && document.redrafted?
+      '<strong>You are about to publish a major edit with a public change note.</strong>
+      <p>Publishing will email subscribers to ' + document.class.title.pluralize + '.</p>'
+    else
+      '<p>Publishing will email subscribers to ' + document.class.title.pluralize + '.</p>'
+    end
+  end
+end

--- a/app/views/documents/_publish_panel.html.erb
+++ b/app/views/documents/_publish_panel.html.erb
@@ -8,6 +8,7 @@
         You don’t have permission to publish this document.
       </p>
     <% elsif @document.can_be_published? %>
+      <%= @publish_warning %>
       <%= form_tag(publish_document_path(current_format.slug, @document.content_id), method: :post) do %>
         <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Publishing will email subscribers to <%= current_format.title.pluralize %> Continue?">Publish</button>
       <% end %>


### PR DESCRIPTION
[Trello](https://trello.com/c/LllK2XSl/133-publishing-major-minor-warning-small)
Publishing text alerts now match those that display in V1 specialist-publisher.
- When a document is publishable, text will appear above the publish button to inform the user that email alerts will be sent out to subscribers of that specific format
- When the document `update_type` is major the appropriate message will appear above the publish button
- When the document `update_type` is minor the appropriate message will appear above the publish button

How v2 publishing text alerts looked before this PR (aka there were none):

![v2-before-changes](https://cloud.githubusercontent.com/assets/5963488/15570742/7af9b0dc-232f-11e6-865c-844cf05bddb9.png)

This is what the publishing warnings look like in specialist-publisher v1.

v1 - Before publish:

![v1-first-published](https://cloud.githubusercontent.com/assets/5963488/15570767/9907d5a4-232f-11e6-8283-693099de93c8.png)

v1 - minor update

![v1-minor-update](https://cloud.githubusercontent.com/assets/5963488/15570776/a5566b04-232f-11e6-8bd9-51ced47c5382.png)

v1 - major update

<img width="777" alt="v1-major-edit" src="https://cloud.githubusercontent.com/assets/5963488/15570786/b0b7ddca-232f-11e6-99ae-21717be51126.png">

This is what the publish warnings looks like in v2 as a result of the changes in this PR:

v2 - before publish

<img width="795" alt="v2-first-published" src="https://cloud.githubusercontent.com/assets/5963488/15570794/bc57f85e-232f-11e6-8003-e52bbebec119.png">

v2 - minor update

<img width="813" alt="v2-minor-update" src="https://cloud.githubusercontent.com/assets/5963488/15570797/c4782144-232f-11e6-8f0d-88d22ee7cfb6.png">

v2 - major update

<img width="802" alt="v2-major-update" src="https://cloud.githubusercontent.com/assets/5963488/15570807/ce832d82-232f-11e6-84f9-82be414c0148.png">
