### PR TITLE
Attachment links display in preview

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -37,9 +37,11 @@ jQuery(function($) {
   $("#preview-button").click(function(){
       $('.preview_container').removeClass('hide');
       var bodyText = $('.body-text').val();
+      var attachments = $('#attachment_data').attr('data');
       $.post(
           "/preview",
-          { bodyText: bodyText
+          { bodyText: bodyText,
+            attachments: attachments
           },
           function(data) {
               $('.govspeak').html(data);

--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -2,7 +2,16 @@ class GovspeakController < ApplicationController
   def preview
     skip_authorization
 
-    govspeak_preview = Govspeak::Document.new(params["bodyText"]).to_html
+    json_attachments = JSON.parse(params["attachments"])
+
+    attachments = json_attachments.map do |attachment|
+      Attachment.new(attachment)
+    end
+
+    document = Document.new({ body: params["bodyText"],
+                            attachments: attachments }, [:attachments])
+    govspeak_presenter = GovspeakPresenter.new(document)
+    govspeak_preview = govspeak_presenter.html_body
     render html: govspeak_preview.html_safe
   end
 end

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -12,19 +12,18 @@ class GovspeakPresenter
     ]
   end
 
+  def html_body
+    Govspeak::Document.new(govspeak_body_with_expanded_attachment_links).to_html
+  end
+
 private
 
   def govspeak_body
     document.body
   end
 
-  def html_body
-    Govspeak::Document.new(govspeak_body_with_expanded_attachment_links).to_html
-  end
-
-
   def govspeak_body_with_expanded_attachment_links
-    document.attachments.reduce(document.body) { |body, attachment|
+    document.attachments.reduce(govspeak_body) { |body, attachment|
       body.gsub(attachment.snippet, attachment_markdown(attachment))
     }
   end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -11,7 +11,7 @@
     <%= form_for @document, url: document_path(document_type_slug: params[:document_type_slug], content_id: @document.content_id), method: :put do |f| %>
         <%= render partial: "shared/form_fields", locals: {f: f} %>
 
-        <%= render partial: "shared/preview_govspeak" %>
+        <%= render partial: "shared/preview_govspeak", locals: {attachments: @document.attachments} %>
 
         <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: {f: f} %>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @document, url: documents_path(params[:document_type_slug]) do |f| %>
       <%= render partial: "shared/form_fields", locals: { f: f } %>
 
-      <%= render partial: "shared/preview_govspeak" %>
+      <%= render partial: "shared/preview_govspeak", locals: {attachments: @document.attachments} %>
 
       <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: { f: f } %>
 

--- a/app/views/shared/_preview_govspeak.html.erb
+++ b/app/views/shared/_preview_govspeak.html.erb
@@ -1,4 +1,5 @@
 <div class="preview_button add-vertical-margins">
+  <%= content_tag :div, nil, id: "attachment_data", data: attachments.to_json %>
   <a href="#preview-container" name="preview" id="preview-button" class="btn btn-primary">Preview</a>
 </div>
 <div id="preview-container" class="preview_container add-vertical-margins hide">

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -273,6 +273,15 @@ RSpec.feature "Editing a CMA case", type: :feature do
           expect(page).not_to have_content("$CTA")
         end
 
+        fill_in "Body", with: "[InlineAttachment:asylum-support-image.jpg]"
+
+        click_link "Preview"
+
+        within(".preview_container") do
+          expect(page).to have_content("asylum report image title")
+          expect(page).not_to have_content("[InlineAttachment:")
+        end
+
         fill_in "Body", with: "[link text](http://www.example.com)"
 
         click_link "Preview"


### PR DESCRIPTION
- Inline attachments now display in preview as links to the attachment

[Trello Card](https://trello.com/c/zomDZwj3/176-inline-attachments-not-being-displayed-in-preview-small)
