### PR TITLE
Remove links from Rummager payloads

### DIFF
--- a/app/exporters/formatters/aaib_report_indexable_formatter.rb
+++ b/app/exporters/formatters/aaib_report_indexable_formatter.rb
@@ -16,8 +16,4 @@ private
       registration: entity.registration,
     }
   end
-
-  def organisation_slugs
-    ["air-accidents-investigation-branch"]
-  end
 end

--- a/app/exporters/formatters/abstract_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_indexable_formatter.rb
@@ -24,7 +24,6 @@ private
       description: description,
       link: link,
       indexable_content: indexable_content,
-      organisations: organisation_slugs,
       public_timestamp: public_timestamp,
     }
   end
@@ -55,9 +54,5 @@ private
 
   def public_timestamp
     entity.updated_at
-  end
-
-  def organisation_slugs
-    raise NotImplementedError
   end
 end

--- a/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/asylum_support_decision_indexable_formatter.rb
@@ -21,8 +21,4 @@ private
       tribunal_decision_sub_category_name: expand_value(:tribunal_decision_sub_category).first,
     }
   end
-
-  def organisation_slugs
-    ["first-tier-tribunal-asylum-support"]
-  end
 end

--- a/app/exporters/formatters/cma_case_indexable_formatter.rb
+++ b/app/exporters/formatters/cma_case_indexable_formatter.rb
@@ -16,8 +16,4 @@ private
       closed_date: entity.closed_date,
     }
   end
-
-  def organisation_slugs
-    ["competition-and-markets-authority"]
-  end
 end

--- a/app/exporters/formatters/countryside_stewardship_grant_indexable_formatter.rb
+++ b/app/exporters/formatters/countryside_stewardship_grant_indexable_formatter.rb
@@ -14,12 +14,4 @@ class CountrysideStewardshipGrantIndexableFormatter < AbstractSpecialistDocument
       funding_amount: entity.funding_amount,
     }
   end
-
-  def organisation_slugs
-    %w(
-      natural-england
-      department-for-environment-food-rural-affairs
-      forestry-commission
-    )
-  end
 end

--- a/app/exporters/formatters/drug_safety_update_indexable_formatter.rb
+++ b/app/exporters/formatters/drug_safety_update_indexable_formatter.rb
@@ -12,8 +12,4 @@ private
       first_published_at: entity.first_published_at,
     }
   end
-
-  def organisation_slugs
-    ["medicines-and-healthcare-products-regulatory-agency"]
-  end
 end

--- a/app/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/employment_appeal_tribunal_decision_indexable_formatter.rb
@@ -18,8 +18,4 @@ private
       tribunal_decision_sub_categories_name: expand_value(:tribunal_decision_sub_categories),
     }
   end
-
-  def organisation_slugs
-    ["employment-appeal-tribunal"]
-  end
 end

--- a/app/exporters/formatters/employment_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/employment_tribunal_decision_indexable_formatter.rb
@@ -16,8 +16,4 @@ private
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
     }
   end
-
-  def organisation_slugs
-    ["employment-tribunal"]
-  end
 end

--- a/app/exporters/formatters/esi_fund_indexable_formatter.rb
+++ b/app/exporters/formatters/esi_fund_indexable_formatter.rb
@@ -16,8 +16,4 @@ private
       closing_date: entity.closing_date
     }
   end
-
-  def organisation_slugs
-    []
-  end
 end

--- a/app/exporters/formatters/international_development_fund_indexable_formatter.rb
+++ b/app/exporters/formatters/international_development_fund_indexable_formatter.rb
@@ -15,8 +15,4 @@ private
       value_of_funding: entity.value_of_funding,
     }
   end
-
-  def organisation_slugs
-    ["department-for-international-development"]
-  end
 end

--- a/app/exporters/formatters/maib_report_indexable_formatter.rb
+++ b/app/exporters/formatters/maib_report_indexable_formatter.rb
@@ -13,8 +13,4 @@ private
       vessel_type: entity.vessel_type,
     }
   end
-
-  def organisation_slugs
-    ["marine-accident-investigation-branch"]
-  end
 end

--- a/app/exporters/formatters/manual_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_indexable_formatter.rb
@@ -16,10 +16,6 @@ private
     entity.summary # Manuals don't have a body
   end
 
-  def organisation_slugs
-    [entity.organisation_slug]
-  end
-
   def specialist_sectors
     if entity.tags.present?
       entity.tags.select { |t| t[:type] == "specialist_sector" }.map { |t| t[:slug] }

--- a/app/exporters/formatters/manual_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_indexable_formatter.rb
@@ -7,20 +7,10 @@ class ManualIndexableFormatter < AbstractIndexableFormatter
 
 private
   def extra_attributes
-    {
-      specialist_sectors: specialist_sectors
-    }
+    {}
   end
 
   def indexable_content
     entity.summary # Manuals don't have a body
-  end
-
-  def specialist_sectors
-    if entity.tags.present?
-      entity.tags.select { |t| t[:type] == "specialist_sector" }.map { |t| t[:slug] }
-    else
-      []
-    end
   end
 end

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -42,8 +42,4 @@ private
   def public_timestamp
     nil
   end
-
-  def organisation_slugs
-    [manual.organisation_slug]
-  end
 end

--- a/app/exporters/formatters/medical_safety_alert_indexable_formatter.rb
+++ b/app/exporters/formatters/medical_safety_alert_indexable_formatter.rb
@@ -13,8 +13,4 @@ private
       issued_date: entity.issued_date,
     }
   end
-
-  def organisation_slugs
-    ["medicines-and-healthcare-products-regulatory-agency"]
-  end
 end

--- a/app/exporters/formatters/raib_report_indexable_formatter.rb
+++ b/app/exporters/formatters/raib_report_indexable_formatter.rb
@@ -13,8 +13,4 @@ private
       railway_type: entity.railway_type,
     }
   end
-
-  def organisation_slugs
-    ["rail-accident-investigation-branch"]
-  end
 end

--- a/app/exporters/formatters/tax_tribunal_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/tax_tribunal_decision_indexable_formatter.rb
@@ -14,8 +14,4 @@ private
       tribunal_decision_decision_date: entity.tribunal_decision_decision_date,
     }
   end
-
-  def organisation_slugs
-    ["upper-tribunal-tax-and-chancery-chamber"]
-  end
 end

--- a/app/exporters/formatters/utaac_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/utaac_decision_indexable_formatter.rb
@@ -18,8 +18,4 @@ private
       tribunal_decision_sub_categories_name: expand_value(:tribunal_decision_sub_categories),
     }
   end
-
-  def organisation_slugs
-    ["upper-tribunal-administrative-appeals-chamber"]
-  end
 end

--- a/app/exporters/formatters/vehicle_recalls_and_faults_alert_indexable_formatter.rb
+++ b/app/exporters/formatters/vehicle_recalls_and_faults_alert_indexable_formatter.rb
@@ -19,8 +19,4 @@ private
       build_end_date: entity.build_end_date,
     }
   end
-
-  def organisation_slugs
-    ["driver-and-vehicle-standards-agency"]
-  end
 end

--- a/app/presenters/finder_rummager_presenter.rb
+++ b/app/presenters/finder_rummager_presenter.rb
@@ -14,7 +14,6 @@ FinderRummagerPresenter = Struct.new(:metadata, :timestamp) do
       "link" => metadata.fetch("base_path"),
       "format" => "finder",
       "public_timestamp" => timestamp,
-      "specialist_sectors" => metadata.fetch("topics", []),
     }
   end
 end

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Republishing documents", type: :feature do
       description: @document.summary,
       link: "/" + @document.slug,
       indexable_content: @document.body,
-      organisations: ["air-accidents-investigation-branch"],
       public_timestamp: public_timestamp,
       aircraft_category: nil,
       report_type: nil,

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -56,9 +56,6 @@ describe RummagerFinderPublisher do
             "link" => "/first-finder",
             "format" => "finder",
             "public_timestamp" => "2015-01-05T10:45:10.000+00:00",
-            "specialist_sectors" => [
-              "business-tax/paye",
-            ]
           })
 
         expect(rummager).to receive(:add_document)
@@ -68,10 +65,6 @@ describe RummagerFinderPublisher do
             "link" => "/second-finder",
             "format" => "finder",
             "public_timestamp" => "2015-02-14T11:43:23.000+00:00",
-            "specialist_sectors" => [
-              "competition/mergers",
-              "competition/markets",
-            ],
           })
 
         RummagerFinderPublisher.new(metadata, logger: test_logger).call


### PR DESCRIPTION
We don't need to send these to Rummager any more - indexing of documents
now includes a step to fetch document links from the publishing API.

trello https://trello.com/c/LbZA0i15/678-stop-apps-from-sending-mainstream-browse-pages-topics-and-organisations-to-rummager