### PR TITLE
Avoid date parsing when re-presenting date input

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,7 +1,7 @@
 module DateHelper
   def date_value(measure, field)
-    if /^\d{4}-\d{2}-\d{2}$/ =~ field
-      sprintf('%02d', Date.strptime(field).public_send(measure))
-    end
+    return if field.blank?
+    year, month, day = field.split("-")
+    { "year" => year, "month" => month, "day" => day }[measure]
   end
 end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -137,9 +137,9 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
     fill_in "Title", with: "Example CMA Case"
     fill_in "Summary", with: "This is the summary of an example CMA case"
-    fill_in "Body", with: "<script>alert('hello')</script>"
+    fill_in "Body", with: "Something"
     fill_in "[cma_case]opened_date(1i)", with: "2016"
-    fill_in "[cma_case]opened_date(2i)", with: "2"
+    fill_in "[cma_case]opened_date(2i)", with: "02"
     fill_in "[cma_case]opened_date(3i)", with: "31"
     select "Energy", from: "Market sector"
 


### PR DESCRIPTION
Date validation is done elsewhere in the `Document` model so
avoid parsing the form/record value when refilling date fields.
The date may be nonsensical in which case we want the `DateValidator`
to catch this.
