### PR TITLE
Validate attachment snippets

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -17,6 +17,7 @@ class Attachment < Document
     @content_id = params[:content_id] || SecureRandom.uuid
     @created_at = params[:created_at]
     @updated_at = params[:updated_at]
+    @params = params
   end
 
   def update_attributes(new_params)
@@ -53,6 +54,10 @@ class Attachment < Document
   end
 
   def snippet
-    "[InlineAttachment:#{url.split('/').last}]"
+    if url
+      "[InlineAttachment:#{url.split('/').last}]"
+    else
+      "[InlineAttachment:#{content_id}]"
+    end
   end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -35,7 +35,7 @@ private
 
   def details
     {
-      body: GovspeakPresenter.new(@document).present,
+      body: GovspeakPresenter.present(@document),
       metadata: metadata,
       change_history: document.change_history.as_json,
       max_cache_time: 10,

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -47,7 +47,7 @@ class GovspeakPresenter
     matches.flatten
   end
 
-  private
+private
 
   def replace_with_markdown_links(body, body_snippet, attachment)
     markdown_link = "[#{attachment.title}](#{attachment.url})"

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -1,6 +1,10 @@
 class GovspeakPresenter
   attr_accessor :document
 
+  def self.present(document)
+    new(document).present
+  end
+
   def initialize(document)
     @document = document
   end
@@ -8,35 +12,61 @@ class GovspeakPresenter
   def present
     [
       { content_type: "text/govspeak", content: govspeak_body },
-      { content_type: "text/html", content: html_body }
+      { content_type: "text/html", content: html_body },
     ]
   end
-
-  def html_body
-    Govspeak::Document.new(govspeak_body_with_expanded_attachment_links).to_html
-  end
-
-private
 
   def govspeak_body
     document.body
   end
 
-  def govspeak_body_with_expanded_attachment_links
-    body = replace_spaces_with_underscores_for_attachments(govspeak_body)
+  def html_body
+    body = govspeak_body
 
-    document.attachments.reduce(body) { |b, attachment|
-      b.gsub(attachment.snippet, attachment_markdown(attachment))
-    }
-  end
-
-  def replace_spaces_with_underscores_for_attachments(string)
-    string.gsub(/\[InlineAttachment(.*?)\]/) do |attachment_snippet|
-      attachment_snippet.gsub(/\s/, "_")
+    snippets_in_body.uniq.each do |body_snippet|
+      document.attachments.each do |attachment|
+        if snippets_match?(body_snippet, attachment.snippet)
+          body = replace_with_markdown_links(body, body_snippet, attachment)
+        end
+      end
     end
+
+    Govspeak::Document.new(body).to_html
   end
 
-  def attachment_markdown(attachment)
-    "[#{attachment.title}](#{attachment.url})"
+  def snippets_match?(a, b)
+    a = sanitise(a)
+    b = sanitise(b)
+
+    (a == b) && a.present?
+  end
+
+  def snippets_in_body
+    body = document.body
+    matches = body.scan(/(\[InlineAttachment:.*?\])/)
+    matches.flatten
+  end
+
+  private
+
+  def replace_with_markdown_links(body, body_snippet, attachment)
+    markdown_link = "[#{attachment.title}](#{attachment.url})"
+    body.gsub(body_snippet, markdown_link)
+  end
+
+  def sanitise(snippet)
+    snippet = CGI::unescape(snippet)
+    path = snippet[/\[\s*InlineAttachment\s*:\s*(.*?)\s*\]/, 1]
+    return unless path
+
+    special_chars = /[^a-zA-Z0-9]/
+    filename = path.split("/").last
+    filename = filename.downcase
+    filename = filename.gsub(special_chars, "_")
+
+    "[InlineAttachment:#{filename}]"
+  end
+
+  def special_chars
   end
 end

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -42,9 +42,11 @@ class GovspeakPresenter
   end
 
   def snippets_in_body
-    body = document.body
-    matches = body.scan(/(\[InlineAttachment:.*?\])/)
-    matches.flatten
+    @snippets_in_body ||= (
+      body = document.body
+      matches = body.scan(/(\[InlineAttachment:.*?\])/)
+      matches.flatten
+    )
   end
 
 private
@@ -65,8 +67,5 @@ private
     filename = filename.gsub(special_chars, "_")
 
     "[InlineAttachment:#{filename}]"
-  end
-
-  def special_chars
   end
 end

--- a/app/reporters/attachment_reporter.rb
+++ b/app/reporters/attachment_reporter.rb
@@ -24,7 +24,7 @@ class AttachmentReporter
     }
   end
 
-  private
+private
 
   attr_accessor :document
 

--- a/app/reporters/attachment_reporter.rb
+++ b/app/reporters/attachment_reporter.rb
@@ -1,0 +1,73 @@
+class AttachmentReporter
+  def self.report(document)
+    new(document).report
+  end
+
+  def initialize(document)
+    self.document = document
+  end
+
+  def report
+    used, unused, matched, unmatched = build_report_data
+
+    {
+      attachment_counts: {
+        used: used.count,
+        unused: unused.count,
+      },
+      snippet_counts: {
+        matched: matched.count,
+        unmatched: unmatched.count,
+      },
+      unused_attachments: unused,
+      unmatched_snippets: unmatched,
+    }
+  end
+
+  private
+
+  attr_accessor :document
+
+  def build_report_data
+    used = []
+    matched = []
+    unmatched = []
+
+    body_snippets.each do |b|
+      match = false
+
+      attachment_snippets.each do |a|
+        if presenter.snippets_match?(a, b)
+          matched.push(b)
+          used |= [a]
+          match = true
+        end
+      end
+
+      unmatched.push(b) unless match
+    end
+    unused = attachment_snippets - used
+
+    filenames_only([used, unused, matched, unmatched])
+  end
+
+  def body_snippets
+    @body_snippets ||= presenter.snippets_in_body
+  end
+
+  def attachment_snippets
+    @attachment_snippets ||= document.attachments.map(&:snippet)
+  end
+
+  def filenames_only(arrays)
+    arrays.map do |array|
+      array.map do |snippet|
+        snippet[/\[InlineAttachment:(.*?)\]/, 1]
+      end
+    end
+  end
+
+  def presenter
+    GovspeakPresenter.new(document)
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,52 +1,62 @@
+desc "validate inline attachments snippets for all documents of a class"
 namespace :report do
   task :attachments, [:class_name] => :environment do |_, args|
-    class_name = args.class_name || "CmaCase"
-    klass = class_name.constantize
+    if args.class_name.blank? || args.class_name == "all"
+      Rails.application.eager_load!
+      classes = Document.subclasses
+    else
+      classes = [args.class_name.constantize]
+    end
 
-    page_size = 10
+    classes.each do |klass|
+      puts "Validating inline attachment snippets for #{klass}"
 
-    response = klass.all(1, page_size)
-    pages = response.to_hash.fetch("pages")
+      page_size = 10
 
-    content_ids = Enumerator.new do |y|
-      1.upto(pages) do |page|
-        response = klass.all(page, page_size)
-        results = response.to_hash.fetch("results")
-        results.each { |r| y.yield r.fetch("content_id") }
+      response = klass.all(1, page_size)
+      pages = response.to_hash.fetch("pages")
+
+      content_ids = Enumerator.new do |y|
+        1.upto(pages) do |page|
+          response = klass.all(page, page_size)
+          results = response.to_hash.fetch("results")
+          results.each { |r| y.yield r.fetch("content_id") }
+        end
+      end
+
+      content_ids.each do |content_id|
+        document = Document.find(content_id)
+
+        begin
+          report = AttachmentReporter.report(document)
+        rescue => e
+          puts "\nfailed to generate report for #{klass} #{content_id}:"
+          puts "  #{e.class}: #{e.message}\n"
+          next
+        end
+
+        unmatched = report.fetch(:unmatched_snippets)
+        unused = report.fetch(:unused_attachments)
+
+        if unmatched.any?
+          puts "\n#{klass} #{content_id} has invalid inline attachments:"
+
+          unmatched.group_by { |u| u }.each do |u, array|
+            puts "  #{array.count}: '#{u}'"
+          end
+
+          if unused.any?
+            puts "Maybe they're supposed to be one of these unused attachments:"
+            unused.each { |u| puts "  '#{u}'" }
+          end
+
+          puts
+        else
+          print "."
+        end
       end
     end
 
-    content_ids.each do |content_id|
-      document = Document.find(content_id)
-      klass = document.class
-
-      begin
-        report = AttachmentReporter.report(document)
-      rescue => e
-        puts "\nfailed to generate report for #{klass} #{content_id}:"
-        puts "  #{e.class}: #{e.message}\n"
-        next
-      end
-
-      unmatched = report.fetch(:unmatched_snippets)
-      unused = report.fetch(:unused_attachments)
-
-      if unmatched.any?
-        puts "\n#{klass} #{content_id} has invalid inline attachments:"
-
-        unmatched.group_by { |u| u }.each do |u, array|
-          puts "  #{array.count}: '#{u}'"
-        end
-
-        if unused.any?
-          puts "Maybe they're supposed to be one of these unused attachments:"
-          unused.each { |u| puts "  '#{u}'" }
-        end
-
-        puts
-      else
-        print "."
-      end
-    end
+    puts
   end
 end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,47 @@
+namespace :report do
+  task attachments: :environment do
+    page_size = 10
+
+    response = CmaCase.all(1, page_size)
+    pages = response.to_hash.fetch("pages")
+
+    content_ids = Enumerator.new do |y|
+      1.upto(pages) do |page|
+        response = CmaCase.all(page, page_size)
+        results = response.to_hash.fetch("results")
+        results.each { |r| y.yield r.fetch("content_id") }
+      end
+    end
+
+    content_ids.each do |content_id|
+      document = Document.find(content_id)
+      klass = document.class
+
+      begin
+        report = AttachmentReporter.report(document)
+      rescue => e
+        puts "failed to generate report for #{klass} #{content_id}:"
+        puts "  #{e.class}: #{e.message}\n\n"
+        next
+      end
+
+      unmatched = report.fetch(:unmatched_snippets)
+      unused = report.fetch(:unused_attachments)
+
+      if unmatched.any?
+        puts "#{klass} #{content_id} has invalid inline attachments:"
+
+        unmatched.group_by { |u| u }.each do |u, array|
+          puts "  #{array.count}: '#{u}'"
+        end
+
+        if unused.any?
+          puts "Maybe they're supposed to be one of these unused attachments:"
+          unused.each { |u| puts "  '#{u}'" }
+        end
+
+        puts
+      end
+    end
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -198,4 +198,22 @@ RSpec.describe Attachment do
       expect(attachment.url).to be_nil
     end
   end
+
+  describe "#snippet" do
+    context "when the attachment has a url" do
+      let(:attachment) { Attachment.new(url: "http://example.com/a/b/c/foo.png") }
+
+      it "returns a snippet containing the suffix of the url" do
+        expect(attachment.snippet).to eq("[InlineAttachment:foo.png]")
+      end
+    end
+
+    context "when the attachment does not have a url" do
+      let(:attachment) { Attachment.new(content_id: "some-content-id") }
+
+      it "returns a snippet containing the content_id" do
+        expect(attachment.snippet).to eq("[InlineAttachment:some-content-id]")
+      end
+    end
+  end
 end

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -1,106 +1,121 @@
 require 'spec_helper'
 
 RSpec.describe GovspeakPresenter do
-  let(:specialist_document) { CmaCase.from_publishing_api(payload) }
-  let(:govspeak_presenter) { GovspeakPresenter.new(specialist_document) }
-  let(:presented_data) { govspeak_presenter.present }
+  let(:body) { "Hello, world" }
+  let(:attachments) { [] }
+  let(:document) { double(:document, body: body, attachments: attachments) }
+  let(:presented) { described_class.present(document) }
 
-  describe "#present" do
-    context "without attachments" do
-      let(:payload) {
-        FactoryGirl.create(:cma_case,
-          details: {
-            body: [{
-              "content_type" => "text/govspeak",
-              "content" => "^callout test^",
-            }],
-          })
-      }
+  it "presents the body as multi-type content" do
+    expect(presented).to eq [
+      { content_type: "text/govspeak", content: "Hello, world" },
+      { content_type: "text/html", content: "<p>Hello, world</p>\n" },
+    ]
+  end
 
-      it "should render html and Govspeak when a Govspeak string is provided" do
-        input_govspeak = "^callout test^"
-        rendered_html = "\n<div role=\"note\" aria-label=\"Information\" "\
-                        "class=\"application-notice info-notice\">\n"\
-                        "<p>callout test</p>\n</div>\n"
-        presented_content = [{ content_type: "text/govspeak", content: input_govspeak },
-                             { content_type: "text/html", content: rendered_html }]
+  context "when the document has inline attachments" do
+    let(:snippet) { "[InlineAttachment:foo.pdf]" }
+    let(:attachment) {
+      double(:attachment, snippet: snippet, title: "Foo", url: "/url/foo.pdf")
+    }
 
-        expect(presented_data).to eq(presented_content)
-      end
+    let(:body) { snippet }
+    let(:attachments) { [attachment] }
+
+    it "replaces the snippet with an anchor" do
+      expect(presented).to eq [
+        { content_type: "text/govspeak", content: snippet },
+        { content_type: "text/html",
+          content: %Q(<p><a href="/url/foo.pdf">Foo</a></p>\n) }
+      ]
+    end
+  end
+
+  describe "#snippets_match?" do
+    let(:subject) { described_class.new(document) }
+
+    def expect_match(a, b)
+      expect(subject.snippets_match?(a, b)).to eq(true),
+        "Expected '#{a}' == '#{b}'"
     end
 
-    context "with attachments" do
-      let(:payload) {
-        FactoryGirl.create(:cma_case,
-          details: {
-            body: [{
-              "content_type" => "text/govspeak",
-              "content" => "[InlineAttachment:asylum-support-image.jpg]",
-            }],
-            attachments: [
-              {
-                "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-                "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-                "content_type" => "application/jpeg",
-                "title" => "asylum report image title",
-                "created_at" => "2015-12-03T16:59:13+00:00",
-                "updated_at" => "2015-12-03T16:59:13+00:00"
-              },
-              {
-                "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
-                "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-                "content_type" => "application/pdf",
-                "title" => "asylum report pdf title",
-                "created_at" => "2015-12-03T16:59:13+00:00",
-                "updated_at" => "2015-12-03T16:59:13+00:00"
-              }
-            ]
-          })
-      }
+    def expect_no_match(a, b)
+      expect(subject.snippets_match?(a, b)).to eq(false),
+        "Expected '#{a}' != '#{b}'"
+    end
 
-      it "does not change the govspeak snippet" do
-        presented_govspeak = presented_data.find { |r| r[:content_type] == "text/govspeak" }[:content]
-        attachment_snippet = "[InlineAttachment:asylum-support-image.jpg]"
+    it "matches on identical strings" do
+      expect_match("[InlineAttachment:foo.pdf]", "[InlineAttachment:foo.pdf]")
+    end
 
-        expect(presented_govspeak).to eq(attachment_snippet)
-      end
+    it "does not match if the filenames differ" do
+      expect_no_match("[InlineAttachment:foo.pdf]", "[InlineAttachment:bar.pdf]")
+      expect_no_match("[InlineAttachment:foo.pdf]", "[InlineAttachment:fooo.pdf]")
+    end
 
+    it "does not match if the extensions differ" do
+      expect_no_match("[InlineAttachment:foo.pdf]", "[InlineAttachment:foo.png]")
+      expect_no_match("[InlineAttachment:foo.pdf]", "[InlineAttachment:foo.txt]")
+    end
 
-      it "expands the attachment snippet to an html link" do
-        presented_html = presented_data.find { |r| r[:content_type] == "text/html" }[:content]
-        expected_html = "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg\">asylum report image title</a></p>\n"
+    it "treats all special characters as the same character" do
+      expect_match("[InlineAttachment:foo!.pdf]", "[InlineAttachment:foo@.pdf]")
+      expect_match("[InlineAttachment:foo&.pdf]", "[InlineAttachment:foo%.pdf]")
+      expect_match("[InlineAttachment:f-oo.pdf]", "[InlineAttachment:f_oo.pdf]")
+      expect_match("[InlineAttachment:f oo.pdf]", "[InlineAttachment:f&oo.pdf]")
+      expect_match("[InlineAttachment:f oo.pdf]", "[InlineAttachment:f oo.pdf]")
 
-        expect(presented_html).to eq(expected_html)
-      end
+      expect_no_match("[InlineAttachment:foo-.pdf]", "[InlineAttachment:f_oo.pdf]")
+      expect_no_match("[InlineAttachment:fooo.pdf]", "[InlineAttachment:foo_.pdf]")
+    end
 
-      context "when the html uses spaces instead of underscores for InlineAttachment" do
-        let(:payload) {
-          FactoryGirl.create(:cma_case,
-            details: {
-              body: [{
-                "content_type" => "text/govspeak",
-                "content" => "[InlineAttachment:asylum support image.jpg]",
-              }],
-              attachments: [
-                {
-                  "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
-                  "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum_support_image.jpg",
-                  "content_type" => "application/jpeg",
-                  "title" => "asylum report image title",
-                  "created_at" => "2015-12-03T16:59:13+00:00",
-                  "updated_at" => "2015-12-03T16:59:13+00:00"
-                },
-              ]
-            })
-        }
+    it "matches on the filename only, not the absolute path" do
+      expect_match("[InlineAttachment:x/foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:/foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:x/y/foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:x/foo.pdf]", "[InlineAttachment:y/foo.pdf]")
+      expect_match("[InlineAttachment:x/y/foo.pdf]", "[InlineAttachment:z/w/foo.pdf]")
+      expect_match("[InlineAttachment:/x/y/foo.pdf]", "[InlineAttachment:y/foo.pdf]")
 
-        it "expands the attachment snippet to an html link" do
-          presented_html = presented_data.find { |r| r[:content_type] == "text/html" }[:content]
-          expected_html = "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum_support_image.jpg\">asylum report image title</a></p>\n"
+      expect_no_match("[InlineAttachment:foo/x.pdf]", "[InlineAttachment:x/foo.pdf]")
+      expect_no_match("[InlineAttachment:x/y.pdf]", "[InlineAttachment:x/y/foo.pdf]")
+    end
 
-          expect(presented_html).to eq(expected_html)
-        end
-      end
+    it "matches urls with CGI escaped character sequences" do
+      expect_match("[InlineAttachment:foo%20bar.pdf]", "[InlineAttachment:foo bar.pdf]")
+      expect_match("[InlineAttachment:%282016%29.pdf]", "[InlineAttachment:(2016).pdf]")
+      expect_match("[InlineAttachment:foo.pdf%20]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:x%2Ffoo.pdf]", "[InlineAttachment:foo.pdf]")
+
+      expect_no_match("[InlineAttachment:foo%28.pdf]", "[InlineAttachment:foo___.pdf]")
+    end
+
+    it "ignores whitespace between words" do
+      expect_match("[ InlineAttachment:foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment :foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment: foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:foo.pdf ]", "[InlineAttachment:foo.pdf]")
+      expect_match("[ InlineAttachment : foo.pdf ]", "[InlineAttachment:foo.pdf]")
+
+      expect_no_match("[Inline Attachment:foo.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_no_match("[InlineAttachment:fo o.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_no_match("[InlineAttachment:foo .pdf]", "[InlineAttachment:foo.pdf]")
+      expect_no_match("[InlineAttachment:foo. pdf]", "[InlineAttachment:foo.pdf]")
+      expect_no_match("[InlineAttachment:foo.pd f]", "[InlineAttachment:foo.pdf]")
+    end
+
+    it "ignores case in the filename" do
+      expect_match("[InlineAttachment:FOO.pdf]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:foo.PDF]", "[InlineAttachment:foo.pdf]")
+      expect_match("[InlineAttachment:FOO.PDF]", "[InlineAttachment:foo.pdf]")
+
+      expect_no_match("[INLINEATTACHMENT:foo.pdf]", "[InlineAttachment:foo.pdf]")
+    end
+
+    it "returns false for garbage input, even if it's the same" do
+      expect_no_match("garbage", "][[]!@£$")
+      expect_no_match("garbage", "garbage")
+      expect_no_match("", "")
     end
   end
 end

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GovspeakPresenter do
       expect(presented).to eq [
         { content_type: "text/govspeak", content: snippet },
         { content_type: "text/html",
-          content: %Q(<p><a href="/url/foo.pdf">Foo</a></p>\n) }
+          content: %(<p><a href="/url/foo.pdf">Foo</a></p>\n) }
       ]
     end
   end

--- a/spec/reporters/attachment_reporter_spec.rb
+++ b/spec/reporters/attachment_reporter_spec.rb
@@ -21,12 +21,14 @@ RSpec.describe AttachmentReporter do
     There's another on the document (unused.pdf) that we're not going to use.
   HTML
 
-  let(:attachments) { [
-    double(:attachment, snippet: "[InlineAttachment:foo.pdf]"),
-    double(:attachment, snippet: "[InlineAttachment:bar.pdf]"),
-    double(:attachment, snippet: "[InlineAttachment:baz.pdf]"),
-    double(:attachment, snippet: "[InlineAttachment:unused.pdf]"),
-  ] }
+  let(:attachments) {
+    [
+      double(:attachment, snippet: "[InlineAttachment:foo.pdf]"),
+      double(:attachment, snippet: "[InlineAttachment:bar.pdf]"),
+      double(:attachment, snippet: "[InlineAttachment:baz.pdf]"),
+      double(:attachment, snippet: "[InlineAttachment:unused.pdf]"),
+    ]
+  }
 
   let(:report) { described_class.report(document) }
 

--- a/spec/reporters/attachment_reporter_spec.rb
+++ b/spec/reporters/attachment_reporter_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe AttachmentReporter do
+  let(:document) { double(:document, body: <<-HTML, attachments: attachments) }
+    # Testing #{described_class}
+
+    This body uses inline attachmments:
+      [InlineAttachment:foo.pdf]
+
+    Some of the attachments are referenced more than once:
+      [InlineAttachment:bar.pdf]
+      [InlineAttachment:bar.pdf]
+      [InlineAttachment:baz.pdf]
+      [InlineAttachment:baz.pdf]
+      [InlineAttachment:baz.pdf]
+
+    This one is used, but is missing from the document:
+      [InlineAttachment:missing.pdf]
+      [InlineAttachment:missing.pdf]
+
+    There's another on the document (unused.pdf) that we're not going to use.
+  HTML
+
+  let(:attachments) { [
+    double(:attachment, snippet: "[InlineAttachment:foo.pdf]"),
+    double(:attachment, snippet: "[InlineAttachment:bar.pdf]"),
+    double(:attachment, snippet: "[InlineAttachment:baz.pdf]"),
+    double(:attachment, snippet: "[InlineAttachment:unused.pdf]"),
+  ] }
+
+  let(:report) { described_class.report(document) }
+
+  it "builds a report of attachments, with respect to the document's body" do
+    expect(report).to eq(
+      attachment_counts: {
+        used: 3,
+        unused: 1,
+      },
+      snippet_counts: {
+        matched: 6,
+        unmatched: 2,
+      },
+      unused_attachments: %w(unused.pdf),
+      unmatched_snippets: %w(missing.pdf missing.pdf)
+    )
+  end
+end


### PR DESCRIPTION
![screen shot 2016-08-25 at 11 18 46](https://cloud.githubusercontent.com/assets/892251/17965698/c42dca18-6ab5-11e6-8d5f-98d296cb9b5b.png)
This pull request makes attachment snippet matching far more robust. It also fixes a problem where some attachments don't have a url, which was resulting in a 500 server error for a few cma case pages.

Eventually, I'd like to see if we can surface some of the information in `AttachmentReporter` to the user-interface so that users can see errors if the snippets are invalid. It also reports on attachments that aren't used in the body of the document.
