### PR TITLE
Preparatory changes for removing redrafted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "31.3.0"
+  gem "gds-api-adapters", "32.1.0"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (31.3.0)
+    gds-api-adapters (32.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -358,7 +358,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 31.3.0)
+  gds-api-adapters (= 32.1.0)
   gds-sso (= 11.0.0)
   govspeak (~> 3.5)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -25,4 +25,12 @@ class DfidResearchOutput < Document
   def self.title
     'DFID Research Output'
   end
+
+  def first_draft?
+    draft? && state_history_one_or_shorter?
+  end
+
+  def state_history_one_or_shorter?
+    state_history.nil? ? true : state_history.size < 2
+  end
 end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -11,9 +11,14 @@ class SearchPresenter
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,
-      public_timestamp: document.public_updated_at.to_datetime.rfc3339,
-      first_published_at: document.first_published_at.to_datetime.rfc3339,
+      public_timestamp: format_date(document.public_updated_at),
+      first_published_at: format_date(document.first_published_at),
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }
+  end
+
+  def format_date(timestamp)
+    raise ArgumentError, "Timestamp is blank" if timestamp.blank?
+    timestamp.to_datetime.rfc3339
   end
 
   def indexable_content

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -20,7 +20,7 @@ module Services
 
   # Asynchronously called from app/workers.
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.new.find('search'))
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find('rummager'))
   end
 
   # Asynchronously called from app/workers.

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
         "headers" => [
           { "text" => "Header", "level" => 2, "id" => "header" }
         ],
-        "temporary_update_type" => false,
+        "temporary_update_type" => nil,
       },
       "routes" => [{ "path" => "/cma-cases/example-cma-case", "type" => "exact" }],
       "redirects" => [],

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -23,11 +23,22 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when the document is a new draft" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
-        title: "Example CMA Case",
-        base_path: "/cma-cases/example-cma-case",
-        public_updated_at: "2015-11-16T11:53:30+00:00",
-        publication_state: "draft")
+      FactoryGirl.create(
+        :cma_case,
+          title: "Example CMA Case",
+          base_path: "/cma-cases/example-cma-case",
+          public_updated_at: "2015-11-16T11:53:30+00:00",
+          publication_state: "draft")
+    }
+
+    let(:published_item) {
+      FactoryGirl.create(
+        :cma_case,
+          :published,
+          content_id: content_id,
+          title: "Example CMA Case",
+          base_path: "/cma-cases/example-cma-case",
+          public_updated_at: "2015-11-16T11:53:30+00:00")
     }
 
     scenario "from the index" do
@@ -41,10 +52,11 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Example CMA Case")
 
+      publishing_api_has_item_in_sequence(content_id, [item, published_item])
+
       click_button "Publish"
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Published Example CMA Case")
-
 
       expected_change_history = [
           {

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -57,8 +57,7 @@ FactoryGirl.define do
     redirects []
     update_type "major"
     public_updated_at "2015-11-16T11:53:30+00:00"
-    # TODO: "draft" documents shouldn't really have a first_published_at
-    first_published_at "2015-11-15T00:00:00Z"
+    first_published_at nil
     last_edited_at "2015-11-15T11:53:30"
     publication_state "draft"
     state_history {
@@ -110,6 +109,7 @@ FactoryGirl.define do
 
     trait :published do
       publication_state 'live'
+      first_published_at "2015-11-15T00:00:00+00:00"
       state_history {
         { "1": "published" }
       }
@@ -126,6 +126,7 @@ FactoryGirl.define do
 
     trait :unpublished do
       publication_state 'unpublished'
+      first_published_at "2015-11-15T00:00:00+00:00"
       state_history {
         { "1": "unpublished" }
       }

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe DrugSafetyUpdate do
 
   context "#publish" do
     let(:payload) {
-      FactoryGirl.create(:drug_safety_update,
-        update_type: "major",
-        publication_state: "draft")
+      FactoryGirl.create(
+        :drug_safety_update,
+          :published,
+          update_type: "major",)
     }
     let(:document) { described_class.from_publishing_api(payload) }
 

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RepublishWorker do
 
   context "when the document is live" do
     let(:document) {
-      FactoryGirl.create(:cma_case, publication_state: "live")
+      FactoryGirl.create(:cma_case, :published)
     }
 
     it "sends the document to the publishing api" do
@@ -85,7 +85,7 @@ RSpec.describe RepublishWorker do
 
   context "when the document is unpublished" do
     let(:document) {
-      FactoryGirl.create(:cma_case, publication_state: "unpublished")
+      FactoryGirl.create(:cma_case, :unpublished)
     }
 
     it "skips republishing of the document" do


### PR DESCRIPTION
Changed the way first_draft operates so that it uses first_published_at instead of the state history 
to check for drafts. However, since DFID documents can have draft documents with first_published_at we must determine first_draft? using state_history for DFID, as was previously used for all formats. This decision was made due to the desire to reduce reliance on state_history in the back end.

We condensed a lot of logic regarding the setting of update type, such that most of it is handled when first receiving the object, rather than both when receiving and saving, and handling. We also replaced 'search' with 'rummager' when using Plek

depends on [this pr](https://github.com/alphagov/gds-api-adapters/pull/540)
