### PR TITLE
Remove external link-icon from attachments

### DIFF
--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -1,4 +1,7 @@
 class GovspeakPresenter
+  PRODUCTION_HOSTS = %w(www.gov.uk assets.publishing.service.gov.uk)
+  INTEGRATION_HOSTS = %w{www-origin.integration.publishing.service.gov.uk assets.digital.cabinet-office.gov.uk }
+
   attr_accessor :document
 
   def self.present(document)
@@ -31,7 +34,8 @@ class GovspeakPresenter
       end
     end
 
-    Govspeak::Document.new(body).to_html
+    internal_hosts = PRODUCTION_HOSTS + INTEGRATION_HOSTS
+    Govspeak::Document.new(body, document_domains: internal_hosts).to_html
   end
 
   def snippets_match?(a, b)

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -309,7 +309,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
               },
               {
                 "content_type" => "text/html",
-                "content" => "<p><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg\">asylum report image title</a></p>\n"
+                "content" => "<p><a href=\"https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg\">asylum report image title</a></p>\n"
               }
             ],
           },

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe GovspeakPresenter do
 
   context "when the document has inline attachments" do
     let(:snippet) { "[InlineAttachment:foo.pdf]" }
+    let(:url) { "/url/foo.pdf" }
     let(:attachment) {
-      double(:attachment, snippet: snippet, title: "Foo", url: "/url/foo.pdf")
+      double(:attachment, snippet: snippet, title: "Foo", url: url)
     }
 
     let(:body) { snippet }
@@ -28,6 +29,17 @@ RSpec.describe GovspeakPresenter do
         { content_type: "text/html",
           content: %(<p><a href="/url/foo.pdf">Foo</a></p>\n) }
       ]
+    end
+
+    context "when they are external" do
+      let(:body) { "[External Link](https://something.external.uk/url/foo.pdf)" }
+
+      it "adds rel='external' to anchor tag" do
+        expect(presented).to eq [
+                                    { content_type: "text/govspeak", content: body },
+                                    { content_type: "text/html",
+                                      content: %(<p><a rel="external" href="https://something.external.uk/url/foo.pdf">External Link</a></p>\n) }]
+      end
     end
   end
 


### PR DESCRIPTION
Added www.gov.uk and assets.publication.service.gov.uk as "whitelist" entries in the Govspeak generation to avoid the 'external-link' icon appearing for attachments and internal references.
