### PR TITLE
Make DFID research outputs visible for testing on integration.

### DIFF
--- a/config/initializers/load_pre_production_formats.rb
+++ b/config/initializers/load_pre_production_formats.rb
@@ -3,7 +3,7 @@ def pre_production
   Dir["lib/documents/schemas/*.json"].each do |file|
     read_file = File.read(file)
     parsed_file = JSON.parse(read_file)
-    if parsed_file["pre_production"]
+    if parsed_file["pre_production"] && parsed_file["base_path"] != "/dfid-research-outputs"
       pre_production_formats << parsed_file["filter"]["document_type"]
     end
   end

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   let(:public_updated_at) { research_output['public_updated_at'] }
 
   before do
-    allow(Rails.env).to receive(:development?).and_return(true)
     log_in_as_editor(:dfid_editor)
 
     Timecop.freeze(Time.parse(public_updated_at))
@@ -19,9 +18,12 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     publishing_api_has_item(research_output)
   end
 
-  scenario "with valid data in development mode" do
+  scenario "with valid data" do
     visit "/dfid-research-outputs/new"
 
+    expect(page.status_code).to eq(200)
+    expect(page).to have_css('div.govspeak-help')
+    expect(page).to have_content('To add an attachment, please save the draft first.')
     title = "Example DFID Research output"
     summary = "This is the summary of an example DFID research output"
 
@@ -30,9 +32,6 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
     select "Infrastructure", from: "Themes"
-
-    expect(page).to have_css('div.govspeak-help')
-    expect(page).to have_content('To add an attachment, please save the draft first.')
 
     click_button "Save as draft"
     assert_publishing_api_put_content(content_id)
@@ -44,6 +43,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   scenario "with no data" do
     visit "/dfid-research-outputs/new"
 
+    expect(page.status_code).to eq(200)
     click_button "Save as draft"
 
     expect(page.status_code).to eq(422)
@@ -57,6 +57,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   scenario "with invalid data" do
     visit "/dfid-research-outputs/new"
 
+    expect(page.status_code).to eq(200)
     fill_in "Title", with: "Example DFID Research output"
     fill_in "Summary", with: "This is the summary of an example DFID Research output"
     fill_in "Body", with: "<script>alert('hello')</script>"

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature do
+  let(:fields)            { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
+  let(:research_output)   { FactoryGirl.create(:employment_appeal_tribunal_decision) }
+  let(:content_id)        { research_output['content_id'] }
+  let(:public_updated_at) { research_output['public_updated_at'] }
+
+  context 'in development' do
+    before do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      log_in_as_editor(:gds_editor)
+
+      Timecop.freeze(Time.parse(public_updated_at))
+      allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+
+      publishing_api_has_item(research_output)
+    end
+
+    scenario "with valid data" do
+      visit "/eat-decisions/new"
+      title = "Example Employment appeal tribunal decision"
+      summary = "This is the summary of an example Employment appeal tribunal decision"
+
+      expect(page.status_code).to eq(200)
+
+      fill_in "Title", with: title
+      fill_in "Summary", with: summary
+      fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example Employment appeal tribunal decision" * 10))
+      select "Age Discrimination", from: "Tribunal decision categories"
+      select "Contract of Employment - Apprenticeship", from: "Tribunal decision sub categories"
+      fill_in "Tribunal decision decision date", with: "2013-01-01"
+      select "Not landmark", from: "Tribunal decision landmark"
+      fill_in "Hidden indexable content", with: "hidden text goes here"
+
+
+      expect(page).to have_css('div.govspeak-help')
+      expect(page).to have_content('To add an attachment, please save the draft first.')
+
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(200)
+      assert_publishing_api_put_content(content_id)
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Created Example Employment appeal tribunal decision")
+    end
+
+    scenario "with no data" do
+      visit "/eat-decisions/new"
+
+      expect(page.status_code).to eq(200)
+
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(422)
+
+      expect(page).to have_content("Title can't be blank")
+      expect(page).to have_content("Summary can't be blank")
+      expect(page).to have_content("Body can't be blank")
+      expect(page).to have_content("Tribunal decision categories can't be blank")
+      expect(page).to have_content("Tribunal decision sub categories can't be blank")
+      expect(page).to have_content("Tribunal decision decision date")
+
+      expect(page).to_not have_content("Hidden indexable content can't be blank")
+    end
+
+    scenario "with invalid data" do
+      visit "/eat-decisions/new"
+
+      expect(page.status_code).to eq(200)
+
+      fill_in "Title", with: "Example Employment appeal tribunal decision"
+      fill_in "Summary", with: "This is the summary of an example Employment appeal tribunal decision"
+      fill_in "Body", with: "<script>alert('hello')</script>"
+
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(422)
+
+      expect(page).to have_content("Body cannot include invalid Govspeak")
+    end
+  end
+
+  context 'in production' do
+    before do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      log_in_as_editor(:gds_editor)
+    end
+
+    scenario "with valid data" do
+      visit "/eat-decisions/new"
+      expect(page.current_path).to eq("/manuals")
+    end
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
 
       click_link('Finders')
 
-      expect(page).not_to have_text('DFID Research Outputs')
+      expect(page).not_to have_text('Employment appeal tribunal decision')
     end
 
     it 'does have a finder for non pre_production finder CMA Cases' do


### PR DESCRIPTION
- DFID will be visible in production to any user that is a writer, owns DFID outputs, or is a GDS account. This shouldn't impact user experience, since no-one owns DFID.

[trello card](https://trello.com/c/Q2zdWkSi/178-grant-dfid-access-to-the-dfid-finder-on-integration-small)
