### PR TITLE
Grant gds_editor visibility of pre-production finders in all envs

### DIFF
--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -16,7 +16,10 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :unpublish?, :publish?
 
   def environment_restricted_formats
-    Rails.env.development? ? [] : PRE_PRODUCTION
+    return [] if gds_editor?
+    return [] if Rails.env.development?
+
+    PRE_PRODUCTION
   end
 
   def restricted_by_environment?
@@ -36,6 +39,6 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   def gds_editor?
-    !restricted_by_environment? && user.gds_editor?
+    user.gds_editor?
   end
 end

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -96,8 +96,8 @@ RSpec.feature "Access control", type: :feature do
 
       scenario "visiting a pre_production finder" do
         visit "/tax-tribunal-decisions"
-        expect(page.current_path).to eq("/manuals")
-        expect(page).to have_content("You aren't permitted to access Tax Tribunal Decisions.")
+        expect(page.current_path).to eq("/tax-tribunal-decisions")
+        expect(page).not_to have_content("You aren't permitted to access Tax Tribunal Decisions.")
       end
 
       scenario "visiting a non pre_production finder" do
@@ -118,6 +118,12 @@ RSpec.feature "Access control", type: :feature do
         expect(page.status_code).to eq(200)
         expect(page).to have_no_content 'Example manual'
         expect(page).to have_content 'Exemplar manual'
+      end
+
+      scenario "visiting a pre_production finder" do
+        visit "/tax-tribunal-decisions"
+        expect(page.current_path).to eq("/manuals")
+        expect(page).to have_content("You aren't permitted to access Tax Tribunal Decisions.")
       end
     end
   end

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -91,9 +91,22 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
       log_in_as_editor(:gds_editor)
     end
 
-    scenario "with valid data" do
-      visit "/eat-decisions/new"
-      expect(page.current_path).to eq("/manuals")
+    context "when logged in as an editor" do
+      before { log_in_as_editor(:editor) }
+
+      scenario "not seeing pre-production formats" do
+        visit "/eat-decisions/new"
+        expect(page.current_path).to eq("/manuals")
+      end
+    end
+
+    context "when logged in as a gds_editor" do
+      before { log_in_as_editor(:gds_editor) }
+
+      scenario "seeing pre-production formats" do
+        visit "/eat-decisions/new"
+        expect(page.current_path).to eq("/eat-decisions/new")
+      end
     end
   end
 end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -8,19 +8,13 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
       log_in_as_editor(:gds_editor)
     end
 
-    it 'has one finder link for each viewable schema' do
+    it 'grants access to view all finders including pre-production' do
       visit '/'
 
       click_link('Finders')
 
-      json_schema_count = Dir['lib/documents/schemas/*.json'].length
-
-      pre_production = DocumentPolicy.new(:user, CmaCase).environment_restricted_formats.length
-
-      expect(page).to have_css(
-        '.dropdown-menu:nth-of-type(1) li',
-          count: json_schema_count - pre_production
-      )
+      count = Dir['lib/documents/schemas/*.json'].length
+      expect(page).to have_css('.dropdown-menu:nth-of-type(1) li', count: count)
     end
 
     it 'does not have a finder for pre_production finder DFID research outputs' do


### PR DESCRIPTION
In Specialist Publisher (V1) we don't restrict which finders
are visible for gds editors. This replicates that behaviour.
