### PR TITLE
Add a dfid_authors field that accepts multiple authors

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -7,6 +7,19 @@ jQuery(function($) {
     placeholder: $(this).data('placeholder')
   });
 
+  ////
+  // Make a select2 that will create new values on return as you type them
+  $(".select2.free-form-list").select2({
+    tags: true,
+    createTag: function (params) {
+      return {
+        id: params.term,
+        text: params.term,
+        newOption: true
+      }
+    }
+  });
+
   $('.js-hidden').hide();
 
   $('.js-update-type-major').click(function() {

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -2,12 +2,13 @@ class DfidResearchOutput < Document
   validates :country, presence: true
   validates :first_published_at, presence: true, date: true
 
-  FORMAT_SPECIFIC_FIELDS = %i(country first_published_at)
+  FORMAT_SPECIFIC_FIELDS = %i(country first_published_at dfid_authors)
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    self.dfid_authors = []
   end
 
   ##

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -148,8 +148,8 @@ class Document
 
   def humanized_attributes
     format_specific_metadata.inject({}) do |attributes, (key, value)|
-      humanized_name = finder_schema.humanized_facet_name(key) { key }
-      humanized_value = finder_schema.humanized_facet_value(key, value) { value }
+      humanized_name = finder_schema.humanized_facet_name(key)
+      humanized_value = finder_schema.humanized_facet_value(key, value)
 
       attributes.merge(humanized_name => humanized_value)
     end

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -1,10 +1,19 @@
-<%= render layout: 'shared/form_group', locals: { f: f, field: :country } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_authors, label: 'Authors' } do %>
+  <%=
+    f.select :dfid_authors, @document.dfid_authors,
+      { include_blank: true },
+      { class: 'select2 free-form-list', multiple: true, data: { placeholder: 'Add authors' } }
+  %>
+<% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: 'Countries' } do %>
   <%=
     f.select :country, facet_options(f, :country),
       { include_blank: true },
       { class: 'select2', multiple: true, data: { placeholder: 'Select countries' } }
   %>
 <% end %>
-<%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at } do %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
   <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
 <% end %>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,8 +1,8 @@
-<% label ||= nil %>
+<% label ||= field.to_s.humanize %>
 
 <div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
   <%= f.label field do %>
-    <%= (label || field).to_s.humanize %>
+    <%= label %>
     <% field_errors(@document, field).each do |msg| %>
       <br />
       <span class="elements-error-message add-label-margin"><%= msg %></span>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,6 +1,8 @@
+<% label ||= nil %>
+
 <div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
   <%= f.label field do %>
-    <%= field.to_s.humanize %>
+    <%= (label || field).to_s.humanize %>
     <% field_errors(@document, field).each do |msg| %>
       <br />
       <span class="elements-error-message add-label-margin"><%= msg %></span>

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -831,6 +831,14 @@
       "type": "date",
       "display_as_result_metadata": true,
       "filterable": true
+    },
+    {
+      "key": "dfid_authors",
+      "name": "Authors",
+      "short_name": "Authors",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
     }
   ]
 }

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -18,18 +18,22 @@ class FinderSchema
     allowed_values_as_option_tuples(allowed_values_for(facet_name))
   end
 
-  def humanized_facet_value(facet_key, value, &block)
-    if facet_data_for(facet_key).fetch("type", nil) == "text"
+  def humanized_facet_value(facet_key, value)
+    type = facet_data_for(facet_key).fetch("type", nil)
+    case
+    when type == "text" && allowed_values_for(facet_key).empty?
+      value
+    when type == "text"
       Array(value).map do |v|
-        value_label_mapping_for(facet_key, v).fetch("label", &block)
+        value_label_mapping_for(facet_key, v).fetch("label") { value }
       end
     else
-      value_label_mapping_for(facet_key, value).fetch("label", &block)
+      value_label_mapping_for(facet_key, value).fetch("label") { value }
     end
   end
 
-  def humanized_facet_name(key, &block)
-    facet_data_for(key).fetch("name", &block)
+  def humanized_facet_name(key)
+    facet_data_for(key).fetch("name") { key }
   end
 
 private

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
-    select "United Kingdom", from: "Country"
+    select "United Kingdom", from: "Countries"
 
     expect(page).to have_css('div.govspeak-help')
     expect(page).to have_content('To add an attachment, please save the draft first.')

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -184,6 +184,7 @@ FactoryGirl.define do
       default_metadata {
         {
           "country" => ["GB"],
+          "authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
           "first_published_at" => "2016-04-28T11:26:00",
           "document_type" => "dfid_research_output",
         }

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'finder_schema'
+
+RSpec.describe FinderSchema do
+  let(:schema) { FinderSchema.new('dfid_research_outputs') }
+
+  describe '#humanized_facet_value' do
+    context 'a text facet' do
+      context 'with allowed_values ' do
+        context 'looking up a single value' do
+          it 'returns an array with only the looked-up value' do
+            expect(schema.humanized_facet_value('country', 'AL')).to eql(['Albania'])
+          end
+        end
+
+        context 'looking up multiple values' do
+          it 'returns an array with the looked-up values' do
+            expect(schema.humanized_facet_value('country', %w(AL AF))).to eql(%w(Albania Afghanistan))
+          end
+        end
+      end
+
+      context 'with an empty set of allowed_values' do
+        it 'returns the value itself' do
+          authors_value = ['Mr. Potato Head', 'Mrs. Potato Head']
+          expect(
+            schema.humanized_facet_value('dfid_authors', authors_value)
+          ).to eql(authors_value)
+        end
+      end
+    end
+
+    context 'a date facet' do
+      it 'just returns the value unmodified' do
+        expect(schema.humanized_facet_value('first_published_at', '2012-01-01')).to eql('2012-01-01')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Multiple free-form author set in `dfid_research_outputs`.

<img width="420" alt="screen shot 2016-06-27 at 12 16 15" src="https://cloud.githubusercontent.com/assets/194511/16377973/016621a6-3c61-11e6-9fbf-4088e3bb2358.png">

Authors are discrete pieces of text, a bit like free-form tags.
 Whereas values like `country` have multiple label/value pairs, we
 treat authors as if the label were always equal to the value. To
 achieve this, we add a `dfid_authors` facet which is of type `text`
 but has no `allowed_values`. To avoid a situation in which these
 stored authors show up incorrectly when showing a DFID research
 output, we add to `FinderSchema#humanized_facet_value`.
## Related PRs
- https://github.com/alphagov/rummager/pull/662 (**don't merge this PR until the Rummager PR's merged**)
- https://github.com/alphagov/dfid-transition/pull/33
