### PR TITLE
Ensure authenticated user header is set

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
   after_action :verify_authorized
 
   helper_method :current_format
@@ -50,5 +51,11 @@ private
       TaxTribunalDecision,
       VehicleRecallsAndFaultsAlert,
     ]
+  end
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
   end
 end

--- a/spec/features/visiting_the_app_spec.rb
+++ b/spec/features/visiting_the_app_spec.rb
@@ -12,4 +12,9 @@ RSpec.feature "Visiting the app", type: :feature do
     visit "/"
     expect(page).to have_content("Your manuals (0)")
   end
+
+  scenario "visiting any path should set an authenticated user header" do
+    visit "/"
+    expect(/uid-\d+/).to match(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user])
+  end
 end


### PR DESCRIPTION
Part of https://trello.com/c/6nDCqZXi/729-user-id-into-event-log
This ensures that `GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]` is set for every request.
