### PR TITLE
Increase the timeout to 30 seconds for the publishing API

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -231,7 +231,8 @@ SpecialistPublisherWiring ||= DependencyContainer.new do
   define_singleton(:publishing_api) {
     GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
+      timeout: 30
     )
   }
 


### PR DESCRIPTION
A particular content item (/cma-cases/31d49965-5826-42ff-ac87-67f305fbb5f9)
has a large number of attachments and the overall time to send this to
the publishing API and the publishing API's time to process against the
V1 API endpoint takes longer then the default 4 seconds currently set in
the GDS-API adapters. This throws a Timeout exception, even though the
publishing API still processes the request.

The V2 endpoint is a lot more responsive, so should not be a problem
with the rebuild of SP.