### PR TITLE
Increase the Publishing API timeout (4 -> 10 seconds)

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -8,6 +8,7 @@ module Services
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      timeout: 10,
     )
   end
 


### PR DESCRIPTION
We're seeing some timeouts with the 30K DFID research
outputs that have been imported into the system. This
isn't a very good fix so I will raise this to the
Publishing Platform team to investigate further.

**Update:**
https://trello.com/c/LvRrrEwg/276-speed-up-getcontentcollection
