### PR TITLE
Medical Safety Alerts flagged as Urgent

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -347,6 +347,18 @@ class Document
     update_type == "major"
   end
 
+  # This is set to nil for all non-urgent emails.
+  # Override to true for urgent email handling for a specific format.
+  # Urgent emails are sent immediately to all users,
+  # regardless of how frequently the users are set to get email updates
+  #
+  # Sending false will force overriding of topic defaults, and should
+  # only be done where we explicitly want an email to be non urgent and
+  # not to fallback to gov delivery defaults
+  def urgent
+    nil
+  end
+
 private
 
   def self.finder_schema

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -17,4 +17,8 @@ class MedicalSafetyAlert < Document
   def self.title
     "Medical Safety Alert"
   end
+
+  def urgent
+    true
+  end
 end

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -10,6 +10,7 @@ class EmailAlertPresenter
       subject: subject,
       body: body,
       tags: tags,
+      urgent: urgent,
       document_type: document.document_type,
     }.merge(extra_options)
   end
@@ -86,6 +87,10 @@ private
 
   def subject
     redrafted? ? document.title + " updated" : document.title
+  end
+
+  def urgent
+    document.urgent
   end
 
   def updated_or_published


### PR DESCRIPTION
Updated app to send an urgent flag with email requests for medical
safety alerts. Flag defaulted to nil in other formats.

[trello card](https://trello.com/c/QbYLGjL2/263-send-medical-device-alerts-urgently)
