### PR TITLE
Validate open close dates

### DIFF
--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -1,5 +1,5 @@
 class CmaCase < Document
-  validates :opened_date, allow_blank: true, date: true
+  validates :opened_date, allow_blank: true, date: true, open_before_closed: true
   validates :market_sector, presence: true
   validates :case_type, presence: true
   validates :case_state, presence: true

--- a/app/validators/open_before_closed_validator.rb
+++ b/app/validators/open_before_closed_validator.rb
@@ -1,0 +1,15 @@
+class OpenBeforeClosedValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    record.errors.add(attribute, error_message) unless before_closed?(record)
+  end
+
+private
+
+  def before_closed?(record)
+    record.opened_date <= record.closed_date || record.closed_date.blank?
+  end
+
+  def error_message
+    options[:message] || "must be before closed date"
+  end
+end

--- a/lib/tasks/opened_closed_dates.rake
+++ b/lib/tasks/opened_closed_dates.rake
@@ -1,0 +1,18 @@
+desc "Find CMA Cases with opened dates that are before closed dates"
+task opened_before_closed_dates: :environment do
+  cma_cases = Services.publishing_api.get_content_items(
+    document_type: "cma_case",
+    per_page: 999999,
+  ).results
+
+  non_blank_opened_dates = cma_cases.select { |cma| !cma.details.metadata.opened_date.blank? }
+  non_blank_closed_dates = cma_cases.select { |cma| !cma.details.metadata.closed_date.blank? }
+
+  non_blank_opened_dates.each do |cma|
+    if non_blank_closed_dates.include? cma
+      unless cma.details.metadata.opened_date <= cma.details.metadata.closed_date
+        puts "Opened date is before closed date. Opened: #{cma.details.metadata.opened_date}, Closed: #{cma.details.metadata.closed_date}, content_id: #{cma.content_id}"
+      end
+    end
+  end
+end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -137,6 +137,78 @@ RSpec.feature "Creating a CMA case", type: :feature do
     expect(page).to have_content("Body cannot include invalid Govspeak")
   end
 
+  scenario "with closed date before opened date" do
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example CMA Case"
+    fill_in "Summary", with: "This is the summary of an example CMA case"
+    fill_in "Body", with: "Body of text"
+    fill_in "Opened date", with: "2016-02-14"
+    fill_in "Closed date", with: "2015-02-14"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css('.elements-error-summary')
+    expect(page).to have_css('.elements-error-message')
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Opened date must be before closed date")
+  end
+
+  scenario "with blank opened date and filled out closed date" do
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example CMA Case"
+    fill_in "Summary", with: "This is the summary of an example CMA case"
+    fill_in "Body", with: "Body of text"
+    fill_in "Opened date", with: ""
+    fill_in "Closed date", with: "2015-02-14"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(200)
+
+    expect(page).to have_content("Created Example CMA Case")
+  end
+
+  scenario "with blank closed date and filled out opened date" do
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example CMA Case"
+    fill_in "Summary", with: "This is the summary of an example CMA case"
+    fill_in "Body", with: "Body of text"
+    fill_in "Opened date", with: "2015-02-14"
+    fill_in "Closed date", with: ""
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(200)
+
+    expect(page).to have_content("Created Example CMA Case")
+  end
+
+  scenario "with blank closed date and opened date" do
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example CMA Case"
+    fill_in "Summary", with: "This is the summary of an example CMA case"
+    fill_in "Body", with: "Body of text"
+    fill_in "Opened date", with: ""
+    fill_in "Closed date", with: ""
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(200)
+
+    expect(page).to have_content("Created Example CMA Case")
+  end
+
   scenario "with a very long title" do
     visit "/cma-cases/new"
 


### PR DESCRIPTION
[Trello](https://trello.com/c/qFKUSFH9/76-sp-will-let-you-set-a-closed-date-before-the-opened-date-small)
- Add validation to ensure `opened_date` is before `closed_date` to reduce risk of human error when creating CMA documents.
- Rake task to get `content_ids` of documents which have an `opened_date` later than their `closed_date`.
- Prints out `opened_date`, `closed_date` and `content_id` for the identified documents. The next step would be to find the problem documents and manually fix these date fields using the printed `content_ids` outputted by this rake task.

Run rake task:

```
bundle exec rake opened_before_closed_dates
```

Produces output like:

```
Opened date is before closed date. Opened: 2015-02-14, Closed: 2012-04-11, content_id: bd71f5c1-b319-4151-9c79-7186135c6bd2
Opened date is before closed date. Opened: 2002-08-27, Closed: 2001-04-18, content_id: d7ee9561-832f-4c6f-ba4c-3c2053520a4b
Opened date is before closed date. Opened: 2015-10-07, Closed: 2015-01-06, content_id: a22e15b2-51be-4d19-a8e2-801ebfc5722b
```
