### PR TITLE
Use an update_type of ‘republish’ when republishing

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -1,11 +1,12 @@
 class SpecialistDocumentPublishingAPIFormatter
   attr_reader :specialist_document, :specialist_document_renderer, :publication_logs, :links
 
-  def initialize(specialist_document, specialist_document_renderer:, publication_logs:, links: links)
+  def initialize(specialist_document, specialist_document_renderer:, publication_logs:, links: links, update_type:)
     @specialist_document = specialist_document
     @specialist_document_renderer = specialist_document_renderer
     @publication_logs = publication_logs
     @links = links
+    @update_type = update_type
   end
 
   def call
@@ -91,7 +92,11 @@ class SpecialistDocumentPublishingAPIFormatter
   end
 
   def update_type
-    specialist_document.minor_update? ? "minor" : "major"
+    if @update_type
+      @update_type
+    else
+      specialist_document.minor_update? ? "minor" : "major"
+    end
   end
 
   def change_history

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -53,12 +53,13 @@ private
   attr_reader :organisation_content_ids
 
   def publishing_api_exporter
-    ->(document) {
+    ->(document, update_type = nil) {
       rendered_document = SpecialistDocumentPublishingAPIFormatter.new(
         document,
         specialist_document_renderer: SpecialistPublisherWiring.get(:specialist_document_renderer),
         publication_logs: PublicationLog,
-        links: format_links_for_publishing_api(document)
+        links: format_links_for_publishing_api(document),
+        update_type: update_type
       )
 
       SpecialistDocumentPublishingAPIExporter.new(
@@ -79,7 +80,7 @@ private
   end
 
   def rummager_exporter
-    ->(document) {
+    ->(document, _ = nil) {
       RummagerIndexer.new.add(
         format_document_for_indexing(document)
       )

--- a/app/services/republish_document_service.rb
+++ b/app/services/republish_document_service.rb
@@ -20,7 +20,7 @@ private
   attr_reader :document_repository, :published_listeners, :draft_listeners, :document_id
 
   def notify_listeners(listeners)
-    listeners.each { |l| l.call(document) }
+    listeners.each { |l| l.call(document, "republish") }
   end
 
   def notify_draft_listeners

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -14,9 +14,12 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
       document,
       specialist_document_renderer: specialist_document_renderer,
       publication_logs: publication_logs,
-      links: { "organisations" => ["0aa1aa33-36b9-4677-a643-52b9034a1c33"] }
+      links: { "organisations" => ["0aa1aa33-36b9-4677-a643-52b9034a1c33"] },
+      update_type: update_type,
     )
   }
+
+  let(:update_type) { nil }
 
   let(:publication_logs) { class_double("PublicationLog", change_notes_for: [publication_log]) }
 
@@ -210,6 +213,14 @@ END_OF_GOVSPEAK
 
       it "includes uids of departmental editors and GDS editors" do
         expect(presented["access_limited"]["users"]).to eq([cma_editor.uid, gds_editor.uid])
+      end
+    end
+
+    context "with a specified update_type" do
+      let(:update_type) { "republish" }
+
+      it "includes the specified update_type" do
+        expect(presented["update_type"]).to eq("republish")
       end
     end
   end

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Republishing documents", type: :feature do
       rendering_app: "specialist-frontend",
       title: @document.title,
       description: @document.summary,
-      update_type: "major",
+      update_type: "republish",
       locale: "en",
       public_updated_at: "2016-05-11T10:56:07+00:00",
       details: {"metadata" => {"opened_date" => "2013-04-20", # These nested hashes use Strings as keys because Symbols gives a false negative in the request_json_matching matcher.


### PR DESCRIPTION
When the Publishing API processes publish
requests, some of its behaviour differs when
republishing. For example, the public_updated_at
field is not affected if the update_type is
‘republish’.

This change makes it so that when we call the
bin/republish_documents script, it uses the
‘republish’ update_type.