### PR TITLE
Sort by last_edited_at on index page

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -212,13 +212,14 @@ class Document
         :base_path,
         :content_id,
         :updated_at,
+        :last_edited_at,
         :title,
         :publication_state,
         :state_history,
       ],
       page: page,
       per_page: per_page,
-      order: "-updated_at",
+      order: "-last_edited_at",
     }
     params[:q] = q if q.present?
     Services.publishing_api.get_content_items(params)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -211,7 +211,6 @@ class Document
       fields: [
         :base_path,
         :content_id,
-        :updated_at,
         :last_edited_at,
         :title,
         :publication_state,

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,7 +1,7 @@
 <li class="document">
   <%= link_to document.title, document_path(current_format.slug, document.content_id), class: 'document-title' %>
   <ul class="metadata">
-    <li class="text-muted">Updated <%= time_ago_in_words(document.updated_at) %> ago</li>
+    <li class="text-muted">Updated <%= time_ago_in_words(document.last_edited_at) %> ago</li>
     <li>
       <%= state_for_frontend(document) %>
     </li>

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Searching and filtering", type: :feature do
         "description" => "This is the summary of example CMA case #{n}",
         "base_path" => "/cma-cases/example-cma-case-#{n}",
         "publication_state" => "draft",
-        "updated_at" => (test_date - (n + 1).days).iso8601,
+        "last_edited_at" => (test_date - (n + 1).days).iso8601,
         "public_updated_at" => (test_date - (10 - n).days).iso8601)
     end
     ten_example_cases[1]["publication_state"] = "live"
@@ -57,7 +57,7 @@ RSpec.feature "Searching and filtering", type: :feature do
       end
     end
 
-    scenario "viewing the updated_at field on the index page" do
+    scenario "viewing the last_edited_at field on the index page" do
       Timecop.freeze(test_date) do
         visit "/cma-cases"
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -59,7 +59,7 @@ FactoryGirl.define do
     public_updated_at "2015-11-16T11:53:30+00:00"
     # TODO: "draft" documents shouldn't really have a first_published_at
     first_published_at "2015-11-15T00:00:00Z"
-    updated_at "2015-11-15T11:53:30"
+    last_edited_at "2015-11-15T11:53:30"
     publication_state "draft"
     state_history {
       { "1": "draft" }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Document do
           fields: [
             :base_path,
             :content_id,
-            :updated_at,
             :last_edited_at,
             :title,
             :publication_state,

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -33,13 +33,14 @@ RSpec.describe Document do
             :base_path,
             :content_id,
             :updated_at,
+            :last_edited_at,
             :title,
             :publication_state,
             :state_history,
           ],
           page: 1,
           per_page: 20,
-          order: "-updated_at",
+          order: "-last_edited_at",
           q: "foo",
         )
 

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -1,6 +1,6 @@
 module PublishingApiHelpers
   def write_payload(document)
-    document.delete("updated_at")
+    document.delete("last_edited_at")
     document.delete("publication_state")
     document.delete("first_published_at")
     document.delete("public_updated_at")


### PR DESCRIPTION
This is a new field added to publishing-api, since the sorting and
writing of this field is handled by publishing-api, we just need to send
the correct params in our request for multiple content items on our
index page
