### PR TITLE
Fixed View on website display logic

### DIFF
--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -20,9 +20,21 @@ module StateHelper
     end
   end
 
-  def last_two_states(state_history)
+  def ordered_history(state_history)
     ordered_history = state_history.sort_by { |k, _v| Integer(k.to_s) }
     ordered_history.map!(&:second)
-    [ordered_history[-2], ordered_history[-1]]
+  end
+
+  def last_two_states(state_history)
+    history = ordered_history(state_history)
+    [history[-2], history[-1]]
+  end
+
+  def show_view_on_website_link?(state_history)
+    last_two_states(state_history).include?("published")
+  end
+
+  def show_preview_draft_link?(state_history)
+    ordered_history(state_history).last == "draft"
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -102,14 +102,6 @@ class Document
     publication_state == "draft" || publication_state.nil?
   end
 
-  def published?
-    live? || redrafted?
-  end
-
-  def not_published?
-    !published?
-  end
-
   # TODO: This is not particularly robust. We'd prefer to check the entire
   # state history of the document to see if it had really ever been published
   # but that's not available via the publishing api yet.  Checking for our

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -200,4 +200,8 @@ class Manual
   def can_be_published?
     sections.any?
   end
+
+  def state_history
+    {}
+  end
 end

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -3,10 +3,10 @@
     <li title='<% if !document.live? %>When published this document will appear at this URL<% end %>'>
       <%= document.base_path %>
     </li>
-    <% if document.published? %>
+    <% if show_view_on_website_link?(document.state_history) %>
       <li><%= view_on_website_link_for(document) %></li>
     <% end %>
-    <% if document.draft? || document.redrafted? %>
+    <% if show_preview_draft_link?(document.state_history) %>
       <li><%= preview_draft_link_for(document) %></li>
     <% end %>
   </li>

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -188,6 +188,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "Example Draft"
 
+      expect(page).not_to have_content("View on website")
+      expect(page).to have_content("Preview draft")
       within(".metadata-list") do
         expect(page).to have_content("Publication state draft")
       end
@@ -197,6 +199,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "Example Published"
 
+      expect(page).to have_content("View on website")
+      expect(page).not_to have_content("Preview draft")
       within(".metadata-list") do
         expect(page).to have_content("Publication state published")
       end
@@ -213,6 +217,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "Example Unpublished"
 
+      expect(page).not_to have_content("View on website")
+      expect(page).not_to have_content("Preview draft")
       within(".metadata-list") do
         expect(page).to have_content("Publication state unpublished")
       end
@@ -222,6 +228,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "Example Published with new draft"
 
+      expect(page).to have_content("View on website")
+      expect(page).to have_content("Preview draft")
       within(".metadata-list") do
         expect(page).to have_content("Publication state published with new draft")
       end
@@ -238,6 +246,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
       visit "/cma-cases"
       click_link "Example Unpublished with new draft"
 
+      expect(page).not_to have_content("View on website")
+      expect(page).to have_content("Preview draft")
       within(".metadata-list") do
         expect(page).to have_content("Publication state unpublished with new draft")
       end


### PR DESCRIPTION
redrafted unpublished documents no longer provide a (non-functional) "View on website" link to the finder

[trello card](https://trello.com/c/EuJotkDM/202-hide-the-view-on-website-link-if-the-document-is-unpublished)
