### PR TITLE
Add a task for performing data comparisons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'timecop', '0.8.0'
   gem 'govuk-content-schema-test-helpers', '1.4.0'
   gem 'govuk-lint'
+  gem 'hashdiff'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       sidekiq (~> 4.1)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
+    hashdiff (0.3.0)
     hashie (3.4.3)
     hike (1.2.3)
     htmlentities (4.3.4)
@@ -365,6 +366,7 @@ DEPENDENCIES
   govuk_admin_template (~> 3.4.0)
   govuk_frontend_toolkit (= 0.44.0)
   govuk_sidekiq (~> 0.0.3)
+  hashdiff
   jquery-rails (~> 3.1.4)
   kaminari
   logstasher (= 0.6.2)

--- a/lib/data_comparison.rb
+++ b/lib/data_comparison.rb
@@ -1,0 +1,54 @@
+require "hashdiff"
+
+module DataComparison
+module_function
+
+  def compare(content_id)
+    Services.publishing_api.client.options[:timeout] = 30
+
+    puts "<<<<<"
+    puts "Comparing #{content_id}"
+
+    before = nil
+
+    begin
+      before = Services.publishing_api.get_content(content_id).to_hash
+    rescue GdsApi::HTTPServerError
+      puts "ERROR: Could not find content_id '#{content_id}'"
+      return
+    end
+
+    document = Document.find(content_id)
+
+    unless document.update_type
+      document.update_type = "major"
+      document.change_note = "some change note"
+    end
+
+    if document.save
+      puts "Saving document"
+    else
+      puts "ERROR: Failed to save document"
+      puts document.errors.messages.inspect
+      return
+    end
+
+    if document.live?
+      puts "Publishing document"
+      document.publish
+    elsif document.unpublished?
+      puts "Publishing document"
+      document.publish
+      puts "Unpublishing document"
+      document.unpublish
+    end
+
+    after = Services.publishing_api.get_content(content_id).to_hash
+
+    diff = HashDiff.diff(before, after)
+    puts "Differences:"
+    puts diff
+
+    puts "<<<<<"
+  end
+end

--- a/lib/tasks/compare.rake
+++ b/lib/tasks/compare.rake
@@ -1,0 +1,20 @@
+desc "Compare the data for a document before and after saving it"
+task :compare, [:content_id] => :environment do |_, args|
+  DataComparison.compare(args.content_id)
+end
+
+task :compare_all, [:document_type] => :environment do |_, args|
+  results = Services
+    .publishing_api
+    .get_content_items(
+      document_type: args.document_type,
+      per_page: 99999,
+      fields: %w(content_id)
+    ).to_hash.fetch("results")
+
+  content_ids = results.map { |r| r.fetch("content_id") }
+
+  content_ids.each do |content_id|
+    DataComparison.compare(content_id)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/IAknDPK2/85-identify-and-fix-any-data-differences-between-v1-and-v2-medium

This lets us see if there are any differences between
data the v1 application has sent to the publishing api
vs. data the v2 application sends as part of the
application's save/publish/unpublish behaviour.

Example output:

```
<<<<<
Comparing 75c9c579-956d-45bd-9357-c6483fc0ecbc
Saving document
Publishing document
Differences:
~
details.attachments[0].updated_at
2016-05-27T14:01:15Z
2016-07-11T11:51:50+00:00
-
details.metadata.bulk_published
false
~
<<<<<
```

> Chris: Data comparison is done, here are my results:
> 
> 1) It re-highlighted the bug with attachment timestamps being updated when a document is saved. This is already captured here: https://trello.com/c/llClS12G/164-sp-rebuild-changes-the-attachment-timestamps-on-document-updates-even-if-the-attachments-themselves-haven-t-been-changed
> 
> 2) Some of the documents are technically invalid because they’re missing a “summary” field. These documents don’t save in either V1 or V2 and the editor would have to set this themselves. This is an existing problem in V1, so it’s fine for V2.
> 
> 3) There’s a `bulk_published` field that V1 uses to hide some fields from the frontend. Specifically, the `updated_at` field is hidden. We could technically drop this behaviour and simplify the app because we do this better now. I might write a ticket for this soon.
> 
> ​**TL;DR**​: The data comparison was successful and there are no major issues that will block us from going live
