### PR TITLE
Fix organisation permissions so that they match V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ The rebuild app can then be accessed in two ways.
 2. At `specialist-publisher-rebuild-standalone.integration.publishing.service.gov.uk`: This is an integration-only instance of the app running only specialist-publisher-rebuild code.
 
 When a format is ready to deploy to production, add the endpoint to this [puppet configuration](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/node/s_backend_lb.pp#L48). This will configure Nginx to route requests for those endpoints to be handled by this app.
+
+## Organisations
+
+There is a list of content_id to organisation slug mappings [here](./organisations.md).

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -10,6 +10,8 @@
   },
   "show_summaries": true,
   "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "7141e343-e7bb-483b-920a-c6a5cf8f758c"
   ],
   "signup_content_id": "307ea825-594c-4d88-85c9-0809fdc9c79e",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -14,9 +14,9 @@
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "organisations": [
     "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+    "b548a09f-8b35-4104-89f4-f1a40bf3136d",
     "de4e9dc6-cca4-43af-a594-682023b84d6c",
-    "e8fae147-6232-4163-a3f1-1c15b755a8a4",
-    "b548a09f-8b35-4104-89f4-f1a40bf3136d"
+    "e8fae147-6232-4163-a3f1-1c15b755a8a4"
   ],
   "subscription_list_title_prefix": {
     "singular": "European Structural and Investment Fund",

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -10,7 +10,11 @@
   "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "show_summaries": true,
-  "organisations": ["4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"],
+  "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
+  ],
   "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions with the following categories:",
   "pre_production": true,
   "document_noun": "decision",

--- a/organisations.md
+++ b/organisations.md
@@ -1,0 +1,26 @@
+##Organisations Mappings
+
+Each of the schemas in `lib/documents/schemas` contains an `organisation` key
+which controls which organisations can access that format.
+
+```
+38eb5d8f-2d89-480c-8655-e2e7ac23f8f4 = air-accidents-investigation-branch
+957eb4ec-089b-4f71-ba2a-dc69ac8919ea = competition-and-markets-authority
+2e7868a8-38f5-4ff6-b62f-9a15d1c22d28 = department-for-communities-and-local-government
+de4e9dc6-cca4-43af-a594-682023b84d6c = department-for-environment-food-rural-affairs
+db994552-7644-404d-a770-a2fe659c661f = department-for-international-development
+b548a09f-8b35-4104-89f4-f1a40bf3136d = department-for-work-pensions
+d39237a5-678b-4bb5-a372-eb2cb036933d = driver-and-vehicle-standards-agency
+caeb418c-d11c-4352-92e9-47b21289f696 = employment-appeal-tribunal
+8bb37087-a5a7-4493-8afe-900b36ebc927 = employment-tribunal
+7141e343-e7bb-483b-920a-c6a5cf8f758c = first-tier-tribunal-asylum-support
+6f757605-ab8f-4b62-84e4-99f79cf085c2 = hm-courts-and-tribunals-service
+9c66b9a3-1e6a-48e8-974d-2a5635f84679 = marine-accident-investigation-branch
+240f72bd-9a4d-4f39-94d9-77235cadde8e = medicines-and-healthcare-products-regulatory-agency
+dcc907d6-433c-42df-9ffb-d9c68be5dc4d = ministry-of-justice
+d3ce4ba7-bc75-46b4-89d9-38cb3240376d = natural-england
+013872d8-8bbb-4e80-9b79-45c7c5cf9177 = rail-accident-investigation-branch
+e8fae147-6232-4163-a3f1-1c15b755a8a4 = rural-payments-agency
+4c2e325a-2d95-442b-856a-e7fb9f9e3cf8 = upper-tribunal-administrative-appeals-chamber
+1a68b2cc-eb52-4528-8989-429f710da00f = upper-tribunal-tax-and-chancery-chamber
+```


### PR DESCRIPTION
I also annotated the files so it's easy to see who
can access what. In total, there were two permission
problems:

Asylum Support Decisions:
- Missing ministry-of-justice, hm-courts-and-tribunals-service

UTAAC:
- Missing ministry-of-justice, hm-courts-and-tribunals-service
