### PR TITLE
Don't send change history to Publishing API

### DIFF
--- a/app/models/change_history.rb
+++ b/app/models/change_history.rb
@@ -27,44 +27,6 @@ class ChangeHistory
     end
   end
 
-  def first_published!
-    if size > 0
-      raise NonEmptyChangeHistoryError, "Change history must be empty to add the 'First published.' item"
-    end
-
-    add_item("First published.")
-  end
-
-  def add_item(change_note)
-    items << Item.new(
-      public_timestamp: Time.zone.now,
-      change_note: change_note,
-    )
-
-    nil
-  end
-
-  def update_item(change_note)
-    last_item = items.last
-
-    unless last_item
-      raise EmptyChangeHistoryError, "Change history must not be empty to update an item."
-    end
-
-    last_item.public_timestamp = Time.zone.now
-    last_item.change_note = change_note
-
-    nil
-  end
-
-  def latest_change_note
-    items.last.change_note if size > 0
-  end
-
-  def ==(other)
-    items == other.items
-  end
-
 protected
 
   attr_accessor :items
@@ -75,11 +37,6 @@ protected
     def initialize(public_timestamp:, change_note:)
       self.public_timestamp = public_timestamp
       self.change_note = change_note
-    end
-
-    def ==(other)
-      public_timestamp == other.public_timestamp &&
-        change_note == other.change_note
     end
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -126,17 +126,12 @@ class Document
 
   def change_note
     return unless update_type == "major"
-    change_history.latest_change_note
+    @change_note
   end
 
   def change_note=(note)
     return unless update_type == "major"
-
-    if @previous_update_type == "major"
-      change_history.update_item(note)
-    else
-      change_history.add_item(note)
-    end
+    @change_note = note
   end
 
   def update_type=(update_type)
@@ -294,7 +289,7 @@ class Document
 
     handle_remote_error do
       if first_draft?
-        change_history.first_published!
+        @change_note = "First published."
         self.update_type = 'major'
         self.save
       end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -12,6 +12,7 @@ class DocumentPresenter
       title: document.title,
       description: document.summary,
       document_type: document.document_type,
+      change_note: document.change_note,
       schema_name: "specialist_document",
       publishing_app: "specialist-publisher",
       rendering_app: "specialist-frontend",
@@ -26,7 +27,7 @@ class DocumentPresenter
       ],
       redirects: [],
       update_type: document.update_type,
-    }
+    }.compact
   end
 
 private
@@ -37,7 +38,6 @@ private
     {
       body: GovspeakPresenter.present(@document),
       metadata: metadata,
-      change_history: document.change_history.as_json,
       max_cache_time: 10,
       temporary_update_type: document.temporary_update_type,
     }.tap do |details_hash|

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -76,7 +76,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
           "case_state" => "open",
           "market_sector" => ["energy"],
         },
-        "change_history" => [],
         "max_cache_time" => 10,
         "headers" => [
           { "text" => "Header", "level" => 2, "id" => "header" }
@@ -320,7 +319,6 @@ RSpec.feature "Creating a CMA case", type: :feature do
           "case_state" => "open",
           "market_sector" => ["energy"],
         },
-        "change_history" => [],
         "max_cache_time" => 10,
         "headers" => [
           { "text" => "Header", "level" => 2, "id" => "header" }

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -59,16 +59,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Published Example CMA Case")
 
-      expected_change_history = [
-          {
-              "public_timestamp" => Time.current.iso8601,
-              "note" => "First published.",
-          }
-      ]
-
-      changed_json = {
-          "details" => item["details"].merge("change_history" => expected_change_history)
-      }
+      changed_json = { "change_note" => "First published." }
 
       assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
 
@@ -170,10 +161,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
         expect(payload["title"]).to eq("Changed title")
         expect(payload["update_type"]).to eq("major")
-        expect(payload["details"]["change_history"]).to eq([
-          { "public_timestamp" => "2016-01-01T00:00:00+00:00", "note" => "First published." },
-          { "public_timestamp" => Time.zone.now.iso8601, "note" => "Updated change note" },
-        ])
+        expect(payload["change_note"]).to eq("Updated change note")
       })
     end
   end

--- a/spec/models/change_history_spec.rb
+++ b/spec/models/change_history_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ChangeHistory do
   describe ".parse" do
     it "parses the change history from the data structure stored in the details hash" do
       change_history = described_class.parse(data_structure)
-      expect(change_history).to eq(subject)
+      expect(change_history.as_json).to eq(subject.as_json)
     end
   end
 
@@ -53,74 +53,6 @@ RSpec.describe ChangeHistory do
     it "returns the size of the change history" do
       expect(subject.size).to eq(2)
       expect(described_class.new.size).to eq(0)
-    end
-  end
-
-  describe "#first_published!" do
-    it "adds a 'First published.' item to the change history" do
-      change_history = described_class.new
-      change_history.first_published!
-
-      expect(change_history.as_json).to eq([
-        {
-          "public_timestamp" => Time.zone.now.iso8601,
-          "note" => "First published."
-        }
-      ])
-    end
-
-    context "when the change history is not empty" do
-      it "raises a helpful error" do
-        expect {
-          subject.first_published!
-        }.to raise_error(/must be empty/)
-      end
-    end
-  end
-
-  describe "#add_item" do
-    it "adds an item to the change history with the current time" do
-      expect {
-        subject.add_item("New change note")
-      }.to change { subject.size }.by(1)
-
-      last_item = subject.as_json.last
-
-      expect(last_item.fetch("note")).to eq("New change note")
-      expect(last_item.fetch("public_timestamp")).to eq(Time.zone.now.iso8601)
-    end
-
-    it "does not leak access to the change history item" do
-      change_history = described_class.new
-      expect(change_history.first_published!).to be_nil
-    end
-  end
-
-  describe "#update_item" do
-    it "updates the last item in the change history" do
-      expect {
-        subject.update_item("Updated change note")
-      }.not_to change { subject.size }
-
-      last_item = subject.as_json.last
-      expect(last_item.fetch("note")).to eq("Updated change note")
-      expect(last_item.fetch("public_timestamp")).to eq(Time.zone.now.iso8601)
-    end
-
-    it "raises an error if there's nothing to update" do
-      expect {
-        described_class.new.update_item("change note")
-      }.to raise_error(EmptyChangeHistoryError)
-    end
-  end
-
-  describe "#latest_change_note" do
-    it "returns the latest item's change note" do
-      expect(subject.latest_change_note).to eq("Some change note")
-    end
-
-    it "returns nil if the change history is empty" do
-      expect(described_class.new.latest_change_note).to be_nil
     end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -225,15 +225,6 @@ RSpec.describe Document do
             }
           }
         end
-
-        it "sets the change note to the second item in the change history" do
-          document.update_type = "major"
-          expect(document.change_note).to eq("Second note")
-        end
-      end
-
-      context "when there is just one item in the change history" do
-        specify { expect(document.change_note).to be_nil }
       end
     end
 
@@ -345,16 +336,9 @@ RSpec.describe Document do
         Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC")) do
           unpublished_document.publish
 
-          expected_change_history = [
-            {
-              "public_timestamp" => Time.current.iso8601,
-              "note" => "First published.",
-            },
-          ]
-
           changed_json = {
-            "update_type" => 'major',
-            "details" => payload["details"].merge("change_history" => expected_change_history),
+            update_type: "major",
+            change_note: "First published.",
           }
 
           assert_publishing_api_put_content(unpublished_document.content_id, request_json_includes(changed_json))

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -6,6 +6,7 @@ module PublishingApiHelpers
     copy.delete("first_published_at")
     copy.delete("public_updated_at")
     copy.delete("state_history")
+    copy.fetch("details", {}).delete("change_history")
     copy
   end
 


### PR DESCRIPTION
Publishing API now manages change history, so Specialist Publisher only
needs to send a change note (now part of the top-level schema).