### PR TITLE
Check state_history instead of using has_ever_been_published?

### DIFF
--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 RSpec.feature "Editing a CMA case", type: :feature do
-  let(:cma_case) { FactoryGirl.create(:cma_case, title: "Example CMA Case") }
+  let(:cma_case) {
+    FactoryGirl.create(:cma_case, title: "Example CMA Case", state_history: { "1" => "draft" })
+  }
   let(:content_id) { cma_case['content_id'] }
   let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
 
@@ -77,6 +79,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         :published,
         title: "Example CMA Case",
         description: "Summary with a typox",
+        state_history: { "1" => "draft", "2" => "published" },
         details: {
           "body" => [
             { "content_type" => "text/govspeak", "content" => "A body" },
@@ -293,14 +296,15 @@ RSpec.feature "Editing a CMA case", type: :feature do
     end
   end
 
-  %i(published unpublished).each do |publication_state|
-    context "a #{publication_state} documented" do
+  %i(unpublished).each do |publication_state|
+    context "a #{publication_state} document" do
       let(:cma_case) {
         FactoryGirl.create(
           :cma_case,
           publication_state,
           title: "Example CMA Case",
           details: {},
+          state_history: { "1" => "published", "2" => publication_state.to_s, "3" => "draft" }
         )
       }
 

--- a/spec/features/temporary_update_type_spec.rb
+++ b/spec/features/temporary_update_type_spec.rb
@@ -47,6 +47,10 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
         :cma_case,
         publication_state: "redrafted",
         update_type: "major",
+        change_history: [{ "public_timestamp" => "2016-07-18T16:21:22+01:00", "note" => "First published." },
+                         { "public_timestamp" => "2016-07-19T16:21:22+01:00", "note" => "an update" }],
+        change_note: "srtj",
+        state_history: { "3" => "draft", "2" => "unpublished", "1" => "superseded" },
       )
     }
 


### PR DESCRIPTION
To clear up TODO:
- Now that state history is implemented we're using it to detect
  whether a document has ever been published, rather than determining
  it from the change history.
- Use the inverse check, to determine whether its a first draft, seemed
  a lot neater based on how it was being used elsewhere in the code
