### PR TITLE
Set attachment `updated_at` timestamp correctly

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -43,7 +43,13 @@ class AttachmentsController < ApplicationController
 
 private
 
+  def flag_updated(document, attachment)
+    updated_attachment = document.attachments.find(attachment.content_id)
+    updated_attachment.being_updated = true
+  end
+
   def save_updated_title(document, attachment)
+    flag_updated(document, attachment)
     if document.save(validate: false)
       flash[:success] = "Attachment succesfully updated"
       redirect_to edit_document_path(document_type_slug, document.content_id)
@@ -54,6 +60,7 @@ private
   end
 
   def update_attachment(document, attachment)
+    flag_updated(document, attachment)
     if document.update_attachment(attachment)
       flash[:success] = "Updated #{attachment.title}"
       redirect_to edit_document_path(document_type_slug, document.content_id)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,7 +1,7 @@
 require "gds_api/asset_manager"
 
 class Attachment < Document
-  attr_accessor :title, :file, :content_type, :url, :content_id, :created_at, :updated_at
+  attr_accessor :title, :file, :content_type, :url, :content_id, :created_at, :updated_at, :being_updated
 
   def self.all_from_publishing_api(payload)
     return [] unless payload.fetch('details', {}).key?('attachments')
@@ -18,6 +18,7 @@ class Attachment < Document
     @created_at = params[:created_at]
     @updated_at = params[:updated_at]
     @params = params
+    @being_updated = false
   end
 
   def update_attributes(new_params)

--- a/app/presenters/attachment_presenter.rb
+++ b/app/presenters/attachment_presenter.rb
@@ -17,7 +17,11 @@ class AttachmentPresenter
 private
 
   def updated_at
-    Time.now.to_datetime.rfc3339
+    if @attachment.updated_at.nil? || @attachment.being_updated == true
+      @attachment.updated_at = Time.now.to_datetime.rfc3339
+    else
+      @attachment.updated_at
+    end
   end
 
   def created_at


### PR DESCRIPTION
[Trello](https://trello.com/c/llClS12G/252-sp-rebuild-changes-the-attachment-timestamps-on-document-updates-even-if-the-attachments-themselves-haven-t-been-changed-medium)

Previously all attachment `updated_at` timestamps on the edited document were updated in these cases:
- Every time anything in the document was updated (for example the document title or body)
- Every time any attachment was updated or uploaded

This PR fixes this by:
- Setting a temporary `being_updated` flag when an attachment's title or file is being updated
- Only set or update the `updated_at` timestamp for attachments that are new or being updated

![attachments_updated_at](https://cloud.githubusercontent.com/assets/5963488/18320139/8ca66e68-7520-11e6-95c6-682bb8fdfb9c.png)
