### PR TITLE
Add DFID peer review dropdown

### DIFF
--- a/app/helpers/dfid_research_outputs_helper.rb
+++ b/app/helpers/dfid_research_outputs_helper.rb
@@ -1,0 +1,21 @@
+module DfidResearchOutputsHelper
+  ##
+  # Only exists here – rather than in the finder schema – because
+  # specialist-frontend won't allow us to suppress any metadata that's
+  # present (unlike finder-frontend, which allows us to suppress with
+  # +display_as_result_metadata+).
+  #
+  # DFID still need to be able to record the value without it showing up
+  # publicly (for now), and until we can add the ability to specialist-frontend
+  # to selectively hide data (we only want "Peer reviewed" to show up when present
+  # as 'unreviewed' means nothing), this is where the backend gets its values.
+  #
+  def dfid_review_status_options
+    # rubocop:disable Style/WordArray
+    [
+      ["Unreviewed",    "unreviewed"],
+      ["Peer reviewed", "peer_reviewed"]
+    ]
+    # rubocop:enable Style/WordArray
+  end
+end

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -4,7 +4,7 @@ class DfidResearchOutput < Document
   validates :dfid_document_type, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
-    dfid_document_type country first_published_at dfid_authors dfid_theme
+    dfid_document_type country first_published_at dfid_authors dfid_theme dfid_review_status
   )
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -33,3 +33,9 @@
 <%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
   <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
 <% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_review_status, label: 'Review status' } do %>
+  <%= f.select :dfid_review_status, dfid_review_status_options,
+    {},
+    { class: 'form-control' } %>
+<% end %>

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "First published at", with: "2013-01-01"
     select "Book Chapter", from: "Document type"
     select "Infrastructure", from: "Themes"
+    select "Peer reviewed", from: "Review status"
 
     click_button "Save as draft"
     assert_publishing_api_put_content(content_id)


### PR DESCRIPTION
Although not currently used as a facet because the label "unreviewed"
makes no sense to researchers, work needs to be done in both
finder-frontend and specialist-frontend to support a piece of
metadata that is either present or absent.

In the meantime, this lets DFID record the peer reviewed status of an
output so that this information is not lost and when the works to
finder-frontend and specialist-frontend are done, the information
will be available to face the public.

In order to do this and keep it out of the finder we need hard-coded
values in a helper.
