### PR TITLE
Restrict attachment filetypes

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -21,6 +21,11 @@ class Attachment < Document
     @being_updated = false
   end
 
+  def self.valid_filetype?(file)
+    extension = File.extname(file.tempfile)
+    EXTENSION_WHITE_LIST.include? extension
+  end
+
   def update_attributes(new_params)
     new_params.each do |k, v|
       self.public_send(:"#{k}=", v)

--- a/config/initializers/extension-whitelist.rb
+++ b/config/initializers/extension-whitelist.rb
@@ -1,0 +1,1 @@
+EXTENSION_WHITE_LIST = %w(.chm .csv .diff .doc .docx .dot .dxf .eps .gif .gml .ics .jpg .kml .odp .ods .odt .pdf .png .ppt .pptx .ps .rdf .rtf .sch .txt .wsdl .xls .xlsm .xlsx .xlt .xml .xsd .xslt .zip)

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -275,7 +275,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         {
           "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
           "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-          "content_type" => "application/jpeg",
+          "content_type" => "application/jpg",
           "title" => "asylum report image title",
           "created_at" => "2015-12-03T16:59:13+00:00",
           "updated_at" => "2015-12-03T16:59:13+00:00"

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -140,6 +140,14 @@ RSpec.describe Attachment do
     end
   end
 
+  describe ".valid_filetype?" do
+    it "should check that a file extension has been white listed" do
+      tempfile = Tempfile.new(['foobar', '.jpeg'])
+      extension = File.extname(tempfile)
+      allow_any_instance_of(File).to receive(:tempfile).and_return(extension)
+      expect(EXTENSION_WHITE_LIST.include? File.extname(tempfile)).to eq(false)
+    end
+  end
 
   describe "#update_attributes" do
     let(:content_id) { SecureRandom.uuid }


### PR DESCRIPTION
[Trello](https://trello.com/c/HiHWa2pE/281-there-are-no-restrictions-on-which-filetypes-can-be-uploaded-small)
