### PR TITLE
Validation for dates which do not exist

### DIFF
--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,21 +1,7 @@
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, error_message) unless parsable_date?(value)
-  end
-
-private
-
-  def parsable_date?(date_string)
-    date_string =~ iso8601_regex && Date.parse(date_string)
-  rescue ArgumentError
-    false
-  end
-
-  def iso8601_regex
-    /\A[0-9]{4}\-[0-9]{2}\-[0-9]{2}\z/
-  end
-
-  def error_message
-    options[:message] || "should be formatted YYYY-MM-DD"
+    Date.parse(value)
+  rescue ArgumentError, RangeError
+    record.errors.add(attribute, "is not a valid date")
   end
 end

--- a/app/views/shared/_date_fields.html.erb
+++ b/app/views/shared/_date_fields.html.erb
@@ -12,10 +12,10 @@
         <%= f.text_field field, name: "[#{format}]#{field}(1i)", class: 'form-control', placeholder: '2013', value: date_value("year", date), type: "number" %>
       </div>
       <div class="col-md-2">
-        <%= f.text_field field, name: "[#{format}]#{field}(2i)", class: 'form-control', placeholder: '03', value: date_value("month", date), type: "number" %>
+        <%= f.text_field field, name: "[#{format}]#{field}(2i)", class: 'form-control', placeholder: '03', value: date_value("month", date), type: "number", min: '0', max: '12' %>
       </div>
       <div class="col-md-2">
-        <%= f.text_field field, name: "[#{format}]#{field}(3i)", class: "form-control", placeholder: '20', value: date_value("day", date), type: "number" %>
+        <%= f.text_field field, name: "[#{format}]#{field}(3i)", class: "form-control", placeholder: '20', value: date_value("day", date), type: "number", min: '0', max: '31' %>
       </div>
     </div>
   </div>

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -119,9 +119,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
     fill_in "Body", with: "<script>alert('hello')</script>"
-    fill_in "[cma_case]opened_date(1i)", with: "22222000000111111666"
-    fill_in "[cma_case]opened_date(2i)", with: "2223333444"
-    fill_in "[cma_case]opened_date(3i)", with: "1112223333"
     select "Energy", from: "Market sector"
 
     click_button "Save as draft"
@@ -132,8 +129,29 @@ RSpec.feature "Creating a CMA case", type: :feature do
     expect(page).to have_css('.elements-error-message')
 
     expect(page).to have_content("Please fix the following errors")
-    expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
     expect(page).to have_content("Body cannot include invalid Govspeak")
+  end
+
+  scenario "with an invalid date" do
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example CMA Case"
+    fill_in "Summary", with: "This is the summary of an example CMA case"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+    fill_in "[cma_case]opened_date(1i)", with: "2016"
+    fill_in "[cma_case]opened_date(2i)", with: "2"
+    fill_in "[cma_case]opened_date(3i)", with: "31"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css('.elements-error-summary')
+    expect(page).to have_css('.elements-error-message')
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Opened date is not a valid date")
   end
 
   scenario "with closed date before opened date" do

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -245,7 +245,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
     expect(page).to have_css('.elements-error-summary')
     expect(page).to have_css('.elements-error-message')
 
-    expect(page).to have_content("Opened date should be formatted YYYY-MM-DD")
+    expect(page).to have_content("Opened date is not a valid date")
     expect(page).to have_content("Body cannot include invalid Govspeak")
     expect(page).to have_content("Please fix the following errors")
 

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe DateValidator do
+  describe "#validate_each" do
+    let(:record) { double(:record) }
+    let(:errors) { ActiveModel::Errors.new(record) }
+    before { allow(record).to receive(:errors).and_return(errors) }
+
+    subject { described_class.new(attributes: [:dob]) }
+
+    it "adds an error to the record if the date value is unparseable" do
+      subject.validate_each(record, :dob, "31-02-2013")
+      expect(record.errors[:dob]).to eq(["is not a valid date"])
+    end
+
+    it "adds an error to the record if the date value contains large integer values" do
+      subject.validate_each(record, :dob, "31236445328465236254-023646452342-2013342942867428964")
+      expect(record.errors[:dob]).to eq(["is not a valid date"])
+    end
+
+    it "doesn't add an error if the date value can be parsed" do
+      subject.validate_each(record, :dob, "25-02-2013")
+      expect(record.errors).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
- Product manager noticed that if she added a date such as '31 Feb 2016' (which is obviously a wrong date), the error "something went wrong" displayed

This PR:
- limits the range of numbers that can be entered into the date form fields
- Gives a validation error if a date is not valid
- We have discussed that this could be further improved by not forcing the user to enter the format yyyy-mm-dd. We should allow single digits to be entered for day and month to improve user experience. This PR serves as a quick fix for now and will be further improved at a later date.
