### PR TITLE
Simplify the drug safety update spec

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -164,6 +164,19 @@ FactoryGirl.define do
     end
   end
 
+  factory :drug_safety_update, parent: :document do
+    base_path "/drug-safety-update/example-drug-safety-update"
+    document_type "drug_safety_update"
+
+    transient do
+      default_metadata {
+        {
+          "document_type" => "drug_safety_update",
+        }
+      }
+    end
+  end
+
   factory :employment_appeal_tribunal_decision, parent: :document do
     base_path "/employment-appeal-tribunal-decisions/example-employment-appeal-tribunal-decision"
     document_type "employment_appeal_tribunal_decision"

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -1,119 +1,27 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe DrugSafetyUpdate do
-  def drug_safety_update_content_item(n)
-    Payloads.drug_safety_update_content_item(
-      "base_path" => "/drug-safety-update/example-drug-safety-update-#{n}",
-      "title" => "Example Drug Safety Update #{n}",
-      "description" => "This is the summary of an example Drug Safety Update #{n}",
-      "routes" => [
-        {
-          "path" => "/drug-safety-update/example-drug-safety-update-#{n}",
-          "type" => "exact",
-        }
-      ]
-    )
-  end
+  let(:payload) { FactoryGirl.create(:drug_safety_update) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
-  let(:indexable_attributes) {
-    {
-      "title" => "Example Drug Safety Update 0",
-      "description" => "This is the summary of an example Drug Safety Update 0",
-      "link" => "/drug-safety-update/example-drug-safety-update-0",
-      "indexable_content" => "Header " + (["This is the long body of an example Drug Safety Update"] * 10).join(" "),
-      "public_timestamp" => "2015-11-16T11:53:30+00:00",
+  context "#publish!" do
+    let(:payload) {
+      FactoryGirl.create(:drug_safety_update,
+        update_type: "major",
+        publication_state: "draft")
     }
-  }
+    let(:document) { described_class.from_publishing_api(payload) }
 
-  let(:drug_safety_updates) { 10.times.map { |n| drug_safety_update_content_item(n) } }
-
-  before do
-    drug_safety_updates.each do |drug_safety_update|
-      publishing_api_has_item(drug_safety_update)
-    end
-
-    Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
-  end
-
-  describe "#save" do
-    it "saves the Drug Safety Update" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      drug_safety_update = drug_safety_updates[0]
-
-      drug_safety_update.delete("publication_state")
-      drug_safety_update.delete("updated_at")
-      drug_safety_update.delete("first_published_at")
-      drug_safety_update.merge!("public_updated_at" => "2015-12-18T10:12:26+00:00")
-      drug_safety_update["details"].merge!(
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-12-18T10:12:26+00:00",
-            "note" => "First published.",
-          }
-        ]
-      )
-
-      c = described_class.find(drug_safety_update["content_id"])
-      expect(c.save).to eq(true)
-
-      assert_publishing_api_put_content(c.content_id, request_json_includes(drug_safety_update))
-      expect(drug_safety_update.to_json).to be_valid_against_schema('specialist_document')
-    end
-  end
-
-  describe "#publish!" do
-    let(:unpublished_drug_safety_update_content_item) { drug_safety_update_content_item(0) }
-    let(:published_drug_safety_update_content_item) {
-      drug_safety_update_content_item(0).deep_merge(
-        "details" => {
-          "metadata" => {
-            "document_type": "drug_safety_update"
-          }
-        },
-        "publication_state" => "live"
-      )
-    }
-
-    before do
-      email_alert_api_accepts_alert
-      allow(Time.zone).to receive(:now).and_return(Time.parse("2015-12-18T10:12:26.000+00:00"))
-      stub_any_rummager_post_with_queueing_enabled
-      stub_any_publishing_api_put_content
-
-      publishing_api_has_item(unpublished_drug_safety_update_content_item)
-      publishing_api_has_item(published_drug_safety_update_content_item)
-    end
-
-    let(:drug_safety_update) { described_class.find(drug_safety_updates[0]["content_id"]) }
-
-    it "publishes the Drug Safety Update" do
-      payload = unpublished_drug_safety_update_content_item
-
+    it "doesn't notify the Email Alert API on major updates" do
+      publishing_api_has_item(payload)
       stub_publishing_api_publish(payload["content_id"], {})
-
-      drug_safety_update = described_class.find(payload["content_id"])
-
-      expect(drug_safety_update.publish!).to eq(true)
-
-      assert_publishing_api_publish(drug_safety_update.content_id)
-      assert_rummager_posted_item(indexable_attributes)
-      assert_not_requested(:post, Plek.current.find('email-alert-api') + "/notifications")
-    end
-
-    it "notifies Airbrake and returns false if publishing-api does not return status 200" do
-      expect(Airbrake).to receive(:notify)
-      stub_publishing_api_publish(drug_safety_updates[0]["content_id"], {}, status: 503)
       stub_any_rummager_post_with_queueing_enabled
-      expect(drug_safety_update.publish!).to eq(false)
-    end
 
-    it "notifies Airbrake and returns false if rummager does not return status 200" do
-      expect(Airbrake).to receive(:notify)
-      stub_publishing_api_publish(drug_safety_updates[0]["content_id"], {})
-      stub_request(:post, %r{#{Plek.new.find('search')}/documents}).to_return(status: 503)
-      expect(drug_safety_update.publish!).to eq(false)
+      document.publish!
+
+      assert_publishing_api_publish(payload["content_id"])
+      assert_not_requested(:post, Plek.current.find('email-alert-api') + "/notifications")
     end
   end
 end

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -56,60 +56,6 @@ module Payloads
     }.deep_merge(attrs)
   end
 
-  def self.drug_safety_update_content_item(attrs = {})
-    {
-      "content_id" => SecureRandom.uuid,
-      "base_path" => "/drug-safety-update/example-drug-safety-update",
-      "title" => "Example Drug Safety Update",
-      "description" => "This is the summary of an example Drug Safety Update",
-      "document_type" => "drug_safety_update",
-      "schema_name" => "specialist_document",
-      "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
-      "locale" => "en",
-      "phase" => "live",
-      "public_updated_at" => "2015-11-16T11:53:30+00:00",
-      "first_published_at" => "2015-11-15T00:00:00+00:00",
-      "updated_at" => "2015-11-15T11:53:30+00:00",
-      "publication_state" => "draft",
-      "details" => {
-        "body" => [
-          {
-            "content_type" => "text/govspeak",
-            "content" => "## Header" + ("\r\n\r\nThis is the long body of an example Drug Safety Update" * 10)
-          },
-          {
-            "content_type" => "text/html",
-            "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example Drug Safety Update</p>\n" * 10)
-          }
-        ],
-        "headers" => [{
-          "text" => "Header",
-          "level" => 2,
-          "id" => "header",
-        }],
-        "metadata" => {
-          "document_type" => "drug_safety_update",
-        },
-        "max_cache_time" => 10,
-        "change_history" => [
-          {
-            "public_timestamp" => "2015-11-16T11:53:30+00:00",
-            "note" => "First published."
-          }
-        ]
-      },
-      "routes" => [
-        {
-          "path" => "/drug-safety-update/example-drug-safety-update",
-          "type" => "exact",
-        }
-      ],
-      "redirects" => [],
-      "update_type" => "major",
-    }.deep_merge(attrs)
-  end
-
   def self.cma_case_with_attachments(attrs = {})
     attachments = {
       "details" => {


### PR DESCRIPTION
After #779, drug safety updates behave almost identically to any other
document (except for email alerts on publishing). Since the majority
of the behaviour is already tested in `document_spec`, `drug_safety_update_spec`
can be simplified to only the model-specific functionality.
