### PR TITLE
Redrafting an unpublished document requires an update_type

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,7 +27,7 @@ class Document
   validates :title, presence: true
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
-  validates :update_type, presence: true, if: :live?
+  validates :update_type, presence: true, if: :has_ever_been_published?
   validates :change_note, presence: true, if: :change_note_required?
 
   COMMON_FIELDS = [
@@ -111,7 +111,7 @@ class Document
   end
 
   def change_note_required?
-    update_type == 'major' && published?
+    update_type == 'major' && has_ever_been_published?
   end
 
   def change_history

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -103,6 +103,10 @@ FactoryGirl.define do
       attributes.merge(details: merged_details)
     }
 
+    # This is the default document state.
+    trait :draft do
+    end
+
     trait :published do
       publication_state 'live'
       state_history {

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -499,6 +499,80 @@ RSpec.describe Document do
       publishing_api_isnt_available
       expect(document.save).to be_falsey
     end
+
+    describe "validations" do
+      subject { Document.from_publishing_api(payload) }
+
+      context "when the document is a draft" do
+        let(:payload) { FactoryGirl.create(:document) }
+
+        it "does not require an update_type" do
+          subject.update_type = ""
+          expect(subject).to be_valid
+        end
+
+        it "does not require a change_note" do
+          subject.change_note = ""
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when the document is published" do
+        let(:payload) { FactoryGirl.create(:document, :published) }
+
+        it "requires an update_type" do
+          subject.update_type = ""
+          subject.change_note = "change note"
+
+          expect(subject).not_to be_valid
+        end
+
+        it "requires a change_note" do
+          subject.update_type = "major"
+          subject.change_note = ""
+
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when the document is unpublished" do
+        let(:payload) { FactoryGirl.create(:document, :unpublished) }
+
+        it "requires an update_type" do
+          subject.update_type = ""
+          subject.change_note = "change note"
+
+          expect(subject).not_to be_valid
+        end
+
+        it "requires a change_note" do
+          subject.update_type = "major"
+          subject.change_note = ""
+
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when the document is brand new" do
+        subject { Document.new }
+
+        before do
+          subject.title = "Title"
+          subject.summary = "Summary"
+          subject.body = "Body"
+        end
+
+        it "does not require an update_type" do
+          subject.update_type = ""
+          expect(subject).to be_valid
+        end
+
+        it "does not require a change_note" do
+          subject.change_note = ""
+          expect(subject).to be_valid
+        end
+      end
+    end
   end
 
   describe ".find" do


### PR DESCRIPTION
This pull request fixes the first part of the following ticket. I will do the second part in a separate pull request.

https://trello.com/c/oxxALgmy/187-changes-to-update-type-for-raib-reports
