### PR TITLE
[DO NOT MERGE] Removed last updated at from attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -16,7 +16,6 @@ class Attachment < Document
     @url = params[:url]
     @content_id = params[:content_id] || SecureRandom.uuid
     @created_at = params[:created_at]
-    @updated_at = params[:updated_at]
   end
 
   def update_attributes(new_params)

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -57,7 +57,6 @@
           <tr class="table-header">
             <th>Title</th>
             <th>Created</th>
-            <th>Last&nbsp;updated</th>
           </tr>
         </thead>
         <% attachments.each_with_index do | attachment, i | %>
@@ -71,7 +70,6 @@
           <tr <% if i > truncate_at_count - 2 %>class="js-toggle-target if-js-hide"<% end %>>
             <td><%= attachment.title %></td>
             <td><%= attachment.created_at.to_date.to_s(:govuk_date) %></td>
-            <td><%= attachment.updated_at.to_date.to_s(:govuk_date) %></td>
           </tr>
         <% end %>
       </table>

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -100,12 +100,10 @@ RSpec.feature "Viewing a specific case", type: :feature do
             attachments: [
               FactoryGirl.create(:attachment_payload,
                 title: 'first attachment',
-                created_at: "2015-12-01T10:12:26+00:00",
-                updated_at: "2015-12-02T10:12:26+00:00"),
+                created_at: "2015-12-01T10:12:26+00:00"),
               FactoryGirl.create(:attachment_payload,
                 title: 'second attachment',
-                created_at: "2015-12-03T10:12:26+00:00",
-                updated_at: "2015-12-04T10:12:26+00:00"),
+                created_at: "2015-12-03T10:12:26+00:00"),
             ]
           }),
       ]
@@ -127,10 +125,8 @@ RSpec.feature "Viewing a specific case", type: :feature do
 
       expect(page).to have_content("first attachment")
       expect(page).to have_content("1 December 2015")
-      expect(page).to have_content("2 December 2015")
       expect(page).to have_content("second attachment")
       expect(page).to have_content("3 December 2015")
-      expect(page).to have_content("4 December 2015")
     end
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Attachment do
         expect(attachment.url).to eq(attachment_payload["url"])
         expect(attachment.content_id).to eq(attachment_payload["content_id"])
         expect(attachment.created_at).to eq(attachment_payload["created_at"])
-        expect(attachment.updated_at).to eq(attachment_payload["updated_at"])
       end
 
       context "when a content id is not provided" do
@@ -71,12 +70,11 @@ RSpec.describe Attachment do
       expect(attachment.file.tempfile).to eq("spec/support/images/cma_case_image.jpg")
       expect(attachment.title).to eq('cma_case_image')
       expect(attachment.created_at).to be(nil)
-      expect(attachment.updated_at).to be(nil)
       expect(attachment.url).to be(nil)
       expect(attachment.content_type).to be(nil)
     end
 
-    it "should set content_id, title, url, created_at and updated_at with data from publishing-api" do
+    it "should set content_id, title, url and created_at with data from publishing-api" do
       content_id = SecureRandom.uuid
       attachment = Attachment.new(
         title: '',
@@ -84,14 +82,12 @@ RSpec.describe Attachment do
         url: "/path/to/file/in/asset/manager/cma_case_image.jpg",
         content_type: 'image/jpg',
         created_at: "2015-12-03T16:59:13+00:00",
-        updated_at: "2015-12-03T16:59:13+00:00",
       )
       expect(attachment.content_id).to eq(content_id)
       expect(attachment.title).to eq('cma_case_image')
       expect(attachment.url).to eq("/path/to/file/in/asset/manager/cma_case_image.jpg")
       expect(attachment.content_type).to eq("image/jpg")
       expect(attachment.created_at).to eq("2015-12-03T16:59:13+00:00")
-      expect(attachment.updated_at).to eq("2015-12-03T16:59:13+00:00")
       expect(attachment.file).to be(nil)
     end
   end
@@ -115,12 +111,11 @@ RSpec.describe Attachment do
       expect(attachment.file.tempfile).to eq("spec/support/images/cma_case_image.jpg")
       expect(attachment.title).to eq('new attachment')
       expect(attachment.created_at).to be(nil)
-      expect(attachment.updated_at).to be(nil)
       expect(attachment.url).to be(nil)
       expect(attachment.content_type).to be(nil)
     end
 
-    it "should set content_id, title, url, created_at and updated_at with data from publishing-api" do
+    it "should set content_id, title, url and created_at with data from publishing-api" do
       content_id = SecureRandom.uuid
       attachment = Attachment.new(
         title: 'new attachment',
@@ -128,14 +123,12 @@ RSpec.describe Attachment do
         url: "/path/to/file/in/asset/manager/cma_case_image.jpg",
         content_type: 'image/jpg',
         created_at: "2015-12-03T16:59:13+00:00",
-        updated_at: "2015-12-03T16:59:13+00:00",
       )
       expect(attachment.content_id).to eq(content_id)
       expect(attachment.title).to eq('new attachment')
       expect(attachment.url).to eq("/path/to/file/in/asset/manager/cma_case_image.jpg")
       expect(attachment.content_type).to eq("image/jpg")
       expect(attachment.created_at).to eq("2015-12-03T16:59:13+00:00")
-      expect(attachment.updated_at).to eq("2015-12-03T16:59:13+00:00")
       expect(attachment.file).to be(nil)
     end
   end
@@ -151,7 +144,6 @@ RSpec.describe Attachment do
         url: "/path/to/file/in/asset/manager",
         content_type: 'image/jpg',
         created_at: "2015-12-03T16:59:13+00:00",
-        updated_at: "2015-12-03T16:59:13+00:00",
       )
     }
 


### PR DESCRIPTION
In line with removing the ability to edit attachments, the last
updated at category has been removed, since it would no longer
make sense.
This removes last updated at from attachment models entirely

[trello card](https://trello.com/c/llClS12G/252-sp-rebuild-changes-the-attachment-timestamps-on-document-updates-even-if-the-attachments-themselves-haven-t-been-changed-medium)
