### PR TITLE
Add the ability to discard a draft

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails s -p 3123
+web: bundle exec rails s -p 3064
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Publishing App for Specialist Documents and Manuals.
 
 ## Nomenclature
 
-
 - **Format**: Category of a Document. Format names are listed in the `Live Examples` section above and include `MAIB Reports` and `CMA Cases`.
 - **Finder**:  Sometimes Formats are referred to as Finders. They are called 'Finders' because each one of them creates a finder on GOV.UK, e.g. https://www.gov.uk/raib-reports. The formats are served by [Finder Frontend](https://github.com/alphagov/finder-frontend).
 - **Document**: Specialist Documents are created by Government editors and can be published to gov.uk. Documents differ from each other depending on their format. These differences are largely determined by what is contained in the [schema](https://github.com/alphagov/specialist-publisher-rebuild/blob/add-dfid-review-status/lib/documents/schemas/aaib_reports.json) of a format.

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
-  before_action :fetch_document, only: [:edit, :show, :publish, :update, :unpublish]
+  before_action :fetch_document, except: [:index, :new, :create]
   before_action :check_authorisation, if: :document_type_slug
 
   def check_authorisation
@@ -90,6 +90,15 @@ class DocumentsController < ApplicationController
       flash[:danger] = "There was an error unpublishing #{@document.title}. Please try again later."
     end
     redirect_to document_path(current_format.slug, params[:content_id])
+  end
+
+  def discard
+    if @document.discard
+      flash[:success] = "Discarded draft of #{@document.title}"
+    else
+      flash[:danger] = "There was an error discarding draft of #{@document.title}. Please try again later."
+    end
+    redirect_to documents_path(current_format.slug)
   end
 
 private

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -16,6 +16,7 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   alias_method :unpublish?, :publish?
+  alias_method :discard?, :publish?
 
   def user_organisation_owns_document_type?
     document_class.organisations.include?(user.organisation_content_id)

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -77,6 +77,30 @@ class ActionsPresenter
     unpublish_document_path(slug, document.content_id)
   end
 
+  def discard_button_visible?
+    policy.discard? && document.draft?
+  end
+
+  def discard_text
+    if state != "draft"
+      text = "<p>There is no draft to discard.</p>"
+    elsif !policy.discard?
+      text = "<p>You don't have permission to discard this draft.</p>"
+    else
+      text = "<p>This draft will be discarded.</p>"
+    end
+
+    text.html_safe
+  end
+
+  def discard_alert
+    "Are you sure you want to discard this draft?"
+  end
+
+  def discard_path
+    discard_document_path(slug, document.content_id)
+  end
+
 private
 
   def state

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -35,5 +35,19 @@
         <% end %>
       </div>
     <% end %>
+
+    <%= form_tag(presenter.discard_path, method: :post, class: 'panel panel-default') do %>
+      <div class="panel-heading"><h3 class="panel-title">Discard draft</h3></div>
+      <div class="panel-body">
+        <%= presenter.discard_text %>
+
+        <% if presenter.discard_button_visible? %>
+          <button name="submit" class="btn btn-warning"
+                  data-module="confirm"
+                  data-message="<%= presenter.discard_alert %>"
+                  data-disable-with="Discarding draft..." >Discard draft</button>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
     post :unpublish, on: :member
     post :publish, on: :member
+    post :discard, on: :member
   end
 
   root to: 'passthrough#index'

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -16,4 +16,15 @@ RSpec.describe DocumentsController, type: :controller do
       expect(response.status).to eq(200)
     end
   end
+
+  describe "POST discard" do
+    before do
+      stub_publishing_api_discard_draft(payload["content_id"])
+    end
+
+    it "responds successfully" do
+      post :discard, document_type_slug: "cma-cases", content_id: payload["content_id"]
+      expect(subject).to redirect_to(documents_path(document_type_slug: "cma-cases"))
+    end
+  end
 end

--- a/spec/features/discarding_a_draft_cma_case_spec.rb
+++ b/spec/features/discarding_a_draft_cma_case_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.feature "Discarding a draft CMA Case", type: :feature do
+  let(:content_id) { item['content_id'] }
+
+  before do
+    publishing_api_has_item(item)
+    stub_publishing_api_discard_draft(content_id)
+    publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
+    stub_any_rummager_delete_content
+  end
+
+  context "a draft document" do
+    let(:item) {
+      FactoryGirl.create(:cma_case,
+        title: "Example CMA Case",
+        publication_state: "draft")
+    }
+
+    context "as a CMA editor" do
+      scenario "clicking the discard button discards the draft" do
+        log_in_as_editor(:cma_editor)
+        visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+        expect(page).to have_content("Example CMA Case")
+        click_button "Discard draft"
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("Discarded draft of Example CMA Case")
+
+        assert_publishing_api_discard_draft(content_id)
+        expect(current_path).to eq(documents_path(document_type_slug: "cma-cases"))
+      end
+    end
+
+    context "as a writer" do
+      scenario "no discard draft button is visible" do
+        log_in_as_editor(:cma_writer)
+        visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+
+        expect(page).to have_content("You don't have permission to discard this draft")
+        expect(page).to have_no_selector(:button, "Discard draft")
+      end
+    end
+  end
+
+  context "a published document with no draft" do
+    let(:item) {
+      FactoryGirl.create(:cma_case,
+        title: "Example CMA Case",
+        publication_state: "published")
+    }
+
+    scenario "where no draft exists" do
+      log_in_as_editor(:cma_editor)
+      visit document_path(content_id: content_id, document_type_slug: "cma-cases")
+
+      expect(page).to have_content("There is no draft to discard")
+      expect(page).to have_no_selector(:button, "Discard draft")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/DBcnCdvK/291-let-editors-discard-drafts-medium

Users can discard a draft document from the document show page if they are an GDS or organisational editor and a draft of the document exists.
