### PR TITLE
Fix a Rails autoload circular dependency problem

### DIFF
--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class EmailAlertApiWorker
   include Sidekiq::Worker
 

--- a/app/workers/rummager_worker.rb
+++ b/app/workers/rummager_worker.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class RummagerWorker
   include Sidekiq::Worker
 


### PR DESCRIPTION
For reasons unknown, Rails was raising this error on integration:
RuntimeError: Circular dependency detected while autoloading constant Services

Add explicit 'require' statements fixes this problem. I'm not sure
why this was happening as 'lib' was on the load path and there's only
one 'Services' in the app. Maybe it was clashing with something inside
Rails.
