### PR TITLE
Preview Govspeak button for document new and edit views

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -19,5 +19,19 @@ jQuery(function($) {
 
   $(".js-length-counter").each(function(){
     new GOVUK.LengthCounter({$el:$(this)});
-  })
+  });
+
+  $("#preview-button").click(function(){
+      $('.preview_container').removeClass('hide');
+      var bodyText = $('.body-text').val();
+      $.post(
+          "/preview",
+          { bodyText: bodyText
+          },
+          function(data) {
+              $('.govspeak').html(data['renderedGovspeak']);
+          }
+      );
+      return false;
+  });
 });

--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -29,7 +29,7 @@ jQuery(function($) {
           { bodyText: bodyText
           },
           function(data) {
-              $('.govspeak').html(data['renderedGovspeak']);
+              $('.govspeak').html(data);
           }
       );
       return false;

--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -2,7 +2,7 @@ class GovspeakController < ApplicationController
   def preview
     skip_authorization
 
-    govspeak_document = Govspeak::Document.new(params["bodyText"])
-    render json: { renderedGovspeak: govspeak_document.to_html }
+    govspeak_preview = Govspeak::Document.new(params["bodyText"]).to_html
+    render html: govspeak_preview.html_safe
   end
 end

--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -1,0 +1,8 @@
+class GovspeakController < ApplicationController
+  def preview
+    skip_authorization
+
+    govspeak_document = Govspeak::Document.new(params["bodyText"])
+    render json: { renderedGovspeak: govspeak_document.to_html }
+  end
+end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumbs do %>
-  <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
-  <li><%= link_to @document.title, document_path(document_type_slug: params[:document_type_slug], content_id: @document.content_id) %></li>
-  <li class='active'>Edit document</li>
+    <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
+    <li><%= link_to @document.title, document_path(document_type_slug: params[:document_type_slug], content_id: @document.content_id) %></li>
+    <li class='active'>Edit document</li>
 <% end %>
 
 <h2>Editing <%= @document.title %></h2>
@@ -9,15 +9,17 @@
 <div class="row">
   <div class="col-md-8">
     <%= form_for @document, url: document_path(document_type_slug: params[:document_type_slug], content_id: @document.content_id), method: :put do |f| %>
-      <%= render partial: "shared/form_fields", locals: { f: f } %>
+        <%= render partial: "shared/form_fields", locals: {f: f} %>
 
-      <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: { f: f } %>
+        <%= render partial: "shared/preview_govspeak" %>
 
-      <%= render partial: "shared/minor_major_update_fields", locals: { f: f, document: @document } %>
+        <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: {f: f} %>
 
-      <div class="actions">
-        <button name="save" class="btn btn-success" data-disable-with="Saving...">Save as draft</button>
-      </div>
+        <%= render partial: "shared/minor_major_update_fields", locals: {f: f, document: @document} %>
+
+        <div class="actions">
+          <button name="save" class="btn btn-success" data-disable-with="Saving...">Save as draft</button>
+        </div>
     <% end %>
   </div>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -10,6 +10,8 @@
     <%= form_for @document, url: documents_path(params[:document_type_slug]) do |f| %>
       <%= render partial: "shared/form_fields", locals: { f: f } %>
 
+      <%= render partial: "shared/preview_govspeak" %>
+
       <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: { f: f } %>
 
       <div class="actions">

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :body } do %>
-  <%= f.text_area :body, rows: 20, class: 'form-control' %>
+  <%= f.text_area :body, rows: 20, class: 'form-control body-text' %>
 <% end %>

--- a/app/views/shared/_preview_govspeak.html.erb
+++ b/app/views/shared/_preview_govspeak.html.erb
@@ -1,0 +1,10 @@
+<div class="preview_button add-vertical-margins">
+  <a href="#preview-container" name="preview" id="preview-button" class="btn btn-primary">Preview</a>
+</div>
+<div id="preview-container" class="preview_container add-vertical-margins hide">
+  <div class="preview">
+    <div class="govspeak">
+
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
   get '/rebuild-healthcheck', to: proc { [200, {}, ['OK']] }
+  post '/preview', to: 'govspeak#preview'
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -52,7 +52,7 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
     app spec lib spec config
 fi
 
-GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas RAILS_ENV=test bundle exec rake
+GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas RAILS_ENV=test xvfb-run -a bundle exec rake
 
 export EXIT_STATUS=$?
 

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -140,4 +140,27 @@ RSpec.feature "Creating a CMA case", type: :feature do
     expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
     expect(page).to have_content("Body cannot include invalid Govspeak")
   end
+
+  scenario "previewing GovSpeak", js: true do
+    visit "/cma-cases/new"
+
+    fill_in "Body", with: "$CTA some text $CTA"
+
+    click_link "Preview"
+
+    within(".preview_container") do
+      expect(page).to have_content("some text")
+      expect(page).not_to have_content("$CTA")
+    end
+
+    fill_in "Body", with: "[link text](http://www.example.com)"
+
+    click_link "Preview"
+
+    within(".preview_container") do
+      expect(page).to have_content("link text")
+      expect(page).not_to have_content("http://www.example.com")
+      expect(page).not_to have_content("some text")
+    end
+  end
 end

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -272,6 +272,27 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page.status_code).to eq(200)
         expect(page).to have_content("Editing Example CMA Case")
       end
+
+      scenario "previewing GovSpeak", js: true do
+        fill_in "Body", with: "$CTA some text $CTA"
+
+        click_link "Preview"
+
+        within(".preview_container") do
+          expect(page).to have_content("some text")
+          expect(page).not_to have_content("$CTA")
+        end
+
+        fill_in "Body", with: "[link text](http://www.example.com)"
+
+        click_link "Preview"
+
+        within(".preview_container") do
+          expect(page).to have_content("link text")
+          expect(page).not_to have_content("http://www.example.com")
+          expect(page).not_to have_content("some text")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This sends an AJAX request and renders the Govspeak body text on the page.
We decided to use a Govspeak controller because serving this ajax call is something that is not specific to documents. 
We've had to update jenkins to run using Xvfb, so that Capybara can run functional tests that rely on Javascript. More details [here](https://github.com/thoughtbot/capybara-webkit#ci).
[trello card](https://trello.com/c/bcRezNAX/145-preview-button-inline-preview-is-missing-medium)
