### PR TITLE
Send updated_at as last_edited_at instead of public_updated_at

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -21,7 +21,7 @@ class SpecialistDocumentPublishingAPIFormatter
       update_type: update_type,
       locale: "en",
       public_updated_at: public_updated_at,
-      last_edited_at: public_updated_at,
+      last_edited_at: updated_at,
       details: details,
       routes: [
         path: base_path,
@@ -90,6 +90,10 @@ class SpecialistDocumentPublishingAPIFormatter
     # Editions only get a public_updated_at when they are published, so field
     # can be blank.
     specialist_document.public_updated_at || specialist_document.updated_at
+  end
+
+  def updated_at
+    specialist_document.updated_at
   end
 
   def update_type

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Republishing documents", type: :feature do
                                  .with(@document.document_type, "/a/b", hash_including(rummager_fields))
     end
 
-    it "should send public_updated_at as last_edited_at timestamp" do
+    it "should send updated_at as last_edited_at timestamp" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
       assert_publishing_api_put_draft_item("/a/b", request_json_matching(last_edited_at: "2016-05-11T10:56:07+00:00"))
     end
@@ -117,7 +117,7 @@ RSpec.describe "Republishing documents", type: :feature do
                                  .with(@document.document_type, "/c/d", hash_including(rummager_fields))
     end
 
-    it "should send public_updated_at as last_edited_at timestamp" do
+    it "should send updated_at as last_edited_at timestamp" do
       SpecialistPublisher.document_services("aaib_report").republish_all.call
       assert_publishing_api_put_item("/c/d", request_json_matching(last_edited_at: "2016-05-11T10:56:07+00:00"))
     end


### PR DESCRIPTION
We use updated_at for ordering documents on the index page, see:
app/views/specialist_documents/index.html.erb

In the rebuild app, last_edited_at is used to control the order
documents appear on the index pages, so we should use updated_at
so that these orders match.

Related to: https://trello.com/c/XJRTeF9f/130-spv2-orders-by-the-wrong-timestamp-on-the-search-index