### PR TITLE
Remove duplicate document_type from metadata

### DIFF
--- a/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
+++ b/app/exporters/formatters/specialist_document_publishing_api_formatter.rb
@@ -84,7 +84,7 @@ class SpecialistDocumentPublishingAPIFormatter
   end
 
   def metadata
-    rendered_document.extra_fields.merge(document_type: specialist_document.document_type)
+    rendered_document.extra_fields
   end
 
   def public_updated_at

--- a/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
+++ b/spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SpecialistDocumentPublishingAPIFormatter do
     end
 
     it "should include the relevant metadata in the details hash" do
-      fields = %w(case_type case_state market_sector opened_date document_type)
+      fields = %w(case_type case_state market_sector opened_date)
       expect(presented["details"]["metadata"].keys).to eq(fields)
     end
 

--- a/spec/features/republishing_documents_spec.rb
+++ b/spec/features/republishing_documents_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe "Republishing documents", type: :feature do
           "market_sector" => "some-market-sector",
           "case_type" => "a-case-type",
           "case_state" => "open",
-          "document_type" => @document.document_type
         },
         "change_history" => [],
         "body" => [


### PR DESCRIPTION
https://trello.com/c/Y0ncSoTO/258-clean-up-remove-document-type-from-pub-api-metadata-payload

The `document_type` property shouldn't be duplicated in the document metadata
as this will be invalid with [upcoming changes to content schemas](https://github.com/alphagov/govuk-content-schemas/pull/381) so don't present
this twice.

See also https://github.com/alphagov/specialist-publisher-rebuild/pull/891