### PR TITLE
Temporary rake task to remove invalid country codes

### DIFF
--- a/lib/tasks/dfid_research_outputs.rake
+++ b/lib/tasks/dfid_research_outputs.rake
@@ -20,6 +20,7 @@ namespace :dfid_research_outputs do
       invalid_country_codes = (country_codes - valid_country_codes)
 
       doc = Document.find(content_id)
+      published = doc.published?
 
       if doc
         if doc.country && invalid_country_codes.any?
@@ -28,6 +29,11 @@ namespace :dfid_research_outputs do
           payload = DocumentPresenter.new(doc).to_json
           puts "ContentItem '#{content_id}' updated with countries: #{doc.country}"
           Services.publishing_api.put_content(doc.content_id, payload)
+
+          if published
+            Services.publishing_api.publish(doc.content_id, "minor")
+            puts "published"
+          end
         end
       else
         puts "No document found for #{content_id}"

--- a/lib/tasks/dfid_research_outputs.rake
+++ b/lib/tasks/dfid_research_outputs.rake
@@ -1,0 +1,37 @@
+namespace :dfid_research_outputs do
+  desc "Clean up invalid country codes"
+  task cleanup_country_codes: :environment do
+    filepath = ENV["INVALID_COUNTRY_CODES_FILEPATH"]
+    no_file_message = <<-ERR.strip_heredoc
+    Please specify a file containing invalid country codes in the format:
+
+    content_id, invalid_country_codes
+    cdfded1b-73ec-46d1-95a5-eb97856503fd, BR TH PE BD TZ NA JP ET RS WS CS
+    ERR
+
+    raise no_file_message unless filepath
+    invalid_country_code_data = File.readlines(filepath)
+
+    valid_country_codes = FinderSchema.new("dfid_research_outputs").options_for("country").map(&:last)
+
+    invalid_country_code_data.each do |line|
+      content_id, country_codes = line.split(",")
+      country_codes = country_codes.split(" ").compact
+      invalid_country_codes = (country_codes - valid_country_codes)
+
+      doc = Document.find(content_id)
+
+      if doc
+        if doc.country && invalid_country_codes.any?
+          doc.country = (doc.country - invalid_country_codes)
+          doc.update_type = "minor"
+          payload = DocumentPresenter.new(doc).to_json
+          puts "ContentItem '#{content_id}' updated with countries: #{doc.country}"
+          Services.publishing_api.put_content(doc.content_id, payload)
+        end
+      else
+        puts "No document found for #{content_id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/qe4L5zdM/262-fix-the-underlying-data-problem-for-50-dfid-documents-small

Dfid transition data contains a number of country codes which are prohibited by
the document schema, so remove the offending codes and update the documents.
This task can be removed once it has been run in production, the admin UI will prevent further updates
from adding invalid codes.

Run it like:

```
bundle exec rake dfid_research_outputs:cleanup_country_codes INVALID_COUNTRY_CODES_FILEPATH=tmp/invalid_country_codes.csv
```

Produces output like:

```
ContentItem 'df2ca14d-8a4c-46ce-89f1-03f2c7e6a64e' updated with countries: ["BD", "GH"]
ContentItem 'cf78b2f1-9c3e-4f88-adfd-09e235a900d5' updated with countries: ["IN", "KE", "TZ", "GA"]
ContentItem 'af82e0ed-be9d-45c0-b3c3-cad9bbc226a2' updated with countries: ["AU"]
ContentItem '5cfe113f-9d29-48a3-a1a7-501712fc46d6' updated with countries: []
ContentItem '54921d4f-9494-4b86-8c28-1a99678be7e0' updated with countries: ["TZ", "SC", "FJ", "VU", "MU", "KM"]
```

This problem is thought to affect 47 documents so it's not gonna choke the publishing api, the trello card contains a CSV file of invalid data and information on how this CSV was generated.
