### PR TITLE
Add a subscription_list_title_prefix

### DIFF
--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -13,9 +13,7 @@
   "organisations": [
     "db994552-7644-404d-a770-a2fe659c661f"
   ],
-  "topics": [
-    "some/dummy-topic"
-  ],
+  "subscription_list_title_prefix": "Research for Development output",
   "document_noun": "output",
   "facets": [
     {


### PR DESCRIPTION
All other finders have this, and we have a problem with our topic
only displaying as '#' on email signup (they still work).

Also, remove the `topics` key containing some/dummy-topic. It isn't
required.
