### PR TITLE
Update finder signup content item presenter

### DIFF
--- a/app/presenters/finders/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finders/finder_signup_content_item_presenter.rb
@@ -2,9 +2,10 @@ FinderSignupContentItemPresenter = Struct.new(:schema, :timestamp) do
   def to_json
     {
       base_path: base_path,
-      format: format,
       content_id: content_id,
       title: title,
+      schema_name: schema_name,
+      document_type: document_type,
       description: description,
       public_updated_at: public_updated_at,
       update_type: update_type,
@@ -12,6 +13,7 @@ FinderSignupContentItemPresenter = Struct.new(:schema, :timestamp) do
       rendering_app: rendering_app,
       routes: routes,
       details: details,
+      locale: locale,
     }
   end
 
@@ -20,6 +22,10 @@ FinderSignupContentItemPresenter = Struct.new(:schema, :timestamp) do
   end
 
 private
+
+  def locale
+    "en"
+  end
 
   def title
     schema.fetch("signup_title", schema.fetch("name"))
@@ -33,7 +39,11 @@ private
     schema.fetch("signup_copy", nil)
   end
 
-  def format
+  def document_type
+    "finder_email_signup"
+  end
+
+  def schema_name
     "finder_email_signup"
   end
 
@@ -78,6 +88,6 @@ private
   end
 
   def public_updated_at
-    timestamp
+    timestamp.to_datetime.rfc3339
   end
 end

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -15,7 +15,7 @@ class PublishingApiFinderPublisher
       if should_publish_in_this_environment?(finder)
         publish(finder)
       else
-        logger.info("Not publishing #{finder[:file]['title']} because it is pre_production")
+        logger.info("Not publishing #{finder[:file]['name']} because it is pre_production")
       end
     end
   end
@@ -47,7 +47,7 @@ private
       finder[:file],
     )
 
-    logger.info("publishing '#{finder[:file]['name']}' finder")
+    logger.info("Publishing '#{finder[:file]['name']}' finder")
 
     Services.publishing_api.put_content(finder_payload.content_id, finder_payload.to_json)
     Services.publishing_api.patch_links(finder_payload.content_id, links_payload.to_json)
@@ -64,7 +64,7 @@ private
       finder[:file],
     )
 
-    logger.info("publishing '#{finder[:file]['name']}' finder signup page")
+    logger.info("Publishing '#{finder[:file]['name']}' finder signup page")
 
     Services.publishing_api.put_content(signup_payload.content_id, signup_payload.to_json)
     Services.publishing_api.patch_links(signup_payload.content_id, links_payload.to_json)

--- a/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe FinderSignupContentItemPresenter do
+  describe "#to_json" do
+    Dir["lib/documents/schemas/*.json"].each do |file|
+      it "is valid against the #{file} content schemas" do
+        read_file = File.read(file)
+        payload = JSON.parse(read_file)
+        if payload.has_key?("signup_content_id")
+          finder_signup_content_presenter = FinderSignupContentItemPresenter.new(payload, File.mtime(file))
+          presented_data = finder_signup_content_presenter.to_json
+
+          expect(presented_data[:schema_name]).to eq("finder_email_signup")
+          expect(presented_data).to be_valid_against_schema("finder_email_signup")
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative "../../../app/presenters/finders/finder_signup_content_item_presenter"
 
 RSpec.describe FinderSignupContentItemPresenter do
   describe "#to_json" do


### PR DESCRIPTION
- Deprecated 'format' and replaced it with 'schema_name' and 'document_type'
- Format 'public_updated_at' to rfc3339 string, as this is the default
  requirement of content-schema validation.

[Trello Card](https://trello.com/c/HnpJ2PQf/147-create-missing-schema-for-finder-email-signup-medium),

[Depends On](https://github.com/alphagov/govuk-content-schemas/pull/327)
