### PR TITLE
Add script to delete editions with xx prefixed titles

### DIFF
--- a/bin/delete_documents_marked_for_delete
+++ b/bin/delete_documents_marked_for_delete
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+
+require "gds_api/publishing_api_v2"
+
+def publishing_api
+  @publishing_api ||= GdsApi::PublishingApiV2.new(
+    Plek.new.find("publishing-api"),
+    bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
+  )
+end
+
+def in_publishing_api?(content_id)
+  publishing_api.get_content(content_id).present?
+end
+
+def marked_editions
+  SpecialistDocumentEdition.where(title: /\Axx/i)
+end
+
+def fetch_duplicated_editions
+  slug_hash = {}
+  marked_editions.all.each do |edition|
+    slug_hash[edition.slug] ||= {}
+    slug_hash[edition.slug][edition.document_id] ||= {state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.document_id, slug: edition.slug}
+    slug_hash[edition.slug][edition.document_id][:editions] += 1
+  end
+
+  slug_hash.values.map(&:values).flatten(1)
+end
+
+puts "**** DRY RUN - NOTHING WILL BE DONE ****" unless ENV["DO_IT"].present?
+
+duplicated_editions = fetch_duplicated_editions
+
+puts "The following #{duplicated_editions.count} editions have been marked as XX for deletion:"
+duplicated_editions.each do |edition|
+  puts [edition[:slug], edition[:document_id], edition[:state], edition[:created_at]].join(",")
+end
+
+known_editions, unknown_editions = duplicated_editions.partition { |edition| in_publishing_api?(edition[:content_id]) }
+
+puts "The following #{unknown_editions.count} are unknown to Publishing API and are safe to delete:"
+unknown_editions.each do |edition|
+  puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
+  SpecialistDocumentEdition.where(document_id: edition[:content_id]).delete_all if ENV["DO_IT"].present?
+end
+
+puts "The following #{known_editions.count} are known to Publishing API and will be deleted after the draft is discarded:"
+known_editions.each do |edition|
+  puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
+  if ENV["DO_IT"].present?
+    publishing_api.discard_draft(edition[:content_id])
+    SpecialistDocumentEdition.where(document_id: edition[:content_id]).delete_all
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/MNx0cl5B/414-delete-duplicate-drafts-from-tax-tribunal-decisions

The application is prone to creating multiple duplicate drafts.  We have
a script, bin/delete_duplicate_drafts, for dealing with these, but
sometimes users will manually mark the duplicates for deletion by adding
xx to the start of the title and asking us to delete them.  When this
happens some of the duplicates end up in the publishing-api and so the
duplicate deleter will not remove them as it only deletes those that the
publishing-api knows nothing about.

This script finds all documents with the 'xx' prefix and deletes them
from the db.  It also asks publishing api to discard the draft if it
knows about it.

It's likely to fail if the editions are not in draft state - but by
default the script only prints out information, to really delete the
editions you must run it with a DO_IT environment variable present.