### PR TITLE
Test that email alerts are configured correctly

### DIFF
--- a/spec/finders/email_alert_configuration_spec.rb
+++ b/spec/finders/email_alert_configuration_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe "Email alert configuration" do
+  all_finders = Dir["lib/documents/schemas/*.json"].map do |filename|
+    JSON.parse(File.read(filename))
+  end
+
+  all_finders.each do |finder|
+    describe "Finder configuration for #{finder['name']}" do
+      next unless finder["email_filter_by"]
+
+      it "only allows people to sign up to alerts that exist" do
+        facet_used_to_email_things = finder["facets"].find do |facet|
+          facet["key"] == finder["email_filter_by"]
+        end
+
+        actually_possible_keys_for_which_emails_will_be_sent = facet_used_to_email_things["allowed_values"].map do |allowed_value|
+          allowed_value["value"]
+        end
+
+        finder["email_signup_choice"].each do |choice|
+          expect(choice["key"]).to be_in(actually_possible_keys_for_which_emails_will_be_sent)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We currently don't test that the "keys" to which a user can subscribe are actually valid. If one of the keys is mistyped or the original value removed, this would result in people being subscribed to subjects for which an email will never be sent.

Having this test would make me confident that https://github.com/alphagov/specialist-publisher/pull/926 is doing the right thing.
