### PR TITLE
Validate inline attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -44,7 +44,7 @@ class AttachmentsController < ApplicationController
 private
 
   def save_updated_title(document, attachment)
-    if document.save
+    if document.save(validate: false)
       flash[:success] = "Attachment succesfully updated"
       redirect_to edit_document_path(document_type_slug, document.content_id)
     else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -102,7 +102,11 @@ private
       }
     )
     errors = content_tag :ul, class: "list-unstyled remove-bottom-margin" do
-      @document.errors.full_messages.map { |e| content_tag(:li, e) }.join('').html_safe
+      list_items = @document.errors.full_messages.map do |message|
+        content_tag(:li, message.html_safe)
+      end
+
+      list_items.join.html_safe
     end
 
     heading + errors

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -260,8 +260,8 @@ class Document
   class RecordNotFound < StandardError; end
   class TypeMismatchError < StandardError; end
 
-  def save
-    return false unless self.valid?
+  def save(validate: true)
+    return false if validate && !self.valid?
 
     self.update_type = 'major' if first_draft?
 
@@ -327,7 +327,7 @@ class Document
 
   def upload_attachment(attachment)
     if attachments.upload(attachment)
-      save
+      save(validate: false)
     else
       false
     end
@@ -335,7 +335,7 @@ class Document
 
   def update_attachment(attachment)
     if attachments.update(attachment)
-      save
+      save(validate: false)
     else
       false
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,7 +31,7 @@ class Document
 
   validates :title, presence: true
   validates :summary, presence: true
-  validates :body, presence: true, safe_html: true
+  validates :body, presence: true, safe_html: true, inline_attachments: true
   validates :update_type, presence: true, unless: :first_draft?
   validates :change_note, presence: true, if: :change_note_required?
 

--- a/app/validators/inline_attachments_validator.rb
+++ b/app/validators/inline_attachments_validator.rb
@@ -1,0 +1,13 @@
+class InlineAttachmentsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    report = AttachmentReporter.report(record)
+    unmatched = report.fetch(:unmatched_snippets)
+
+    unmatched.uniq.each do |filename|
+      filename = CGI::escapeHTML(filename)
+      message = "contains an attachment that can't be found: '#{filename}'"
+
+      record.errors.add(attribute, message)
+    end
+  end
+end

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -5,7 +5,7 @@
     <%= label %>
     <% field_errors(@document, field).each do |msg| %>
       <br />
-      <span class="elements-error-message add-label-margin"><%= msg %></span>
+      <span class="elements-error-message add-label-margin"><%= msg.html_safe %></span>
     <% end %>
   <% end %>
   <%= yield %>

--- a/spec/features/attachment_validation_spec.rb
+++ b/spec/features/attachment_validation_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.feature "Validating inline attachments", type: :feature do
+  before do
+    log_in_as_editor(:cma_editor)
+  end
+
+  scenario "creating a document that references attachments that don't exist" do
+    visit "/cma-cases/new"
+    fill_in "Body", with: "[InlineAttachment:missing.pdf]"
+    click_button "Save"
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content(
+      "Body contains an attachment that can't be found: 'missing.pdf'"
+    )
+  end
+end

--- a/spec/features/attachment_validation_spec.rb
+++ b/spec/features/attachment_validation_spec.rb
@@ -15,4 +15,19 @@ RSpec.feature "Validating inline attachments", type: :feature do
       "Body contains an attachment that can't be found: 'missing.pdf'"
     )
   end
+
+  scenario "escaping inline attachments so that they are html safe" do
+    visit "/cma-cases/new"
+    fill_in "Body", with: "[InlineAttachment:<not>safe.pdf]"
+    click_button "Save"
+
+    expect(page).to have_content("Please fix the following errors")
+
+    expect(page).to have_content(
+      "Body contains an attachment that can't be found: '<not>safe.pdf'"
+    )
+    expect(page).not_to have_content(
+      "Body contains an attachment that can't be found: '&lt;not&gt;safe.pdf'"
+    )
+  end
 end

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -359,6 +359,21 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page).to have_content("Editing Example CMA Case")
       end
 
+      context "when the document is in an invalid state" do
+        let(:cma_case) { FactoryGirl.create(:cma_case, details: { body: "" }) }
+
+        scenario "successfully adding an attachment to the invalid document" do
+          click_link "Add attachment"
+
+          fill_in "Title", with: "Some title"
+          page.attach_file('attachment_file', "spec/support/images/cma_case_image.jpg")
+          click_button "Save attachment"
+
+          expect(page.status_code).to eq(200)
+          expect(page).to have_content("Editing Example document")
+        end
+      end
+
       scenario "adding a nil attachment on a #{publication_state} CMA case" do
         # this is to force app to not update asset manager on invalid error
         stub_request(:post, "#{Plek.find('asset-manager')}/assets")

--- a/spec/validators/inline_attachments_validators_spec.rb
+++ b/spec/validators/inline_attachments_validators_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+RSpec.describe InlineAttachmentsValidator do
+  class FakeErrors < Hash
+    def add(attr, message)
+      self[attr] ||= []
+      self[attr].push(message)
+    end
+  end
+
+  let(:record) do
+    double(
+      :record,
+      errors: FakeErrors.new,
+      body: body,
+      attachments: [
+        double(:attachment, snippet: "[InlineAttachment:foo.pdf]"),
+        double(:attachment, snippet: "[InlineAttachment:bar.pdf]"),
+      ],
+    )
+  end
+
+  subject { described_class.new(attributes: [:body]) }
+
+  context "when there are no inline attachments" do
+    let(:body) { "some body" }
+
+    it "validates successfully" do
+      subject.validate_each(record, :body, body)
+      expect(record.errors[:body]).to be_blank
+    end
+  end
+
+  context "when all of the inline attachments match" do
+    let(:body) { <<-HTML }
+      [InlineAttachment:foo.pdf]
+      [InlineAttachment:bar.pdf]
+    HTML
+
+    it "validates successfully" do
+      subject.validate_each(record, :body, body)
+      expect(record.errors[:body]).to be_blank
+    end
+  end
+
+  context "when there are unmatched inline attachments" do
+    let(:body) { <<-HTML }
+      [InlineAttachment:missing1.pdf]
+      [InlineAttachment:foo.pdf]
+      [InlineAttachment:missing2.pdf]
+      [InlineAttachment:bar.pdf]
+      [InlineAttachment:missing1.pdf]
+    HTML
+
+    it "adds an error for each unique missing attachment" do
+      subject.validate_each(record, :body, body)
+
+      expect(record.errors[:body]).to eq [
+        "contains an attachment that can't be found: 'missing1.pdf'",
+        "contains an attachment that can't be found: 'missing2.pdf'",
+      ]
+    end
+  end
+end


### PR DESCRIPTION
We now check that all inline attachments used in
the body of the document match with an attachment
in the list on the right-hand side.

I've made it so we don't validate the document when
saving/updating attachments. This was already a
problem with fields like 'summary' which was missing
on some documents.
## Screenshot

![screen shot 2016-09-06 at 15 38 02](https://cloud.githubusercontent.com/assets/892251/18277896/0cc97fba-7448-11e6-824b-b752d272ca17.png)
