### PR TITLE
Set BUNDLED_WITH to correct version of bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,4 +408,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.1
+   1.10.6


### PR DESCRIPTION
This app uses ruby 2.2.4 which is pinned to bundler 1.10.6 on our deployed
environments and in the dev VM.  (see: https://github.com/alphagov/govuk-puppet/blob/7e617c711ebc4cc2536465cac761b103f3c936c7/modules/govuk_rbenv/manifests/all.pp#L53-L55)

Setting BUNDLED_WITH to a different version causes warnings about bundler
being different and might cause problems so we pin it back to 1.10.6 in
the Gemfile.lock.  That's not to say we shouldn't upgrade the bundler used
in our environments for this version of ruby, but this fixes the issue for now.
