### PR TITLE
Attachments can be added on first publish

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -121,7 +121,11 @@ class Document
   end
 
   def update_type
-    @update_type || "major"
+    if self.draft?
+      'major'
+    else
+      @update_type || 'major'
+    end
   end
 
   def users

--- a/app/workers/republish_worker.rb
+++ b/app/workers/republish_worker.rb
@@ -5,19 +5,22 @@ class RepublishWorker
 
   def perform(content_id, _ = nil)
     document = Document.find(content_id)
-    document.update_type = "republish"
 
     unless safe_to_republish?(document)
       print_limitations_of_republishing(document)
       return
     end
 
-    publishing_api_put_content(document)
-    publishing_api_patch_links(document)
-
     if document.publication_state == "live"
+      document.update_type = "republish"
+
+      publishing_api_put_content(document)
+      publishing_api_patch_links(document)
       publishing_api_publish(document)
       rummager_add_document(document)
+    else
+      publishing_api_put_content(document)
+      publishing_api_patch_links(document)
     end
   end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe Document do
 
     it "doesn't alerts the email API for minor updates" do
       document.update_type = "minor"
+      document.publication_state = "live"
 
       expect(document.publish).to eq(true)
 

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe RepublishWorker do
   let(:document) { FactoryGirl.create(:cma_case) }
   let(:content_id) { document["content_id"] }
 
-  let(:republish_matcher) {
+  let(:uses_republish_update_type) {
     request_json_includes("update_type" => "republish")
+  }
+
+  let(:does_not_use_republish_update_type) {
+    request_json_includes("update_type" => "major")
   }
 
   before do
@@ -24,7 +28,7 @@ RSpec.describe RepublishWorker do
       it "sends the document to the publishing api" do
         subject.perform(content_id)
 
-        assert_publishing_api_put_content(content_id, republish_matcher)
+        assert_publishing_api_put_content(content_id, does_not_use_republish_update_type)
         assert_publishing_api_patch_links(content_id)
       end
 
@@ -56,14 +60,14 @@ RSpec.describe RepublishWorker do
     it "sends the document to the publishing api" do
       subject.perform(content_id)
 
-      assert_publishing_api_put_content(content_id, republish_matcher)
+      assert_publishing_api_put_content(content_id, uses_republish_update_type)
       assert_publishing_api_patch_links(content_id)
     end
 
     it "publishes the document" do
       subject.perform(content_id)
 
-      assert_publishing_api_publish(content_id, republish_matcher)
+      assert_publishing_api_publish(content_id, uses_republish_update_type)
     end
 
     it "sends the document to rummager" do


### PR DESCRIPTION
[Trello](https://trello.com/c/8jJTC2vu/155-adding-an-attachment-should-preserve-the-update-type-medium)
- Paired with @seraphiana
- Previously, if an attachment was added to a draft document, the document would fail to publish
- Ensures that update type is always major for draft document
- If document is not a draft then the user can select the preferred update_type
- republish_worker no longer sets a `republish` update_type for draft documents
- If the update_type for drafts was set to `republish` then emails wouldn't be sent. Content wouldn't be sent on the message queue if the document was subsequently published by an editor
- [v1 fix for similar issue](alphagov/specialist-publisher@8f5f504)

Testing - We felt this [exisiting test](https://github.com/alphagov/specialist-publisher-rebuild/blob/master/spec/features/editing_a_cma_case_spec.rb#L228) covered as much of the journey as we could achieve without full end to end testing
