### PR TITLE
Fix an issue with attachments and spaces/underscores

### DIFF
--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -23,9 +23,17 @@ private
   end
 
   def govspeak_body_with_expanded_attachment_links
-    document.attachments.reduce(govspeak_body) { |body, attachment|
-      body.gsub(attachment.snippet, attachment_markdown(attachment))
+    body = replace_spaces_with_underscores_for_attachments(govspeak_body)
+
+    document.attachments.reduce(body) { |b, attachment|
+      b.gsub(attachment.snippet, attachment_markdown(attachment))
     }
+  end
+
+  def replace_spaces_with_underscores_for_attachments(string)
+    string.gsub(/\[InlineAttachment(.*?)\]/) do |attachment_snippet|
+      attachment_snippet.gsub(/\s/, "_")
+    end
   end
 
   def attachment_markdown(attachment)

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -72,6 +72,35 @@ RSpec.describe GovspeakPresenter do
 
         expect(presented_html).to eq(expected_html)
       end
+
+      context "when the html uses spaces instead of underscores for InlineAttachment" do
+        let(:payload) {
+          FactoryGirl.create(:cma_case,
+            details: {
+              body: [{
+                "content_type" => "text/govspeak",
+                "content" => "[InlineAttachment:asylum support image.jpg]",
+              }],
+              attachments: [
+                {
+                  "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+                  "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum_support_image.jpg",
+                  "content_type" => "application/jpeg",
+                  "title" => "asylum report image title",
+                  "created_at" => "2015-12-03T16:59:13+00:00",
+                  "updated_at" => "2015-12-03T16:59:13+00:00"
+                },
+              ]
+            })
+        }
+
+        it "expands the attachment snippet to an html link" do
+          presented_html = presented_data.find { |r| r[:content_type] == "text/html" }[:content]
+          expected_html = "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum_support_image.jpg\">asylum report image title</a></p>\n"
+
+          expect(presented_html).to eq(expected_html)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It looks like V1 used to swap out spaces with underscores
when processing the body of a document in order to inline
attachment links. We need to replicate this behaviour,
otherwise attachment links won't work for filenames that
contain spaces.
