### PR TITLE
Guard last edited at

### DIFF
--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,7 +1,9 @@
 <li class="document">
   <%= link_to document.title, document_path(current_format.slug, document.content_id), class: 'document-title' %>
   <ul class="metadata">
-    <li class="text-muted">Updated <%= time_ago_in_words(document.last_edited_at) %> ago</li>
+    <% if document.last_edited_at %>
+      <li class="text-muted last-edited-at">Updated <%= time_ago_in_words(document.last_edited_at) %> ago</li>
+    <% end %>
     <li>
       <%= state_for_frontend(document) %>
     </li>

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature "Searching and filtering", type: :feature do
     scenario "viewing the last_edited_at field on the index page" do
       Timecop.freeze(test_date) do
         visit "/cma-cases"
+        expect(page).to have_css(".last-edited-at")
 
         within(".document-list li.document:nth-child(1)") do
           expect(page).to have_content("Updated 1 day ago")
@@ -102,6 +103,20 @@ RSpec.feature "Searching and filtering", type: :feature do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_content("No CMA Cases available.")
+    end
+  end
+
+  context "when publishing-api returns null values for last-edited-at" do
+    scenario "last-edited-at should be hidden when value is nil" do
+      cma_cases_with_missing_last_edited_at = cma_cases.each { |item| item.merge!("last_edited_at" => nil) }
+      expect(cma_cases_with_missing_last_edited_at.sample["last_edited_at"]).to eq(nil)
+
+      publishing_api_has_content(cma_cases_with_missing_last_edited_at, hash_including(document_type: CmaCase.document_type))
+
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).not_to have_css(".last-edited-at")
     end
   end
 end


### PR DESCRIPTION
As `last_edited_at` field is rather new from publishing-api, we will
need to do some data migration to populate that field for existing
documents. In the meantime, a nil value will cause an error at
`time_ago_in_words` so I'm adding a guard clause for a smoother
transition.

Branched off of #804 as we might not need this work-around if we know that the api will never return nil for `last_edited_at`
