### PR TITLE
Add a deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Warning: This repository is deprecated. It has been replaced with [manuals-publisher](https://github.com/alphagov/manuals-publisher). Please update your git remote.
+
 [![Code Climate](https://codeclimate.com/github/alphagov/specialist-publisher.png)](https://codeclimate.com/github/alphagov/specialist-publisher)
 
 # Specialist publisher


### PR DESCRIPTION
We're mid-way through renaming this application to manuals-publisher. After that, the rebuild app will be renamed to specialist-publisher, replacing this repository.

This adds a warning to prevent people pushing to this repository in the meantime.