### PR TITLE
Add dfid review status facet

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,5 +1,6 @@
 class DfidResearchOutput < Document
   validates :first_published_at, presence: true, date: true
+  validates :dfid_review_status, inclusion: %w(unreviewed peer_reviewed)
 
   FORMAT_SPECIFIC_FIELDS = %i(
     country first_published_at dfid_authors dfid_review_status

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,7 +1,9 @@
 class DfidResearchOutput < Document
   validates :first_published_at, presence: true, date: true
 
-  FORMAT_SPECIFIC_FIELDS = %i(country first_published_at dfid_authors)
+  FORMAT_SPECIFIC_FIELDS = %i(
+    country first_published_at dfid_authors dfid_review_status
+  )
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
 

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -17,3 +17,9 @@
 <%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
   <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
 <% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_review_status, label: 'Review status' } do %>
+  <%= f.select :dfid_review_status, facet_options(f, :dfid_review_status),
+    {},
+    { class: 'form-control' } %>
+<% end %>

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -839,6 +839,25 @@
       "type": "text",
       "display_as_result_metadata": true,
       "filterable": false
+    },
+    {
+      "key": "dfid_review_status",
+      "name": "Review Status",
+      "short_name": "Review Status",
+      "type": "text",
+      "preposition": "that are",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "unreviewed",
+          "label": "Unreviewed"
+        },
+        {
+          "value": "peer_reviewed",
+          "label": "Peer reviewed"
+        }
+      ]
     }
   ]
 }

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -845,7 +845,7 @@
       "name": "Review Status",
       "short_name": "Review Status",
       "type": "text",
-      "preposition": "that are",
+      "preposition": "with review status",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -204,6 +204,7 @@ FactoryGirl.define do
           "country" => ["GB"],
           "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
           "first_published_at" => "2016-04-28",
+          "dfid_review_status" => "unreviewed",
           "bulk_published" => true
         }
       }


### PR DESCRIPTION
Allows filtering of research outputs based on their review status, which can be either of `unreviewed` or `peer_reviewed`. Validates based on these two values.
- [x] This build won't pass until https://github.com/alphagov/govuk-content-schemas/pull/341 is merged
- [x] This facet won't work in finder-frontend until https://github.com/alphagov/rummager/pull/673 is merged

All good to go now 👍 
