### PR TITLE
Delete attachments on unpublish, conditionally restore them on republish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "36.2.0"
+  gem "gds-api-adapters", "37.1.0"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    gds-api-adapters (36.2.0)
+    gds-api-adapters (37.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -147,7 +147,7 @@ GEM
     highline (1.7.8)
     hike (1.2.3)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     jquery-rails (3.1.4)
@@ -380,7 +380,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   factory_girl
   foreman (= 0.74.0)
-  gds-api-adapters (= 36.2.0)
+  gds-api-adapters (= 37.1.0)
   gds-sso (= 11.0.0)
   govspeak (~> 5.0.1)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -41,7 +41,7 @@ class Attachment < Document
 
   def upload
     response = Services.asset_api.create_asset(file: @file)
-    @url = response.file_url
+    @url = response["file_url"]
     true
   rescue GdsApi::BaseError => e
     Airbrake.notify(e)
@@ -50,7 +50,7 @@ class Attachment < Document
 
   def update
     response = Services.asset_api.update_asset(id_from_url, file: @file)
-    @url = response.file_url
+    @url = response["file_url"]
     true
   rescue GdsApi::BaseError => e
     Airbrake.notify(e)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -244,9 +244,11 @@ class Document
   end
 
   def self.find(content_id)
-    response = Services.publishing_api.get_content(content_id)
-
-    raise RecordNotFound, "Document: #{content_id}" unless response
+    begin
+      response = Services.publishing_api.get_content(content_id)
+    rescue GdsApi::HTTPNotFound
+      raise RecordNotFound, "Document: #{content_id}"
+    end
 
     attributes = response.to_hash
     document_type = attributes.fetch("document_type")

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -306,6 +306,7 @@ class Document
     handle_remote_error do
       Services.publishing_api.unpublish(content_id, type: 'gone')
 
+      AttachmentDeleteWorker.perform_async(content_id)
       RummagerDeleteWorker.perform_async(base_path)
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -299,6 +299,10 @@ class Document
       if send_email_on_publish?
         EmailAlertApiWorker.perform_async(EmailAlertPresenter.new(self).to_json)
       end
+
+      if previously_unpublished?
+        AttachmentRestoreWorker.perform_async(self.content_id)
+      end
     end
   end
 
@@ -387,5 +391,10 @@ private
 
   def finder_schema
     self.class.finder_schema
+  end
+
+  def previously_unpublished?
+    ordered_states = state_history.sort.to_h.values
+    ordered_states.last(2) == %w(unpublished draft)
   end
 end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -5,11 +5,11 @@ class PaginationPresenter < SimpleDelegator
 
   def initialize(api_response, _per_page)
     # actually delegate to the API response's `results` array
-    super(present_results(api_response.results))
+    super(present_results(api_response["results"]))
 
-    @current_page = api_response.current_page
-    @total_pages = api_response.pages || 1
-    @total_count = api_response.total
+    @current_page = api_response["current_page"]
+    @total_pages = api_response["pages"] || 1
+    @total_count = api_response["total"]
   end
 
 private

--- a/app/workers/attachment_delete_worker.rb
+++ b/app/workers/attachment_delete_worker.rb
@@ -1,0 +1,13 @@
+require "services"
+
+class AttachmentDeleteWorker
+  include Sidekiq::Worker
+
+  def perform(content_id)
+    document = Document.find(content_id)
+
+    document.attachments.each do |attachment|
+      Services.asset_api.delete_asset(attachment.id_from_url)
+    end
+  end
+end

--- a/app/workers/attachment_restore_worker.rb
+++ b/app/workers/attachment_restore_worker.rb
@@ -1,0 +1,13 @@
+require "services"
+
+class AttachmentRestoreWorker
+  include Sidekiq::Worker
+
+  def perform(content_id)
+    document = Document.find(content_id)
+
+    document.attachments.each do |attachment|
+      Services.asset_api.restore_asset(attachment.id_from_url)
+    end
+  end
+end

--- a/lib/republisher.rb
+++ b/lib/republisher.rb
@@ -31,7 +31,7 @@ module_function
         document_type: document_type,
         fields: [:content_id],
         per_page: 999999,
-      ).results.map(&:content_id)
+      )["results"].map { |r| r["content_id"] }
     end
   end
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -53,6 +53,8 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
       publishing_api_has_item_in_sequence(content_id, [item, published_item])
 
+      expect(AttachmentRestoreWorker).not_to receive(:perform_async)
+
       click_button "Publish"
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Published Example CMA Case")

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
     stub_publishing_api_publish(content_id, {})
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
     email_alert_api_accepts_alert
   end
 

--- a/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
+++ b/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.feature "Publishing a previously unpublished CMA Case", type: :feature do
+  let(:content_id) { item['content_id'] }
+
+  let(:existing_attachments) { [] }
+
+  let(:item) do
+    FactoryGirl.create(:cma_case,
+                       :unpublished,
+                       title: "Example CMA Case",
+                       publication_state: "draft",
+                       state_history: { "1" => "unpublished", "2" => "draft" },
+                       details:  { attachments: existing_attachments })
+  end
+
+  before do
+    log_in_as_editor(:cma_editor)
+
+    publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
+    publishing_api_has_item(item)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+    stub_publishing_api_publish(content_id, {})
+    stub_any_rummager_post_with_queueing_enabled
+    email_alert_api_accepts_alert
+
+    visit "/cma-cases/#{content_id}"
+  end
+
+  context "a new draft of a previously unpublished document with attachments" do
+    let(:existing_attachments) do
+      [
+        {
+          "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+          "content_type" => "application/jpeg",
+          "title" => "asylum report image title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
+        },
+        {
+          "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+          "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+          "content_type" => "application/pdf",
+          "title" => "asylum report pdf title",
+          "created_at" => "2015-12-03T16:59:13+00:00",
+          "updated_at" => "2015-12-03T16:59:13+00:00"
+        }
+      ]
+    end
+
+    describe "#publish" do
+      it "restores the assets via the asset api" do
+        expect(Services.asset_api).to receive(:restore_asset).once.ordered
+          .with("513a0efbed915d425e000002")
+        expect(Services.asset_api).to receive(:restore_asset).once.ordered
+          .with("513a0efbed915d425e000004")
+
+        Sidekiq::Testing.inline! { click_on "Publish" }
+      end
+    end
+  end
+
+  context "a new draft of a previously unpublished document without attachments" do
+    describe "#publish" do
+      it "doesn't call the asset api" do
+        expect(Services.asset_api).not_to receive(:restore_asset)
+
+        Sidekiq::Testing.inline! { click_on "Publish" }
+      end
+    end
+  end
+end

--- a/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
+++ b/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Publishing a previously unpublished CMA Case", type: :feature do
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
     stub_publishing_api_publish(content_id, {})
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
     email_alert_api_accepts_alert
 
     visit "/cma-cases/#{content_id}"

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -20,7 +20,9 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
     scenario "clicking the unpublish button redirects back to the show page" do
       visit document_path(content_id: content_id, document_type_slug: "cma-cases")
       expect(page).to have_content("Example CMA Case")
+
       click_button "Unpublish document"
+
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Unpublished Example CMA Case")
 
@@ -33,6 +35,54 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
       visit document_path(content_id: content_id, document_type_slug: "cma-cases")
 
       expect(page).to have_no_selector(:button, 'Unpublish document')
+    end
+
+    context "with attachments" do
+      let(:existing_attachments) {
+        [
+          {
+            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+            "content_type" => "application/jpeg",
+            "title" => "asylum report image title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00"
+          },
+          {
+            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+            "content_type" => "application/pdf",
+            "title" => "asylum report pdf title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00"
+          }
+        ]
+      }
+
+      let(:item) {
+        FactoryGirl.create(
+          :cma_case,
+          :published,
+          title: "Example CMA Case",
+          details: { "attachments" => existing_attachments }
+        )
+      }
+
+      scenario "clicking the unpublish button deletes document attachments" do
+        Sidekiq::Testing.inline! do
+          visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+
+          expect(Services.asset_api).to receive(:delete_asset).once.ordered
+            .with("513a0efbed915d425e000002")
+          expect(Services.asset_api).to receive(:delete_asset).once.ordered
+            .with("513a0efbed915d425e000004")
+
+          click_button "Unpublish document"
+
+          expect(page.status_code).to eq(200)
+          expect(page).to have_content("Unpublished Example CMA Case")
+        end
+      end
     end
   end
 

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -20,9 +20,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
     scenario "clicking the unpublish button redirects back to the show page" do
       visit document_path(content_id: content_id, document_type_slug: "cma-cases")
       expect(page).to have_content("Example CMA Case")
-
       click_button "Unpublish document"
-
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Unpublished Example CMA Case")
 

--- a/spec/lib/rummager_finder_publisher_spec.rb
+++ b/spec/lib/rummager_finder_publisher_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RummagerFinderPublisher do
   let(:test_logger) { Logger.new(nil) }
 
   before do
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
   end
 
   describe "#call" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -433,6 +433,12 @@ RSpec.describe Document do
       assert_rummager_deleted_content document.base_path
     end
 
+    it "deletes document attachments" do
+      expect(AttachmentDeleteWorker).to receive(:perform_async).with(payload["content_id"])
+
+      document.unpublish
+    end
+
     context "unsuccessful #unpublish" do
       it "notifies Airbrake and returns false if publishing-api does not return status 200" do
         expect(Airbrake).to receive(:notify)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Document do
       stub_any_publishing_api_patch_links
       stub_publishing_api_publish(document.content_id, {})
       publishing_api_has_item(payload)
-      stub_any_rummager_post_with_queueing_enabled
+      stub_any_rummager_post
       @email_alert_api = email_alert_api_accepts_alert
     end
 
@@ -411,7 +411,7 @@ RSpec.describe Document do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
       stub_publishing_api_publish(document.content_id, {}, status: 503)
-      stub_any_rummager_post_with_queueing_enabled
+      stub_any_rummager_post
       expect(document.publish).to eq(false)
     end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -348,6 +348,19 @@ RSpec.describe Document do
           assert_publishing_api_put_content(unpublished_document.content_id, request_json_includes(changed_json))
         end
       end
+
+      context "when the document has previously been unpublished" do
+        before do
+          document.state_history = { "1" => "unpublished", "2" => "draft" }
+        end
+
+        it "asynchronously restores attachments" do
+          expect(AttachmentRestoreWorker).to receive(:perform_async)
+            .with(document.content_id)
+
+          document.publish
+        end
+      end
     end
 
     shared_examples_for 'publishing changes to a document that has previously been published' do

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DrugSafetyUpdate do
 
       publishing_api_has_item(payload)
       stub_publishing_api_publish(payload["content_id"], {})
-      stub_any_rummager_post_with_queueing_enabled
+      stub_any_rummager_post
 
       document.publish
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,8 @@ RSpec.configure do |config|
   config.include(GdsApi::TestHelpers::Rummager)
   config.include(GdsApi::TestHelpers::EmailAlertApi)
 
+  GdsApi.config.always_raise_for_not_found = true
+
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.

--- a/spec/workers/attachment_delete_worker_spec.rb
+++ b/spec/workers/attachment_delete_worker_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe AttachmentDeleteWorker do
+  let(:existing_attachments) {
+    [
+      {
+        "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+        "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+        "content_type" => "application/jpeg",
+        "title" => "asylum report image title",
+        "created_at" => "2015-12-03T16:59:13+00:00",
+        "updated_at" => "2015-12-03T16:59:13+00:00"
+      },
+      {
+        "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+        "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+        "content_type" => "application/pdf",
+        "title" => "asylum report pdf title",
+        "created_at" => "2015-12-03T16:59:13+00:00",
+        "updated_at" => "2015-12-03T16:59:13+00:00"
+      }
+    ]
+  }
+
+  let(:content_id) { SecureRandom.uuid }
+
+  let!(:document) do
+    FactoryGirl.create(:cma_case,
+                       :published,
+                       content_id: content_id)
+  end
+
+  before do
+    document["details"]["attachments"] = existing_attachments
+    publishing_api_has_item(document)
+  end
+
+  describe "perform" do
+    it "calls delete_asset on the asset API for each attachment" do
+      expect(Services.asset_api).to receive(:delete_asset).once.ordered
+        .with("513a0efbed915d425e000002")
+      expect(Services.asset_api).to receive(:delete_asset).once.ordered
+        .with("513a0efbed915d425e000004")
+
+      subject.perform(content_id)
+    end
+  end
+end

--- a/spec/workers/attachment_restore_worker_spec.rb
+++ b/spec/workers/attachment_restore_worker_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe AttachmentRestoreWorker do
+  let(:existing_attachments) {
+    [
+      {
+        "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+        "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+        "content_type" => "application/jpeg",
+        "title" => "asylum report image title",
+        "created_at" => "2015-12-03T16:59:13+00:00",
+        "updated_at" => "2015-12-03T16:59:13+00:00"
+      },
+      {
+        "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+        "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+        "content_type" => "application/pdf",
+        "title" => "asylum report pdf title",
+        "created_at" => "2015-12-03T16:59:13+00:00",
+        "updated_at" => "2015-12-03T16:59:13+00:00"
+      }
+    ]
+  }
+
+  let(:content_id) { SecureRandom.uuid }
+
+  let!(:document) do
+    FactoryGirl.create(:cma_case,
+                       :published,
+                       content_id: content_id)
+  end
+
+  before do
+    document["details"]["attachments"] = existing_attachments
+    publishing_api_has_item(document)
+  end
+
+  describe "perform" do
+    it "calls delete_asset on the asset API for each attachment" do
+      expect(Services.asset_api).to receive(:restore_asset).once.ordered
+        .with("513a0efbed915d425e000002")
+      expect(Services.asset_api).to receive(:restore_asset).once.ordered
+        .with("513a0efbed915d425e000004")
+
+      subject.perform(content_id)
+    end
+  end
+end

--- a/spec/workers/rummager_worker_spec.rb
+++ b/spec/workers/rummager_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RummagerWorker do
   include GdsApi::TestHelpers::Rummager
 
   before do
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
   end
 
   around do |example|


### PR DESCRIPTION
https://trello.com/c/Vn2SpooI/279-document-attachments-still-visible-when-document-is-unpublished-large

This PR ensures that unpublishing a document with attachments will also make sure that the attachment assets are made unavailable on the asset API.
It also adds the logic to restore these assets when an unpublished document gets drafted and republished.
