### PR TITLE
Live publication state replaced with published

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def state(document)
-    state = document.publication_state == "live" ? "published" : document.publication_state
+    state = document.publication_state
 
     if document.publication_state == "draft"
       classes = "label label-primary"

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -92,7 +92,7 @@ class Document
     "live"
   end
 
-  %w{live superseded unpublished}.each do |state|
+  %w{published superseded unpublished}.each do |state|
     define_method("#{state}?") do
       publication_state == state
     end
@@ -180,7 +180,7 @@ class Document
     if document.temporary_update_type?
       document.update_type = nil
       document.temporary_update_type = false
-    elsif document.live? || document.unpublished?
+    elsif document.published? || document.unpublished?
       document.update_type = nil
     elsif document.first_draft?
       document.update_type = 'major'

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -17,7 +17,7 @@ class ActionsPresenter
   end
 
   def publish_text
-    if state == "live"
+    if state == "published"
       text = "<p>There are no changes to publish.</p>"
     elsif state == "unpublished"
       text = "<p>The document is unpublished. You need to create a new draft before it can be published.</p>"
@@ -48,7 +48,7 @@ class ActionsPresenter
   end
 
   def unpublish_button_visible?
-    policy.unpublish? && state == "live"
+    policy.unpublish? && state == "published"
   end
 
   def unpublish_text
@@ -60,7 +60,7 @@ class ActionsPresenter
       text = "<p>The document is already unpublished.</p>"
     elsif !policy.unpublish?
       text = "<p>You don't have permission to unpublish this document.</p>"
-    elsif state == "live"
+    elsif state == "published"
       text = "<p>The document will be removed from the site. It will still be possible to edit and publish a new version.</p>"
     else
       raise ArgumentError, "Unrecognised state: '#{state}'"

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,6 +1,6 @@
 <h1 class="page-header"><%= document.title %>
   <ul class='document-slug'>
-    <li title='<% if !document.live? %>When published this document will appear at this URL<% end %>'>
+    <li title='<% if !document.published? %>When published this document will appear at this URL<% end %>'>
       <%= document.base_path %>
     </li>
     <% if show_view_on_website_link?(document.state_history) %>
@@ -9,5 +9,5 @@
     <% if show_preview_draft_link?(document.state_history) %>
       <li><%= preview_draft_link_for(document) %></li>
     <% end %>
-  </li>
+  </ul>
 </h1>

--- a/app/workers/republish_worker.rb
+++ b/app/workers/republish_worker.rb
@@ -11,7 +11,7 @@ class RepublishWorker
       return
     end
 
-    if document.publication_state == "live"
+    if document.publication_state == "published"
       document.update_type = "republish"
 
       publishing_api_put_content(document)
@@ -27,7 +27,7 @@ class RepublishWorker
 private
 
   def safe_to_republish?(document)
-    %w(draft live).include?(document.publication_state)
+    %w(draft published).include?(document.publication_state)
   end
 
   def print_limitations_of_republishing(document)

--- a/lib/data_comparison.rb
+++ b/lib/data_comparison.rb
@@ -33,7 +33,7 @@ module_function
       return
     end
 
-    if document.live?
+    if document.published?
       puts "Publishing document"
       document.publish
     elsif document.unpublished?

--- a/lib/ops_tasks.rb
+++ b/lib/ops_tasks.rb
@@ -23,7 +23,7 @@ module_function
     document.update_type = "republish"
 
     state = document.publication_state
-    raise_helpful_error(state) unless state == "live"
+    raise_helpful_error(state) unless state == "published"
 
     payload = DocumentPresenter.new(document).to_json
     payload.merge!("public_updated_at" => timestamp)

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -1,5 +1,5 @@
 # At present, these tasks will only republish documents that are in a draft,
-# live or republished state.
+# published or republished state.
 
 namespace :republish do
   desc "republish all documents"

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Searching and filtering", type: :feature do
         "last_edited_at" => (test_date - (n + 1).days).iso8601,
         "public_updated_at" => (test_date - (10 - n).days).iso8601)
     end
-    ten_example_cases[1]["publication_state"] = "live"
+    ten_example_cases[1]["publication_state"] = "published"
     ten_example_cases[1]["state_history"] = { "1" => "published" }
     ten_example_cases[2]["publication_state"] = "draft"
     ten_example_cases[2]["state_history"] = { "1" => "published", "2" => "unpublished", "3" => "draft" }

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
     let(:item) {
       FactoryGirl.create(:cma_case,
         title: "Example CMA Case",
-        publication_state: "live")
+        publication_state: "published")
     }
 
     scenario "clicking the unpublish button redirects back to the show page" do
@@ -40,7 +40,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
     let(:item) {
       FactoryGirl.create(:cma_case,
         title: "Example CMA Case",
-        publication_state: "live")
+        publication_state: "published")
     }
 
     scenario "clicking the unpublish button shows an error message" do

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
                           ),
         FactoryGirl.create(:cma_case,
           title: "Example Published",
-          publication_state: "live",
+          publication_state: "published",
           state_history: { "1" => "published" }
                           ),
         FactoryGirl.create(:cma_case,
@@ -176,7 +176,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
           }),
         FactoryGirl.create(:cma_case,
           title: "More states Published",
-          publication_state: "live",
+          publication_state: "published",
           state_history: {
             "1" => "unpublished",
             "2" => "published"

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -108,7 +108,7 @@ FactoryGirl.define do
     end
 
     trait :published do
-      publication_state 'live'
+      publication_state 'published'
       first_published_at "2015-11-15T00:00:00+00:00"
       state_history {
         { "1": "published" }

--- a/spec/lib/ops_tasks_spec.rb
+++ b/spec/lib/ops_tasks_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OpsTasks do
   describe "#set_public_updated_at" do
     describe "when the document is live" do
       let(:payload) {
-        FactoryGirl.create(:cma_case, publication_state: "live")
+        FactoryGirl.create(:cma_case, publication_state: "published")
       }
 
       before do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Document do
         MyDocumentType.from_publishing_api(
           FactoryGirl.create(:document,
             payload_attributes.merge(
-              publication_state: 'live',
+              publication_state: 'published',
               update_type: 'minor',
               content_id: document.content_id
             ))
@@ -374,7 +374,7 @@ RSpec.describe Document do
     end
 
     context "when document is in live state" do
-      let(:publication_state) { 'live' }
+      let(:publication_state) { 'published' }
       it_behaves_like 'publishing changes to a document that has previously been published'
     end
 

--- a/spec/support/payloads/document.rb
+++ b/spec/support/payloads/document.rb
@@ -44,7 +44,7 @@ module Payloads
       "phase" => "live",
       "update_type" => "major",
       "need_ids" => [],
-      "publication_state" => "live",
+      "publication_state" => "published",
       "live_version" => 2,
       "version" => 2
     }.merge(attr)
@@ -92,7 +92,7 @@ module Payloads
         "phase" => "live",
         "update_type" => "major",
         "need_ids" => [],
-        "publication_state" => "live",
+        "publication_state" => "published",
         "live_version" => 2,
         "version" => 2
       },
@@ -139,7 +139,7 @@ module Payloads
         "phase" => "live",
         "update_type" => "major",
         "need_ids" => [],
-        "publication_state" => "live",
+        "publication_state" => "published",
         "live_version" => 2,
         "version" => 2
       },

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RepublishWorker do
     end
   end
 
-  context "when the document is live" do
+  context "when the document is published" do
     let(:document) {
       FactoryGirl.create(:cma_case, :published)
     }


### PR DESCRIPTION
Pretty much a straightforward name change. Notably, I didn't update
manuals since it broke pretty much everything.

Needs to be deployed at the same time as [this](https://github.com/alphagov/publishing-api/pull/446)

[Trello Card](https://trello.com/c/xOZFV4n1/225-rename-live-to-published-throughout-the-app)
