### PR TITLE
Check dfid_research_output against schemas

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -183,10 +183,11 @@ FactoryGirl.define do
     transient do
       default_metadata {
         {
-          "country" => ["GB"],
-          "authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
-          "first_published_at" => "2016-04-28T11:26:00",
           "document_type" => "dfid_research_output",
+          "country" => ["GB"],
+          "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
+          "first_published_at" => "2016-04-28",
+          "bulk_published" => true
         }
       }
     end

--- a/spec/models/dfid_research_output_spec.rb
+++ b/spec/models/dfid_research_output_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
+require 'models/valid_against_schema'
 
 RSpec.describe DfidResearchOutput do
+  let(:payload) { FactoryGirl.create(:dfid_research_output) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
   subject(:output) { DfidResearchOutput.new }
 
   it 'is always bulk published to hide the publishing-api published date' do


### PR DESCRIPTION
Due to work in govuk_content_schemas, can enable same check as for
all other models.
## Related PRs

Checks here won't pass until https://github.com/alphagov/govuk-content-schemas/pull/339 is merged
