### PR TITLE
Add dfid_document_type facet

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -1,9 +1,10 @@
 class DfidResearchOutput < Document
   validates :first_published_at, presence: true, date: true
   validates :dfid_theme, presence: true
+  validates :dfid_document_type, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
-    country first_published_at dfid_authors dfid_theme
+    dfid_document_type country first_published_at dfid_authors dfid_theme
   )
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -1,3 +1,11 @@
+<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_document_type, label: 'Document type' } do %>
+  <%=
+    f.select :dfid_document_type, facet_options(f, :dfid_document_type),
+      { include_blank: true },
+      { class: 'select2', multiple: false, data: { placeholder: 'Select document type' } }
+  %>
+<% end %>
+
 <%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_authors, label: 'Authors' } do %>
   <%=
     f.select :dfid_authors, @document.dfid_authors || [],

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -19,6 +19,280 @@
   "document_noun": "output",
   "facets": [
     {
+      "key": "dfid_document_type",
+      "name": "Document Type",
+      "type": "text",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "abstract",
+          "label": "Abstract"
+        },
+        {
+          "value": "academic_thesis",
+          "label": "Academic Thesis"
+        },
+        {
+          "value": "annual_report",
+          "label": "Annual Report"
+        },
+        {
+          "value": "audio",
+          "label": "Audio"
+        },
+        {
+          "value": "bibliography",
+          "label": "Bibliography"
+        },
+        {
+          "value": "blog",
+          "label": "Blog"
+        },
+        {
+          "value": "book",
+          "label": "Book"
+        },
+        {
+          "value": "book_chapter",
+          "label": "Book Chapter"
+        },
+        {
+          "value": "briefing",
+          "label": "Briefing"
+        },
+        {
+          "value": "bulletin",
+          "label": "Bulletin"
+        },
+        {
+          "value": "bulletin_article",
+          "label": "Bulletin Article"
+        },
+        {
+          "value": "cd-rom",
+          "label": "CD-ROM"
+        },
+        {
+          "value": "case_study",
+          "label": "Case Study"
+        },
+        {
+          "value": "computer_software",
+          "label": "Computer Software"
+        },
+        {
+          "value": "conference_paper",
+          "label": "Conference Paper"
+        },
+        {
+          "value": "conference_poster",
+          "label": "Conference Poster"
+        },
+        {
+          "value": "conference_proceedings",
+          "label": "Conference Proceedings"
+        },
+        {
+          "value": "country_report",
+          "label": "Country Report"
+        },
+        {
+          "value": "dvd",
+          "label": "DVD"
+        },
+        {
+          "value": "dataset",
+          "label": "Dataset"
+        },
+        {
+          "value": "discussion_paper",
+          "label": "Discussion Paper"
+        },
+        {
+          "value": "document",
+          "label": "Document"
+        },
+        {
+          "value": "draft",
+          "label": "Draft"
+        },
+        {
+          "value": "evaluation_report",
+          "label": "Evaluation Report"
+        },
+        {
+          "value": "event_(miscellaneous)",
+          "label": "Event (Miscellaneous)"
+        },
+        {
+          "value": "extension_leaflet_booklet",
+          "label": "Extension Leaflet/Booklet"
+        },
+        {
+          "value": "fact_sheet",
+          "label": "Fact Sheet"
+        },
+        {
+          "value": "flyer",
+          "label": "Flyer"
+        },
+        {
+          "value": "highlights",
+          "label": "Highlights"
+        },
+        {
+          "value": "inception_report",
+          "label": "Inception Report"
+        },
+        {
+          "value": "interim_report",
+          "label": "Interim Report"
+        },
+        {
+          "value": "journal_article",
+          "label": "Journal Article"
+        },
+        {
+          "value": "journal_correspondence",
+          "label": "Journal Correspondence"
+        },
+        {
+          "value": "journal_editorial_commentary",
+          "label": "Journal Editorial/Commentary"
+        },
+        {
+          "value": "journal_issue",
+          "label": "Journal Issue"
+        },
+        {
+          "value": "key_document",
+          "label": "Key Document"
+        },
+        {
+          "value": "lessons_learned",
+          "label": "Lessons Learned"
+        },
+        {
+          "value": "literature_review",
+          "label": "Literature Review"
+        },
+        {
+          "value": "magazine_newsletter",
+          "label": "Magazine/Newsletter"
+        },
+        {
+          "value": "magazine_newsletter_newspaper_article",
+          "label": "Magazine/Newsletter/Newspaper Article"
+        },
+        {
+          "value": "manual",
+          "label": "Manual"
+        },
+        {
+          "value": "map",
+          "label": "Map"
+        },
+        {
+          "value": "media",
+          "label": "Media"
+        },
+        {
+          "value": "meeting",
+          "label": "Meeting"
+        },
+        {
+          "value": "meeting_report",
+          "label": "Meeting Report"
+        },
+        {
+          "value": "news",
+          "label": "News"
+        },
+        {
+          "value": "oral_presentation",
+          "label": "Oral Presentation"
+        },
+        {
+          "value": "poster",
+          "label": "Poster"
+        },
+        {
+          "value": "powerpoint_presentation",
+          "label": "PowerPoint Presentation"
+        },
+        {
+          "value": "protocol",
+          "label": "Protocol"
+        },
+        {
+          "value": "questionnaire",
+          "label": "Questionnaire"
+        },
+        {
+          "value": "radio",
+          "label": "Radio"
+        },
+        {
+          "value": "report",
+          "label": "Report"
+        },
+        {
+          "value": "research_paper",
+          "label": "Research Paper"
+        },
+        {
+          "value": "systematic_review",
+          "label": "Systematic Review"
+        },
+        {
+          "value": "technical_report",
+          "label": "Technical Report"
+        },
+        {
+          "value": "television",
+          "label": "Television"
+        },
+        {
+          "value": "thematic_summary",
+          "label": "Thematic Summary"
+        },
+        {
+          "value": "tool_kit",
+          "label": "Tool kit"
+        },
+        {
+          "value": "training_event",
+          "label": "Training Event"
+        },
+        {
+          "value": "training_materials",
+          "label": "Training Materials"
+        },
+        {
+          "value": "video",
+          "label": "Video"
+        },
+        {
+          "value": "visit",
+          "label": "Visit"
+        },
+        {
+          "value": "visit_report",
+          "label": "Visit Report"
+        },
+        {
+          "value": "web_content",
+          "label": "Web Content"
+        },
+        {
+          "value": "working_paper",
+          "label": "Working Paper"
+        }
+      ]
+    },
+    {
       "key": "country",
       "name": "Country",
       "type": "text",

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -27,30 +27,6 @@
       "filterable": true,
       "allowed_values": [
         {
-          "value": "abstract",
-          "label": "Abstract"
-        },
-        {
-          "value": "academic_thesis",
-          "label": "Academic Thesis"
-        },
-        {
-          "value": "annual_report",
-          "label": "Annual Report"
-        },
-        {
-          "value": "audio",
-          "label": "Audio"
-        },
-        {
-          "value": "bibliography",
-          "label": "Bibliography"
-        },
-        {
-          "value": "blog",
-          "label": "Blog"
-        },
-        {
           "value": "book",
           "label": "Book"
         },
@@ -63,44 +39,16 @@
           "label": "Briefing"
         },
         {
-          "value": "bulletin",
-          "label": "Bulletin"
-        },
-        {
-          "value": "bulletin_article",
-          "label": "Bulletin Article"
-        },
-        {
-          "value": "cd-rom",
-          "label": "CD-ROM"
-        },
-        {
           "value": "case_study",
           "label": "Case Study"
-        },
-        {
-          "value": "computer_software",
-          "label": "Computer Software"
         },
         {
           "value": "conference_paper",
           "label": "Conference Paper"
         },
         {
-          "value": "conference_poster",
-          "label": "Conference Poster"
-        },
-        {
-          "value": "conference_proceedings",
-          "label": "Conference Proceedings"
-        },
-        {
           "value": "country_report",
           "label": "Country Report"
-        },
-        {
-          "value": "dvd",
-          "label": "DVD"
         },
         {
           "value": "dataset",
@@ -111,64 +59,16 @@
           "label": "Discussion Paper"
         },
         {
-          "value": "document",
-          "label": "Document"
-        },
-        {
-          "value": "draft",
-          "label": "Draft"
-        },
-        {
           "value": "evaluation_report",
           "label": "Evaluation Report"
-        },
-        {
-          "value": "event_(miscellaneous)",
-          "label": "Event (Miscellaneous)"
-        },
-        {
-          "value": "extension_leaflet_booklet",
-          "label": "Extension Leaflet/Booklet"
-        },
-        {
-          "value": "fact_sheet",
-          "label": "Fact Sheet"
-        },
-        {
-          "value": "flyer",
-          "label": "Flyer"
-        },
-        {
-          "value": "highlights",
-          "label": "Highlights"
-        },
-        {
-          "value": "inception_report",
-          "label": "Inception Report"
-        },
-        {
-          "value": "interim_report",
-          "label": "Interim Report"
         },
         {
           "value": "journal_article",
           "label": "Journal Article"
         },
         {
-          "value": "journal_correspondence",
-          "label": "Journal Correspondence"
-        },
-        {
-          "value": "journal_editorial_commentary",
-          "label": "Journal Editorial/Commentary"
-        },
-        {
           "value": "journal_issue",
           "label": "Journal Issue"
-        },
-        {
-          "value": "key_document",
-          "label": "Key Document"
         },
         {
           "value": "lessons_learned",
@@ -179,48 +79,8 @@
           "label": "Literature Review"
         },
         {
-          "value": "magazine_newsletter",
-          "label": "Magazine/Newsletter"
-        },
-        {
-          "value": "magazine_newsletter_newspaper_article",
-          "label": "Magazine/Newsletter/Newspaper Article"
-        },
-        {
           "value": "manual",
           "label": "Manual"
-        },
-        {
-          "value": "map",
-          "label": "Map"
-        },
-        {
-          "value": "media",
-          "label": "Media"
-        },
-        {
-          "value": "meeting",
-          "label": "Meeting"
-        },
-        {
-          "value": "meeting_report",
-          "label": "Meeting Report"
-        },
-        {
-          "value": "news",
-          "label": "News"
-        },
-        {
-          "value": "oral_presentation",
-          "label": "Oral Presentation"
-        },
-        {
-          "value": "poster",
-          "label": "Poster"
-        },
-        {
-          "value": "powerpoint_presentation",
-          "label": "PowerPoint Presentation"
         },
         {
           "value": "protocol",
@@ -229,14 +89,6 @@
         {
           "value": "questionnaire",
           "label": "Questionnaire"
-        },
-        {
-          "value": "radio",
-          "label": "Radio"
-        },
-        {
-          "value": "report",
-          "label": "Report"
         },
         {
           "value": "research_paper",
@@ -251,10 +103,6 @@
           "label": "Technical Report"
         },
         {
-          "value": "television",
-          "label": "Television"
-        },
-        {
           "value": "thematic_summary",
           "label": "Thematic Summary"
         },
@@ -263,28 +111,8 @@
           "label": "Tool kit"
         },
         {
-          "value": "training_event",
-          "label": "Training Event"
-        },
-        {
           "value": "training_materials",
           "label": "Training Materials"
-        },
-        {
-          "value": "video",
-          "label": "Video"
-        },
-        {
-          "value": "visit",
-          "label": "Visit"
-        },
-        {
-          "value": "visit_report",
-          "label": "Visit Report"
-        },
-        {
-          "value": "web_content",
-          "label": "Web Content"
         },
         {
           "value": "working_paper",

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
+    select "Book Chapter", from: "Document type"
     select "Infrastructure", from: "Themes"
 
     expect(page).to have_css('div.govspeak-help')

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Editing a DFID Research Output", type: :feature do
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
     fill_in "First published at", with: "2013-01-01"
     select "United Kingdom", from: "Countries"
+    select "Book Chapter", from: "Document type"
 
     click_button "Save as draft"
     assert_publishing_api_put_content(content_id)

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -201,6 +201,7 @@ FactoryGirl.define do
       default_metadata {
         {
           "document_type" => "dfid_research_output",
+          "dfid_document_type" => "book_chapter",
           "country" => ["GB"],
           "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
           "dfid_theme" => ["infrastructure"],


### PR DESCRIPTION
e.g. Conference Paper, Book Chapter. Single-valued.
## Related PRs
- [x] Build will not pass here until https://github.com/alphagov/govuk-content-schemas/pull/344 is merged
- [x] https://github.com/alphagov/rummager/pull/677
- [x] https://github.com/alphagov/dfid-transition/pull/37
- [x] https://github.com/alphagov/rummager/pull/678
- [x] https://github.com/alphagov/govuk-content-schemas/pull/345
- [x] Have now [restricted document_types](https://github.com/alphagov/specialist-publisher-rebuild/pull/823/commits/e4f65d6ea68e76546a116d4cff17dc7a6833b767) by removing those not associated with outputs.
