### PR TITLE
Republish withdrawn documents to the Publishing API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", :path => "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "30.2.0"
+  gem "gds-api-adapters", "31.4.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
@@ -99,7 +99,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (30.2.0)
+    gds-api-adapters (31.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -380,7 +380,7 @@ DEPENDENCIES
   faraday (= 0.9.0)
   fetchable (= 1.0.0)
   foreman (= 0.74.0)
-  gds-api-adapters (= 30.2.0)
+  gds-api-adapters (= 31.4.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.11.0)
   govspeak (= 3.1.0)

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -7,6 +7,7 @@ require "finder_schema"
 require "footnotes_section_heading_renderer"
 require "gds_api/email_alert_api"
 require "gds_api/publishing_api"
+require "gds_api/publishing_api_v2"
 require "gds_api/rummager"
 require "gds_api_proxy"
 require "govspeak_to_html_renderer"
@@ -229,6 +230,13 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
 
   define_singleton(:publishing_api) {
     GdsApi::PublishingApi.new(
+      Plek.new.find("publishing-api"),
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
+    )
+  }
+
+  define_singleton(:publishing_api_v2) {
+    GdsApi::PublishingApiV2.new(
       Plek.new.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
     )

--- a/app/services/abstract_document_service_registry.rb
+++ b/app/services/abstract_document_service_registry.rb
@@ -77,6 +77,7 @@ class AbstractDocumentServiceRegistry
       document_repository: document_repository,
       published_listeners: observers.republication,
       draft_listeners: observers.draft_republication,
+      withdrawn_listeners: observers.withdrawn_republication,
       document_id: document_id,
     )
   end


### PR DESCRIPTION
https://trello.com/c/fVOYrf0P/139-update-spv1-republishing-script-for-withdrawn-documents-medium

We need to republish all documents from v1 to v2
for when we move over to the rebuilt app. When we
do so, anything that’s ‘withdrawn’ needs to be
‘unpublished’ in v2 and so we need to use the new
v2 ‘unpublish’ mechanism rather than creating a
‘gone’ piece of content and sending that through.

We recently added support to the Publishing API to
support safely republishing content into a ‘gone’
state. It is now possible to transition content
directly from ‘draft’ to ‘unpublished’, without
going through the ‘published’ state that is deemed
unsafe, i.e. it would result in unpublished
content being temporarily live on GOV.UK.

One thing to be wary of in this work is that
documents are correctly republished when there is
a subsequent draft. Documents can be in more than
one state at once (‘withdrawn’ & ‘draft’) and so
the conditional in RepublishDocumentService needs
to separately check if the document is withdrawn
before sending a draft, if there is one.