### PR TITLE
Remove DFID 'Questionnaire' document type

### DIFF
--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -87,10 +87,6 @@
           "label": "Protocol"
         },
         {
-          "value": "questionnaire",
-          "label": "Questionnaire"
-        },
-        {
           "value": "research_paper",
           "label": "Research Paper"
         },


### PR DESCRIPTION
- No longer in use as of last week
