### PR TITLE
last_edited_at now displaying for new drafts

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -84,10 +84,14 @@ class Document
     "live"
   end
 
-  %w{draft live redrafted superseded unpublished}.each do |state|
+  %w{live redrafted superseded unpublished}.each do |state|
     define_method("#{state}?") do
       publication_state == state
     end
+  end
+
+  def draft?
+    publication_state == "draft" || publication_state.nil?
   end
 
   def published?

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
       },
       "routes" => [{ "path" => "/cma-cases/example-cma-case", "type" => "exact" }],
       "redirects" => [],
-      "update_type" => nil,
+      "update_type" => "major",
     }
 
     assert_publishing_api_put_content(content_id, expected_sent_payload)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Document do
     end
   end
 
+  context "saving a new draft" do
+    subject { MyDocumentType.new }
+
+    before do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      subject.title = "Title"
+      subject.summary = "Summary"
+      subject.body = "Body"
+      subject.publication_state = nil
+    end
+
+    it "sends a correct document" do
+      expect(subject.save).to be true
+      assert_publishing_api_put_content(subject.content_id, request_json_includes(update_type: "major"))
+    end
+  end
+
   let(:finder_schema) {
     {
       base_path: "/my-document-types",
@@ -554,7 +572,12 @@ RSpec.describe Document do
 
   context "change_history" do
     let(:note) { 'my change note' }
-    let(:document) { MyDocumentType.new.tap { |document| document.change_note = note } }
+    let(:document) {
+      MyDocumentType.new.tap { |document|
+        document.change_note = note
+        document.publication_state = 'live'
+      }
+    }
 
     it 'add note when major change' do
       document.update_type = 'major'


### PR DESCRIPTION
- last edited at time was not displaying for new drafts
- this was due to new drafts not having a publication state prior
  to being put to the publishing API

[Trello Card](https://trello.com/c/YBoHXzl7/201-bug-last-edited-at-not-displaying-for-new-drafts)
