### PR TITLE
Embeddable attachment snippet

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -33,4 +33,8 @@ class Attachment < Document
     Airbrake.notify(e)
     false
   end
+
+  def snippet
+    "[InlineAttachment:#{url.split('/').last}]"
+  end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -35,7 +35,7 @@ private
 
   def details
     {
-      body: GovspeakPresenter.present(document.body),
+      body: GovspeakPresenter.new(@document).present,
       metadata: metadata,
       change_history: change_history,
       max_cache_time: 10,

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -1,16 +1,35 @@
-module GovspeakPresenter
-  class << self
-    def present(govspeak)
-      [
-        { content_type: "text/govspeak", content: govspeak },
-        { content_type: "text/html", content: html(govspeak) }
-      ]
-    end
+class GovspeakPresenter
+  attr_accessor :document
 
-  private
+  def initialize(document)
+    @document = document
+  end
 
-    def html(govspeak)
-      Govspeak::Document.new(govspeak).to_html
-    end
+  def present
+    [
+      { content_type: "text/govspeak", content: govspeak_body },
+      { content_type: "text/html", content: html_body }
+    ]
+  end
+
+private
+
+  def govspeak_body
+    document.body
+  end
+
+  def html_body
+    Govspeak::Document.new(govspeak_body_with_expanded_attachment_links).to_html
+  end
+
+
+  def govspeak_body_with_expanded_attachment_links
+    document.attachments.reduce(document.body) { |body, attachment|
+      body.gsub(attachment.snippet, attachment_markdown(attachment))
+    }
+  end
+
+  def attachment_markdown(attachment)
+    "[#{attachment.title}](#{attachment.url})"
   end
 end

--- a/app/views/attachments/_attachment_links.html.erb
+++ b/app/views/attachments/_attachment_links.html.erb
@@ -13,10 +13,9 @@
             <li class="attachment">
               <span class="title"><%= attachment.title %></span>
               <%= link_to "edit", edit_document_attachment_path(params[:document_type_slug], @document.content_id, attachment.content_id) %>
+              <%= attachment.snippet %>
             </li>
         <% end %>
       </ul>
   <% end %>
 </div>
-
-

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -219,6 +219,22 @@ RSpec.feature "Editing a CMA case", type: :feature do
       }
 
       scenario "adding an attachment to a #{publication_state} CMA case" do
+        updated_cma_case = cma_case.deep_merge(
+          "update_type" => "minor",
+          "details" => {
+            "body" => [
+              {
+                "content_type" => "text/govspeak",
+                "content" => "[InlineAttachment:asylum-support-image.jpg]"
+              },
+              {
+                "content_type" => "text/html",
+                "content" => "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg\">asylum report image title</a></p>\n"
+              }
+            ],
+          },
+        )
+
         click_link "Add attachment"
         expect(page.status_code).to eq(200)
 
@@ -230,6 +246,17 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page.status_code).to eq(200)
         expect(page).to have_content("Editing Example CMA Case")
         expect(page).to have_content("New cma case image")
+        expect(page).to have_content("[InlineAttachment:asylum-support-image.jpg]")
+
+        fill_in "Body", with: "[InlineAttachment:asylum-support-image.jpg]"
+        choose "Update type minor"
+
+        publishing_api_has_item(updated_cma_case)
+
+        click_button "Save as draft"
+
+        assert_publishing_api_put_content(content_id, write_payload(updated_cma_case))
+
         expect(page).to have_content("[InlineAttachment:asylum-support-image.jpg]")
       end
 

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -230,6 +230,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page.status_code).to eq(200)
         expect(page).to have_content("Editing Example CMA Case")
         expect(page).to have_content("New cma case image")
+        expect(page).to have_content("[InlineAttachment:asylum-support-image.jpg]")
       end
 
       scenario "editing an attachment on a #{publication_state} CMA case" do

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -77,18 +77,13 @@ FactoryGirl.define do
           "body" => [
             {
               "content_type" => "text/govspeak",
-              "content" => "## Header" + ("\r\n\r\nThis is the long body of an example document" * 10)
+              "content" => "default text"
             },
             {
               "content_type" => "text/html",
-              "content" => ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example document</p>\n" * 10)
+              "content" => "<p>default text</p>\n"
             }
           ],
-          "headers" => [{
-            "text" => "Header",
-            "level" => 2,
-            "id" => "header",
-          }],
           "metadata" => default_metadata,
           "max_cache_time" => 10,
           "change_history" => [],

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -65,11 +65,11 @@ RSpec.describe Document do
         body: [
           {
             content_type: "text/govspeak",
-            content: "## Header" + ("\r\n\r\nThis is the long body of an example document" * 10),
+            content: "This is the body of an example document",
           },
           {
             content_type: "text/html",
-            content: ("<h2 id=\"header\">Header</h2>\n" + "\n<p>This is the long body of an example document</p>\n" * 10),
+            content: "<p>This is the body of an example document</p>\n",
           },
         ],
         metadata: {
@@ -108,7 +108,7 @@ RSpec.describe Document do
       assert_rummager_posted_item(
         "title" => "Example document",
         "description" => "This is a summary",
-        "indexable_content" => "Header " + (["This is the long body of an example document"] * 10).join(" "),
+        "indexable_content" => "This is the body of an example document",
         "link" => "/my-document-types/example-document",
         "public_timestamp" => "2015-11-16T11:53:30+00:00",
         "first_published_at" => "2015-11-15T00:00:00+00:00",
@@ -149,7 +149,7 @@ RSpec.describe Document do
         assert_rummager_posted_item(
           "title" => "Example document",
           "description" => "This is a summary",
-          "indexable_content" => "Header " + (["This is the long body of an example document"] * 10).join(" "),
+          "indexable_content" => "This is the body of an example document",
           "link" => "/my-document-types/example-document",
           "public_timestamp" => "2015-11-16T11:53:30+00:00",
           "first_published_at" => "2015-11-15T00:00:00+00:00",

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe DocumentPresenter do
     it "is valid against the content schemas" do
       expect(presented_data).to be_valid_against_schema("specialist_document")
     end
+
+    it "adds the header to the payload" do
+      expected_headers_payload = [{ text: "heading", level: 2, id: "heading" }]
+
+      expect(presented_data[:details][:headers]).to eq(expected_headers_payload)
+    end
   end
 
   describe '#to_json with nested headers' do
@@ -103,6 +109,18 @@ RSpec.describe DocumentPresenter do
     it "is valid against the content schemas" do
       expect(presented_data).to be_valid_against_schema("specialist_document")
     end
+
+    it "adds the nested header to the payload" do
+      expected_headers_payload = [
+        { text: "heading2", level: 2, id: "heading2", headers: [
+            { text: "heading3", level: 3, id: "heading3", headers: [
+                { text: "heading4", level: 4, id: "heading4" }
+              ] }] },
+        { text: "anotherheading2", level: 2, id: "anotherheading2" }
+      ]
+
+      expect(presented_data[:details][:headers]).to eq(expected_headers_payload)
+    end
   end
 
   describe '#to_json without headers' do
@@ -112,6 +130,10 @@ RSpec.describe DocumentPresenter do
 
     it 'is valid against the content schemas' do
       expect(presented_data).to be_valid_against_schema("specialist_document")
+    end
+
+    it 'does not add a headers section to the payload' do
+      expect(presented_data[:details]).to_not include(:headers)
     end
   end
 

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -1,12 +1,77 @@
 require 'spec_helper'
 
 RSpec.describe GovspeakPresenter do
-  it "should render html and Govspeak when a Govspeak string is provided" do
-    input_govspeak = "^callout test^"
-    rendered_html = "\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>callout test</p>\n</div>\n"
-    presented_content = [{ content_type: "text/govspeak", content: input_govspeak },
-                         { content_type: "text/html", content: rendered_html }]
+  let(:specialist_document) { CmaCase.from_publishing_api(payload) }
+  let(:govspeak_presenter) { GovspeakPresenter.new(specialist_document) }
+  let(:presented_data) { govspeak_presenter.present }
 
-    expect(GovspeakPresenter.present(input_govspeak)).to eq(presented_content)
+  describe "#present" do
+    context "without attachments" do
+      let(:payload) {
+        FactoryGirl.create(:cma_case,
+          details: {
+            body: [{
+              "content_type" => "text/govspeak",
+              "content" => "^callout test^",
+            }],
+          })
+      }
+
+      it "should render html and Govspeak when a Govspeak string is provided" do
+        input_govspeak = "^callout test^"
+        rendered_html = "\n<div role=\"note\" aria-label=\"Information\" "\
+                        "class=\"application-notice info-notice\">\n"\
+                        "<p>callout test</p>\n</div>\n"
+        presented_content = [{ content_type: "text/govspeak", content: input_govspeak },
+                             { content_type: "text/html", content: rendered_html }]
+
+        expect(presented_data).to eq(presented_content)
+      end
+    end
+
+    context "with attachments" do
+      let(:payload) {
+        FactoryGirl.create(:cma_case,
+          details: {
+            body: [{
+              "content_type" => "text/govspeak",
+              "content" => "[InlineAttachment:asylum-support-image.jpg]",
+            }],
+            attachments: [
+              {
+                "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+                "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+                "content_type" => "application/jpeg",
+                "title" => "asylum report image title",
+                "created_at" => "2015-12-03T16:59:13+00:00",
+                "updated_at" => "2015-12-03T16:59:13+00:00"
+              },
+              {
+                "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+                "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
+                "content_type" => "application/pdf",
+                "title" => "asylum report pdf title",
+                "created_at" => "2015-12-03T16:59:13+00:00",
+                "updated_at" => "2015-12-03T16:59:13+00:00"
+              }
+            ]
+          })
+      }
+
+      it "does not change the govspeak snippet" do
+        presented_govspeak = presented_data.find { |r| r[:content_type] == "text/govspeak" }[:content]
+        attachment_snippet = "[InlineAttachment:asylum-support-image.jpg]"
+
+        expect(presented_govspeak).to eq(attachment_snippet)
+      end
+
+
+      it "expands the attachment snippet to an html link" do
+        presented_html = presented_data.find { |r| r[:content_type] == "text/html" }[:content]
+        expected_html = "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg\">asylum report image title</a></p>\n"
+
+        expect(presented_html).to eq(expected_html)
+      end
+    end
   end
 end


### PR DESCRIPTION
This displays attachment snippets under the Attachments heading (right hand side of screen), to be used for copying and pasting into the body as part of govspeak text. These snippets get expanded into full html links by GovukPresenter as part of saving a document (thereby being sent to the publishing api).

To start, it might be best to read the test in "editing_a_cma_case_spec.rb" around attachments and the changes made in this PR for a high level overview.

As part of the PR, the GovukPresenter was refactored to accommodate more logic for expanding the attachment snippets into html links.

Writing the feature tests proved trickier than anticipated. As a consequence, there's a commit that simplifies the default document factory by removing headers from it, as headers come with their own bit of logic which we probably shouldn't bring into every test. As part of this, we added extra tests to make sure that headers are put into the payload correctly.

Paired with @Rosa-Fox 

For https://trello.com/c/DKCyHGmg/151-ability-to-embed-attachments-into-documents
# Before

<img width="220" alt="screen shot 2016-06-09 at 17 28 05" src="https://cloud.githubusercontent.com/assets/5112255/15937647/a2aebcce-2e67-11e6-9dd6-edb556f9d2f6.png">
# After

<img width="287" alt="screen shot 2016-06-09 at 17 28 29" src="https://cloud.githubusercontent.com/assets/5112255/15937649/a427246a-2e67-11e6-80e1-666e0ae4f98d.png">

<img width="651" alt="screen shot 2016-06-09 at 17 28 00" src="https://cloud.githubusercontent.com/assets/5112255/15937677/bad481f8-2e67-11e6-81b1-e715518533dc.png">
