### PR TITLE
Mark vehicle recalls as pre-production

### DIFF
--- a/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
+++ b/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
@@ -4,6 +4,7 @@
   "format_name": "Vehicle recalls and faults",
   "name": "Vehicle recalls and faults",
   "beta": true,
+  "pre_production": true,
   "summary": "<p>Find out if your vehicle has been recalled by the manufacturer or has a fault. You can also search for child car seats, tyres and other vehicle parts.</p>",
   "filter": {
     "document_type": "vehicle_recalls_and_faults_alert"


### PR DESCRIPTION
https://trello.com/c/UdZddSaD/271-vehicle-recalls-faults-is-empty-small

The vehicle recalls finder wasn't marked as pre-production, accompanying router-data redirect [here](https://github.gds/gds/router-data/pull/557)
