### PR TITLE
Revert "Add DFID peer review dropdown"

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -4,7 +4,7 @@ class DfidResearchOutput < Document
   validates :dfid_document_type, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
-    dfid_document_type country first_published_at dfid_authors dfid_theme dfid_review_status
+    dfid_document_type country first_published_at dfid_authors dfid_theme
   )
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -33,9 +33,3 @@
 <%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
   <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
 <% end %>
-
-<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_review_status, label: 'Review status' } do %>
-  <%= f.select :dfid_review_status, facet_options(f, :dfid_review_status),
-    {},
-    { class: 'form-control' } %>
-<% end %>

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -981,25 +981,6 @@
       "type": "text",
       "display_as_result_metadata": true,
       "filterable": false
-    },
-    {
-      "key": "dfid_review_status",
-      "name": "Review Status",
-      "short_name": "Review Status",
-      "type": "text",
-      "preposition": "with review status",
-      "display_as_result_metadata": false,
-      "filterable": false,
-      "allowed_values": [
-        {
-          "value": "unreviewed",
-          "label": "Unreviewed"
-        },
-        {
-          "value": "peer_reviewed",
-          "label": "Peer reviewed"
-        }
-      ]
     }
   ]
 }

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -33,7 +33,6 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "First published at", with: "2013-01-01"
     select "Book Chapter", from: "Document type"
     select "Infrastructure", from: "Themes"
-    select "Peer reviewed", from: "Review status"
 
     click_button "Save as draft"
     assert_publishing_api_put_content(content_id)


### PR DESCRIPTION
This reverts commit c47f41fdfc26dec9900dc9375dcfe11b9f1924f8.

We can't currently do this; although finder-frontend respects the
`display_as_metadata: false`, specialist-frontend does not, meaning any
newly-published documents will see a "Review status: unreviewed" or
"Review status: peer_reviewed" in the metadata fields. Since we were
trying to avoid the public seeing the term "unreviewed" which is
confusing/not always relevant, we need to roll this back until
specialist-frontend has seen some work.
