### PR TITLE
Use Capybara ‘have_no’ matchers to mitigate race conditions…

### DIFF
--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature "Access control", type: :feature do
         visit "/manuals"
 
         expect(page.status_code).to eq(200)
-        expect(page).not_to have_content 'Example manual'
+        expect(page).to have_no_content 'Example manual'
         expect(page).to have_content 'Exemplar manual'
       end
     end

--- a/spec/features/publishing_a_manual_spec.rb
+++ b/spec/features/publishing_a_manual_spec.rb
@@ -57,6 +57,6 @@ RSpec.feature "Publishing a Manual", type: :feature do
 
     click_link "A Manual"
 
-    expect(page).not_to have_selector(:button, 'Publish')
+    expect(page).to have_no_selector(:button, 'Publish')
   end
 end

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Viewing a Manual", type: :feature do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("A CMA Manual")
-      expect(page).to_not have_content("Competition And Markets Authority")
+      expect(page).to have_no_content("Competition And Markets Authority")
 
       click_link "A CMA Manual"
 

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -121,7 +121,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "CMA Case with attachments"
 
-      expect(page).not_to have_content("This document doesn’t have any attachments")
+      expect(page).to have_no_content("This document doesn’t have any attachments")
       expect(page).to have_content("2 attachments")
 
       expect(page).to have_content("first attachment")


### PR DESCRIPTION
When asserting that content does not appear on a
page it is important to use the ‘have_no’ matchers
rather than negating the positive case. This is
because Capybara asserts against the current state
of the page. If it is has not finished following a
link, it can result in a false positive.

This has a bit more information:
http://stackoverflow.com/questions/11980109/cucumber-capybara-check-that-a-page-does-not-have-content
