### PR TITLE
Fix a schema validation error

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -52,6 +52,7 @@ class SpecialistDocumentPublishingAPIFormatter
         }
       ],
       max_cache_time: 10,
+      temporary_update_type: false,
     }
     details_hash[:attachments] = attachments if specialist_document.attachments.present?
     details_hash.merge(headers)

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Republishing documents", type: :feature do
           {"content_type" => "text/govspeak", "content" => "My body"}
         ],
         "max_cache_time" => 10,
+        "temporary_update_type" => false,
       },
     }
   end


### PR DESCRIPTION
We introduced this field in Specialist Publisher Rebuild.
V1 doesn't need it, but we regularly do republishes into
the new system and that causes errors.