### PR TITLE
Remove first published at

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,7 +3,7 @@ class Document
   include ActiveModel::Validations
   include PublishingHelper
 
-  attr_accessor :content_id, :base_path, :title, :summary, :body, :format_specific_fields, :public_updated_at, :state, :bulk_published, :publication_state, :change_note, :document_type, :attachments
+  attr_accessor :content_id, :base_path, :title, :summary, :body, :format_specific_fields, :public_updated_at, :state, :bulk_published, :publication_state, :change_note, :document_type, :attachments, :first_published_at
 
   attr_writer :change_history, :update_type
 
@@ -19,6 +19,7 @@ class Document
     :body,
     :publication_state,
     :public_updated_at,
+    :first_published_at,
   ]
 
   def self.policy_class
@@ -136,7 +137,8 @@ class Document
       summary: payload['description'],
       body: extract_body_from_payload(payload),
       publication_state: payload['publication_state'],
-      public_updated_at: payload['public_updated_at']
+      public_updated_at: payload['public_updated_at'],
+      first_published_at: payload['first_published_at'],
     )
 
     document.base_path = payload['base_path']

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -220,11 +220,13 @@ class Document
   class RecordNotSaved < StandardError; end
 
   def publish!
-    indexable_document = SearchPresenter.new(self)
-
     handle_remote_error do
       update_type = self.update_type || 'major'
       Services.publishing_api.publish(content_id, update_type)
+
+      published_document = self.class.find(self.content_id)
+      indexable_document = SearchPresenter.new(published_document)
+
       Services.rummager.add_document(
         search_document_type,
         base_path,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -233,7 +233,7 @@ class Document
         indexable_document.to_json,
       )
 
-      if self.update_type == "major"
+      if send_email_on_publish?
         Services.email_alert_api.send_alert(EmailAlertPresenter.new(self).to_json)
       end
     end
@@ -249,6 +249,10 @@ class Document
 
   def can_be_published?
     !live?
+  end
+
+  def send_email_on_publish?
+    update_type == "major"
   end
 
 private

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -9,22 +9,11 @@ class DrugSafetyUpdate < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
-  def publish!
-    indexable_document = SearchPresenter.new(self)
-
-    handle_remote_error do
-      update_type = self.update_type || 'major'
-
-      Services.publishing_api.publish(content_id, update_type)
-      Services.rummager.add_document(
-        search_document_type,
-        base_path,
-        indexable_document.to_json,
-      )
-    end
-  end
-
   def self.title
     "Drug Safety Update"
+  end
+
+  def send_email_on_publish?
+    false
   end
 end

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -1,7 +1,6 @@
 class DrugSafetyUpdate < Document
   FORMAT_SPECIFIC_FIELDS = [
     :therapeutic_area,
-    :first_published_at,
   ]
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
@@ -16,8 +15,6 @@ class DrugSafetyUpdate < Document
     handle_remote_error do
       update_type = self.update_type || 'major'
 
-      save_first_published_at if not_published?
-
       Services.publishing_api.publish(content_id, update_type)
       Services.rummager.add_document(
         search_document_type,
@@ -29,14 +26,5 @@ class DrugSafetyUpdate < Document
 
   def self.title
     "Drug Safety Update"
-  end
-
-private
-
-  def save_first_published_at
-    self.first_published_at = Time.zone.now
-    presented_document = DocumentPresenter.new(self).to_json
-
-    Services.publishing_api.put_content(self.content_id, presented_document)
   end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -63,17 +63,17 @@ private
   end
 
   def metadata
-    merged_fields = document.format_specific_fields.map { |f|
-      {
-        f => document.send(f)
-      }
-    }.reduce({}, :merge)
-      .merge(
-        document_type: document.document_type,
-        bulk_published: document.bulk_published,
-      )
+    fields = document.format_specific_fields
+    metadata = fields.each_with_object({}) do |field, hash|
+      hash[field] = document.public_send(field)
+    end
 
-    merged_fields.reject { |_k, v| v.blank? }
+    metadata.merge!(
+      document_type: document.document_type,
+      bulk_published: document.bulk_published,
+    )
+
+    metadata.reject { |_k, v| v.blank? }
   end
 
   def public_updated_at

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -12,6 +12,7 @@ class SearchPresenter
       link: document.base_path,
       indexable_content: indexable_content,
       public_timestamp: document.public_updated_at.to_datetime.rfc3339,
+      first_published_at: document.first_published_at.to_datetime.rfc3339,
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }
   end
 

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     click_button "Save as draft"
 
     cma_case.delete("updated_at")
+    cma_case.delete("first_published_at")
     assert_publishing_api_put_content(content_id, request_json_includes(cma_case))
 
     expect(page.status_code).to eq(200)

--- a/spec/features/editing_a_draft_cma_case_spec.rb
+++ b/spec/features/editing_a_draft_cma_case_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature "Editing a draft CMA case", type: :feature do
 
     @changed_json.delete("publication_state")
     @changed_json.delete("updated_at")
+    @changed_json.delete("first_published_at")
     Timecop.freeze(Time.parse("2015-12-03T16:59:13+00:00"))
 
     stub_request(:post, "#{Plek.find('asset-manager')}/assets")

--- a/spec/features/editing_a_published_cma_case_spec.rb
+++ b/spec/features/editing_a_published_cma_case_spec.rb
@@ -67,6 +67,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     changed_json.delete("publication_state")
     changed_json.delete("updated_at")
+    changed_json.delete("first_published_at")
 
     visit "/cma-cases/#{content_id}"
 
@@ -106,6 +107,7 @@ RSpec.feature "Editing a published CMA case", type: :feature do
 
     changed_json.delete("publication_state")
     changed_json.delete("updated_at")
+    changed_json.delete("first_published_at")
 
     visit "/cma-cases/#{content_id}"
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -57,6 +57,7 @@ FactoryGirl.define do
     redirects []
     update_type "major"
     public_updated_at "2015-11-16T11:53:30+00:00"
+    first_published_at "2015-11-15T00:00:00"
     updated_at "2015-11-15T11:53:30"
     publication_state "draft"
     routes {

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Document do
         "indexable_content" => "Header " + (["This is the long body of an example document"] * 10).join(" "),
         "link" => "/my-document-types/example-document",
         "public_timestamp" => "2015-11-16T11:53:30+00:00",
+        "first_published_at" => "2015-11-15T00:00:00+00:00",
         "field1" => "2015-12-01",
         "field2" => "open",
       )

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Document do
   context "successful #publish!" do
     before do
       stub_publishing_api_publish(document.content_id, {})
+      publishing_api_has_item(payload)
       stub_any_rummager_post_with_queueing_enabled
       @email_alert_api = email_alert_api_accepts_alert
     end
@@ -139,6 +140,24 @@ RSpec.describe Document do
 
       expect(@email_alert_api).to_not have_been_requested
     end
+
+    context "document has never been published" do
+      let(:unpublished_document) { MyDocumentType.from_publishing_api(payload.except("first_published_at")) }
+
+      it 'sends first_published_at to Rummager' do
+        unpublished_document.publish!
+        assert_rummager_posted_item(
+          "title" => "Example document",
+          "description" => "This is a summary",
+          "indexable_content" => "Header " + (["This is the long body of an example document"] * 10).join(" "),
+          "link" => "/my-document-types/example-document",
+          "public_timestamp" => "2015-11-16T11:53:30+00:00",
+          "first_published_at" => "2015-11-15T00:00:00+00:00",
+          "field1" => "2015-12-01",
+          "field2" => "open",
+        )
+      end
+    end
   end
 
   context "unsuccessful #publish!" do
@@ -152,6 +171,7 @@ RSpec.describe Document do
     it "notifies Airbrake and returns false if rummager does not return status 200" do
       expect(Airbrake).to receive(:notify)
       stub_publishing_api_publish(document.content_id, {})
+      publishing_api_has_item(payload)
       stub_request(:post, %r{#{Plek.new.find('search')}/documents}).to_return(status: 503)
       expect(document.publish!).to eq(false)
     end

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe DrugSafetyUpdate do
       drug_safety_update_content_item(0).deep_merge(
         "details" => {
           "metadata" => {
-            "first_published_at": "2015-12-18T10:12:26.000+00:00",
             "document_type": "drug_safety_update"
           }
         },
@@ -114,41 +113,6 @@ RSpec.describe DrugSafetyUpdate do
       stub_publishing_api_publish(drug_safety_updates[0]["content_id"], {})
       stub_request(:post, %r{#{Plek.new.find('search')}/documents}).to_return(status: 503)
       expect(drug_safety_update.publish!).to eq(false)
-    end
-
-    context "for the first time" do
-      it "sets first_published_at" do
-        payload = unpublished_drug_safety_update_content_item
-
-        stub_publishing_api_publish(payload["content_id"], {})
-
-        drug_safety_update = described_class.find(payload["content_id"])
-        expect(drug_safety_update.publish!).to eq(true)
-
-        expected_details_payload = payload["details"]
-        expected_details_payload["metadata"].merge!(
-          "first_published_at" => "2015-12-18T10:12:26.000+00:00"
-        )
-
-        assert_publishing_api_put_content(
-          drug_safety_update.content_id,
-          request_json_includes("details": expected_details_payload)
-        )
-      end
-    end
-
-    context "an already published drug safety update" do
-      it "does not update first_published_at" do
-        payload = published_drug_safety_update_content_item
-
-        stub_publishing_api_publish(payload["content_id"], {})
-
-        drug_safety_update = described_class.find(payload["content_id"])
-        expect(drug_safety_update.publish!).to eq(true)
-
-        assert_not_requested(:put, "#{Plek.current.find('publishing-api')}/v2/content/#{payload['content_id']}")
-        assert_publishing_api_publish(drug_safety_update.content_id)
-      end
     end
   end
 end

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe DrugSafetyUpdate do
 
       drug_safety_update.delete("publication_state")
       drug_safety_update.delete("updated_at")
+      drug_safety_update.delete("first_published_at")
       drug_safety_update.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
       drug_safety_update["details"].merge!(
         "change_history" => [

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -114,4 +114,40 @@ RSpec.describe DocumentPresenter do
       expect(presented_data).to be_valid_against_schema("specialist_document")
     end
   end
+
+  describe '#to_json with format_specific_fields' do
+    let(:payload) {
+      FactoryGirl.create(:cma_case,
+        details: {
+          metadata: {
+            case_state: "open",
+            case_type: "ca98-and-civil-cartels",
+            outcome_type: "",
+            bulk_published: true,
+          }
+        })
+    }
+
+    let(:metadata) { presented_data[:details][:metadata] }
+
+    it 'returns the format specific fields in the details.metadata' do
+      expect(metadata).to include(
+        case_state: "open",
+        case_type: "ca98-and-civil-cartels",
+      )
+    end
+
+    it 'does not return fields that are blank' do
+      expect(metadata).not_to include(
+        :outcome_type
+      )
+    end
+
+    it 'returns document_type and bulk_published in details metadata' do
+      expect(metadata).to include(
+        document_type: "cma_case",
+        bulk_published: true,
+      )
+    end
+  end
 end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchPresenter do
         summary:                  'A summary',
         base_path:                '/some-finder/a-title',
         public_updated_at:        Time.now,
+        first_published_at:       Time.now,
         body:                     '## A Title',
         format_specific_metadata: { country: ['GB'], blank_value: '' }
       )

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -12,6 +12,7 @@ module Payloads
       "locale" => "en",
       "phase" => "live",
       "public_updated_at" => "2015-12-03T16:59:13+00:00",
+      "first_published_at" => "2015-11-15T00:00:00+00:00",
       "updated_at" => "2015-12-02T16:59:13+00:00",
       "details" => {
         "body" => [
@@ -68,6 +69,7 @@ module Payloads
       "locale" => "en",
       "phase" => "live",
       "public_updated_at" => "2015-11-16T11:53:30+00:00",
+      "first_published_at" => "2015-11-15T00:00:00+00:00",
       "updated_at" => "2015-11-15T11:53:30+00:00",
       "publication_state" => "draft",
       "details" => {

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -2,6 +2,7 @@ module PublishingApiHelpers
   def write_payload(document)
     document.delete("updated_at")
     document.delete("publication_state")
+    document.delete("first_published_at")
     document
   end
 


### PR DESCRIPTION
Remove logic in DrugSafetyUpdate#publish! to save `first_published_at` on publish, because this is duplicating a behaviour in _publishing-api_.
[Trello](https://trello.com/c/NECj21MU/124-handle-first-publication-date-logic-through-the-publishing-api-medium)

This PR is only part of the story, as it involves changes in SPv1 and a migration for publishing-api.
mob: @tuzz, @issyl0, @Rosa-Fox, and myself.
