### PR TITLE
Rename Document#save! to Document#save

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -35,7 +35,7 @@ class DocumentsController < ApplicationController
     )
 
     if @document.valid?
-      if @document.save!
+      if @document.save
         flash[:success] = "Created #{@document.title}"
         redirect_to document_path(current_format.slug, @document.content_id)
       else
@@ -60,7 +60,7 @@ class DocumentsController < ApplicationController
     end
 
     if @document.valid?
-      if @document.save!
+      if @document.save
         flash[:success] = "Updated #{@document.title}"
         redirect_to document_path(current_format.slug, @document.content_id)
       else

--- a/app/models/attachment_uploader.rb
+++ b/app/models/attachment_uploader.rb
@@ -6,7 +6,7 @@ class AttachmentUploader
   def upload(attachment, document)
     attachment.url = file_url(attachment.file)
     add_attachment(document, attachment) unless attachment.changed?
-    document.save!
+    document.save
   rescue GdsApi::BaseError => e
     Airbrake.notify(e)
     false

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -201,7 +201,7 @@ class Document
 
   class RecordNotFound < StandardError; end
 
-  def save!
+  def save
     if self.valid?
       self.public_updated_at = Time.zone.now if self.update_type == 'major'
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -202,22 +202,18 @@ class Document
   class RecordNotFound < StandardError; end
 
   def save
-    if self.valid?
-      self.public_updated_at = Time.zone.now if self.update_type == 'major'
+    return false unless self.valid?
 
-      presented_document = DocumentPresenter.new(self)
-      presented_links = DocumentLinksPresenter.new(self)
+    self.public_updated_at = Time.zone.now if self.update_type == 'major'
 
-      handle_remote_error do
-        Services.publishing_api.put_content(self.content_id, presented_document.to_json)
-        Services.publishing_api.patch_links(self.content_id, presented_links.to_json)
-      end
-    else
-      raise RecordNotSaved
+    presented_document = DocumentPresenter.new(self)
+    presented_links = DocumentLinksPresenter.new(self)
+
+    handle_remote_error do
+      Services.publishing_api.put_content(self.content_id, presented_document.to_json)
+      Services.publishing_api.patch_links(self.content_id, presented_links.to_json)
     end
   end
-
-  class RecordNotSaved < StandardError; end
 
   def publish!
     handle_remote_error do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -193,6 +193,21 @@ RSpec.describe Document do
       expected_payload = saved_for_the_first_time(write_payload(payload.deep_stringify_keys))
       assert_publishing_api_put_content(c.content_id, expected_payload)
     end
+
+    it "returns false without making any Publishing API calls if the document is invalid" do
+      stub = stub_any_publishing_api_call
+
+      document.title = nil # this is an invalid title
+      expect(document).to_not be_valid
+
+      expect(document.save).to be_falsey
+      expect(stub).to_not have_been_requested
+    end
+
+    it "returns false if the Publishing API calls fail" do
+      publishing_api_isnt_available
+      expect(document.save).to be_falsey
+    end
   end
 
   describe ".find" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Document do
     end
   end
 
-  describe "#save!" do
+  describe "#save" do
     before do
       publishing_api_has_item(payload)
       Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
@@ -188,7 +188,7 @@ RSpec.describe Document do
       stub_any_publishing_api_patch_links
 
       c = MyDocumentType.find(payload["content_id"])
-      expect(c.save!).to eq(true)
+      expect(c.save).to eq(true)
 
       expected_payload = saved_for_the_first_time(write_payload(payload.deep_stringify_keys))
       assert_publishing_api_put_content(c.content_id, expected_payload)

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DrugSafetyUpdate do
     Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
   end
 
-  describe "#save!" do
+  describe "#save" do
     it "saves the Drug Safety Update" do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
@@ -56,7 +56,7 @@ RSpec.describe DrugSafetyUpdate do
       )
 
       c = described_class.find(drug_safety_update["content_id"])
-      expect(c.save!).to eq(true)
+      expect(c.save).to eq(true)
 
       assert_publishing_api_put_content(c.content_id, request_json_includes(drug_safety_update))
       expect(drug_safety_update.to_json).to be_valid_against_schema('specialist_document')

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples "it saves payloads that are valid against the 'specialist_document' schema" do
-  describe "#save!" do
+  describe "#save" do
     it "saves a valid document" do
       publishing_api_has_item(payload)
       Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
@@ -7,7 +7,7 @@ RSpec.shared_examples "it saves payloads that are valid against the 'specialist_
       stub_any_publishing_api_patch_links
 
       instance = described_class.find(payload["content_id"])
-      expect(instance.save!).to eq(true)
+      expect(instance.save).to eq(true)
 
       expected_payload_sent_to_publishing_api = saved_for_the_first_time(write_payload(payload))
 


### PR DESCRIPTION
Currently, the save method on Document is a weird mix of returning true/false and raising exceptions. This PR makes it behave like ActiveRecord's `save` and adds some missing specs.
