### PR TITLE
Make Rails's flash messages work across both apps

### DIFF
--- a/config/initializers/rails_3_4_flash_compatibility.rb
+++ b/config/initializers/rails_3_4_flash_compatibility.rb
@@ -1,0 +1,46 @@
+# Taken from:
+# https://gist.github.com/henrik/bb6732d5d4cddb5085a4
+
+# The way the flash is stored in the session changed in a backwards-incompatible way.
+
+if Rails::VERSION::MAJOR == 3
+  module ActionDispatch
+    class Flash
+      def call(env)
+        if (session = env["rack.session"]) && (flash = session["flash"])
+
+          # Beginning of change!
+
+          if flash.respond_to?(:sweep)
+            flash.sweep
+          else
+            session.delete("flash")
+          end
+
+          # End of change!
+
+        end
+
+        @app.call(env)
+      ensure
+        session    = env["rack.session"] || {}
+        flash_hash = env[KEY]
+
+        if flash_hash
+          if !flash_hash.empty? || session.key?("flash")
+            session["flash"] = flash_hash
+            new_hash = flash_hash.dup
+          else
+            new_hash = flash_hash
+          end
+
+          env[KEY] = new_hash
+        end
+
+        if session.key?("flash") && session["flash"].empty?
+          session.delete("flash")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
While this app is deployed alongside the rebuild, there
are cases when a user is redirected to a page on the
other app with a flash message.

When Rails 4 was released, they changed the interface for
flash messages and this broke compatibility. This
initializer fixes it.