### PR TITLE
Fix exploding DFID edit page

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -8,7 +8,6 @@ class DfidResearchOutput < Document
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
-    self.dfid_authors = []
   end
 
   ##

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_authors, label: 'Authors' } do %>
   <%=
-    f.select :dfid_authors, @document.dfid_authors,
+    f.select :dfid_authors, @document.dfid_authors || [],
       { include_blank: true },
       { class: 'select2 free-form-list', multiple: true, data: { placeholder: 'Add authors' } }
   %>

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.feature "Editing a DFID Research Output", type: :feature do
+  let(:research_output)   { FactoryGirl.create(:dfid_research_output) }
+  let(:content_id)        { research_output['content_id'] }
+  let(:public_updated_at) { research_output['public_updated_at'] }
+
+  before do
+    log_in_as_editor(:dfid_editor)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    publishing_api_has_item(research_output)
+  end
+
+  scenario "with valid data" do
+    visit  "/dfid-research-outputs/#{content_id}/edit"
+    expect(page).to have_css('div.govspeak-help')
+
+    title = "Example DFID Research output"
+    summary = "This is the summary of an example DFID research output"
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: summary
+    fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
+    fill_in "First published at", with: "2013-01-01"
+    select "United Kingdom", from: "Countries"
+
+    click_button "Save as draft"
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Updated Example DFID Research output")
+  end
+end


### PR DESCRIPTION
- Was falling over with `NoMethodError` for `NilClass#empty?`
- Due to `Document#from_publishing_api` wiping out format-specific
  metadata, we can't use #initialize to set defaults
- We only need to ensure that we don't send `FormHelpers#select` `nil`
  instead of an empty collection. Do that in the view
