### PR TITLE
Write last_edited_at to publishing-api

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -21,6 +21,7 @@ class SpecialistDocumentPublishingAPIFormatter
       update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,
+      last_edited_at: public_updated_at,
       details: details,
       routes: [
         path: base_path,

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Republishing documents", type: :feature do
       update_type: "republish",
       locale: "en",
       public_updated_at: "2016-05-11T10:56:07+00:00",
+      last_edited_at: "2016-05-11T10:56:07+00:00",
       details: {"metadata" => {"opened_date" => "2013-04-20", # These nested hashes use Strings as keys because Symbols gives a false negative in the request_json_matching matcher.
                                "market_sector" => "some-market-sector",
                                "case_type" => "a-case-type",
@@ -86,6 +87,11 @@ RSpec.describe "Republishing documents", type: :feature do
                                  .with(@document.document_type, "/a/b", hash_including(rummager_fields))
     end
 
+    it "should send public_updated_at as last_edited_at timestamp" do
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+      assert_publishing_api_put_draft_item("/a/b", request_json_matching(last_edited_at: "2016-05-11T10:56:07+00:00"))
+    end
+
     it "should add job to worker queue when republishing all documents" do
       Sidekiq::Testing.fake! do
         expect {
@@ -109,6 +115,11 @@ RSpec.describe "Republishing documents", type: :feature do
       assert_publishing_api_put_item("/c/d", request_json_matching(publishing_api_fields))
       expect(fake_rummager).to have_received(:add_document)
                                  .with(@document.document_type, "/c/d", hash_including(rummager_fields))
+    end
+
+    it "should send public_updated_at as last_edited_at timestamp" do
+      SpecialistPublisher.document_services("aaib_report").republish_all.call
+      assert_publishing_api_put_item("/c/d", request_json_matching(last_edited_at: "2016-05-11T10:56:07+00:00"))
     end
   end
 


### PR DESCRIPTION
This field will be used in V2, so to support data-migrations, the
presenter will write the last_edited_at to the API.
The value of last-edited-at is the same as public-updated-at because
that is the field that last_edited_at will replace in V2.

The only necessary spec change is https://github.com/alphagov/specialist-publisher/pull/725/files#diff-a7872724f11dc4d45a18efd35cd8455fR19
but I decided to add two more details test because `assert_publishing_api_put_draft_item` doesn't output specific differences in payload, so a more narrow test might help with debugging/documenting.

Test will fail temporarily because of a dependence on schema validations here https://github.com/alphagov/govuk-content-schemas/pull/332