### PR TITLE
Refactor to edit attachment journey

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -17,10 +17,10 @@ class AttachmentsController < ApplicationController
       attachment = document.attachments.build(attachment_params)
       attachment.content_type = attachment.file.content_type
 
-      upload_attachment(document, attachment, new_attachment: true)
+      upload_attachment(document, attachment)
     else
       flash[:danger] = "Adding an attachment failed. Please make sure you have uploaded an attachment."
-      redirect_to previous_address(document, Attachment.new, new: true)
+      redirect_to new_document_attachment_path(document_type_slug, document.content_id)
     end
   end
 
@@ -37,7 +37,7 @@ class AttachmentsController < ApplicationController
     if attachment.file.nil?
       save_updated_title(document, attachment)
     else
-      upload_attachment(document, attachment, new_attachment: false)
+      update_attachment(document, attachment)
     end
   end
 
@@ -53,21 +53,23 @@ private
     end
   end
 
-  def upload_attachment(document, attachment, new_attachment:)
-    if document.upload_attachment(attachment)
-      flash[:success] = new_attachment ? "Attached #{attachment.title}" : "Attachment succesfully updated"
+  def update_attachment(document, attachment)
+    if document.update_attachment(attachment)
+      flash[:success] = "Updated #{attachment.title}"
       redirect_to edit_document_path(document_type_slug, document.content_id)
     else
-      flash[:danger] = "There was an error uploading the attachment, please try again later."
-      redirect_to previous_address(document, attachment, new: new_attachment)
+      flash[:danger] = "There was an error updating the attachment, please try again later."
+      redirect_to edit_document_attachment_path(document_type_slug, document.content_id, attachment.content_id)
     end
   end
 
-  def previous_address(document, attachment, new:)
-    if new
-      new_document_attachment_path(document_type_slug, document.content_id)
+  def upload_attachment(document, attachment)
+    if document.upload_attachment(attachment)
+      flash[:success] = "Attached #{attachment.title}"
+      redirect_to edit_document_path(document_type_slug, document.content_id)
     else
-      edit_document_attachment_path(document_type_slug, document.content_id, attachment.content_id)
+      flash[:danger] = "There was an error uploading the attachment, please try again later."
+      redirect_to new_document_attachment_path(document_type_slug, document.content_id)
     end
   end
 

--- a/app/models/attachment_collection.rb
+++ b/app/models/attachment_collection.rb
@@ -19,6 +19,10 @@ class AttachmentCollection
     attachment.upload if has_attachment?(attachment)
   end
 
+  def update(attachment)
+    attachment.update if has_attachment?(attachment)
+  end
+
   def has_attachment?(attachment)
     !!find(attachment.content_id)
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -333,6 +333,14 @@ class Document
     end
   end
 
+  def update_attachment(attachment)
+    if attachments.update(attachment)
+      save
+    else
+      false
+    end
+  end
+
   def set_temporary_update_type!
     return if update_type
     self.temporary_update_type = true

--- a/app/views/shared/_attachments_form.html.erb
+++ b/app/views/shared/_attachments_form.html.erb
@@ -1,13 +1,18 @@
-<%= form_for(@attachment, :url => url, method: method) do |f| %>
+<%= form_for(@attachment, url: url, method: method) do |f| %>
   <p>
     <%= f.label :title %>
     <%= f.text_field :title, class: 'form-control input-md-8' %>
   </p>
+  <% if @document.attachments.has_attachment?(@attachment) %>
+    <p><strong>Previous file: </strong><%= link_to @attachment.filename, @attachment.url %></p>
+  <% end %>
   <p>
     <%= f.label :file %>
     <%= f.file_field :file %>
   </p>
   <div class='actions'>
     <button type="submit" class='btn btn-success'>Save attachment</button>
+    or
+    <%= link_to 'cancel', edit_document_path(current_format.slug, @document.content_id)%>
   </div>
 <% end %>

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -101,8 +101,7 @@ RSpec.describe AttachmentsController, type: :controller do
 
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
-      stub_request(:post, "#{Plek.find('asset-manager')}/assets")
-        .with(body: %r{.*})
+      stub_request(:put, %r{#{Plek.find('asset-manager')}/assets/.*})
         .to_return(body: JSON.dump(asset_manager_response), status: 201)
 
       post :update, document_type_slug: document_type_slug, document_content_id: document_content_id, attachment_content_id: attachment_content_id, attachment: { file: Rack::Test::UploadedFile.new("spec/support/images/updated_cma_case_image.jpg", "mime/type"), title: 'updated test attachment upload' }

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -362,7 +362,6 @@ RSpec.feature "Editing a CMA case", type: :feature do
       scenario "adding a nil attachment on a #{publication_state} CMA case" do
         # this is to force app to not update asset manager on invalid error
         stub_request(:post, "#{Plek.find('asset-manager')}/assets")
-          .with(body: %r{.*})
           .to_return(body: asset_manager_response.to_json, status: 500)
 
         click_link "Add attachment"
@@ -378,10 +377,13 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
 
       scenario "editing an attachment on a #{publication_state} CMA case" do
+        stub_request(:put, %r{#{Plek.find('asset-manager')}/assets/.*})
+          .to_return(body: asset_manager_response.to_json, status: 201)
         find('.attachments').first(:link, "edit").click
         expect(page.status_code).to eq(200)
         expect(find('#attachment_title').value).to eq('asylum report image title')
 
+        expect(page).to have_content('asylum-support-image.jpg')
         fill_in "Title", with: "Updated cma case image"
         page.attach_file('attachment_file', "spec/support/images/updated_cma_case_image.jpg")
 

--- a/spec/features/editing_a_manual_section_spec.rb
+++ b/spec/features/editing_a_manual_section_spec.rb
@@ -80,39 +80,5 @@ RSpec.feature "editing a manual section" do
         .with(body: %r{.*})
         .to_return(body: JSON.dump(asset_manager_response), status: 201)
     end
-
-    scenario "adding an attachment" do
-      visit manual_path(manual_content_id)
-      click_link 'First section'
-      click_link 'Edit section'
-
-      click_link "Add attachment"
-      expect(page.status_code).to eq(200)
-
-      fill_in "Title", with: "New section image"
-      page.attach_file('attachment_file', "spec/support/images/section_image.jpg")
-
-      click_button "Save attachment"
-      expect(page.status_code).to eq(200)
-
-      expect(page).to have_content('Attached New section image')
-      expect(page).to have_content("Edit section")
-    end
-
-    scenario "editing an attachment" do
-      visit manual_path(manual_content_id)
-      click_link 'Second section'
-      click_link 'Edit section'
-      find('.attachments').first(:link, "edit").click
-
-      expect(page.status_code).to eq(200)
-
-      fill_in "Title", with: "Updated section image"
-      page.attach_file('attachment_file', "spec/support/images/updated_section_image.jpg")
-
-      click_button("Save attachment")
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content("Attachment succesfully updated")
-    end
   end
 end


### PR DESCRIPTION
Change to the edit attachment logic, to use the Update rather than
Create route on asset manager. This will mean that editing an
attachment will replace it on the asset manager, using the same
address.

Also includes some changes to the front end, to improve the user
journey.

[Trello card](https://trello.com/c/MWCqZrvY/267-changes-to-edit-attachment-functionality)
