### PR TITLE
Add RAIB safety digest report type

### DIFF
--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -68,7 +68,8 @@
         {"label": "Investigation report", "value": "investigation-report"},
         {"label": "Bulletin", "value": "bulletin"},
         {"label": "Interim report", "value": "interim-report"},
-        {"label": "Discontinuation report", "value": "discontinuation-report"}
+        {"label": "Discontinuation report", "value": "discontinuation-report"},
+        {"label": "Safety digest", "value": "safety-digest"}
       ]
     },
     {


### PR DESCRIPTION
This has been requested by RAIB

Trello: https://trello.com/c/e4i1jjw1/31-add-new-raib-report-type

![screen shot 2016-07-22 at 13 38 20](https://cloud.githubusercontent.com/assets/444232/17057426/b846a012-5011-11e6-8fae-751e44061b44.png)
