### PR TITLE
Warn user if document path is already taken

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -113,7 +113,6 @@ private
       list_items = @document.errors.full_messages.map do |message|
         content_tag(:li, message.html_safe)
       end
-
       list_items.join.html_safe
     end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -34,21 +34,23 @@ class DocumentsController < ApplicationController
       filtered_params(params[current_format.document_type])
     )
 
-    if @document.valid?
-      if @document.save
-        flash[:success] = "Created #{@document.title}"
-        redirect_to document_path(current_format.slug, @document.content_id)
-      else
-        flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
-        render :new
-      end
-    else
+    if @document.save
+      flash[:success] = "Created #{@document.title}"
+      redirect_to document_path(current_format.slug, @document.content_id)
+    elsif @document.errors.any?
       flash.now[:errors] = document_error_messages
       render :new, status: 422
+    else
+      flash.now[:danger] = "There was an error creating #{@document.title}. Please try again later."
+      render :new
     end
   end
 
-  def show; end
+  def show
+    if @document.content_item_blocking_publish?
+      flash[:danger] = "Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title."
+    end
+  end
 
   def edit; end
 

--- a/app/helpers/publishing_helper.rb
+++ b/app/helpers/publishing_helper.rb
@@ -4,7 +4,7 @@ module PublishingHelper
       block.call
       true
     rescue GdsApi::HTTPErrorResponse => e
-      @publishable.errors.add(:base, e.message) if @publishable
+      error_response_message(:base, e.message) if @publishable
       Airbrake.notify(e)
       false
     end
@@ -17,5 +17,13 @@ module PublishingHelper
     end
 
     @publishable = obj
+  end
+
+  def error_response_message(key, message)
+    if message.include? "conflicts with content_id"
+      @publishable.errors.add(key, "Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title.")
+    else
+      @publishable.errors.add(:base, message)
+    end
   end
 end

--- a/app/helpers/publishing_helper.rb
+++ b/app/helpers/publishing_helper.rb
@@ -4,8 +4,18 @@ module PublishingHelper
       block.call
       true
     rescue GdsApi::HTTPErrorResponse => e
+      @publishable.errors.add(:base, e.message) if @publishable
       Airbrake.notify(e)
       false
     end
+  end
+
+  def set_errors_on(obj)
+    unless obj.class.include?(ActiveModel::Validations)
+      raise ArgumentError.new(
+        "Can only set errors on an object which includes ActiveModel::Validations")
+    end
+
+    @publishable = obj
   end
 end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -359,4 +359,20 @@ RSpec.feature "Creating a CMA case", type: :feature do
       expect(page).not_to have_content("some text")
     end
   end
+
+  scenario "a draft with the same path as an existing draft" do
+    stub_any_publishing_api_put_content.to_raise(
+      GdsApi::HTTPErrorResponse.new(422, "Content item base path=/cma-cases/example-document conflicts with content_id=#{content_id} and locale=en"))
+
+    visit "/cma-cases/new"
+
+    fill_in "Title", with: "Example document"
+    fill_in "Summary", with: "An explanation"
+    fill_in "Body", with: "Some text"
+    select "Energy", from: "Market sector"
+
+    click_button "Save as draft"
+
+    expect(page).to have_content(%r{Content item base path=/cma-cases/example-document conflicts})
+  end
 end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -373,6 +373,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     click_button "Save as draft"
 
-    expect(page).to have_content(%r{Content item base path=/cma-cases/example-document conflicts})
+    expect(page).to have_content("Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title.")
   end
 end

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -253,4 +253,18 @@ RSpec.feature "Viewing a specific case", type: :feature do
       end
     end
   end
+
+  context "when a published item exists with the same base path" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:draft) { FactoryGirl.create(:cma_case, content_id: content_id, title: "Example draft", base_path: "/cma-cases/foo") }
+
+    scenario "displays warnings" do
+      stub_request(:get, %r{/v2/content/#{content_id}})
+        .to_return(status: 200, body: draft.merge(warnings: { "content_item_blocking_publish" => true }).to_json)
+
+      visit "/cma-cases/#{content_id}"
+
+      expect(page).to have_content("Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title.")
+    end
+  end
 end

--- a/spec/helpers/publishing_helper_spec.rb
+++ b/spec/helpers/publishing_helper_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe PublishingHelper, type: :helper do
+  class SomeDocumentType; include ActiveModel::Validations; end
+  let(:document) { SomeDocumentType.new }
+  let(:http_error) { GdsApi::HTTPErrorResponse.new(422, "boom!") }
+
+  describe "#handle_remote_error" do
+    it "calls the given block" do
+      expect(document).to receive(:publish!).once
+
+      handled = handle_remote_error do
+        document.publish!
+      end
+
+      expect(handled).to be true
+    end
+
+    it "rescues GdsApi::HTTPErrorResponse exceptions" do
+      allow(document).to receive(:explode!).and_raise(http_error)
+      expect(Airbrake).to receive(:notify).with(http_error)
+
+      handled = handle_remote_error do
+        document.explode!
+      end
+
+      expect(handled).to be false
+    end
+  end
+
+  describe "#set_errors_on", type: :helper do
+    it "assigns an object which can be used to store errors" do
+      allow(document).to receive(:errors).and_return(ActiveModel::Errors.new(document))
+      allow(document).to receive(:explode!).and_raise(http_error)
+      expect(Airbrake).to receive(:notify).with(http_error)
+
+      handled = handle_remote_error do
+        set_errors_on(document)
+        document.explode!
+      end
+
+      expect(document.errors[:base]).to eq(["boom!"])
+      expect(handled).to be false
+    end
+
+    it "only assigns instances of ActiveModel" do
+      expect { set_errors_on(double(:thing)) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -758,4 +758,54 @@ RSpec.describe Document do
       expect(subject.first_draft?).to eq(false)
     end
   end
+
+  context "saving a draft where another draft has the same base_path" do
+    before do
+      stub_any_publishing_api_put_content
+        .to_raise(GdsApi::HTTPErrorResponse.new(422, "base path=/foo/bar conflicts with content_id=123"))
+    end
+
+    subject do
+      MyDocumentType.new(title: "A document",
+                         summary: "An introduction",
+                         body: "Some text")
+    end
+
+    it "cannot be saved" do
+      expect(subject.save).to be false
+    end
+
+    it "populates an error on the document" do
+      subject.save
+      expect(subject.errors[:base]).to eq(["base path=/foo/bar conflicts with content_id=123"])
+    end
+  end
+
+  context "a draft where a published item has the same base_path" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:published) { FactoryGirl.create(:document, document_type: "my_document_type", content_id: content_id) }
+
+    before do
+      stub_request(:get, %r{/v2/content/#{content_id}})
+        .to_return(status: 200,
+                   body: published.merge(warnings: { "content_item_blocking_publish" => "foo" }).to_json)
+    end
+
+    subject { described_class.find(content_id) }
+
+    it "cannot be published" do
+      expect(subject.publish).to be false
+    end
+
+    it "populates warnings on the document" do
+      expect(subject.warnings).to eq("content_item_blocking_publish" => "foo")
+    end
+
+    it "can be saved" do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      subject.update_type = "minor"
+      expect(subject.save).to be true
+    end
+  end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -777,7 +777,7 @@ RSpec.describe Document do
 
     it "populates an error on the document" do
       subject.save
-      expect(subject.errors[:base]).to eq(["base path=/foo/bar conflicts with content_id=123"])
+      expect(subject.errors[:base]).to eq(["Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title."])
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/xiUYc6Y1/280-warn-the-user-and-disable-publish-if-a-document-s-path-is-already-taken-medium

There are a couple of scenarios where Specialist Publisher may attempt to save a draft with a path that is already taken:
1. A draft is present in the Publishing API with the same `base_path`
2. A published item is present in the Publishing API with the same `base_path`

In the case of a draft being present, the Publishing API responds with an error, in the case of a publishing item being present a warning is returned as part of a successful response.

This PR attempts to propagate these errors and warnings to the editor or writer by storing them on the document and displaying as part of the relevant interaction in the UI.
