### PR TITLE
Update name for Democratic Republic of the Congo

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -47,8 +47,8 @@
           "value": "burma"
         },
         {
-          "label": "Democratic Republic of Congo",
-          "value": "democratic-republic-of-congo"
+          "label": "Democratic Republic of the Congo",
+          "value": "democratic-republic-of-the-congo"
         },
         {
           "label": "Ethiopia",


### PR DESCRIPTION
**trello**: https://trello.com/c/rxjklHjL/191-country-name-change-democratic-republic-of-the-congo

> The country formerly known as 'Democratic Republic of Congo' is now officially called 'Democratic Republic of **the** Congo'.
