### PR TITLE
Grant writers/editors access to pre-prod finders

### DIFF
--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -15,16 +15,8 @@ class DocumentPolicy < ApplicationPolicy
 
   alias_method :unpublish?, :publish?
 
-  def environment_restricted_formats
-    gds_editor? ? [] : PRE_PRODUCTION
-  end
-
-  def restricted_by_environment?
-    environment_restricted_formats.include?(document_class.document_type)
-  end
-
   def user_organisation_owns_document_type?
-    document_class.organisations.include?(user.organisation_content_id) && !restricted_by_environment?
+    document_class.organisations.include?(user.organisation_content_id)
   end
 
   def departmental_editor?

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -88,15 +88,27 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
   context 'in production' do
     before do
       allow(Rails.env).to receive(:development?).and_return(false)
-      log_in_as_editor(:gds_editor)
+      stub_any_publishing_api_call
+      publishing_api_has_item(research_output)
     end
 
     context "when logged in as an editor" do
-      before { log_in_as_editor(:editor) }
+      before { log_in_as_editor(:moj_editor) }
 
-      scenario "not seeing pre-production formats" do
+      scenario "seeing pre-production formats" do
         visit "/eat-decisions/new"
-        expect(page.current_path).to eq("/manuals")
+        expect(page.status_code).to eq(200), page.html
+        expect(page.current_path).to eq("/eat-decisions/new")
+      end
+    end
+
+    context "when logged in as a writer" do
+      before { log_in_as_editor(:moj_writer) }
+
+      scenario "seeing pre-production formats" do
+        visit "/eat-decisions/new"
+        expect(page.status_code).to eq(200), page.html
+        expect(page.current_path).to eq("/eat-decisions/new")
       end
     end
 
@@ -105,6 +117,7 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
 
       scenario "seeing pre-production formats" do
         visit "/eat-decisions/new"
+        expect(page.status_code).to eq(200), page.html
         expect(page.current_path).to eq("/eat-decisions/new")
       end
     end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     end
   end
 
+  # Editor factories:
   factory :editor, parent: :user do
     permissions %w(signin editor)
   end
@@ -24,10 +25,9 @@ FactoryGirl.define do
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   end
 
-  factory :writer, aliases: [:cma_writer], parent: :editor do
-    organisation_slug "competition-and-markets-authority"
-    organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-    permissions %w(signin)
+  factory :moj_editor, parent: :editor do
+    organisation_slug "ministry-of-justice"
+    organisation_content_id "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   end
 
   factory :aaib_editor, parent: :editor do
@@ -38,6 +38,18 @@ FactoryGirl.define do
   factory :dfid_editor, parent: :editor do
     organisation_slug "department-for-international-development"
     organisation_content_id "db994552-7644-404d-a770-a2fe659c661f"
+  end
+
+  # Writer factories:
+  factory :writer, aliases: [:cma_writer], parent: :editor do
+    organisation_slug "competition-and-markets-authority"
+    organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+    permissions %w(signin)
+  end
+
+  factory :moj_writer, parent: :writer do
+    organisation_slug "ministry-of-justice"
+    organisation_content_id "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   end
 
   sequence :content_id do |_|


### PR DESCRIPTION
Previously we only allowed gds_editors to access
pre-prod finders in the rebuild. This isn't right
as V1 has no restrictions on this. The only real
difference between prod/pre-prod is that the finder
hasn't been published and no user has yet published
a document for that finder.
