### PR TITLE
Refactor sending attachments to asset-manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "30.1.0"
+  gem "gds-api-adapters", "30.8.0"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (30.1.0)
+    gds-api-adapters (30.8.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -332,7 +332,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 30.1.0)
+  gds-api-adapters (= 30.8.0)
   gds-sso (= 11.0.0)
   govspeak (~> 3.5)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -31,4 +31,13 @@ class Attachment < Document
     return nil unless payload.fetch('details', {}).key?('attachments')
     payload['details']['attachments'].map { |attachment| Attachment.new(attachment) }
   end
+
+  def upload
+    response = Services.asset_api.create_asset(file: @file)
+    @url = response.file_url
+    true
+  rescue GdsApi::BaseError => e
+    Airbrake.notify(e)
+    false
+  end
 end

--- a/app/models/attachment_uploader.rb
+++ b/app/models/attachment_uploader.rb
@@ -1,35 +1,17 @@
 class AttachmentUploader
-  def initialize(publisher: SpecialistPublisher)
-    @publisher = publisher
-  end
-
   def upload(attachment, document)
-    attachment.url = file_url(attachment.file)
-    add_attachment(document, attachment) unless attachment.changed?
-    document.save
-  rescue GdsApi::BaseError => e
-    Airbrake.notify(e)
-    false
+    if attachment.upload
+      add_attachment(document, attachment) unless attachment.changed?
+      document.save
+    else
+      false
+    end
   end
 
 private
 
-  attr_reader :publisher
-
   def add_attachment(document, attachment)
     document.attachments ||= []
     document.attachments.push(attachment)
-  end
-
-  def file_url(file)
-    response(file).file_url
-  end
-
-  def response(file)
-    asset_api.create_asset(file: file)
-  end
-
-  def asset_api
-    publisher.services(:asset_api)
   end
 end

--- a/spec/models/attachment_uploader_spec.rb
+++ b/spec/models/attachment_uploader_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
-
+require 'gds_api/test_helpers/asset_manager'
 RSpec.describe AttachmentUploader do
+  include GdsApi::TestHelpers::AssetManager
+  before do
+    asset_manager_receives_an_asset(url)
+  end
   context 'for a CMA case document' do
     let(:cma_cases) {
       [
@@ -39,12 +43,8 @@ RSpec.describe AttachmentUploader do
     end
 
     describe "uploader" do
-      subject { described_class.new(publisher: publisher) }
+      subject { described_class.new }
       let(:url) { '/uploaded/document.jpg' }
-
-      let(:service) { double("service", create_asset: double("file", file_url: url)) }
-      let(:publisher) { double("publisher", services: service) }
-
       let(:attachment) { Attachment.new(changed: false) }
       let(:document) { CmaCase.find(cma_cases[0]["content_id"]) }
 
@@ -59,7 +59,7 @@ RSpec.describe AttachmentUploader do
           expect(attachment.url).to eq(url)
         end
 
-        it "document attachemnt should be changed" do
+        it "document attachment should be changed" do
           expect(document.attachments).to_not be
           subject.upload(attachment, document)
           expect(document.attachments).to eq([attachment])
@@ -70,7 +70,7 @@ RSpec.describe AttachmentUploader do
         let(:document) { CmaCase.find(cma_cases[1]["content_id"]) }
         let(:attachment) { document.attachments.first }
 
-        it "document attachemnt should be changed" do
+        it "document attachment should be changed" do
           attachment.changed = true
           expect(document.attachments.count).to eq(2)
           subject.upload(attachment, document)
@@ -80,7 +80,7 @@ RSpec.describe AttachmentUploader do
 
       context 'publisher raises an error' do
         before do
-          allow(service).to receive(:create_asset).and_raise(GdsApi::BaseError)
+          asset_manager_upload_failure
         end
 
         it 'returns false' do
@@ -132,7 +132,7 @@ RSpec.describe AttachmentUploader do
     end
 
     describe "uploader" do
-      subject { described_class.new(publisher: publisher) }
+      subject { described_class.new }
       let(:url) { '/uploaded/document.jpg' }
 
       let(:service) { double("service", create_asset: double("file", file_url: url)) }
@@ -173,7 +173,7 @@ RSpec.describe AttachmentUploader do
 
       context 'publisher raises an error' do
         before do
-          allow(service).to receive(:create_asset).and_raise(GdsApi::BaseError)
+          asset_manager_upload_failure
         end
 
         it 'returns false' do


### PR DESCRIPTION
- Moves the functionality that uploads attachments to asset-manager (which then returns a url) from AttachmentUploader to Attachment upload method.
- Purpose of this is to improve code readability
- Not to be merged until [this](https://github.com/alphagov/gds-api-adapters/pull/516) has been merged and the gem version bumped
