### PR TITLE
Truncate long urls

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,7 @@
 class Document
   include ActiveModel::Model
   include ActiveModel::Validations
+  include ActionView::Helpers::TextHelper
   include PublishingHelper
 
   attr_accessor(
@@ -74,6 +75,7 @@ class Document
     else
       @base_path
     end
+    truncate(@base_path, length: 250, omission: "")
   end
 
   def document_type


### PR DESCRIPTION
[Trello](https://trello.com/c/PVT5Fnpd/255-truncate-over-length-dfid-urls-medium)
- Shorten urls to 250 characters
- Every night a crawler backs up govuk. Before the change made in this PR, when the crawler tried to back up pages with long urls in specialist-publisher-rebuild it failed. This problems was fixed temporarily by [this change to Puppet](https://github.com/alphagov/govuk-puppet/pull/4791).
