### PR TITLE
Countries are no longer mandatory

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,5 +1,4 @@
 class DfidResearchOutput < Document
-  validates :country, presence: true
   validates :first_published_at, presence: true, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i(country first_published_at dfid_authors)

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
-    select "United Kingdom", from: "Countries"
 
     expect(page).to have_css('div.govspeak-help')
     expect(page).to have_content('To add an attachment, please save the draft first.')
@@ -50,7 +49,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     expect(page).to have_content("Title can't be blank")
     expect(page).to have_content("Summary can't be blank")
     expect(page).to have_content("Body can't be blank")
-    expect(page).to have_content("Country can't be blank")
+    expect(page).not_to have_content("Country can't be blank")
   end
 
   scenario "with invalid data" do


### PR DESCRIPTION
We are seeing outputs that are not related to countries. This is
normal, though relatively uncommon.
