### PR TITLE
Disable double submit on save and publish for documents with js

### DIFF
--- a/app/views/documents/_publish_panel.html.erb
+++ b/app/views/documents/_publish_panel.html.erb
@@ -10,7 +10,7 @@
     <% elsif @document.can_be_published? %>
       <%= publish_warning(@document) %>
       <%= form_tag(publish_document_path(current_format.slug, @document.content_id), method: :post) do %>
-        <button name="submit" class="btn btn-danger" data-module="confirm" data-message="<%= pop_up_warning_for_publishing(@document) %>" >Publish</button>
+        <button name="submit" class="btn btn-danger" data-module="confirm" data-message="<%= pop_up_warning_for_publishing(@document) %>" data-disable-with="Publishing..." >Publish</button>
       <% end %>
     <% else %>
       <p class="remove-bottom-margin">

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -16,7 +16,7 @@
       <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
 
       <div class="actions">
-        <button name="save" class="btn btn-success">Save as draft</button>
+        <button name="save" class="btn btn-success" data-disable-with="Saving...">Save as draft</button>
       </div>
     <% end %>
   </div>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -13,7 +13,7 @@
       <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: { f: f } %>
 
       <div class="actions">
-        <button name="save" class="btn btn-success">Save as draft</button>
+        <button name="save" class="btn btn-success" data-disable-with="Saving...">Save as draft</button>
       </div>
     <% end %>
   </div>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
   let(:cma_case) { FactoryGirl.create(:cma_case) }
   let(:content_id) { cma_case['content_id'] }
+  let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
 
   before do
     log_in_as_editor(:cma_editor)
@@ -45,6 +46,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     expect(page).to have_css('div.govspeak-help')
     expect(page).to have_content('To add an attachment, please save the draft first.')
+    expect(save_button_disable_with_message).to eq("Saving...")
 
     click_button "Save as draft"
 

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
   }
 
   let(:content_id) { cma_case['content_id'] }
+  let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
 
   before do
     log_in_as_editor(:cma_editor)
@@ -65,6 +66,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     expect(page).to have_css('div.govspeak-help')
     expect(page).to have_content('Add attachment')
+    expect(save_button_disable_with_message).to eq("Saving...")
 
     click_button "Save as draft"
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.feature "Publishing a CMA case", type: :feature do
   let(:content_id) { item['content_id'] }
   let(:publish_alert_message) { page.find_button('Publish')["data-message"] }
+  let(:publish_disable_with_message) { page.find_button('Publish')["data-disable-with"] }
 
   before do
     log_in_as_editor(:cma_editor)
@@ -53,6 +54,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       expect(page).to have_content("Publishing will email subscribers to CMA Cases.")
 
       expect(publish_alert_message).to eq("Publishing will email subscribers to CMA Cases. Continue?")
+      expect(publish_disable_with_message).to eq("Publishing...")
     end
 
     scenario "writers don't see a publish button" do


### PR DESCRIPTION
Rails provides a "disable_with" data attribute on button tags that can
prevent double submission when js is enabled.

I was not able to find a way to mimic  double clicking in feature test, so I went for checking the data-attribute is set correctly. Please let me know of any suggestions.
