### PR TITLE
Untangle change history from redrafted

### DIFF
--- a/app/models/change_history.rb
+++ b/app/models/change_history.rb
@@ -1,0 +1,88 @@
+class ChangeHistory
+  def self.parse(change_history_array)
+    items = change_history_array.map do |item_hash|
+      Item.new(
+        public_timestamp: DateTime.parse(item_hash.fetch("public_timestamp")),
+        change_note: item_hash.fetch("note")
+      )
+    end
+
+    new(items)
+  end
+
+  def initialize(items = [])
+    self.items = items
+  end
+
+  def size
+    items.size
+  end
+
+  def as_json
+    items.map do |item|
+      {
+        "public_timestamp" => item.public_timestamp.iso8601,
+        "note" => item.change_note,
+      }
+    end
+  end
+
+  def first_published!
+    if size > 0
+      raise NonEmptyChangeHistoryError, "Change history must be empty to add the 'First published.' item"
+    end
+
+    add_item("First published.")
+  end
+
+  def add_item(change_note)
+    items << Item.new(
+      public_timestamp: Time.zone.now,
+      change_note: change_note,
+    )
+
+    nil
+  end
+
+  def update_item(change_note)
+    last_item = items.last
+
+    unless last_item
+      raise EmptyChangeHistoryError, "Change history must not be empty to update an item."
+    end
+
+    last_item.public_timestamp = Time.zone.now
+    last_item.change_note = change_note
+
+    nil
+  end
+
+  def latest_change_note
+    items.last.change_note if size > 0
+  end
+
+  def ==(other)
+    items == other.items
+  end
+
+protected
+
+  attr_accessor :items
+
+  class Item
+    attr_accessor :public_timestamp, :change_note
+
+    def initialize(public_timestamp:, change_note:)
+      self.public_timestamp = public_timestamp
+      self.change_note = change_note
+    end
+
+    def ==(other)
+      public_timestamp == other.public_timestamp &&
+        change_note == other.change_note
+    end
+  end
+
+  class ::EmptyChangeHistoryError < StandardError; end
+  class ::NonEmptyChangeHistoryError < StandardError; end
+end

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -25,7 +25,7 @@ class ActionsPresenter
       text = "<p>You don't have permission to publish this document.</p>"
     elsif update_type == "minor"
       text = "<p>You are about to publish a <strong>minor edit</strong>.</p>"
-    elsif update_type == "major" && state == "redrafted"
+    elsif update_type == "major" && !document.first_draft?
       text = "<p><strong>You are about to publish a major edit with a public change note.</strong></p>"
       text += "<p>Publishing will email subscribers to #{klass_name}.</p>"
     else
@@ -52,9 +52,9 @@ class ActionsPresenter
   end
 
   def unpublish_text
-    if state == "draft"
+    if document.first_draft?
       text = "<p>The document has never been published.</p>"
-    elsif state == "redrafted"
+    elsif state == "draft"
       text = "<p>The document cannot be unpublished because it has a draft. You need to publish the draft first.</p>"
     elsif state == "unpublished"
       text = "<p>The document is already unpublished.</p>"

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -54,7 +54,7 @@ class ActionsPresenter
   def unpublish_text
     if document.first_draft?
       text = "<p>The document has never been published.</p>"
-    elsif state == "draft"
+    elsif state == "draft" || state == "redrafted"
       text = "<p>The document cannot be unpublished because it has a draft. You need to publish the draft first.</p>"
     elsif state == "unpublished"
       text = "<p>The document is already unpublished.</p>"

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -37,7 +37,7 @@ private
     {
       body: GovspeakPresenter.new(@document).present,
       metadata: metadata,
-      change_history: document.change_history,
+      change_history: document.change_history.as_json,
       max_cache_time: 10,
       temporary_update_type: document.temporary_update_type,
     }.tap do |details_hash|

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -87,7 +87,11 @@ private
   end
 
   def redrafted?
-    document.publication_state == "redrafted"
+    document.publication_state == "redrafted" || redrafted_check
+  end
+
+  def redrafted_check
+    document.publication_state == "draft" && !document.first_draft?
   end
 
   def extra_options

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -1,4 +1,4 @@
-<% unless document.draft? %>
+<% unless document.first_draft? %>
   <div class="checkbox add-vertical-margins">
     <%= f.radio_button :update_type, :minor, class: 'js-update-type-minor' %>
     <%= f.label :update_type_minor %>

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -127,6 +127,94 @@ RSpec.feature "Editing a CMA case", type: :feature do
       assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
     end
 
+    context "when a document already has a change note" do
+      let(:cma_case) do
+        FactoryGirl.create(
+          :cma_case,
+          update_type: "major",
+          first_published_at: "2016-01-01",
+          details: {
+            change_history: [
+              {
+                "public_timestamp" => "2016-01-01T00:00:00+00:00",
+                "note" => "First published."
+              },
+              {
+                "public_timestamp" => "2016-02-02T00:00:00+00:00",
+                "note" => "Some change note"
+              },
+            ]
+          }
+        )
+      end
+
+      it "updates the timestamp on the existing change note" do
+        radio_major = field_labeled("cma_case_update_type_major")
+        expect(radio_major).to be_checked
+
+        expect(page).to have_content("Some change note")
+
+        click_button "Save as draft"
+
+        assert_publishing_api_put_content(content_id, ->(request) {
+          payload = JSON.parse(request.body)
+          change_history = payload.fetch("details").fetch("change_history")
+
+          expect(change_history).to eq [
+            { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
+            { "public_timestamp" => "2015-12-03T16:59:13+00:00", "note" => "Some change note" }
+          ]
+        })
+      end
+    end
+
+    context "when the document has a temporary update type" do
+      let(:cma_case) do
+        FactoryGirl.create(
+          :cma_case,
+          update_type: "minor",
+          first_published_at: "2016-01-01",
+          details: {
+            temporary_update_type: true,
+            change_history: [
+              {
+                "public_timestamp" => "2015-01-01T00:00:00+00:00",
+                "note" => "First published."
+              },
+              {
+                "public_timestamp" => "2015-02-02T00:00:00+00:00",
+                "note" => "Some change note"
+              },
+            ]
+          }
+        )
+      end
+
+      it "appends to the change history, rather than updating the last item" do
+        radio_minor = field_labeled("cma_case_update_type_minor")
+        radio_major = field_labeled("cma_case_update_type_major")
+
+        expect(radio_minor).not_to be_checked
+        expect(radio_major).not_to be_checked
+
+        choose "Update type major"
+        fill_in "Change note", with: "New change note"
+
+        click_button "Save as draft"
+
+        assert_publishing_api_put_content(content_id, ->(request) {
+          payload = JSON.parse(request.body)
+          change_history = payload.fetch("details").fetch("change_history")
+
+          expect(change_history).to eq [
+            { "public_timestamp" => "2015-01-01T00:00:00+00:00", "note" => "First published." },
+            { "public_timestamp" => "2015-02-02T00:00:00+00:00", "note" => "Some change note" },
+            { "public_timestamp" => "2015-12-03T16:59:13+00:00", "note" => "New change note" }
+          ]
+        })
+      end
+    end
+
     context "a bulk published document" do
       scenario "the 'bulk published' flag isn't lost after an update" do
         expect(cma_case["details"]["metadata"]["bulk_published"]).to be_truthy
@@ -296,64 +384,62 @@ RSpec.feature "Editing a CMA case", type: :feature do
     end
   end
 
-  %i(unpublished).each do |publication_state|
-    context "a #{publication_state} document" do
-      let(:cma_case) {
-        FactoryGirl.create(
-          :cma_case,
-          publication_state,
-          title: "Example CMA Case",
-          details: {},
-          state_history: { "1" => "published", "2" => publication_state.to_s, "3" => "draft" }
-        )
-      }
+  context "an unpublished document" do
+    let(:cma_case) {
+      FactoryGirl.create(
+        :cma_case,
+        :unpublished,
+        title: "Example CMA Case",
+        details: {},
+        state_history: { "1" => "published", "2" => "unpublished", "3" => "draft" }
+      )
+    }
 
-      scenario "showing the update type radio buttons" do
-        within(".new_cma_case") do
-          expect(page).to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
-          expect(page).to have_content('This will notify subscribers to ')
-          expect(page).to have_content('Update type minor')
-          expect(page).to have_content('Update type major')
-        end
-      end
-
-      scenario "insisting that an update type is chosen" do
-        click_button "Save as draft"
-
-        expect(page).to have_content("Please fix the following errors")
-        expect(page).to have_content("Update type can't be blank")
-
-        expect(page.status_code).to eq(422)
-      end
-
-      scenario "updating the title does not update the base path" do
-        fill_in "Title", with: "New title"
-        choose "Update type minor"
-        click_button "Save as draft"
-        changed_json = {
-          "title" => "New title",
-          "update_type" => "minor",
-          "base_path" => "/cma-cases/example-document"
-        }
-        assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+    scenario "showing the update type radio buttons" do
+      within(".new_cma_case") do
+        expect(page).to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
+        expect(page).to have_content('This will notify subscribers to ')
+        expect(page).to have_content('Update type minor')
+        expect(page).to have_content('Update type major')
       end
     end
 
-    context "a draft document" do
-      scenario "not showing the update type radio buttons" do
-        within(".new_cma_case") do
-          expect(page).not_to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
-          expect(page).not_to have_content('This will notify subscribers to ')
-          expect(page).not_to have_content('Update type minor')
-          expect(page).not_to have_content('Update type major')
-        end
-      end
+    scenario "insisting that an update type is chosen" do
+      click_button "Save as draft"
 
-      scenario "saving the document without an update type" do
-        click_button "Save as draft"
-        expect(page).to have_content("Updated Example CMA Case")
-        expect(page.status_code).to eq(200)
+      expect(page).to have_content("Please fix the following errors")
+      expect(page).to have_content("Update type can't be blank")
+
+      expect(page.status_code).to eq(422)
+    end
+
+    scenario "updating the title does not update the base path" do
+      fill_in "Title", with: "New title"
+      choose "Update type minor"
+      click_button "Save as draft"
+      changed_json = {
+        "title" => "New title",
+        "update_type" => "minor",
+        "base_path" => "/cma-cases/example-document"
+      }
+      assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+    end
+  end
+
+  context "a draft document" do
+    scenario "not showing the update type radio buttons" do
+      within(".new_cma_case") do
+        expect(page).not_to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
+        expect(page).not_to have_content('This will notify subscribers to ')
+        expect(page).not_to have_content('Update type minor')
+        expect(page).not_to have_content('Update type major')
       end
+    end
+
+    scenario "saving the document without an update type" do
+      click_button "Save as draft"
+      expect(page).to have_content("Updated Example CMA Case")
+      expect(page.status_code).to eq(200)
     end
   end
 end

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -123,10 +123,8 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     let(:item) {
       FactoryGirl.create(
         :cma_case,
-        :draft,
-        first_published_at: "2016-01-01",
+        :redrafted,
         title: "Major Update Case",
-        update_type: "major",
         change_history: [
           { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
           { "public_timestamp" => "2016-02-02T00:00:00+00:00", "note" => "Some change note" },
@@ -182,13 +180,9 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     let(:item) {
       FactoryGirl.create(
         :cma_case,
-        :draft,
-        first_published_at: "2016-01-01",
+        :redrafted,
         title: "Minor Update Case",
         update_type: "minor",
-        change_history: [
-          { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
-        ]
       )
     }
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -12,6 +12,8 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
     publishing_api_has_item(item)
 
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
     stub_publishing_api_publish(content_id, {})
     stub_any_rummager_post_with_queueing_enabled
     email_alert_api_accepts_alert
@@ -42,9 +44,6 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     }
 
     scenario "from the index" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
       visit "/cma-cases"
       expect(page.status_code).to eq(200)
 
@@ -122,11 +121,17 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when there is a redrafted document with a major update" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
-        :published,
+      FactoryGirl.create(
+        :cma_case,
+        :draft,
+        first_published_at: "2016-01-01",
         title: "Major Update Case",
         update_type: "major",
-        publication_state: "redrafted")
+        change_history: [
+          { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
+          { "public_timestamp" => "2016-02-02T00:00:00+00:00", "note" => "Some change note" },
+        ]
+      )
     }
 
     scenario "publish warning and popup text will indicate that it is a major edit" do
@@ -153,35 +158,38 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       expect(page.status_code).to eq(200)
 
       click_link "Edit document"
-      fill_in "Title", with: "Changed title"
 
+      fill_in "Title", with: "Changed title"
       choose "Update type major"
-      fill_in "Change note", with: "This is a change note for a major update to redrafted document."
+      fill_in "Change note", with: "Updated change note"
+
       click_button "Save as draft"
 
-      expected_change_history = item['details']['change_history'] + [
-          {
-              "public_timestamp" => Time.current.iso8601,
-              "note" => "This is a change note for a major update to redrafted document.",
-          }
-      ]
+      assert_publishing_api_put_content(content_id, ->(request) {
+        payload = JSON.parse(request.body)
 
-      changed_json = {
-          "title" => "Changed title",
-          "update_type" => "major",
-          "details" => item["details"].merge("change_history" => expected_change_history),
-      }
-      assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+        expect(payload["title"]).to eq("Changed title")
+        expect(payload["update_type"]).to eq("major")
+        expect(payload["details"]["change_history"]).to eq([
+          { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
+          { "public_timestamp" => Time.zone.now.iso8601, "note" => "Updated change note" },
+        ])
+      })
     end
   end
 
   context "when there is a redrafted document with a minor update" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
-        :published,
+      FactoryGirl.create(
+        :cma_case,
+        :draft,
+        first_published_at: "2016-01-01",
         title: "Minor Update Case",
         update_type: "minor",
-        publication_state: "redrafted")
+        change_history: [
+          { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
+        ]
+      )
     }
 
     scenario "alerts should not be sent when the item is published" do
@@ -221,7 +229,8 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when the document is unpublished" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryGirl.create(
+        :cma_case,
         :published,
         title: "Unpublished Item",
         publication_state: "unpublished")

--- a/spec/features/temporary_update_type_spec.rb
+++ b/spec/features/temporary_update_type_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
     let(:payload) {
       FactoryGirl.create(
         :cma_case,
-        publication_state: "redrafted",
+        :redrafted,
         update_type: "major",
         change_history: [{ "public_timestamp" => "2016-07-18T16:21:22+01:00", "note" => "First published." },
                          { "public_timestamp" => "2016-07-19T16:21:22+01:00", "note" => "an update" }],
@@ -70,7 +70,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
     let(:payload) {
       FactoryGirl.create(
         :cma_case,
-        publication_state: "redrafted",
+        :redrafted,
         update_type: "minor",
         details: {
           temporary_update_type: true,

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -154,21 +154,21 @@ RSpec.feature "Viewing a specific case", type: :feature do
                           ),
         FactoryGirl.create(:cma_case,
           title: "Example Published with new draft",
-          publication_state: "redrafted",
+          publication_state: "draft",
           state_history: {
             "1" => "published",
             "2" => "draft"
           }),
         FactoryGirl.create(:cma_case,
           title: "Example Unpublished with new draft",
-          publication_state: "redrafted",
+          publication_state: "draft",
           state_history: {
             "1" => "unpublished",
             "2" => "draft"
           }),
         FactoryGirl.create(:cma_case,
           title: "More states",
-          publication_state: "redrafted",
+          publication_state: "draft",
           state_history: {
             "1" => "unpublished",
             "2" => "published",

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -117,8 +117,8 @@ FactoryGirl.define do
       change_history do
         [
           {
-            'published_timestamp' => Time.current.iso8601,
-            'note' => Document::FIRST_PUBLISHED_NOTE
+            'public_timestamp' => Time.current.iso8601,
+            'note' => "First published.",
           }
         ]
       end
@@ -134,8 +134,8 @@ FactoryGirl.define do
       change_history do
         [
           {
-            'published_timestamp' => Time.current.iso8601,
-            'note' => Document::FIRST_PUBLISHED_NOTE
+            'public_timestamp' => Time.current.iso8601,
+            'note' => "First published.",
           }
         ]
       end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -124,6 +124,25 @@ FactoryGirl.define do
       end
     end
 
+    trait :redrafted do
+      state_history {
+        { "2": "draft", "1": "published" }
+      }
+
+      publication_state 'draft'
+      first_published_at "2015-11-15T00:00:00+00:00"
+
+      update_type "major"
+      change_history do
+        [
+            {
+                'public_timestamp' => Time.current.iso8601,
+                'note' => "First published.",
+            },
+        ]
+      end
+    end
+
     trait :unpublished do
       publication_state 'unpublished'
       first_published_at "2015-11-15T00:00:00+00:00"

--- a/spec/models/change_history_spec.rb
+++ b/spec/models/change_history_spec.rb
@@ -1,0 +1,126 @@
+require "spec_helper"
+
+RSpec.describe ChangeHistory do
+  subject do
+    described_class.new([
+      described_class::Item.new(
+        public_timestamp: DateTime.new(2016, 1, 1),
+        change_note: "First published.",
+      ),
+      described_class::Item.new(
+        public_timestamp: DateTime.new(2016, 2, 2),
+        change_note: "Some change note",
+      ),
+    ])
+  end
+
+  let(:data_structure) do
+    [
+      {
+        "public_timestamp" => "2016-01-01T00:00:00+00:00",
+        "note" => "First published."
+      },
+      {
+        "public_timestamp" => "2016-02-02T00:00:00+00:00",
+        "note" => "Some change note"
+      },
+    ]
+  end
+
+  around do |example|
+    Timecop.freeze { example.run }
+  end
+
+  it "encapsulates its items in an attempt to keep all change history logic in this model" do
+    expect(subject).not_to respond_to(:items)
+  end
+
+  describe ".parse" do
+    it "parses the change history from the data structure stored in the details hash" do
+      change_history = described_class.parse(data_structure)
+      expect(change_history).to eq(subject)
+    end
+  end
+
+  describe "#as_json" do
+    it "builds the data structure to be stored in the details hash from the change history" do
+      result = subject.as_json
+      expect(result).to eq(data_structure)
+    end
+  end
+
+  describe "#size" do
+    it "returns the size of the change history" do
+      expect(subject.size).to eq(2)
+      expect(described_class.new.size).to eq(0)
+    end
+  end
+
+  describe "#first_published!" do
+    it "adds a 'First published.' item to the change history" do
+      change_history = described_class.new
+      change_history.first_published!
+
+      expect(change_history.as_json).to eq([
+        {
+          "public_timestamp" => Time.zone.now.iso8601,
+          "note" => "First published."
+        }
+      ])
+    end
+
+    context "when the change history is not empty" do
+      it "raises a helpful error" do
+        expect {
+          subject.first_published!
+        }.to raise_error(/must be empty/)
+      end
+    end
+  end
+
+  describe "#add_item" do
+    it "adds an item to the change history with the current time" do
+      expect {
+        subject.add_item("New change note")
+      }.to change { subject.size }.by(1)
+
+      last_item = subject.as_json.last
+
+      expect(last_item.fetch("note")).to eq("New change note")
+      expect(last_item.fetch("public_timestamp")).to eq(Time.zone.now.iso8601)
+    end
+
+    it "does not leak access to the change history item" do
+      change_history = described_class.new
+      expect(change_history.first_published!).to be_nil
+    end
+  end
+
+  describe "#update_item" do
+    it "updates the last item in the change history" do
+      expect {
+        subject.update_item("Updated change note")
+      }.not_to change { subject.size }
+
+      last_item = subject.as_json.last
+      expect(last_item.fetch("note")).to eq("Updated change note")
+      expect(last_item.fetch("public_timestamp")).to eq(Time.zone.now.iso8601)
+    end
+
+    it "raises an error if there's nothing to update" do
+      expect {
+        described_class.new.update_item("change note")
+      }.to raise_error(EmptyChangeHistoryError)
+    end
+  end
+
+  describe "#latest_change_note" do
+    it "returns the latest item's change note" do
+      expect(subject.latest_change_note).to eq("Some change note")
+    end
+
+    it "returns nil if the change history is empty" do
+      expect(described_class.new.latest_change_note).to be_nil
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe Document do
       let(:payload) do
         FactoryGirl.create(
           :document,
-          payload_attributes.merge(publication_state: "redrafted"),
+          :redrafted,
+          payload_attributes.merge(update_type: "minor"),
         )
       end
       it "sets the update type" do
@@ -218,6 +219,7 @@ RSpec.describe Document do
         end
 
         it "sets the change note to the second item in the change history" do
+          document.update_type = "major"
           expect(document.change_note).to eq("Second note")
         end
       end

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -65,19 +65,13 @@ RSpec.describe ActionsPresenter do
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted") }
+      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "draft") }
       specify { expect(subject.publish_text).to include("major edit") }
       specify { expect(subject.publish_text).to include("will email subscribers") }
     end
 
-    context "when the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted", update_type: "minor") }
-      specify { expect(subject.publish_text).to include("minor edit") }
-      specify { expect(subject.publish_text).not_to include("will email subscribers") }
-    end
-
     context "when the document is redrafted and the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted", update_type: "minor") }
+      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "redrafted", update_type: "minor") }
       specify { expect(subject.publish_text).to include("minor edit") }
       specify { expect(subject.publish_text).not_to include("will email subscribers") }
     end
@@ -128,7 +122,7 @@ RSpec.describe ActionsPresenter do
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted") }
+      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "draft") }
       specify { expect(subject.unpublish_text).to include("publish the draft first") }
     end
 

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe ActionsPresenter do
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "draft") }
+      let(:payload) { FactoryGirl.create(:cma_case, :redrafted) }
       specify { expect(subject.publish_text).to include("major edit") }
       specify { expect(subject.publish_text).to include("will email subscribers") }
     end
 
     context "when the document is redrafted and the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "redrafted", update_type: "minor") }
+      let(:payload) { FactoryGirl.create(:cma_case, :redrafted, update_type: "minor") }
       specify { expect(subject.publish_text).to include("minor edit") }
       specify { expect(subject.publish_text).not_to include("will email subscribers") }
     end
@@ -122,7 +122,7 @@ RSpec.describe ActionsPresenter do
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, first_published_at: "2016-01-01", publication_state: "draft") }
+      let(:payload) { FactoryGirl.create(:cma_case, :redrafted) }
       specify { expect(subject.unpublish_text).to include("publish the draft first") }
     end
 

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe EmailAlertPresenter do
   let(:cma_case_payload) { FactoryGirl.create(:cma_case) }
   let(:medical_safety_payload) { FactoryGirl.create(:medical_safety_alert) }
-  let(:cma_case_redrafted_payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted") }
+  let(:cma_case_redrafted_payload) { FactoryGirl.create(:cma_case, :redrafted, title: "updated") }
 
   describe "#to_json" do
     context "any finders document" do


### PR DESCRIPTION
This change makes ChangeHistory a first-class
object that exposes some methods for adding and
updating items. This means the app doesn’t need
to know the details of how the change history is
represented.

Other than refactoring, the driver for this change
is to remove all reference of ‘redrafted’ from the
code base. Previously, change history was so
tangled up with ‘redrafted’ that it makes sense to
fix this first before continuing with that work.
