### PR TITLE
Stop sending "signup_link" to publishing-api

### DIFF
--- a/app/presenters/finders/finder_content_item_presenter.rb
+++ b/app/presenters/finders/finder_content_item_presenter.rb
@@ -42,7 +42,6 @@ private
       filter: file.fetch("filter", nil),
       format_name: file.fetch("format_name", nil),
       logo_path: file.fetch("logo_path", nil),
-      signup_link: file.fetch("signup_link", nil),
       show_summaries: file.fetch("show_summaries", false),
       summary: file.fetch("summary", nil),
       facets: file.fetch("facets", nil),

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -9,7 +9,6 @@
   },
   "show_summaries": true,
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
-  "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": [

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -8,7 +8,6 @@
     "document_type": "medical_safety_alert"
   },
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
-  "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",
   "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "show_summaries": true,


### PR DESCRIPTION
This attribute used to be used to link a finder to its email signup page. This is no longer used because finders are linked to their signup page in the links hash.

Related: https://github.com/alphagov/govuk-content-schemas/pull/386
