### PR TITLE
Fix CI: Clean up users before each test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,10 @@ RSpec.configure do |config|
     mocks.syntax = :expect
   end
 
+  config.before(:each) do
+    User.destroy_all
+  end
+
   config.after(:each) do
     Timecop.return
     GDS::SSO.test_user = nil


### PR DESCRIPTION
On CI, there were 2300 users in the database.
There's no uniqueness constraint on the 'uid'
field which means the wrong user is retrieved
in feature tests if more than one request is
made because the user is cached in the
authenticated users header.

I'm not sure why this started failing now. Some
external factor must have changed
