### PR TITLE
Pre production user restrictions

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
     document_class.organisations.include?(user.organisation_content_id)
   end
 
-  def departmental_editor
+  def departmental_editor?
     user_organisation_owns_document_type? && user.permissions.include?('editor')
   end
 
-  def writer
+  def writer?
     user_organisation_owns_document_type?
   end
 
-  def gds_editor
+  def gds_editor?
     user.gds_editor?
   end
 end

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,6 +1,6 @@
 class AttachmentPolicy < ApplicationPolicy
   def new?
-    gds_editor || departmental_editor || writer
+    gds_editor? || departmental_editor? || writer?
   end
 
   alias_method :create?, :new?

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -1,6 +1,6 @@
 class DocumentPolicy < ApplicationPolicy
   def index?
-    gds_editor || departmental_editor || writer
+    gds_editor? || departmental_editor? || writer?
   end
 
   alias_method :new?, :index?
@@ -10,32 +10,32 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :show?, :index?
 
   def publish?
-    gds_editor || departmental_editor
+    gds_editor? || departmental_editor?
   end
 
   alias_method :unpublish?, :publish?
 
-  def pre_production_formats
+  def environment_restricted_formats
     Rails.env.development? ? [] : PRE_PRODUCTION
   end
 
-  def removed_pre_production?
-    !pre_production_formats.include?(document_class.document_type)
+  def restricted_by_environment?
+    environment_restricted_formats.include?(document_class.document_type)
   end
 
   def user_organisation_owns_document_type?
-    document_class.organisations.include?(user.organisation_content_id) && removed_pre_production?
+    document_class.organisations.include?(user.organisation_content_id) && !restricted_by_environment?
   end
 
-  def departmental_editor
+  def departmental_editor?
     user_organisation_owns_document_type? && user.permissions.include?('editor')
   end
 
-  def writer
+  def writer?
     user_organisation_owns_document_type?
   end
 
-  def gds_editor
-    removed_pre_production? && user.gds_editor?
+  def gds_editor?
+    !restricted_by_environment? && user.gds_editor?
   end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -16,7 +16,7 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :unpublish?, :publish?
 
   def pre_production_formats
-    PRE_PRODUCTION
+    Rails.env.development? ? [] : PRE_PRODUCTION
   end
 
   def removed_pre_production?

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -14,4 +14,28 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   alias_method :unpublish?, :publish?
+
+  def pre_production_formats
+    PRE_PRODUCTION
+  end
+
+  def removed_pre_production?
+    !pre_production_formats.include?(document_class.document_type)
+  end
+
+  def user_organisation_owns_document_type?
+    document_class.organisations.include?(user.organisation_content_id) && removed_pre_production?
+  end
+
+  def departmental_editor
+    user_organisation_owns_document_type? && user.permissions.include?('editor')
+  end
+
+  def writer
+    user_organisation_owns_document_type?
+  end
+
+  def gds_editor
+    removed_pre_production? && user.gds_editor?
+  end
 end

--- a/app/policies/manual_policy.rb
+++ b/app/policies/manual_policy.rb
@@ -10,7 +10,7 @@ class ManualPolicy < ApplicationPolicy
   alias_method :show?, :index?
 
   def publish?
-    gds_editor || departmental_editor
+    gds_editor? || departmental_editor?
   end
 
   class Scope

--- a/config/initializers/load_pre_production_formats.rb
+++ b/config/initializers/load_pre_production_formats.rb
@@ -1,0 +1,13 @@
+def pre_production
+  pre_production_formats = []
+  Dir["lib/documents/schemas/*.json"].each do |file|
+    read_file = File.read(file)
+    parsed_file = JSON.parse(read_file)
+    if read_file.include? "\"pre_production\": true"
+      pre_production_formats << parsed_file["filter"]["document_type"]
+    end
+  end
+  pre_production_formats
+end
+
+PRE_PRODUCTION = pre_production

--- a/config/initializers/load_pre_production_formats.rb
+++ b/config/initializers/load_pre_production_formats.rb
@@ -3,7 +3,7 @@ def pre_production
   Dir["lib/documents/schemas/*.json"].each do |file|
     read_file = File.read(file)
     parsed_file = JSON.parse(read_file)
-    if read_file.include? "\"pre_production\": true"
+    if parsed_file["pre_production"]
       pre_production_formats << parsed_file["filter"]["document_type"]
     end
   end

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -93,6 +93,18 @@ RSpec.feature "Access control", type: :feature do
         expect(page).to have_content 'Example manual'
         expect(page).to have_content 'Exemplar manual'
       end
+
+      scenario "visiting a pre_production finder" do
+        visit "/tax-tribunal-decisions"
+        expect(page.current_path).to eq("/manuals")
+        expect(page).to have_content("You aren't permitted to access Tax Tribunal Decisions.")
+      end
+
+      scenario "visiting a non pre_production finder" do
+        visit "/cma-cases"
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("CMA Cases")
+      end
     end
 
     context 'as a organisation editor' do

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   let(:public_updated_at) { research_output['public_updated_at'] }
 
   before do
-    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor).and_return(true)
+    allow(Rails.env).to receive(:development?).and_return(true)
     log_in_as_editor(:dfid_editor)
 
     Timecop.freeze(Time.parse(public_updated_at))
@@ -19,7 +19,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     publishing_api_has_item(research_output)
   end
 
-  scenario "with valid data" do
+  scenario "with valid data in development mode" do
     visit "/dfid-research-outputs/new"
 
     title = "Example DFID Research output"

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   let(:public_updated_at) { research_output['public_updated_at'] }
 
   before do
+    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor).and_return(true)
     log_in_as_editor(:dfid_editor)
 
     Timecop.freeze(Time.parse(public_updated_at))

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Editing a DFID Research Output", type: :feature do
   let(:public_updated_at) { research_output['public_updated_at'] }
 
   before do
-    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor).and_return(true)
+    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor?).and_return(true)
 
     log_in_as_editor(:dfid_editor)
 

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature "Editing a DFID Research Output", type: :feature do
   let(:public_updated_at) { research_output['public_updated_at'] }
 
   before do
+    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor).and_return(true)
+
     log_in_as_editor(:dfid_editor)
 
     stub_any_publishing_api_put_content

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -8,24 +8,35 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
       log_in_as_editor(:gds_editor)
     end
 
-    it 'has one finder link per document schema' do
+    it 'has one finder link for each viewable schema' do
       visit '/'
 
       click_link('Finders')
 
       json_schema_count = Dir['lib/documents/schemas/*.json'].length
+
+      pre_production = DocumentPolicy.new(:user, CmaCase).pre_production_formats.length
+
       expect(page).to have_css(
         '.dropdown-menu:nth-of-type(1) li',
-        count: json_schema_count
+          count: json_schema_count - pre_production
       )
     end
 
-    it 'has a finder for DFID research outputs' do
+    it 'does not have a finder for pre_production finder DFID research outputs' do
       visit '/'
 
       click_link('Finders')
 
-      expect(page).to have_text('DFID Research Outputs')
+      expect(page).not_to have_text('DFID Research Outputs')
+    end
+
+    it 'does have a finder for non pre_production finder CMA Cases' do
+      visit '/'
+
+      click_link('Finders')
+
+      expect(page).to have_text('CMA Cases')
     end
   end
 end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
 
       json_schema_count = Dir['lib/documents/schemas/*.json'].length
 
-      pre_production = DocumentPolicy.new(:user, CmaCase).pre_production_formats.length
+      pre_production = DocumentPolicy.new(:user, CmaCase).environment_restricted_formats.length
 
       expect(page).to have_css(
         '.dropdown-menu:nth-of-type(1) li',


### PR DESCRIPTION
[Trello](https://trello.com/c/bG8T12G6/163-pre-production-formats-are-visible-and-editable-on-production-environments-medium)

Pre-production formats can no longer be accessed by publishers.

Previously:
- Writers and departmental editors could only interact with documents of their own organisation
- `gds_editor` could view/edit/publish documents for all formats

This PR removes the ability for publishers to access pre-production formats on all environments other than development.
