### PR TITLE
application no longer breaks when no attachment selected

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -12,10 +12,16 @@ class AttachmentsController < ApplicationController
 
   def create
     document = fetch_document
-    attachment = document.attachments.build(attachment_params)
-    attachment.content_type = attachment.file.content_type
 
-    upload_attachment(document, attachment, new_attachment: true)
+    if attachment_valid?
+      attachment = document.attachments.build(attachment_params)
+      attachment.content_type = attachment.file.content_type
+
+      upload_attachment(document, attachment, new_attachment: true)
+    else
+      flash[:danger] = "Adding an attachment failed. Please make sure you have uploaded an attachment."
+      redirect_to previous_address(document, Attachment.new, new: true)
+    end
   end
 
   def edit
@@ -53,11 +59,11 @@ private
       redirect_to edit_document_path(document_type_slug, document.content_id)
     else
       flash[:danger] = "There was an error uploading the attachment, please try again later."
-      redirect_to previous_address(document, attachment, new_attachment)
+      redirect_to previous_address(document, attachment, new: new_attachment)
     end
   end
 
-  def previous_address(document, attachment, new)
+  def previous_address(document, attachment, new:)
     if new
       new_document_attachment_path(document_type_slug, document.content_id)
     else
@@ -82,5 +88,9 @@ private
 
   def attachment_params
     params.require(:attachment).permit(:title, :file)
+  end
+
+  def attachment_valid?
+    !params["attachment"].nil? && !params["attachment"]["file"].nil?
   end
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(document.attachments.count).to eq(3)
       expect(response).to redirect_to(edit_document_path(document_type_slug: document_type_slug, content_id: document_content_id))
     end
+
+    it "shows an error if no attachment is uploaded" do
+      document = CmaCase.find(document_content_id)
+      allow_any_instance_of(AttachmentsController).to receive(:fetch_document).and_return(document)
+
+      post :create, document_type_slug: document_type_slug, document_content_id: document_content_id, attachment: nil
+
+      expect(response).to redirect_to(new_document_attachment_path(document_type_slug: document_type_slug))
+    end
   end
 
   describe "GET edit" do

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -270,6 +270,24 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page).to have_content("Editing Example CMA Case")
       end
 
+      scenario "adding a nil attachment on a #{publication_state} CMA case" do
+        # this is to force app to not update asset manager on invalid error
+        stub_request(:post, "#{Plek.find('asset-manager')}/assets")
+          .with(body: %r{.*})
+          .to_return(body: asset_manager_response.to_json, status: 500)
+
+        click_link "Add attachment"
+        expect(page.status_code).to eq(200)
+
+        fill_in "Title", with: "Updated cma case image"
+
+        click_button("Save attachment")
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("Adding an attachment failed. Please make sure you have uploaded an attachment")
+      end
+
+
       scenario "editing an attachment on a #{publication_state} CMA case" do
         find('.attachments').first(:link, "edit").click
         expect(page.status_code).to eq(200)


### PR DESCRIPTION
Previously an error page would be shown if no attachment was selected
Now the user is returned to the new attachment page and shown an error
