### PR TITLE
Change date field format

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -132,3 +132,17 @@ h2.with-actions {
     margin-bottom: 32px;
   }
 }
+
+.date-layout .row .col-md-2{
+  font-weight: normal;
+}
+
+.date-layout .form-hint {
+  color: #80858A;
+}
+// Two digit date form inputs are formatted 03 rather than 3. Using the spin buttons displayed single digit numbers (aka 3 rather than 03) which could be confusing to a user. The code below removes the spin buttons.
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -55,8 +55,9 @@ class DocumentsController < ApplicationController
   def update
     new_params = filtered_params(params[current_format.document_type])
 
-    new_params.each do |k, v|
-      @document.public_send(:"#{k}=", v)
+    new_params.each do |k|
+      key = k[0].gsub(/\(\di\)$/, "")
+      @document.public_send(:"#{key}=", Document.param_value(new_params, key))
     end
 
     if @document.valid?

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,7 @@
+module DateHelper
+  def date_value(measure, field)
+    if /^\d{4}-\d{2}-\d{2}$/ =~ field
+      sprintf('%02d', Date.strptime(field).public_send(measure))
+    end
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -55,12 +55,25 @@ class Document
     DocumentPolicy
   end
 
+  def self.param_value(params, key)
+    if params.has_key?(:"#{key.to_s}(1i)")
+      format_date = [
+        params.fetch(:"#{key.to_s}(1i)"),
+        params.fetch(:"#{key.to_s}(2i)"),
+        params.fetch(:"#{key.to_s}(3i)")
+      ]
+      format_date.delete_if(&:empty?).join("-")
+    else
+      params.fetch(key, nil)
+    end
+  end
+
   def initialize(params = {}, format_specific_fields = [])
     @content_id = params.fetch(:content_id, SecureRandom.uuid)
     @format_specific_fields = format_specific_fields
 
     (COMMON_FIELDS + format_specific_fields).each do |field|
-      public_send(:"#{field.to_s}=", params.fetch(field, nil))
+      public_send(:"#{field.to_s}=", self.class.param_value(params, field))
     end
 
     @change_history ||= ChangeHistory.new

--- a/app/views/metadata_fields/_aaib_reports.html.erb
+++ b/app/views/metadata_fields/_aaib_reports.html.erb
@@ -1,5 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
-  <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23', class: 'form-control' %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :date_of_occurrence, format: :aaib_report } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :aircraft_type } do %>
   <%= f.text_field :aircraft_type, class: 'form-control' %>

--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -38,12 +38,10 @@
                    class: 'form-control'
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_decision_date} do %>
-  <%= f.text_field :tribunal_decision_decision_date, placeholder: '2012-04-23', class: 'form-control' %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :asylum_support_decision } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: {f: f, field: :hidden_indexable_content} do %>
   <%= f.text_area :hidden_indexable_content,
                   class: 'form-control'
   %>
 <% end %>
-

--- a/app/views/metadata_fields/_cma_cases.html.erb
+++ b/app/views/metadata_fields/_cma_cases.html.erb
@@ -1,8 +1,6 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :opened_date } do %>
-  <%= f.text_field :opened_date, placeholder: '2012-04-23', class: 'form-control' %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :opened_date, format: :cma_case } do %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :closed_date } do %>
-  <%= f.text_field :closed_date, placeholder: '2013-10-19', class: 'form-control' %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :closed_date, format: :cma_case } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :case_type } do %>
   <%= f.select :case_type, facet_options(f, :case_type), {}, { class: 'form-control' } %>

--- a/app/views/metadata_fields/_dfid_research_outputs.html.erb
+++ b/app/views/metadata_fields/_dfid_research_outputs.html.erb
@@ -25,11 +25,8 @@
              { class: 'select2', multiple: true, data: { placeholder: 'Select themes' } }
   %>
 <% end %>
-
-<%= render layout: 'shared/form_group', locals: { f: f, field: :first_published_at, label: 'First published at' } do %>
-  <%= f.text_field :first_published_at, placeholder: '2012-04-23', class: 'form-control' %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :first_published_at, format: :dfid_research_output } do %>
 <% end %>
-
 <%= render layout: 'shared/form_group', locals: { f: f, field: :dfid_review_status, label: 'Review status' } do %>
   <%= f.select :dfid_review_status, dfid_review_status_options,
     {},

--- a/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
@@ -33,12 +33,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
-  <%= f.text_field :tribunal_decision_decision_date,
-      label: "Decision date",
-      placeholder: '2015-07-30',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :employment_appeal_tribunal_decision } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
   <%= f.text_area :hidden_indexable_content, class: 'form-control' %>

--- a/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
@@ -19,12 +19,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
-  <%= f.text_field :tribunal_decision_decision_date,
-      label: "Decision date",
-      placeholder: '2015-07-30',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :employment_tribunal_decision } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
   <%= f.text_area :hidden_indexable_content, class: 'form-control' %>

--- a/app/views/metadata_fields/_esi_funds.html.erb
+++ b/app/views/metadata_fields/_esi_funds.html.erb
@@ -38,9 +38,5 @@
       }
     %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :closing_date } do %>
-  <%= f.text_field :closing_date,
-      placeholder: '2018-10-19',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :closing_date, format: :esi_fund } do %>
 <% end %>

--- a/app/views/metadata_fields/_maib_reports.html.erb
+++ b/app/views/metadata_fields/_maib_reports.html.erb
@@ -1,8 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
-  <%= f.text_field :date_of_occurrence,
-      placeholder: '2012-04-23',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :date_of_occurrence, format: :maib_report } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :vessel_type } do %>
   <%= f.select :vessel_type,

--- a/app/views/metadata_fields/_medical_safety_alerts.html.erb
+++ b/app/views/metadata_fields/_medical_safety_alerts.html.erb
@@ -23,9 +23,5 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :issued_date } do %>
-  <%= f.text_field :issued_date,
-      placeholder: '2012-04-23',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :issued_date, format: :medical_safety_alert } do %>
 <% end %>

--- a/app/views/metadata_fields/_raib_reports.html.erb
+++ b/app/views/metadata_fields/_raib_reports.html.erb
@@ -1,8 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :date_of_occurrence } do %>
-  <%= f.text_field :date_of_occurrence,
-      placeholder: '2012-04-23',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :date_of_occurrence, format: :raib_report } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :railway_type } do %>
   <%= f.select :railway_type,

--- a/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
@@ -5,12 +5,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
-  <%= f.text_field :tribunal_decision_decision_date,
-      label: "Release date",
-      placeholder: '2015-07-30',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :tax_tribunal_decision } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
   <%= f.text_area :hidden_indexable_content,

--- a/app/views/metadata_fields/_utaac_decisions.html.erb
+++ b/app/views/metadata_fields/_utaac_decisions.html.erb
@@ -31,11 +31,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_decision_date } do %>
-    <%= f.text_field :tribunal_decision_decision_date,
-         placeholder: '2015-07-30',
-         class: 'form-control'
-    %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :utaac_decision } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
     <%= f.text_area :hidden_indexable_content,

--- a/app/views/metadata_fields/_vehicle_recalls_and_faults_alerts.html.erb
+++ b/app/views/metadata_fields/_vehicle_recalls_and_faults_alerts.html.erb
@@ -7,11 +7,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :alert_issue_date} do %>
-  <%= f.text_field :alert_issue_date,
-      placeholder: Date.today.to_s,
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :alert_issue_date, format: :vehicle_recalls_and_faults_alert } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :faulty_item_type} do %>
   <%= f.select :faulty_item_type,
@@ -47,15 +43,7 @@
       label: "Serial number/Vehicle ID"
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :build_start_date} do %>
-  <%= f.text_field :build_start_date,
-      placeholder: '2014-07-12',
-      class: 'form-control'
-  %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :build_start_date, format: :vehicle_recalls_and_faults_alert } do %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :build_end_date} do %>
-    <%= f.text_field :build_end_date,
-        placeholder: '2014-10-15',
-        class: 'form-control'
-    %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :build_end_date, format: :vehicle_recalls_and_faults_alert } do %>
 <% end %>

--- a/app/views/shared/_date_fields.html.erb
+++ b/app/views/shared/_date_fields.html.erb
@@ -1,0 +1,22 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: field } do %>
+<% date = @document.public_send(field) %>
+  <div class="date-layout">
+    <p class="form-hint">For example, 2013 03 20</p>
+    <div class="row">
+      <%= f.label :name, 'Year', class: "col-md-2" %>
+      <%= f.label :name, 'Month', class: "col-md-2" %>
+      <%= f.label :name, 'Day', class: "col-md-2" %>
+    </div>
+    <div class="form-group row">
+      <div class="col-md-2">
+        <%= f.text_field field, name: "[#{format}]#{field}(1i)", class: 'form-control', placeholder: '2013', value: date_value("year", date), type: "number" %>
+      </div>
+      <div class="col-md-2">
+        <%= f.text_field field, name: "[#{format}]#{field}(2i)", class: 'form-control', placeholder: '03', value: date_value("month", date), type: "number" %>
+      </div>
+      <div class="col-md-2">
+        <%= f.text_field field, name: "[#{format}]#{field}(3i)", class: "form-control", placeholder: '20', value: date_value("day", date), type: "number" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -41,7 +41,9 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 2)
-    fill_in "Opened date", with: "2014-01-01"
+    fill_in "[cma_case]opened_date(1i)", with: "2014"
+    fill_in "[cma_case]opened_date(2i)", with: "01"
+    fill_in "[cma_case]opened_date(3i)", with: "01"
     select "Energy", from: "Market sector"
 
     expect(page).to have_css('div.govspeak-help')
@@ -121,7 +123,9 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "<script>alert('hello')</script>"
-    fill_in "Opened date", with: "Not a date"
+    fill_in "[cma_case]opened_date(1i)", with: "22222000000111111666"
+    fill_in "[cma_case]opened_date(2i)", with: "2223333444"
+    fill_in "[cma_case]opened_date(3i)", with: "1112223333"
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -142,8 +146,12 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "Body of text"
-    fill_in "Opened date", with: "2016-02-14"
-    fill_in "Closed date", with: "2015-02-14"
+    fill_in "[cma_case]opened_date(1i)", with: "2016"
+    fill_in "[cma_case]opened_date(2i)", with: "02"
+    fill_in "[cma_case]opened_date(3i)", with: "14"
+    fill_in "[cma_case]closed_date(1i)", with: "2015"
+    fill_in "[cma_case]closed_date(2i)", with: "02"
+    fill_in "[cma_case]closed_date(3i)", with: "14"
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -163,8 +171,12 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "Body of text"
-    fill_in "Opened date", with: ""
-    fill_in "Closed date", with: "2015-02-14"
+    fill_in "[cma_case]opened_date(1i)", with: ""
+    fill_in "[cma_case]opened_date(2i)", with: ""
+    fill_in "[cma_case]opened_date(3i)", with: ""
+    fill_in "[cma_case]closed_date(1i)", with: "2015"
+    fill_in "[cma_case]closed_date(2i)", with: "02"
+    fill_in "[cma_case]closed_date(3i)", with: "14"
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -180,8 +192,12 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "Body of text"
-    fill_in "Opened date", with: "2015-02-14"
-    fill_in "Closed date", with: ""
+    fill_in "[cma_case]opened_date(1i)", with: "2015"
+    fill_in "[cma_case]opened_date(2i)", with: "02"
+    fill_in "[cma_case]opened_date(3i)", with: "14"
+    fill_in "[cma_case]closed_date(1i)", with: ""
+    fill_in "[cma_case]closed_date(2i)", with: ""
+    fill_in "[cma_case]closed_date(3i)", with: ""
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -197,8 +213,12 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "Body of text"
-    fill_in "Opened date", with: ""
-    fill_in "Closed date", with: ""
+    fill_in "[cma_case]opened_date(1i)", with: ""
+    fill_in "[cma_case]opened_date(2i)", with: ""
+    fill_in "[cma_case]opened_date(3i)", with: ""
+    fill_in "[cma_case]closed_date(1i)", with: ""
+    fill_in "[cma_case]closed_date(2i)", with: ""
+    fill_in "[cma_case]closed_date(3i)", with: ""
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -214,7 +234,10 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "At veroeos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 2)
-    fill_in "Opened date", with: "2014-01-01"
+    fill_in "[cma_case]opened_date(1i)", with: "2014"
+    fill_in "[cma_case]opened_date(2i)", with: "01"
+    fill_in "[cma_case]opened_date(3i)", with: "01"
+
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -30,7 +30,9 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
     fill_in "Title", with: title
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
-    fill_in "First published at", with: "2013-01-01"
+    fill_in "[dfid_research_output]first_published_at(1i)", with: "2013"
+    fill_in "[dfid_research_output]first_published_at(2i)", with: "01"
+    fill_in "[dfid_research_output]first_published_at(3i)", with: "01"
     select "Book Chapter", from: "Document type"
     select "Infrastructure", from: "Themes"
     select "Peer reviewed", from: "Review status"

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -32,7 +32,9 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
       fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example Employment appeal tribunal decision" * 10))
       select "Age Discrimination", from: "Tribunal decision categories"
       select "Contract of Employment - Apprenticeship", from: "Tribunal decision sub categories"
-      fill_in "Tribunal decision decision date", with: "2013-01-01"
+      fill_in "[employment_appeal_tribunal_decision]tribunal_decision_decision_date(1i)", with: "2013"
+      fill_in "[employment_appeal_tribunal_decision]tribunal_decision_decision_date(2i)", with: "01"
+      fill_in "[employment_appeal_tribunal_decision]tribunal_decision_decision_date(3i)", with: "01"
       select "Not landmark", from: "Tribunal decision landmark"
       fill_in "Hidden indexable content", with: "hidden text goes here"
 

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -58,7 +58,9 @@ RSpec.feature "Editing a CMA case", type: :feature do
     fill_in "Title", with: "Changed title"
     fill_in "Summary", with: "Changed summary"
     fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 2)
-    fill_in "Opened date", with: "2014-01-01"
+    fill_in "[cma_case]opened_date(1i)", with: "2014"
+    fill_in "[cma_case]opened_date(2i)", with: "01"
+    fill_in "[cma_case]opened_date(3i)", with: "01"
     select "Energy", from: "Market sector"
 
     expect(page).to have_css('div.govspeak-help')
@@ -238,7 +240,9 @@ RSpec.feature "Editing a CMA case", type: :feature do
     fill_in "Title", with: "Changed title"
     fill_in "Summary", with: "Changed summary"
     fill_in "Body", with: "<script>alert('hello')</script>"
-    fill_in "Opened date", with: "Not a date"
+    fill_in "[cma_case]opened_date(1i)", with: "not"
+    fill_in "[cma_case]opened_date(2i)", with: "a"
+    fill_in "[cma_case]opened_date(3i)", with: "date"
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -26,7 +26,9 @@ RSpec.feature "Editing a DFID Research Output", type: :feature do
     fill_in "Title", with: title
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example DFID research output" * 10))
-    fill_in "First published at", with: "2013-01-01"
+    fill_in "[dfid_research_output]first_published_at(1i)", with: "2013"
+    fill_in "[dfid_research_output]first_published_at(2i)", with: "01"
+    fill_in "[dfid_research_output]first_published_at(3i)", with: "01"
     select "United Kingdom", from: "Countries"
     select "Book Chapter", from: "Document type"
 

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -23,7 +23,12 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       fill_in "Title", with: "Example CMA Case"
       fill_in "Summary", with: "This is the summary of an example CMA case"
       fill_in "Body", with: "## Header" + ("\n\nThis is the long body of an example CMA case" * 2)
-      fill_in "Opened date", with: "2014-01-01"
+      fill_in "[cma_case]opened_date(1i)", with: "2014"
+      fill_in "[cma_case]opened_date(2i)", with: "01"
+      fill_in "[cma_case]opened_date(3i)", with: "01"
+      fill_in "[cma_case]closed_date(1i)", with: "2015"
+      fill_in "[cma_case]closed_date(2i)", with: "01"
+      fill_in "[cma_case]closed_date(3i)", with: "01"
       select "Energy", from: "cma_case_market_sector", visible: false # The hidden select2 select element
     end
 
@@ -100,7 +105,9 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       fill_in "Title", with: "Amended example document"
       fill_in "Summary", with: "This is an update to the summary of an example CMA case"
       fill_in "Body", with: "## Header" + ("\n\nThis is the updated body text of an example CMA case" * 2)
-      fill_in "Opened date", with: "2014-02-02"
+      fill_in "[cma_case]opened_date(1i)", with: "2014"
+      fill_in "[cma_case]opened_date(2i)", with: "02"
+      fill_in "[cma_case]opened_date(3i)", with: "02"
       select "Energy", from: "cma_case_market_sector", visible: false # The hidden select2 select element
     end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Document do
     expect(MyDocumentType.document_type).to eq("my_document_type")
   end
 
+  describe "parsing date params" do
+    it "sets a date string from rails date select style params" do
+      doc = MyDocumentType.new("field1(1i)": "2016", "field1(2i)": "09", "field1(3i)": "07")
+      expect(doc.field1).to eq("2016-09-07")
+    end
+  end
+
   describe ".all" do
     it "makes a request to the publishing api with the correct params" do
       publishing_api = double(:publishing_api)


### PR DESCRIPTION
[Trello](https://trello.com/c/xbySvXdM/278-improve-date-field-to-be-more-user-friendly-medium)
- Improve date fields to be more user friendly

Before:

<img width="815" alt="dates-creating-new-aaib-previous-way" src="https://cloud.githubusercontent.com/assets/5963488/19272838/0f56b528-8fc2-11e6-8d09-c42ac1ed0e6c.png">

After:

<img width="610" alt="dates-creating-new-aaib-report-new-look" src="https://cloud.githubusercontent.com/assets/5963488/19272848/19ec9f0c-8fc2-11e6-92e9-a7353b456c69.png">

Based on the styling of [memorable dates](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/dates.html#memorable-dates) but styled to fit with Specialist Publisher's look.
