### PR TITLE
Withdraw documents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "30.8.0"
+  gem "gds-api-adapters", "30.9.0"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (30.8.0)
+    gds-api-adapters (30.9.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -332,7 +332,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 30.8.0)
+  gds-api-adapters (= 30.9.0)
   gds-sso (= 11.0.0)
   govspeak (~> 3.5)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
-  before_action :fetch_document, only: [:edit, :show, :publish, :update]
+  before_action :fetch_document, only: [:edit, :show, :publish, :update, :withdraw]
   before_action :check_authorisation, if: :document_type_slug
 
   def check_authorisation
@@ -79,6 +79,12 @@ class DocumentsController < ApplicationController
     else
       flash[:danger] = "There was an error publishing #{@document.title}. Please try again later."
     end
+    redirect_to document_path(current_format.slug, params[:content_id])
+  end
+
+  def withdraw
+    @document.withdraw
+    flash[:success] = "Withdrawn #{@document.title}"
     redirect_to document_path(current_format.slug, params[:content_id])
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -83,8 +83,11 @@ class DocumentsController < ApplicationController
   end
 
   def withdraw
-    @document.withdraw
-    flash[:success] = "Withdrawn #{@document.title}"
+    if @document.withdraw
+      flash[:success] = "Withdrawn #{@document.title}"
+    else
+      flash[:danger] = "There was an error withdrawing #{@document.title}. Please try again later."
+    end
     redirect_to document_path(current_format.slug, params[:content_id])
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -225,6 +225,12 @@ class Document
     end
   end
 
+  def withdraw
+    handle_remote_error do
+      Services.publishing_api.unpublish(content_id, type: 'gone')
+    end
+  end
+
   def has_attachment?(attachment)
     find_attachment(attachment.content_id).present?
   end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -13,7 +13,5 @@ class DocumentPolicy < ApplicationPolicy
     gds_editor || departmental_editor
   end
 
-  def withdraw?
-    true #FIXME: Find out withdraw permissions
-  end
+  alias_method :withdraw?, :publish?
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -12,4 +12,8 @@ class DocumentPolicy < ApplicationPolicy
   def publish?
     gds_editor || departmental_editor
   end
+
+  def withdraw?
+    true #FIXME: Find out withdraw permissions
+  end
 end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -89,5 +89,16 @@
     </div>
 
     <%= render partial: 'publish_panel' %>
+    <%= form_tag(withdraw_document_path(current_format.slug, @document.content_id), method: :post, class: 'panel panel-default') do %>
+      <div class="panel-heading">
+        <div class="panel-title">
+          Withdraw document
+        </div>
+      </div>
+      <div class="panel-body">
+        <p>The document will be removed from the site. It will still be possible to edit the document and publish a new version.</p>
+        <button name="submit" class="btn btn-warning" data-module="confirm" data-message="Are you sure you want to withdraw this document?" data-disable-with="Withdrawing..." >Withdraw document</button>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -89,16 +89,18 @@
     </div>
 
     <%= render partial: 'publish_panel' %>
-    <%= form_tag(withdraw_document_path(current_format.slug, @document.content_id), method: :post, class: 'panel panel-default') do %>
-      <div class="panel-heading">
-        <div class="panel-title">
-          Withdraw document
+    <% if policy(@document).withdraw? %>
+      <%= form_tag(withdraw_document_path(current_format.slug, @document.content_id), method: :post, class: 'panel panel-default') do %>
+        <div class="panel-heading">
+          <div class="panel-title">
+            Withdraw document
+          </div>
         </div>
-      </div>
-      <div class="panel-body">
-        <p>The document will be removed from the site. It will still be possible to edit the document and publish a new version.</p>
-        <button name="submit" class="btn btn-warning" data-module="confirm" data-message="Are you sure you want to withdraw this document?" data-disable-with="Withdrawing..." >Withdraw document</button>
-      </div>
+        <div class="panel-body">
+          <p>The document will be removed from the site. It will still be possible to edit the document and publish a new version.</p>
+          <button name="submit" class="btn btn-warning" data-module="confirm" data-message="Are you sure you want to withdraw this document?" data-disable-with="Withdrawing..." >Withdraw document</button>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/spec/features/withdrawing_a_cma_case_spec.rb
+++ b/spec/features/withdrawing_a_cma_case_spec.rb
@@ -25,6 +25,14 @@ RSpec.feature "Withdrawing a CMA Case", type: :feature do
 
       assert_publishing_api_unpublish(content_id)
     end
+
+    scenario "writers don't see a withdraw document button" do
+      log_in_as_editor(:cma_writer)
+
+      visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+
+      expect(page).to have_no_selector(:button, 'Withdraw document')
+    end
   end
 
   context "publishing-api returns error" do

--- a/spec/features/withdrawing_a_cma_case_spec.rb
+++ b/spec/features/withdrawing_a_cma_case_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Withdrawing a CMA Case", type: :feature do
         publication_state: "live")
     }
 
-    scenario "clicking the withdraw button should redirect back to the show page" do
+    scenario "clicking the withdraw button redirects back to the show page" do
       visit document_path(content_id: content_id, document_type_slug: "cma-cases")
       expect(page).to have_content("Example CMA Case")
       click_button "Withdraw document"
@@ -24,6 +24,24 @@ RSpec.feature "Withdrawing a CMA Case", type: :feature do
       expect(page).to have_content("Withdrawn Example CMA Case")
 
       assert_publishing_api_unpublish(content_id)
+    end
+  end
+
+  context "publishing-api returns error" do
+    let(:item) {
+      FactoryGirl.create(:cma_case,
+        title: "Example CMA Case",
+        publication_state: "live")
+    }
+
+    scenario "clicking the withdraw button shows an error message" do
+      stub_publishing_api_unpublish(content_id, { body: { type: 'gone' } }, status: 409)
+
+      visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+      click_button "Withdraw document"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("There was an error withdrawing Example CMA Case. Please try again later.")
     end
   end
 end

--- a/spec/features/withdrawing_a_cma_case_spec.rb
+++ b/spec/features/withdrawing_a_cma_case_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.feature "Withdrawing a CMA Case", type: :feature do
+  let(:content_id) { item['content_id'] }
+
+  before do
+    log_in_as_editor(:cma_editor)
+    publishing_api_has_item(item)
+    stub_publishing_api_unpublish(content_id, body: { type: 'gone' })
+  end
+
+  context "a published document" do
+    let(:item) {
+      FactoryGirl.create(:cma_case,
+        title: "Example CMA Case",
+        publication_state: "live")
+    }
+
+    scenario "clicking the withdraw button should redirect back to the show page" do
+      visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+      click_button "Withdraw document"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Withdrawn Example CMA Case")
+
+      assert_publishing_api_unpublish(content_id)
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -177,6 +177,28 @@ RSpec.describe Document do
     end
   end
 
+  describe "#withdraw" do
+    before do
+      publishing_api_has_item(payload)
+      document = MyDocumentType.find(payload["content_id"])
+      stub_publishing_api_unpublish(document.content_id, body: { type: 'gone' })
+    end
+
+    it "sends correct payload to publishing api" do
+      expect(document.withdraw).to eq(true)
+
+      assert_publishing_api_unpublish(document.content_id)
+    end
+
+    context "unsuccessful #unpublish" do
+      it "notifies Airbrake and returns false if publishing-api does not return status 200" do
+        expect(Airbrake).to receive(:notify)
+        stub_publishing_api_unpublish(document.content_id, { body: { type: 'gone' } }, status: 409)
+        expect(document.withdraw).to eq(false)
+      end
+    end
+  end
+
   describe "#save" do
     before do
       publishing_api_has_item(payload)

--- a/spec/policies/document_policy_spec.rb
+++ b/spec/policies/document_policy_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DocumentPolicy do
     end
   end
 
-  permissions :publish? do
+  permissions :publish?, :withdraw? do
     it 'denies access to users without editors permissions' do
       expect(described_class).not_to permit(departmental_writer, allowed_document_type)
     end


### PR DESCRIPTION
Adding the feature to withdraw a document.
It sends an `unpublish` request with `type: 'gone'` to publishing-api.

Before 
![screen shot 2016-06-07 at 16 26 20](https://cloud.githubusercontent.com/assets/3989823/15863868/982569ac-2ccc-11e6-8428-696da2b66aeb.png)

After 
![before-withdraw](https://cloud.githubusercontent.com/assets/3989823/15863873/9e18630a-2ccc-11e6-9aaf-6b1c6b5bf29c.png)
