### PR TITLE
Make OpenBeforeClosedValidator robust to nils

### DIFF
--- a/app/validators/open_before_closed_validator.rb
+++ b/app/validators/open_before_closed_validator.rb
@@ -6,7 +6,10 @@ class OpenBeforeClosedValidator < ActiveModel::EachValidator
 private
 
   def before_closed?(record)
-    record.opened_date <= record.closed_date || record.closed_date.blank?
+    opened = record.opened_date
+    closed = record.closed_date
+
+    opened.blank? || closed.blank? || opened <= closed
   end
 
   def error_message

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -4,4 +4,33 @@ require 'models/valid_against_schema'
 RSpec.describe CmaCase do
   let(:payload) { FactoryGirl.create(:cma_case) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  describe "validations" do
+    subject { described_class.from_publishing_api(payload) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid if the opened date is after the closed date" do
+      subject.opened_date = "2016-01-01"
+      subject.closed_date = "2015-12-31"
+
+      expect(subject).to be_invalid
+      expect(subject.errors[:opened_date]).to eq ["must be before closed date"]
+    end
+
+    it "is valid if opened/closed date are nil" do
+      subject.opened_date = nil
+      subject.closed_date = nil
+      expect(subject).to be_valid
+
+      subject.opened_date = "2016-01-01"
+      expect(subject).to be_valid
+
+      subject.opened_date = nil
+      subject.closed_date = "2015-12-31"
+      expect(subject).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
We received a Zendesk ticket. Upon investigation,
this validator was raising an error. Normally these
dates would be empty strings which would work with
the previous implementation but because this data
was imported from the old specialist publisher it
is sometimes nil.

https://govuk.zendesk.com/agent/tickets/1413926
