### PR TITLE
Allow multiple values for tribunal_decision_category in Asylum Finder

### DIFF
--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -1,19 +1,21 @@
 class AsylumSupportDecision < Document
-  validates :tribunal_decision_category, presence: true
+  validates :tribunal_decision_categories, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_judges, presence: true
   validates :tribunal_decision_landmark, presence: true
   validates :tribunal_decision_reference_number, presence: true
-  validates :tribunal_decision_sub_category, presence: true, asylum_support_decision_sub_category: true
+  validates :tribunal_decision_sub_categories, presence: true, asylum_support_decision_sub_category: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
       hidden_indexable_content
       tribunal_decision_category
+      tribunal_decision_categories
       tribunal_decision_decision_date
       tribunal_decision_judges
       tribunal_decision_landmark
       tribunal_decision_reference_number
       tribunal_decision_sub_category
+      tribunal_decision_sub_categories
   ).freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/validators/asylum_support_decision_sub_category_validator.rb
+++ b/app/validators/asylum_support_decision_sub_category_validator.rb
@@ -1,6 +1,6 @@
 class AsylumSupportDecisionSubCategoryValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, error_message) unless related_sub_category?(record.tribunal_decision_category, value)
+    record.errors.add(attribute, error_message) unless related_sub_category?(record.tribunal_decision_categories, value)
   end
 
 private

--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -1,15 +1,27 @@
 <%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_category} do %>
   <%= f.select :tribunal_decision_category,
-     f.object.facet_options(:tribunal_decision_category),
+     f.object.facet_options(:tribunal_decision_categories),
      {},
-     {class: 'form-control'}
+     {
+         class: 'select2 form-control',
+         multiple: true,
+         data: {
+             placeholder: 'Select judges'
+         }
+     }
   %>
 <% end %>
 <%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_sub_category} do %>
   <%= f.select :tribunal_decision_sub_category,
-     f.object.facet_options(:tribunal_decision_sub_category),
+     f.object.facet_options(:tribunal_decision_sub_categories),
      {},
-     {class: 'form-control'}
+     {
+         class: 'select2 form-control',
+         multiple: true,
+         data: {
+             placeholder: 'Select judges'
+         }
+     }
   %>
 <% end %>
 <%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_judges} do %>

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -173,12 +173,12 @@ FactoryGirl.define do
       default_metadata {
         {
           "hidden_indexable_content" => "some hidden content",
-          "tribunal_decision_category" => "section-95-support-for-asylum-seekers",
+          "tribunal_decision_categories" => ["section-95-support-for-asylum-seekers"],
           "tribunal_decision_decision_date" => "2015-10-10",
           "tribunal_decision_judges" => ["bayati-c"],
           "tribunal_decision_landmark" => "not-landmark",
           "tribunal_decision_reference_number" => "1234567890",
-          "tribunal_decision_sub_category" => "section-95-destitution",
+          "tribunal_decision_sub_categories" => ["section-95-destitution"],
         }
       }
     end


### PR DESCRIPTION
Amend the asylum finder category and sub category to allow multiple
types
