### PR TITLE
Fixed flash message issue for new files

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -25,11 +25,14 @@ class Attachment < Document
     end
   end
 
-  def extract_title params
+  def extract_title(params)
     if params[:title].blank?
       if params[:url]
         separated_url = params[:url].split('/')
-        separated_url[separated_url.length - 1].split('.').first
+        filename = separated_url[separated_url.length - 1]
+        remove_extension_from_filename(filename)
+      elsif params[:file]
+        remove_extension_from_filename(params[:file].original_filename)
       end
     else
       params[:title]
@@ -43,6 +46,10 @@ class Attachment < Document
   rescue GdsApi::BaseError => e
     Airbrake.notify(e)
     false
+  end
+
+  def remove_extension_from_filename(filename)
+    filename.split('.').first
   end
 
   def snippet

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -52,13 +52,14 @@ RSpec.describe Attachment do
     end
   end
 
-  describe "#new" do
+  describe "#new without title" do
     let(:attachment) {
       Attachment.new(
-        title: 'test attachment',
+        title: '',
         file: ActionDispatch::Http::UploadedFile.new(
           tempfile: "spec/support/images/cma_case_image.jpg",
           filename: File.basename("spec/support/images/cma_case_image.jpg"),
+          original_filename: 'cma_case_image.jpg',
           type: "image/jpeg"
         ),
       )
@@ -68,7 +69,7 @@ RSpec.describe Attachment do
       expect(attachment.content_id).to be_truthy
       expect(attachment.file.content_type).to eq("image/jpeg")
       expect(attachment.file.tempfile).to eq("spec/support/images/cma_case_image.jpg")
-      expect(attachment.title).to eq('test attachment')
+      expect(attachment.title).to eq('cma_case_image')
       expect(attachment.created_at).to be(nil)
       expect(attachment.updated_at).to be(nil)
       expect(attachment.url).to be(nil)
@@ -94,6 +95,51 @@ RSpec.describe Attachment do
       expect(attachment.file).to be(nil)
     end
   end
+
+  describe "#new with title" do
+    let(:attachment) {
+      Attachment.new(
+        title: 'new attachment',
+        file: ActionDispatch::Http::UploadedFile.new(
+          tempfile: "spec/support/images/cma_case_image.jpg",
+          filename: File.basename("spec/support/images/cma_case_image.jpg"),
+          original_filename: 'cma_case_image.jpg',
+          type: "image/jpeg"
+        ),
+      )
+    }
+
+    it "should set content_id and file attributes with data from attachments new form" do
+      expect(attachment.content_id).to be_truthy
+      expect(attachment.file.content_type).to eq("image/jpeg")
+      expect(attachment.file.tempfile).to eq("spec/support/images/cma_case_image.jpg")
+      expect(attachment.title).to eq('new attachment')
+      expect(attachment.created_at).to be(nil)
+      expect(attachment.updated_at).to be(nil)
+      expect(attachment.url).to be(nil)
+      expect(attachment.content_type).to be(nil)
+    end
+
+    it "should set content_id, title, url, created_at and updated_at with data from publishing-api" do
+      content_id = SecureRandom.uuid
+      attachment = Attachment.new(
+        title: 'new attachment',
+        content_id: content_id,
+        url: "/path/to/file/in/asset/manager/cma_case_image.jpg",
+        content_type: 'image/jpg',
+        created_at: "2015-12-03T16:59:13+00:00",
+        updated_at: "2015-12-03T16:59:13+00:00",
+      )
+      expect(attachment.content_id).to eq(content_id)
+      expect(attachment.title).to eq('new attachment')
+      expect(attachment.url).to eq("/path/to/file/in/asset/manager/cma_case_image.jpg")
+      expect(attachment.content_type).to eq("image/jpg")
+      expect(attachment.created_at).to eq("2015-12-03T16:59:13+00:00")
+      expect(attachment.updated_at).to eq("2015-12-03T16:59:13+00:00")
+      expect(attachment.file).to be(nil)
+    end
+  end
+
 
   describe "#update_attributes" do
     let(:content_id) { SecureRandom.uuid }


### PR DESCRIPTION
Fixed issue whereby flash message when a new attachment was added
would not show attachment name if it had been automatically generated

Also added some more tests to cover this
