### PR TITLE
Add dfid_theme to:

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,7 +1,10 @@
 class DfidResearchOutput < Document
   validates :first_published_at, presence: true, date: true
+  validates :dfid_theme, presence: true
 
-  FORMAT_SPECIFIC_FIELDS = %i(country first_published_at dfid_authors)
+  FORMAT_SPECIFIC_FIELDS = %i(
+    country first_published_at dfid_authors dfid_theme
+  )
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
 

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -14,6 +14,14 @@
   %>
 <% end %>
 
+<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_theme, label: 'Themes' } do %>
+  <%=
+    f.select :dfid_theme, facet_options(f, :dfid_theme),
+             { include_blank: false },
+             { class: 'select2', multiple: true, data: { placeholder: 'Select themes' } }
+  %>
+<% end %>
+
 <%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
   <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
 <% end %>

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -825,6 +825,64 @@
       ]
     },
     {
+      "key": "dfid_theme",
+      "name": "Theme",
+      "type": "text",
+      "preposition": "about",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "agriculture",
+          "label": "Agriculture"
+        },
+        {
+          "value": "climate_and_environment",
+          "label": "Climate and Environment"
+        },
+        {
+          "value": "economic_growth",
+          "label": "Economic Growth"
+        },
+        {
+          "value": "education",
+          "label": "Education"
+        },
+        {
+          "value": "food_and_nutrition",
+          "label": "Food and Nutrition"
+        },
+        {
+          "value": "governance_and_conflict",
+          "label": "Governance and Conflict"
+        },
+        {
+          "value": "health",
+          "label": "Health"
+        },
+        {
+          "value": "humanitarian_disasters_and_emergencies",
+          "label": "Humanitarian Disasters and Emergencies"
+        },
+        {
+          "value": "infrastructure",
+          "label": "Infrastructure"
+        },
+        {
+          "value": "research_communication_and_uptake",
+          "label": "Research Communication and Uptake"
+        },
+        {
+          "value": "social_change",
+          "label": "Social Change"
+        },
+        {
+          "value": "water_and_sanitation",
+          "label": "Water and Sanitation"
+        }
+      ]
+    },
+    {
       "key": "first_published_at",
       "name": "First published",
       "short_name": "First published",

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
+    select "Infrastructure", from: "Themes"
 
     expect(page).to have_css('div.govspeak-help')
     expect(page).to have_content('To add an attachment, please save the draft first.')

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -203,6 +203,7 @@ FactoryGirl.define do
           "document_type" => "dfid_research_output",
           "country" => ["GB"],
           "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
+          "dfid_theme" => ["infrastructure"],
           "first_published_at" => "2016-04-28",
           "bulk_published" => true
         }


### PR DESCRIPTION
- The finder, as a filterable facet with 12 allowed values
- Model field (validate its presence, there should always be at
  least one)
- Metadata controls (behaves as per country)
## Related PRs
- https://github.com/alphagov/govuk-content-schemas/pull/342 (this build will not pass until that is merged)
- https://github.com/alphagov/rummager/pull/676
- https://github.com/alphagov/dfid-transition/pull/36
