### PR TITLE
Revert "Hotfix: Fix RAIB permissions"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,16 +19,4 @@ class User
   def gds_editor?
     permissions.include?('gds_editor')
   end
-
-  def organisation_content_id
-    organisation_content_id = super
-
-    if organisation_content_id.present?
-      organisation_content_id
-    else
-      {
-        "rail-accident-investigation-branch" => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
-      }[organisation_slug]
-    end
-  end
 end


### PR DESCRIPTION
The organisation_content_id field now gets set by SPv1
as per this commit:
https://github.com/alphagov/specialist-publisher/pull/732/commits/75dc26807c0662a9a8c0fe76f8bb682db04dd1e2

The next time a user logs in through signon, that field
is set and this application can leverage it for checking
permissions.
