### PR TITLE
Fix 'free-form-lists' which were broken by downgrading select2

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -9,16 +9,24 @@ jQuery(function($) {
 
   ////
   // Make a select2 that will create new values on return as you type them
-  $(".select2.free-form-list").select2({
-    tags: true,
-    createTag: function (params) {
-      return {
-        id: params.term,
-        text: params.term,
-        newOption: true
+  (function () {
+    var element = $(".free-form-list");
+    if (element.length === 0) return;
+
+    var value = element.val();
+    var tags = (value === "") ? [] : value.split("::");
+
+    element.select2({
+      tags: tags,
+      separator: "::"
+    }).on("change", function (event) {
+      var added = event.added;
+
+      if (typeof added !== "undefined" && tags.indexOf(added.text) === -1) {
+        tags.push(added.text);
       }
-    }
-  });
+    });
+  })();
 
   $('.js-hidden').hide();
 

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -16,6 +16,7 @@ class DfidResearchOutput < Document
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    self.dfid_author_tags = params[:dfid_author_tags]
   end
 
   ##
@@ -37,5 +38,13 @@ class DfidResearchOutput < Document
 
   def state_history_one_or_shorter?
     state_history.nil? ? true : state_history.size < 2
+  end
+
+  def dfid_author_tags
+    (dfid_authors || []).join("::")
+  end
+
+  def dfid_author_tags=(tags)
+    self.dfid_authors = (tags || "").split("::")
   end
 end

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -7,11 +7,7 @@
 <% end %>
 
 <%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_authors, label: 'Authors' } do %>
-  <%=
-    f.select :dfid_authors, @document.dfid_authors || [],
-      { include_blank: true },
-      { class: 'select2 free-form-list', multiple: true, data: { placeholder: 'Add authors' } }
-  %>
+  <%= f.text_field :dfid_author_tags, class: 'form-control free-form-list', data: { placeholder: 'Add authors' } %>
 <% end %>
 
 <%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: 'Countries' } do %>

--- a/spec/models/dfid_research_output_spec.rb
+++ b/spec/models/dfid_research_output_spec.rb
@@ -10,4 +10,15 @@ RSpec.describe DfidResearchOutput do
   it 'is always bulk published to hide the publishing-api published date' do
     expect(output.bulk_published).to be true
   end
+
+  it "has a dfid_author_tags virtual attribute" do
+    subject.dfid_author_tags = "a, b::c"
+    expect(subject.dfid_authors).to eq ["a, b", "c"]
+
+    subject.dfid_authors = ["foo, bar", "baz"]
+    expect(subject.dfid_author_tags).to eq "foo, bar::baz"
+
+    subject = described_class.new(dfid_author_tags: "foo, bar::baz")
+    expect(subject.dfid_authors).to eq ["foo, bar", "baz"]
+  end
 end


### PR DESCRIPTION
We recently downgraded select2 to make it use the same styles
from the old Specialist Publisher that our users are familiar
with. In doing so, we broke 'free-form-lists' which are a
bespoke feature used on the dfid-research-outputs format.

These changes make 'free-form-lists' work with the older
select2 version. At present, there is a single 'tags'
array for all 'free-form-lists' that appear on the page.
This means that tags users type in between input fields
will appear as options for others.

This isn't great, but at present, we only have a single
'free-form-list' on the page and the code that stored
separate 'tags' arrays was becoming unreadable. It used
a function as the value of the 'tags' property instead
of a simple array.
