### PR TITLE
Create attachment collection

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -11,11 +11,11 @@ class AttachmentsController < ApplicationController
   end
 
   def create
-    attachment = Attachment.new(attachment_params)
     document = fetch_document
+    attachment = document.attachments.build(attachment_params)
     attachment.content_type = attachment.file.content_type
 
-    if upload_attachment(attachment, document)
+    if document.upload_attachment(attachment)
       flash[:success] = "Attached #{attachment.title}"
       redirect_to edit_document_path(document_type_slug, document.content_id)
     else
@@ -26,15 +26,15 @@ class AttachmentsController < ApplicationController
 
   def edit
     @document = fetch_document
-    @attachment = @document.find_attachment(attachment_content_id)
+    @attachment = @document.attachments.find(attachment_content_id)
   end
 
   def update
     document = fetch_document
-    attachment = document.find_attachment(attachment_content_id)
+    attachment = document.attachments.find(attachment_content_id)
     attachment.update_attributes(attachment_params)
 
-    if upload_attachment(attachment, document)
+    if document.upload_attachment(attachment)
       flash[:success] = "Attachment succesfully updated"
       redirect_to edit_document_path(document_type_slug, document.content_id)
     else
@@ -58,10 +58,6 @@ private
 
   def attachment_content_id
     params[:attachment_content_id]
-  end
-
-  def upload_attachment(attachment, document)
-    document.upload_attachment(attachment)
   end
 
   def attachment_params

--- a/app/controllers/manual_sections_attachments_controller.rb
+++ b/app/controllers/manual_sections_attachments_controller.rb
@@ -11,11 +11,11 @@ class ManualSectionsAttachmentsController < ApplicationController
   end
 
   def create
-    attachment = Attachment.new(attachment_params)
     section = fetch_section
+    attachment = section.attachments.build(attachment_params)
     attachment.content_type = attachment.file.content_type
 
-    if upload_attachment(attachment, section)
+    if section.upload_attachment(attachment)
       flash[:success] = "Attached #{attachment.title}"
       redirect_to edit_manual_section_path(section.manual_content_id, section.content_id)
     else
@@ -26,14 +26,15 @@ class ManualSectionsAttachmentsController < ApplicationController
 
   def edit
     @section = fetch_section
-    @attachment = @section.find_attachment(attachment_content_id)
+    @attachment = @section.attachments.find(attachment_content_id)
   end
 
   def update
     section = fetch_section
-    attachment = section.find_attachment(attachment_content_id)
+    attachment = section.attachments.find(attachment_content_id)
     attachment.update_attributes(attachment_params)
-    if upload_attachment(attachment, section)
+
+    if section.upload_attachment(attachment)
       flash[:success] = "Attachment succesfully updated"
       redirect_to edit_manual_section_path(section.manual_content_id, section.content_id)
     else
@@ -60,10 +61,6 @@ private
 
   def attachment_content_id
     params[:attachment_content_id]
-  end
-
-  def upload_attachment(attachment, section)
-    section.upload_attachment(attachment)
   end
 
   def attachment_params

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -21,7 +21,7 @@ class Attachment < Document
   end
 
   def self.all_from_publishing_api(payload)
-    return nil unless payload.fetch('details', {}).key?('attachments')
+    return [] unless payload.fetch('details', {}).key?('attachments')
     payload['details']['attachments'].map { |attachment| Attachment.new(attachment) }
   end
 

--- a/app/models/attachment_collection.rb
+++ b/app/models/attachment_collection.rb
@@ -1,0 +1,31 @@
+class AttachmentCollection
+  include Enumerable
+
+  def initialize(attachments = [])
+    @attachments = attachments
+  end
+
+  def find(content_id)
+    @attachments.detect { |attachment| attachment.content_id == content_id }
+  end
+
+  def build(params)
+    new_attachment = Attachment.new(params)
+    @attachments << new_attachment
+    new_attachment
+  end
+
+  def upload(attachment)
+    attachment.upload if has_attachment?(attachment)
+  end
+
+  def has_attachment?(attachment)
+    !!find(attachment.content_id)
+  end
+
+  def each(&block)
+    @attachments.each do |attachment|
+      block.call(attachment)
+    end
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -231,17 +231,16 @@ class Document
     end
   end
 
-  def has_attachment?(attachment)
-    find_attachment(attachment.content_id).present?
+  def attachments=(attachments)
+    @attachments = AttachmentCollection.new(attachments)
   end
 
-  def find_attachment(attachment_content_id)
-    self.attachments.detect { |attachment| attachment.content_id == attachment_content_id }
+  def attachments
+    @attachments ||= AttachmentCollection.new
   end
 
   def upload_attachment(attachment)
-    if attachment.upload
-      add_attachment(attachment) unless has_attachment?(attachment)
+    if attachments.upload(attachment)
       save
     else
       false
@@ -258,14 +257,6 @@ class Document
 
   def send_email_on_publish?
     update_type == "major"
-  end
-
-  def add_attachment(attachment)
-    self.attachments.push(attachment)
-  end
-
-  def attachments
-    @attachments ||= []
   end
 
 private

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -152,25 +152,16 @@ class Section
     end
   end
 
-  def has_attachment?(attachment)
-    find_attachment(attachment.content_id).present?
-  end
-
-  def find_attachment(attachment_content_id)
-    self.attachments.detect { |attachment| attachment.content_id == attachment_content_id }
-  end
-
-  def add_attachment(attachment)
-    self.attachments.push(attachment)
+  def attachments=(attachments)
+    @attachments = AttachmentCollection.new(attachments)
   end
 
   def attachments
-    @attachments ||= []
+    @attachments ||= AttachmentCollection.new
   end
 
   def upload_attachment(attachment)
-    if attachment.upload
-      add_attachment(attachment) unless has_attachment?(attachment)
+    if attachments.upload(attachment)
       save
     else
       false

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -40,7 +40,7 @@ private
       change_history: change_history,
       max_cache_time: 10,
     }.tap do |details_hash|
-      details_hash[:attachments] = attachments if document.attachments.present?
+      details_hash[:attachments] = attachments if document.attachments.any?
       details_hash[:headers] = headers if !headers.empty?
     end
   end

--- a/app/presenters/section_presenter.rb
+++ b/app/presenters/section_presenter.rb
@@ -31,7 +31,7 @@ private
         base_path: @section.manual.base_path
       },
     }.tap do |details_hash|
-      details_hash[:attachments] = attachments if @section.attachments.present?
+      details_hash[:attachments] = attachments if @section.attachments.any?
     end
   end
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -45,11 +45,11 @@
 <div class="row">
   <div class="col-md-8">
     <%
-      truncate_at_size = 5
+      truncate_at_count = 5
       attachments = @document.attachments || []
     %>
     <h2 class="add-bottom-margin">
-      <%= number_with_delimiter(attachments.size) %> <%= 'attachment'.pluralize(attachments.size) %>
+      <%= number_with_delimiter(attachments.count) %> <%= 'attachment'.pluralize(attachments.count) %>
     </h2>
     <% if attachments.any? %>
       <table class="table table-bordered table-striped add-bottom-margin" data-module="toggle">
@@ -61,14 +61,14 @@
           </tr>
         </thead>
         <% attachments.each_with_index do | attachment, i | %>
-          <% if i == truncate_at_size - 1 %>
+          <% if i == truncate_at_count - 1 %>
             <tr class="table-header">
               <td colspan="3" class="js-toggle-target text-center">
-                <strong><a href="#expand-table" class="js-toggle">…and <%= attachments.size - (truncate_at_size - 1) %> more</a></strong>
+                <strong><a href="#expand-table" class="js-toggle">…and <%= attachments.count - (truncate_at_count - 1) %> more</a></strong>
               </td>
             </tr>
           <% end %>
-          <tr <% if i > truncate_at_size - 2 %>class="js-toggle-target if-js-hide"<% end %>>
+          <tr <% if i > truncate_at_count - 2 %>class="js-toggle-target if-js-hide"<% end %>>
             <td><%= attachment.title %></td>
             <td><%= attachment.created_at.to_date.to_s(:govuk_date) %></td>
             <td><%= attachment.updated_at.to_date.to_s(:govuk_date) %></td>

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe AttachmentsController, type: :controller do
   describe "GET edit" do
     it "renders the edit attachment form" do
       document = CmaCase.find(document_content_id)
-      attachment = document.find_attachment(attachment_content_id)
+      attachment = document.attachments.find(attachment_content_id)
       allow_any_instance_of(AttachmentsController).to receive(:fetch_document).and_return(document)
 
       get :edit, document_type_slug: document_type_slug, document_content_id: document_content_id, attachment_content_id: attachment_content_id

--- a/spec/controllers/manual_sections_attachments_controller_spec.rb
+++ b/spec/controllers/manual_sections_attachments_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ManualSectionsAttachmentsController, type: :controller do
 
   describe "GET edit" do
     it "renders the edit attachment form" do
-      attachment = section.find_attachment(attachment_content_id)
+      attachment = section.attachments.find(attachment_content_id)
 
       get :edit, manual_content_id: section.manual_content_id, section_content_id: section.content_id, attachment_content_id: attachment_content_id
 

--- a/spec/models/attachment_collection_spec.rb
+++ b/spec/models/attachment_collection_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe AttachmentCollection do
+  let(:attachment_jpeg) { Attachment.new(title: 'jolly jpeg') }
+  let(:attachment_gif) { Attachment.new(title: 'great gif') }
+  let(:missing_attachment) { Attachment.new(title: 'cool csv') }
+  let(:attachments) { described_class.new([attachment_jpeg, attachment_gif]) }
+
+  describe '#find' do
+    it 'returns the correct attachment' do
+      expect(attachments.find(attachment_gif.content_id)).to eq(attachment_gif)
+    end
+
+    it 'returns nil for an non-existent attachment' do
+      expect(attachments.find(missing_attachment.content_id)).to be_nil
+    end
+  end
+
+  describe '#build' do
+    it 'adds a new attachment to entries' do
+      expect { attachments.build(title: 'new and shiny') }.to change { attachments.count }.from(2).to(3)
+      expect(attachments.to_a.last.title).to eq('new and shiny')
+    end
+  end
+
+  describe '#upload' do
+    it 'triggers upload if the current attachment is in the array' do
+      expect(attachment_jpeg).to receive(:upload)
+      attachments.upload(attachment_jpeg)
+    end
+
+    it 'does not call upload if attachment not found' do
+      expect(missing_attachment).to_not receive(:upload)
+      attachments.upload(missing_attachment)
+    end
+  end
+
+  describe '#has_attachment?' do
+    it 'returns true for a found attachment' do
+      expect(attachments.has_attachment?(attachment_jpeg)).to eq(true)
+    end
+
+    it 'returns false for a non-existent attachment' do
+      expect(attachments.has_attachment?(missing_attachment)).to eq(false)
+    end
+  end
+
+  describe '#each' do
+    it 'iterates over its attachments' do
+      titles = []
+
+      attachments.each { |a| titles << a.title }
+
+      expect(titles).to eq([attachment_jpeg.title, attachment_gif.title])
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -246,6 +246,44 @@ RSpec.describe Document do
     end
   end
 
+  describe "attachment methods" do
+    let(:attachment) { Attachment.new }
+
+    describe "#attachments=" do
+      it "creates an AttachmentCollection with the given attachments" do
+        subject.attachments = [attachment]
+
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.first).to eq(attachment)
+      end
+    end
+
+    describe "#attachments" do
+      it "returns an empty AttachmentCollection if none is set" do
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.count).to eq(0)
+      end
+    end
+
+    describe "#upload_attachment" do
+      before do
+        subject.attachments = [attachment]
+      end
+
+      it "saves itself on successful attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(true)
+        expect(subject).to receive(:save)
+        subject.upload_attachment(attachment)
+      end
+
+      it "returns false on failed attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(false)
+
+        expect(subject.upload_attachment(attachment)).to eq(false)
+      end
+    end
+  end
+
   context "with attachments" do
     let(:payload) {
       FactoryGirl.create(:document,
@@ -287,62 +325,6 @@ RSpec.describe Document do
         payload["details"]["attachments"][0].merge("updated_at" => "2016-01-30T10:12:26+00:00"),
         payload["details"]["attachments"][1].merge("updated_at" => "2016-01-30T10:12:26+00:00"),
       ])
-    end
-
-    describe "#find_attachment" do
-      it "finds an attachment object in the document payload" do
-        attachment_content_id = payload["details"]["attachments"][0]["content_id"]
-        document = MyDocumentType.from_publishing_api(payload)
-        attachment = document.find_attachment(attachment_content_id)
-
-        expect(attachment).to eq(document.attachments[0])
-      end
-    end
-
-    describe "#upload_attachment" do
-      let(:url) { '/uploaded/mocked_asset_name.jpg' }
-      context "for new attachment" do
-        context "on successful attachment upload" do
-          it "adds attachment to document and saves the document" do
-            new_attachment = Attachment.new
-
-            expect(document).to receive(:save)
-            expect(new_attachment).to receive(:upload).and_return(url)
-
-            document.upload_attachment(new_attachment)
-
-            expect(document.attachments).to include(new_attachment)
-          end
-        end
-
-        context "on failed attachment upload" do
-          it "does not add attachment and does not save the document" do
-            new_attachment = Attachment.new
-
-            expect(new_attachment).to receive(:upload).and_return(false)
-            expect(document).to_not receive(:save)
-
-            document.upload_attachment(new_attachment)
-
-            expect(document.attachments).to_not include(new_attachment)
-          end
-        end
-      end
-
-      context "for existing attachment" do
-        it "does not add the attachment to the attachments array" do
-          attachment_content_id = payload["details"]["attachments"][0]["content_id"]
-          document = MyDocumentType.from_publishing_api(payload)
-          attachment = document.find_attachment(attachment_content_id)
-
-          expect(attachment).to receive(:upload).and_return(url)
-          expect(document).to receive(:save)
-
-          document.upload_attachment(attachment)
-
-          expect(document).to_not receive(:add_attachment)
-        end
-      end
     end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -283,48 +283,4 @@ RSpec.describe Document do
       end
     end
   end
-
-  context "with attachments" do
-    let(:payload) {
-      FactoryGirl.create(:document,
-        document_type: "my_document_type",
-        details: {
-          "metadata" => {
-            "document_type" => "my_document_type"
-          },
-          "attachments" => [
-            {
-              "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-              "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-              "content_type" => "application/jpeg",
-              "title" => "asylum report image title",
-              "created_at" => "2015-12-18T10:12:26+00:00",
-              "updated_at" => "2015-12-18T10:12:26+00:00"
-            },
-            {
-              "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-              "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-              "content_type" => "application/pdf",
-              "title" => "asylum report pdf title",
-              "created_at" => "2015-12-18T10:12:26+00:00",
-              "updated_at" => "2015-12-18T10:12:26+00:00"
-            }
-          ]
-        })
-    }
-
-    before do
-      Timecop.freeze(Time.parse("2016-01-30 10:12:26 UTC"))
-    end
-
-    it "re-sends attachments to the Publishing API with updated timestamps" do
-      document = MyDocumentType.from_publishing_api(payload)
-      presented_document = DocumentPresenter.new(document).to_json.deep_stringify_keys
-
-      expect(presented_document["details"]["attachments"]).to eq([
-        payload["details"]["attachments"][0].merge("updated_at" => "2016-01-30T10:12:26+00:00"),
-        payload["details"]["attachments"][1].merge("updated_at" => "2016-01-30T10:12:26+00:00"),
-      ])
-    end
-  end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -231,80 +231,42 @@ RSpec.describe Section do
     end
   end
 
-  context "with attachments" do
-    before do
-      @section = described_class.new(manual_content_id: '1234-56789', title: 'A section')
-      @section.attachments = [
-        Attachment.new(
-          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/section-image.jpg",
-          "content_type" => "application/jpeg",
-          "title" => "esction image title",
-          "created_at" => "2015-12-18T10:12:26+00:00",
-          "updated_at" => "2015-12-18T10:12:26+00:00"
-        ),
-        Attachment.new(
-          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/section-pdf.pdf",
-          "content_type" => "application/pdf",
-          "title" => "section pdf title",
-          "created_at" => "2015-12-18T10:12:26+00:00",
-          "updated_at" => "2015-12-18T10:12:26+00:00"
-        )
-      ]
+  describe "attachment methods" do
+    let(:attachment) { Attachment.new }
+    let(:subject) { described_class.new(manual_content_id: '1234-56789', title: 'A section') }
+
+    describe "#attachments=" do
+      it "creates an AttachmentCollection with the given attachments" do
+        subject.attachments = [attachment]
+
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.first).to eq(attachment)
+      end
     end
 
-    describe "#find_attachment" do
-      it "finds attachment object inside the document object" do
-        attachment_content_id = @section.attachments[0].content_id
-
-        attachment = @section.find_attachment(attachment_content_id)
-        expect(attachment).to eq(@section.attachments[0])
+    describe "#attachments" do
+      it "returns an empty AttachmentCollection if none is set" do
+        subject = described_class.new(manual_content_id: '1234-56789', title: 'A section')
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.count).to eq(0)
       end
     end
 
     describe "#upload_attachment" do
-      let(:url) { '/uploaded/mocked_asset_name.jpg' }
-
-      context "for new attachment" do
-        context "on successful attachment upload" do
-          it "adds attachment to document and saves the document" do
-            new_attachment = Attachment.new
-
-            expect(@section).to receive(:save)
-            expect(new_attachment).to receive(:upload).and_return(url)
-
-            @section.upload_attachment(new_attachment)
-
-            expect(@section.attachments).to include(new_attachment)
-          end
-        end
-
-        context "on failed attachment upload" do
-          it "does not add attachment and does not save the section" do
-            new_attachment = Attachment.new
-
-            expect(new_attachment).to receive(:upload).and_return(false)
-            expect(@section).to_not receive(:save)
-
-            @section.upload_attachment(new_attachment)
-
-            expect(@section.attachments).to_not include(new_attachment)
-          end
-        end
+      before do
+        subject.attachments = [attachment]
       end
 
-      context "for existing attachment" do
-        it "does not add the attachment to the attachments array" do
-          attachment = @section.attachments[0]
+      it "saves itself on successful attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(true)
+        expect(subject).to receive(:save)
+        subject.upload_attachment(attachment)
+      end
 
-          expect(attachment).to receive(:upload).and_return(url)
-          expect(@section).to receive(:save)
+      it "returns false on failed attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(false)
 
-          @section.upload_attachment(attachment)
-
-          expect(@section).to_not receive(:add_attachment)
-        end
+        expect(subject.upload_attachment(attachment)).to eq(false)
       end
     end
   end

--- a/spec/presenters/attachment_presenter_spec.rb
+++ b/spec/presenters/attachment_presenter_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe AttachmentPresenter do
       expect(presented_data[:content_id]).to eq(content_id)
       expect(presented_data[:title]).to eq('test specialist document attachment')
       expect(presented_data[:created_at]).to eq("2015-12-03T16:59:13+00:00")
+    end
+
+    it "sets updated_at to the current time" do
       expect(presented_data[:updated_at]).to eq("2015-12-03T16:59:13+00:00")
     end
   end


### PR DESCRIPTION
An attempt to encapsulate common functionality for attachments.
This follows from trying to set up a `has_many` association between
Documents and Attachments, but associations come from ActiveRecord
so not really feasible use them here. Instead we opt for a Collections
model extracts related methods from the Document and Section classes.
