### PR TITLE
attachment titles are automatically set if not supplied

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -10,7 +10,7 @@ class Attachment < Document
 
   def initialize(params = {})
     params = params.symbolize_keys
-    @title = params[:title]
+    @title = extract_title(params)
     @file = params[:file]
     @content_type = params[:content_type]
     @url = params[:url]
@@ -22,6 +22,17 @@ class Attachment < Document
   def update_attributes(new_params)
     new_params.each do |k, v|
       self.public_send(:"#{k}=", v)
+    end
+  end
+
+  def extract_title params
+    if params[:title].blank?
+      if params[:url]
+        separated_url = params[:url].split('/')
+        separated_url[separated_url.length - 1].split('.').first
+      end
+    else
+      params[:title]
     end
   end
 

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -209,6 +209,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         )
       }
 
+      #TODO this test isn't actually checking that the attachment has been added
       scenario "adding an attachment to a #{publication_state} CMA case" do
         updated_cma_case = cma_case.deep_merge(
           "update_type" => "minor",
@@ -254,6 +255,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
       scenario "editing an attachment on a #{publication_state} CMA case" do
         find('.attachments').first(:link, "edit").click
         expect(page.status_code).to eq(200)
+        expect(find('#attachment_title').value).to eq('asylum report image title')
 
         fill_in "Title", with: "Updated cma case image"
         page.attach_file('attachment_file', "spec/support/images/updated_cma_case_image.jpg")

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Attachment do
       expect(attachment.content_id).to be_truthy
       expect(attachment.file.content_type).to eq("image/jpeg")
       expect(attachment.file.tempfile).to eq("spec/support/images/cma_case_image.jpg")
+      expect(attachment.title).to eq('test attachment')
       expect(attachment.created_at).to be(nil)
       expect(attachment.updated_at).to be(nil)
       expect(attachment.url).to be(nil)
@@ -77,15 +78,16 @@ RSpec.describe Attachment do
     it "should set content_id, title, url, created_at and updated_at with data from publishing-api" do
       content_id = SecureRandom.uuid
       attachment = Attachment.new(
-        title: 'test attachment',
+        title: '',
         content_id: content_id,
-        url: "/path/to/file/in/asset/manager",
+        url: "/path/to/file/in/asset/manager/cma_case_image.jpg",
         content_type: 'image/jpg',
         created_at: "2015-12-03T16:59:13+00:00",
         updated_at: "2015-12-03T16:59:13+00:00",
       )
       expect(attachment.content_id).to eq(content_id)
-      expect(attachment.url).to eq("/path/to/file/in/asset/manager")
+      expect(attachment.title).to eq('cma_case_image')
+      expect(attachment.url).to eq("/path/to/file/in/asset/manager/cma_case_image.jpg")
       expect(attachment.content_type).to eq("image/jpg")
       expect(attachment.created_at).to eq("2015-12-03T16:59:13+00:00")
       expect(attachment.updated_at).to eq("2015-12-03T16:59:13+00:00")


### PR DESCRIPTION
if an attachment is added to a document and the title is not set,
then the document will default to using the name of the file.

This had the side effect of prefilling the form when going to edit
an attachment.
