### PR TITLE
Reflect changes in PublishingAPI

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -223,6 +223,7 @@ class Document
 
   def self.all(page, per_page, q: nil)
     params = {
+      publishing_app: "specialist-publisher",
       document_type: self.document_type,
       fields: [
         :base_path,

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -2,7 +2,7 @@ namespace :permissions do
   desc "Grant a user 'gds_editor' and 'view_all' permissions"
   task :grant, [:name] => :environment do |_, args|
     user = User.where(name: args.name).first
-    user.permissions |= %w(gds_editor view_all)
+    user.permissions |= %w(gds_editor)
     user.save
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Document do
 
       expect(publishing_api).to receive(:get_content_items)
         .with(
+          publishing_app: "specialist-publisher",
           document_type: "my_document_type",
           fields: [
             :base_path,


### PR DESCRIPTION
This addresses the changes introduced in the Publishing API in https://github.com/alphagov/publishing-api/pull/503

The Publishing API change doesn't cause any immediate problems this just will add an extra layer of isolation between this and any apps that may use the same `document_type` later.
