### PR TITLE
Update type buttons

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -121,11 +121,7 @@ class Document
   end
 
   def update_type
-    if self.draft?
-      'major'
-    else
-      @update_type || 'major'
-    end
+    self.draft? ? 'major' : @update_type
   end
 
   def users
@@ -173,6 +169,10 @@ class Document
     end
   end
 
+  def self.extract_update_type_from_payload(payload)
+    payload['update_type'] if payload['publication_state'] == 'redrafted'
+  end
+
   def self.extract_change_note_from_payload(payload)
     # If the document is redrafted remove the last/most
     # recent change note from the change_history array
@@ -193,7 +193,7 @@ class Document
       state_history: payload['state_history'],
       public_updated_at: payload['public_updated_at'],
       first_published_at: payload['first_published_at'],
-      update_type: payload['update_type'],
+      update_type: extract_update_type_from_payload(payload),
       bulk_published: payload['details']['metadata']['bulk_published'],
       change_note: extract_change_note_from_payload(payload),
       change_history: payload['details']['change_history'].map(&:to_h),

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -1,4 +1,4 @@
-<% if document.published? %>
+<% unless document.draft? %>
   <div class="checkbox add-vertical-margins">
     <%= f.radio_button :update_type, :minor, class: 'js-update-type-minor' %>
     <%= f.label :update_type_minor %>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
       },
       "routes" => [{ "path" => "/cma-cases/example-cma-case", "type" => "exact" }],
       "redirects" => [],
-      "update_type" => "major",
+      "update_type" => nil,
     }
 
     assert_publishing_api_put_content(content_id, expected_sent_payload)

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -285,4 +285,43 @@ RSpec.feature "Editing a CMA case", type: :feature do
       end
     end
   end
+
+  context 'setting update type:' do
+    %w(live redrafted unpublished).each do |publication_state|
+      let(:cma_case) {
+        FactoryGirl.create(:cma_case,
+                           title: "Example CMA Case",
+                           publication_state: publication_state,
+                           details: {},)
+      }
+
+      scenario "visibility of update type radio buttons when editing a #{publication_state} document" do
+        within(".new_cma_case") do
+          expect(page).to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
+          expect(page).to have_content('This will notify subscribers to ')
+          expect(page).to have_content('Update type minor')
+          expect(page).to have_content('Update type major')
+        end
+      end
+    end
+  end
+
+  context 'hiding update type buttons:' do
+    %w(draft).each do |publication_state|
+      let(:cma_case) {
+        FactoryGirl.create(:cma_case,
+                           title: "Example CMA Case",
+                           publication_state: publication_state,)
+      }
+
+      scenario "(in)visibility of update type radio buttons when editing a #{publication_state} document" do
+        within(".new_cma_case") do
+          expect(page).not_to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
+          expect(page).not_to have_content('This will notify subscribers to ')
+          expect(page).not_to have_content('Update type minor')
+          expect(page).not_to have_content('Update type major')
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -362,6 +362,11 @@ FactoryGirl.define do
     end
   end
 
+  factory :my_document_type, parent: :document do
+    base_path "/base-path-for-my-document-type"
+    document_type "my_document_type"
+  end
+
   factory :attachment_payload, class: Hash do
     content_id
     sequence(:url) { |n|

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -1,11 +1,12 @@
 module PublishingApiHelpers
   def write_payload(document)
-    document.delete("last_edited_at")
-    document.delete("publication_state")
-    document.delete("first_published_at")
-    document.delete("public_updated_at")
-    document.delete("state_history")
-    document
+    copy = FactoryGirl.create(document["document_type"], document)
+    copy.delete("last_edited_at")
+    copy.delete("publication_state")
+    copy.delete("first_published_at")
+    copy.delete("public_updated_at")
+    copy.delete("state_history")
+    copy
   end
 
   def assert_no_publishing_api_put_content(content_id)


### PR DESCRIPTION
[Trello Card](https://trello.com/c/V7VRbJSq/175-bug-cannot-choose-an-update-type-after-unpublished-and-probably-republished-too-medium)

Fixed the issue whereby users couldn't set the update type when on a "republished with new draft" or "unpublished with new draft"

Also made a minor change so that the radio buttons wouldn't be preselected when editing a published or unpublished document, but would be when viewing a redrafted document
