### PR TITLE
Reverting the value for Democratic Republic of the Congo

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -48,7 +48,7 @@
         },
         {
           "label": "Democratic Republic of the Congo",
-          "value": "democratic-republic-of-the-congo"
+          "value": "democratic-republic-of-congo"
         },
         {
           "label": "Ethiopia",


### PR DESCRIPTION
During PR: https://github.com/alphagov/rummager/pull/700
It was agreed to keep the value so search continues to work.
This PR reverts 5895be401ad12789d4a2d9cf4e064254c67de059

Partially reverts https://github.com/alphagov/specialist-publisher-rebuild/pull/908

\cc @steventux 
