### PR TITLE
Add schema_name for withdrawing manuals

### DIFF
--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -21,6 +21,7 @@ private
 
   def exportable_attributes
     {
+      schema_name: "gone",
       format: "gone",
       publishing_app: "specialist-publisher",
       update_type: "major",

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -1,0 +1,17 @@
+require "fast_spec_helper"
+require "support/govuk_content_schema_helpers"
+require "publishing_api_withdrawer"
+
+RSpec.describe PublishingAPIWithdrawer do
+  let(:publishing_api) { double("PublishingAPI") }
+  let(:entity) { double("Entity", slug: "some-slug") }
+  let(:subject) { PublishingAPIWithdrawer.new(publishing_api: publishing_api, entity: entity) }
+
+  it "exports a gone item valid against the schema" do
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema("gone")
+  end
+
+  it "exports schema name" do
+    expect(subject.send(:exportable_attributes)).to include(:schema_name)
+  end
+end


### PR DESCRIPTION
Previously when using the the script `bin/withdraw_manual`, an error would occur in ContentStore in 'content_item.rb' with this code:

```
  def register_routes(previous_item: nil)
    return if self.schema_name.start_with?("placeholder")
    return if previous_item && previous_item.route_set == self.route_set
    self.route_set.register!
  end
```

As SpecialistPublisher still uses V1 publishing endpoints to post the gone item, no `schema_name` attribute was added which would cause this error:

```
NoMethodError (undefined method `start_with?' for nil:NilClass):
app/models/content_item.rb:134:in `register_routes'
app/models/content_item.rb:19:in `create_or_replace'
app/controllers/content_items_controller.rb:28:in `block in update'
app/controllers/content_items_controller.rb:27:in `update'
```

This commit adds the hardcoded attribute. It was briefly attempted to convert to using the V2 `unpublish` endpoint, but proved to be too much work considering that a new Manuals app will be written in future.

For https://trello.com/c/PLHlw54s/453-unpublish-and-redirect-care-act-manual-3