### PR TITLE
Alert editors to unsaved changes

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -1,6 +1,7 @@
 //= require jquery
 //= require select2
 //= require length_counter
+//= require form_change_protection
 
 jQuery(function($) {
   $(".select2").select2({

--- a/app/assets/javascript/form_change_protection.js
+++ b/app/assets/javascript/form_change_protection.js
@@ -1,0 +1,46 @@
+(function () {
+  "use strict";
+  var root = this,
+      $ = root.jQuery;
+
+  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var formChangeProtection = {
+    init: function (form, message) {
+      this.$form = $(form);
+      this.message = message;
+      this.initialState = this.serialisedFormValues();
+
+      this.preventLossOfUnsavedChanges();
+    },
+
+    serialisedFormValues: function () {
+      var formdata = this.$form.find("*").
+        not('input[name=authenticity_token]').serialize();
+
+      this.$form.find('input[type=file]').each(function () {
+        formdata = formdata + $(this).val();
+      });
+
+      return formdata;
+    },
+
+    alertIfUnsavedChanges: function () {
+      var current = formChangeProtection.serialisedFormValues();
+
+      if (current != formChangeProtection.initialState) {
+        return formChangeProtection.message;
+      }
+    },
+
+    preventLossOfUnsavedChanges: function () {
+      $(window).bind('beforeunload', this.alertIfUnsavedChanges);
+      // unbind when the form is submitted to stop the alert
+      this.$form.bind('submit', function() {
+        $(window).unbind('beforeunload');
+      });
+    }
+  }
+
+  root.GOVUK.formChangeProtection = formChangeProtection;
+}).call(this);

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -5,12 +5,18 @@
     <li class='active'>Edit document</li>
 <% end %>
 
+<% content_for :document_ready do -%>
+  GOVUK.formChangeProtection.init($('.edit_document'), 'You have unsaved changes that will be lost if you leave this page.');
+<% end -%>
+
 <h2>Editing <%= @document.title %></h2>
 
 <div class="row">
   <div class="col-md-8">
     <%= form_for @document, url: document_path(document_type_slug: params[:document_type_slug],
-                                               content_id: @document.content_id), method: :put do |f| %>
+                                               content_id: @document.content_id),
+                                               method: :put,
+                                               html: { class: "edit_document" } do |f| %>
         <%= render partial: "shared/form_fields", locals: {f: f} %>
 
         <%= render partial: "shared/preview_govspeak", locals: {attachments: @document.attachments} %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -3,11 +3,16 @@
   <li class='active'>New document</li>
 <% end %>
 
+<% content_for :document_ready do -%>
+  GOVUK.formChangeProtection.init($('.new_document'), 'You have unsaved changes that will be lost if you leave this page.');
+<% end -%>
+
 <h2>New <%= current_format.title.singularize %></h2>
 
 <div class="row">
   <div class="col-md-8">
-    <%= form_for @document, url: documents_path(params[:document_type_slug]) do |f| %>
+    <%= form_for @document, url: documents_path(params[:document_type_slug]),
+                            html: { class: "new_document" } do |f| %>
       <%= render partial: "shared/form_fields", locals: { f: f } %>
 
       <%= render partial: "shared/preview_govspeak", locals: {attachments: @document.attachments} %>

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -452,7 +452,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
     }
 
     scenario "showing the update type radio buttons" do
-      within(".new_cma_case") do
+      within(".edit_document") do
         expect(page).to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
         expect(page).to have_content('This will notify subscribers to ')
         expect(page).to have_content('Update type minor')
@@ -484,7 +484,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
   context "a draft document" do
     scenario "not showing the update type radio buttons" do
-      within(".new_cma_case") do
+      within(".edit_document") do
         expect(page).not_to have_content('Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.')
         expect(page).not_to have_content('This will notify subscribers to ')
         expect(page).not_to have_content('Update type minor')

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -1,0 +1,162 @@
+require 'spec_helper'
+
+RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
+  let(:message) { "You have unsaved changes that will be lost if you leave this page." }
+  let(:cma_case) { FactoryGirl.create(:cma_case) }
+  let(:content_id) { cma_case['content_id'] }
+
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+    publishing_api_has_content([cma_case], hash_including(document_type: CmaCase.document_type))
+    publishing_api_has_item(cma_case)
+
+    log_in_as_editor(:cma_editor)
+    visit "/cma-cases"
+  end
+
+  context "a new document" do
+    before do
+      click_on "Add another CMA Case"
+
+      fill_in "Title", with: "Example CMA Case"
+      fill_in "Summary", with: "This is the summary of an example CMA case"
+      fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 2)
+      fill_in "Opened date", with: "2014-01-01"
+      select "Energy", from: "cma_case_market_sector", visible: false # The hidden select2 select element
+    end
+
+    scenario "when an 'Your documents' is clicked and the confirmation is cancelled" do
+      dismiss_confirm message do
+        click_link "Your documents"
+      end
+
+      expect(current_path).to eq("/cma-cases/new")
+    end
+
+    scenario "when an 'Your documents' is clicked and the confirmation is accepted" do
+      accept_confirm message do
+        click_link "Your documents"
+      end
+
+      expect(current_path).to eq("/cma-cases")
+    end
+
+    pending "when attempting to close the current window and accepting the confirmation" do
+      # accept_confirm curiously times out finding the modal dialog, dismiss_confirm works fine.
+      accept_confirm message do
+        page.evaluate_script "window.close();"
+      end
+
+      expect(current_window).to be_closed
+    end
+
+    scenario "when attempting to close the current window and cancelling the confirmation" do
+      dismiss_confirm message do
+        page.evaluate_script "window.close();"
+      end
+
+      expect(current_path).to eq("/cma-cases/new")
+    end
+
+    scenario "when attempting to go back a page and accepting the confirmation" do
+      accept_confirm message do
+        page.evaluate_script "window.history.back();"
+      end
+
+      expect(current_path).to eq("/cma-cases")
+    end
+
+    scenario "when attempting to go back a page and cancelling the confirmation" do
+      dismiss_confirm message do
+        page.evaluate_script "window.history.back();"
+      end
+
+      expect(current_path).to eq("/cma-cases/new")
+    end
+
+    scenario "when changes are saved" do
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(200)
+
+      within(".alert-success") do
+        expect(page).to have_content("Created Example CMA Case")
+      end
+
+      click_on "Edit document"
+      click_link "Add attachment"
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/attachments/new")
+    end
+  end
+
+  context "an existing document" do
+    before do
+      click_on "Example document"
+      click_on "Edit document"
+
+      fill_in "Title", with: "Amended example document"
+      fill_in "Summary", with: "This is an update to the summary of an example CMA case"
+      fill_in "Body", with: "## Header" + ("\n\nThis is the updated body text of an example CMA case" * 2)
+      fill_in "Opened date", with: "2014-02-02"
+      select "Energy", from: "cma_case_market_sector", visible: false # The hidden select2 select element
+    end
+
+    scenario "when an 'Add attachment' is clicked and the confirmation is cancelled" do
+      dismiss_confirm message do
+        click_link "Add attachment"
+      end
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/edit")
+    end
+
+    scenario "when an 'Add attachment' is clicked and the confirmation is accepted" do
+      accept_confirm message do
+        click_link "Add attachment"
+      end
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/attachments/new")
+    end
+
+    scenario "when attempting to close the current window and cancelling the confirmation" do
+      dismiss_confirm message do
+        page.evaluate_script "window.close();"
+      end
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/edit")
+    end
+
+    scenario "when attempting to go back a page and accepting the confirmation" do
+      accept_confirm message do
+        page.evaluate_script "window.history.back();"
+      end
+
+      expect(current_path).to eq("/cma-cases/#{content_id}")
+    end
+
+    scenario "when attempting to go back a page and cancelling the confirmation" do
+      dismiss_confirm message do
+        page.evaluate_script "window.history.back();"
+      end
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/edit")
+    end
+
+    scenario "when changes are saved" do
+      click_button "Save as draft"
+
+      expect(page.status_code).to eq(200)
+
+      within(".alert-success") do
+        expect(page).to have_content("Updated Amended example document")
+      end
+
+      click_on "Edit document"
+      click_link "Add attachment"
+
+      expect(current_path).to eq("/cma-cases/#{content_id}/attachments/new")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/V8tu3RRf/259-show-a-popup-if-a-user-tries-to-navigate-away-from-this-page-without-saving-their-document-medium

Updates to new or existing documents could be lost without notice
so add a way to inform the user that they have changes to save
before they navigate away from the page or close the current window.

[The javascript class used to track changes to the current form is from Whitehall](https://github.com/alphagov/whitehall/blob/master/app/assets/javascripts/admin/form_change_protection.js).

![screenshot from 2016-09-15 15 47 53](https://cloud.githubusercontent.com/assets/93511/18554333/d5d12f06-7b5b-11e6-94ad-10a763d7779f.png)

Worth noting that the custom message support has changed in some browsers recently, this doesn't affect behaviour but the message displayed is variable depending on the browser.

https://www.chromestatus.com/feature/5349061406228480
https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Notes
