### PR TITLE
Editing attachment title no longer requires re-upload

### DIFF
--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -253,6 +253,24 @@ RSpec.feature "Editing a CMA case", type: :feature do
       end
 
       scenario "editing an attachment on a #{publication_state} CMA case" do
+        # this is to force app to not update asset manager on only-name edits
+        stub_request(:post, "#{Plek.find('asset-manager')}/assets")
+          .with(body: %r{.*})
+          .to_return(body: asset_manager_response.to_json, status: 500)
+
+        find('.attachments').first(:link, "edit").click
+        expect(page.status_code).to eq(200)
+        expect(find('#attachment_title').value).to eq('asylum report image title')
+
+        fill_in "Title", with: "Updated cma case image"
+
+        click_button("Save attachment")
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("Editing Example CMA Case")
+      end
+
+      scenario "editing an attachment on a #{publication_state} CMA case" do
         find('.attachments').first(:link, "edit").click
         expect(page.status_code).to eq(200)
         expect(find('#attachment_title').value).to eq('asylum report image title')


### PR DESCRIPTION
added handling that checks whether a new file has been uploaded,
and if it hasn't (ie the title has been updated only) then it
saves the new title for the attachment.

Also made some refactors in an attempt to clear up a bit of the
duplication in the controller.
