### PR TITLE
Populate authenticated user header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   extend Forwardable
 
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
 
   protect_from_forgery with: :exception
 
@@ -118,5 +119,11 @@ class ApplicationController < ActionController::Base
 
   def permission_checker
     @permission_checker ||= PermissionChecker.new(current_user)
+  end
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
   end
 end

--- a/app/services/abstract_document_service_registry.rb
+++ b/app/services/abstract_document_service_registry.rb
@@ -84,7 +84,11 @@ class AbstractDocumentServiceRegistry
   def republish_all
     -> {
       document_repository.all.each do |document|
-        RepublishDocumentWorker.perform_async(document.id, document.document_type)
+        RepublishDocumentWorker.perform_async(
+          document.id,
+          document.document_type,
+          govuk_header_params
+        )
       end
     }
   end
@@ -117,6 +121,13 @@ private
 
   def document_builder
     @builder
+  end
+
+  def govuk_header_params
+    {
+      request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+    }
   end
 
   attr_reader :observers

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -8,7 +8,7 @@ class QueuePublishManualService
 
   def call
     task = create_publish_task(manual)
-    worker.perform_async(task.to_param)
+    worker.perform_async(task.to_param, govuk_header_params)
     manual
   end
 
@@ -31,4 +31,10 @@ private
     @manual ||= repository.fetch(manual_id)
   end
 
+  def govuk_header_params
+    {
+      request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+    }
+  end
 end

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -7,7 +7,10 @@ class PublishManualWorker
     backtrace: true,
   )
 
-  def perform(task_id)
+  def perform(task_id, params = {})
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, params["authenticated_user"])
+
     task = ManualPublishTask.find(task_id)
     task.start!
 

--- a/app/workers/republish_document_worker.rb
+++ b/app/workers/republish_document_worker.rb
@@ -8,7 +8,10 @@ class RepublishDocumentWorker
     queue: "bulk_republishing",
   )
 
-  def perform(document_id, type)
+  def perform(document_id, type, params = {})
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, params["authenticated_user"])
+
     services = SpecialistPublisher.document_services(type)
     services.republish(document_id).call
   end

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -11,6 +11,10 @@ describe ManualsController, type: :controller do
       post :publish, id: manual_id
     end
 
+    after do
+      GdsApi::GovukHeaders.clear_headers
+    end
+
     it "redirects to the manual's show page" do
       expect(response).to redirect_to manual_path(id: manual_id)
     end
@@ -21,6 +25,10 @@ describe ManualsController, type: :controller do
 
     it "does not publish the manual" do
       expect(ManualsController).not_to have_received(:publish)
+    end
+
+    it "sets the authenticated user header" do
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to match(/uid-\d+/)
     end
   end
 end

--- a/spec/workers/publish_manual_worker_spec.rb
+++ b/spec/workers/publish_manual_worker_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "sidekiq/testing"
+
+RSpec.describe PublishManualWorker do
+
+  after do
+    GdsApi::GovukHeaders.clear_headers
+  end
+
+  it "places job in the default queue" do
+    Sidekiq::Testing.fake! do
+      PublishManualWorker.perform_async("1")
+      expect(PublishManualWorker.jobs.size).to eq(1)
+      expect(PublishManualWorker.jobs.first.fetch("queue")).to eq("default")
+    end
+  end
+
+  it "repopulates worker request headers" do
+    task = double(:task, start!: nil, finish!: nil, manual_id: 1, version_number: 2)
+    expect(ManualPublishTask).to receive(:find).with("1").and_return(task)
+    expect(PublishManualService).to receive(:new).and_return(double(:publish, call: nil))
+
+    Sidekiq::Testing.inline! do
+      PublishManualWorker.perform_async("1", { request_id: "12345", authenticated_user: "abc123" })
+      expect(GdsApi::GovukHeaders.headers[:govuk_request_id]).to eq("12345")
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq("abc123")
+    end
+  end
+end

--- a/spec/workers/republish_document_worker_spec.rb
+++ b/spec/workers/republish_document_worker_spec.rb
@@ -2,11 +2,27 @@ require "spec_helper"
 require "sidekiq/testing"
 
 RSpec.describe RepublishDocumentWorker do
+
+  after do
+    GdsApi::GovukHeaders.clear_headers
+  end
+
   it "place job in bulk republishing queue" do
     Sidekiq::Testing.fake! do
       RepublishDocumentWorker.perform_async("1", "doc_type")
       expect(RepublishDocumentWorker.jobs.size).to eq(1)
       expect(RepublishDocumentWorker.jobs.first.fetch("queue")).to eq("bulk_republishing")
+    end
+  end
+
+  it "place job in bulk republishing queue" do
+    expect(SpecialistPublisher).to receive(:document_services)
+      .and_return(double(:service, republish: double(:thing, call: nil)))
+
+    Sidekiq::Testing.inline! do
+      RepublishDocumentWorker.perform_async("1", "doc_type", request_id: "12345", authenticated_user: "abc123")
+      expect(GdsApi::GovukHeaders.headers[:govuk_request_id]).to eq("12345")
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq("abc123")
     end
   end
 end


### PR DESCRIPTION
Part of https://trello.com/c/6nDCqZXi/729-user-id-into-event-log
This ensures that `GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]` is set and repopulated in an sidekiq worker jobs.