### PR TITLE
Redrafted removed - Merge in sync with P-API

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -92,7 +92,7 @@ class Document
     "live"
   end
 
-  %w{live redrafted superseded unpublished}.each do |state|
+  %w{live superseded unpublished}.each do |state|
     define_method("#{state}?") do
       publication_state == state
     end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -25,14 +25,14 @@ class Manual
     @base_path ||= "/guidance/#{title.parameterize}"
   end
 
-  %w{draft live redrafted}.each do |state|
+  %w{draft live}.each do |state|
     define_method("#{state}?") do
       publication_state == state
     end
   end
 
   def published?
-    live? || redrafted?
+    live?
   end
 
   def updated_at

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -24,7 +24,7 @@ class Section
     @base_path ||= "#{manual.base_path}/#{title.parameterize}"
   end
 
-  %w{draft live redrafted}.each do |state|
+  %w{draft live}.each do |state|
     define_method("#{state}?") do
       publication_state == state
     end

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -13,7 +13,7 @@ class ActionsPresenter
   end
 
   def publish_button_visible?
-    policy.publish? && %w(draft redrafted).include?(document.publication_state)
+    policy.publish? && document.draft?
   end
 
   def publish_text
@@ -54,7 +54,7 @@ class ActionsPresenter
   def unpublish_text
     if document.first_draft?
       text = "<p>The document has never been published.</p>"
-    elsif state == "draft" || state == "redrafted"
+    elsif state == "draft"
       text = "<p>The document cannot be unpublished because it has a draft. You need to publish the draft first.</p>"
     elsif state == "unpublished"
       text = "<p>The document is already unpublished.</p>"

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -87,10 +87,6 @@ private
   end
 
   def redrafted?
-    document.publication_state == "redrafted" || redrafted_check
-  end
-
-  def redrafted_check
     document.publication_state == "draft" && !document.first_draft?
   end
 

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -87,7 +87,7 @@ private
   end
 
   def redrafted?
-    document.publication_state == "draft" && !document.first_draft?
+    document.draft? && !document.first_draft?
   end
 
   def extra_options

--- a/app/workers/republish_worker.rb
+++ b/app/workers/republish_worker.rb
@@ -27,7 +27,7 @@ class RepublishWorker
 private
 
   def safe_to_republish?(document)
-    %w(draft redrafted live).include?(document.publication_state)
+    %w(draft live).include?(document.publication_state)
   end
 
   def print_limitations_of_republishing(document)

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Searching and filtering", type: :feature do
     end
     ten_example_cases[1]["publication_state"] = "live"
     ten_example_cases[1]["state_history"] = { "1" => "published" }
-    ten_example_cases[2]["publication_state"] = "redrafted"
+    ten_example_cases[2]["publication_state"] = "draft"
     ten_example_cases[2]["state_history"] = { "1" => "published", "2" => "unpublished", "3" => "draft" }
     ten_example_cases
   }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe Document do
     end
 
     context 'when document is in redrafted state' do
-      let(:publication_state) { 'redrafted' }
+      let(:publication_state) { 'draft' }
       it_behaves_like 'publishing changes to a document that has previously been published'
     end
 

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ActionsPresenter do
     specify { expect(subject.publish_alert).to include("will email subscribers to CMA Cases") }
 
     context "when the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "redrafted", update_type: "minor") }
+      let(:payload) { FactoryGirl.create(:cma_case, :redrafted, update_type: "minor") }
       specify { expect(subject.publish_alert).to include("minor edit") }
     end
   end

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe RepublishWorker do
     publishing_api_has_item(document)
   end
 
-  %w(draft redrafted).each do |publication_state|
+  %i(draft redrafted).each do |publication_state|
     context "when the publication_state is '#{publication_state}'" do
       let(:document) {
-        FactoryGirl.create(:cma_case, publication_state: publication_state)
+        FactoryGirl.create(:cma_case, publication_state)
       }
 
       it "sends the document to the publishing api" do


### PR DESCRIPTION
all use of redrafted from publishing api should be removed
Please test pretty heavily: I'm suspicious about how little 
work needed doing. 

needs to be deployed at the time as [this PR](https://github.com/alphagov/publishing-api/pull/419)

[trello card](https://trello.com/c/dIpFzkTg/200-remove-all-references-to-redrafted-medium)
