### PR TITLE
Don't preselect the 'minor' radio button after adding an attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ log
 tmp
 coverage
 /coverage
+.DS_Store

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -46,9 +46,9 @@ class AttachmentsController < ApplicationController
 private
 
   def fetch_document
-    current_format.find(params[:document_content_id]).tap do |document|
-      document.update_type = "minor"
-    end
+    document = current_format.find(params[:document_content_id])
+    document.set_temporary_update_type!
+    document
   rescue Document::RecordNotFound => e
     flash[:danger] = "Document not found"
     redirect_to documents_path(document_type_slug: document_type_slug)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -19,7 +19,8 @@ class Document
     :document_type,
     :attachments,
     :first_published_at,
-    :previous_version
+    :previous_version,
+    :temporary_update_type
   )
 
   attr_writer :change_history, :update_type
@@ -43,6 +44,7 @@ class Document
     :bulk_published,
     :change_note,
     :change_history,
+    :temporary_update_type,
   ]
 
   FIRST_PUBLISHED_NOTE = 'First published.'.freeze
@@ -58,6 +60,8 @@ class Document
     (COMMON_FIELDS + format_specific_fields).each do |field|
       public_send(:"#{field.to_s}=", params.fetch(field, nil))
     end
+
+    clear_temporary_update_type!
   end
 
   def bulk_published
@@ -201,7 +205,8 @@ class Document
       bulk_published: payload['details']['metadata']['bulk_published'],
       change_note: extract_change_note_from_payload(payload),
       change_history: payload['details']['change_history'].map(&:to_h),
-      previous_version: payload['previous_version']
+      previous_version: payload['previous_version'],
+      temporary_update_type: payload['details']['temporary_update_type']
     )
 
     document.attachments = Attachment.all_from_publishing_api(payload)
@@ -322,6 +327,17 @@ class Document
     else
       false
     end
+  end
+
+  def set_temporary_update_type!
+    return if update_type
+    self.temporary_update_type = true
+    self.update_type = "minor"
+  end
+
+  def clear_temporary_update_type!
+    self.update_type = nil if temporary_update_type
+    self.temporary_update_type = false
   end
 
   def self.slug

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -39,6 +39,7 @@ private
       metadata: metadata,
       change_history: document.change_history,
       max_cache_time: 10,
+      temporary_update_type: document.temporary_update_type,
     }.tap do |details_hash|
       details_hash[:attachments] = attachments if document.attachments.any?
       details_hash[:headers] = headers if !headers.empty?

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -84,6 +84,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
         "headers" => [
           { "text" => "Header", "level" => 2, "id" => "header" }
         ],
+        "temporary_update_type" => false,
       },
       "routes" => [{ "path" => "/cma-cases/example-cma-case", "type" => "exact" }],
       "redirects" => [],

--- a/spec/features/temporary_update_type_spec.rb
+++ b/spec/features/temporary_update_type_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+require "gds_api/test_helpers/asset_manager"
+
+RSpec.feature "Temporary update types, relating to attachments", type: :feature do
+  include GdsApi::TestHelpers::AssetManager
+
+  let(:payload) { FactoryGirl.create(:cma_case, :published) }
+  let(:content_id) { payload.fetch("content_id") }
+
+  before do
+    asset_manager_receives_an_asset("http://example.com/attachment.jpg")
+
+    stub_any_publishing_api_call
+    publishing_api_has_item(payload)
+
+    log_in_as_editor(:cma_editor)
+  end
+
+  def add_attachment_to_document
+    visit "/cma-cases/#{content_id}/attachments/new"
+
+    fill_in "Title", with: "My attachment"
+    page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
+
+    click_button "Save attachment"
+    expect(page.status_code).to eq(200)
+  end
+
+  context "when the update_type was not set by a user" do
+    let(:payload) { FactoryGirl.create(:cma_case, :published) }
+
+    scenario "setting temporary_update_type to true and using a minor update_type" do
+      add_attachment_to_document
+
+      assert_publishing_api_put_content(content_id, -> (request) {
+        data = JSON.parse(request.body)
+
+        expect(data.fetch("update_type")).to eq("minor")
+        expect(data.fetch("details").fetch("temporary_update_type")).to eq(true)
+      })
+    end
+  end
+
+  context "when the update_type was set by a user" do
+    let(:payload) {
+      FactoryGirl.create(
+        :cma_case,
+        publication_state: "redrafted",
+        update_type: "major",
+      )
+    }
+
+    scenario "setting temporary_update_type to false and using the existing update_type" do
+      add_attachment_to_document
+
+      assert_publishing_api_put_content(content_id, -> (request) {
+        data = JSON.parse(request.body)
+
+        expect(data.fetch("update_type")).to eq("major")
+        expect(data.fetch("details").fetch("temporary_update_type")).to eq(false)
+      })
+    end
+  end
+
+  context "when temporary_update_type was previously set" do
+    let(:payload) {
+      FactoryGirl.create(
+        :cma_case,
+        publication_state: "redrafted",
+        update_type: "minor",
+        details: {
+          temporary_update_type: true,
+        },
+      )
+    }
+
+    scenario "preserving the temporary_update_type" do
+      add_attachment_to_document
+
+      assert_publishing_api_put_content(content_id, -> (request) {
+        data = JSON.parse(request.body)
+
+        expect(data.fetch("update_type")).to eq("minor")
+        expect(data.fetch("details").fetch("temporary_update_type")).to eq(true)
+      })
+    end
+
+    scenario "giving the user a choice of update_type when editing the document" do
+      visit "/cma-cases/#{content_id}/edit"
+      expect(page.status_code).to eq(200)
+
+      radio_minor = field_labeled("cma_case_update_type_minor")
+      radio_major = field_labeled("cma_case_update_type_major")
+
+      expect(radio_minor).not_to be_checked
+      expect(radio_major).not_to be_checked
+    end
+  end
+
+  context "when the document is a draft" do
+    let(:payload) {
+      FactoryGirl.create(
+        :cma_case,
+        publication_state: "draft",
+      )
+    }
+
+    scenario "reverting to the default behaviour for saving a draft" do
+      add_attachment_to_document
+
+      assert_publishing_api_put_content(content_id, -> (request) {
+        data = JSON.parse(request.body)
+
+        expect(data.fetch("update_type")).to eq("major")
+        expect(data.fetch("details").fetch("temporary_update_type")).to eq(false)
+      })
+    end
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -92,6 +92,7 @@ FactoryGirl.define do
           "metadata" => default_metadata,
           "max_cache_time" => 10,
           "change_history" => change_history,
+          "temporary_update_type" => false,
         }
       }
       change_history { [] }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -644,6 +644,66 @@ RSpec.describe Document do
     end
   end
 
+  describe "#set_temporary_update_type!"do
+    before { subject.publication_state = "published" }
+
+    context "when the document has an update_type" do
+      before do
+        subject.update_type = "major"
+        subject.set_temporary_update_type!
+      end
+
+      it "preserves the existing attributes" do
+        expect(subject.update_type).to eq("major")
+        expect(subject.temporary_update_type).to eq(false)
+      end
+    end
+
+    context "when the document does not have an update_type" do
+      before do
+        subject.update_type = nil
+        subject.set_temporary_update_type!
+      end
+
+      it "sets update_type to minor and temporary_update_type to true" do
+        expect(subject.update_type).to eq("minor")
+        expect(subject.temporary_update_type).to eq(true)
+      end
+    end
+  end
+
+  describe "clear_temporary_update_type!" do
+    before { subject.publication_state = "published" }
+
+    context "when the document has a temporary_update_type" do
+      before do
+        subject.temporary_update_type = true
+        subject.update_type = "major"
+
+        subject.clear_temporary_update_type!
+      end
+
+      it "sets update_type to nil and temporary_update_type to false" do
+        expect(subject.temporary_update_type).to eq(false)
+        expect(subject.update_type).to be_nil
+      end
+    end
+
+    context "when the document does not have a temporary_update_type" do
+      before do
+        subject.temporary_update_type = false
+        subject.update_type = "major"
+
+        subject.clear_temporary_update_type!
+      end
+
+      it "preserves the existing attributes" do
+        expect(subject.update_type).to eq("major")
+        expect(subject.temporary_update_type).to eq(false)
+      end
+    end
+  end
+
   context "change_history" do
     let(:note) { 'my change note' }
     let(:document) {


### PR DESCRIPTION
```
When attachments are added to a document, the document's
metadata is updated and the document is saved. Previously,
it always set the update_type to 'minor' when this
happened.

This is problematic because the next time the user edits
the document, the 'minor' update radio button is
pre-selected. The user may not have chosen an update_type
yet or they may have chosen a 'major' update_type. In both
these cases, the update_type is being overriden.

This change introduces a 'temporary_update_type' field that
is set to true when adding an attachment if the user has
not previously set an update_type. The next time the
document is initialized, the update_type will be cleared if
this field is true.

This approach fixes the problem for both of the problems
described above. Note that we should not unconditionally
set temporary_update_type to true because that would cause
the user's choice to be cleared out rather than preserved
the next time the document is loaded. We should only set it
if the update_type has not yet been set by the user.
```
