### PR TITLE
Stop writing/updating public_updated_at

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -163,14 +163,6 @@ class Document
     document
   end
 
-  def public_updated_at
-    @public_updated_at ||= Time.zone.now
-  end
-
-  def public_updated_at=(timestamp)
-    @public_updated_at = Time.parse(timestamp.to_s) unless timestamp.nil?
-  end
-
   def self.all(page, per_page, q: nil)
     params = {
       document_type: self.document_type,
@@ -203,8 +195,6 @@ class Document
 
   def save
     return false unless self.valid?
-
-    self.public_updated_at = Time.zone.now if self.update_type == 'major'
 
     presented_document = DocumentPresenter.new(self)
     presented_links = DocumentLinksPresenter.new(self)

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -75,14 +75,11 @@ private
     metadata.reject { |_k, v| v.blank? }
   end
 
-  def public_updated_at
-    document.public_updated_at.to_datetime.rfc3339
-  end
-
   def change_history
     case document.update_type
     when "major"
-      document.change_history + [{ public_timestamp: public_updated_at, note: document.change_note || "First published." }]
+      # FIXME: public timestamp used an incorrectly set public_updated_at, using the STUB_TIME_STAMP as a temporary measure to decouple the two until future bug fix story is in play.
+      document.change_history + [{ public_timestamp: STUB_TIME_STAMP, note: document.change_note || "First published." }]
     when "minor"
       document.change_history
     end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -17,7 +17,6 @@ class DocumentPresenter
       rendering_app: "specialist-frontend",
       locale: "en",
       phase: document.phase,
-      public_updated_at: public_updated_at,
       details: details,
       routes: [
         {

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+STUB_TIME_STAMP = "2015-12-03T16:59:13+00:00"
+
 module SpecialistPublisher
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
         },
         "change_history" => [
           {
-            "public_timestamp" => "2015-12-03T16:59:13+00:00",
+            "public_timestamp" => STUB_TIME_STAMP,
             "note" => "First published."
           }
         ],

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -59,7 +59,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "rendering_app" => "specialist-frontend",
       "locale" => "en",
       "phase" => "live",
-      "public_updated_at" => "2015-12-03T16:59:13+00:00",
       "details" => {
         "body" => [
           {

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -32,7 +32,6 @@ RSpec.feature "Editing a CMA case", type: :feature do
     updated_cma_case = cma_case.deep_merge(
       "title" => "Changed title",
       "description" => "Changed summary",
-      "public_updated_at" => "2015-12-03T16:59:13+00:00",
       "details" => {
         "metadata" => {
           "opened_date" => "2014-01-01",
@@ -87,7 +86,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
           ],
           "change_history" => [
             {
-              "public_timestamp" => "2014-12-03T16:59:13+00:00",
+              "public_timestamp" => STUB_TIME_STAMP,
               "note" => "First published.",
             }
           ],
@@ -106,11 +105,11 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
       expected_change_history = [
         {
-          "public_timestamp" => "2014-12-03T16:59:13+00:00",
+          "public_timestamp" => STUB_TIME_STAMP,
           "note" => "First published.",
         },
         {
-          "public_timestamp" => "2015-12-03T16:59:13+00:00",
+          "public_timestamp" => STUB_TIME_STAMP,
           "note" => "This is a change note.",
         }
       ]

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DocumentPresenter do
     end
 
     it "returns a specialist document content item" do
-      expected = write_payload(saved_for_the_first_time(payload, at_time: payload["public_updated_at"]))
+      expected = write_payload(saved_for_the_first_time(payload))
       expect(presented_data).to eq(expected.to_h.deep_symbolize_keys)
     end
   end

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -3,12 +3,12 @@ module PublishingApiHelpers
     document.delete("updated_at")
     document.delete("publication_state")
     document.delete("first_published_at")
+    document.delete("public_updated_at")
     document
   end
 
   def saved_for_the_first_time(document, at_time: Time.now.to_datetime.rfc3339)
     document.deep_merge(
-      "public_updated_at" => at_time,
       "details" => {
         "change_history" => [
           {

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -7,12 +7,12 @@ module PublishingApiHelpers
     document
   end
 
-  def saved_for_the_first_time(document, at_time: Time.now.to_datetime.rfc3339)
+  def saved_for_the_first_time(document)
     document.deep_merge(
       "details" => {
         "change_history" => [
           {
-            "public_timestamp" => at_time,
+            "public_timestamp" => STUB_TIME_STAMP,
             "note" => "First published.",
           }
         ]


### PR DESCRIPTION
The main behaviour change here is in the first commit. We stop updating and sending `public_updated_at` to publishing-api because this is handled by publishing-api at publish time.

The second commit is cleaning up unused code. Note that there are still some consumption of `public_updated_at` for `Rummager` in the `Search Presenter`, but that is fine because the document passed to `SearchPresenter` is always a published document, which will then have `public_updated_at` set.
Also, we were using `public_updated_at` to populate the `timestamp` within `change-history`, the logic there is flagged as currently incorrect. So instead of trying to dig into the issue to decouple the two properly, I "hardcoded" the timestamp in the correct data format to pass schema validations tests but hopefully this will make it easy for future changes to rip out.
