### PR TITLE
Extract service objects from `Document` class

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -102,7 +102,7 @@ private
     document = current_format.find(params[:document_content_id])
     document.set_temporary_update_type!
     document
-  rescue Document::RecordNotFound => e
+  rescue DocumentFinder::RecordNotFound => e
     flash[:danger] = "Document not found"
     redirect_to documents_path(document_type_slug: document_type_slug)
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -118,7 +118,7 @@ private
 
   def fetch_document
     @document = current_format.find(params[:content_id])
-  rescue Document::RecordNotFound => e
+  rescue DocumentFinder::RecordNotFound => e
     flash[:danger] = "Document not found"
     redirect_to documents_path(document_type_slug: document_type_slug)
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -170,61 +170,8 @@ class Document
     end
   end
 
-  def self.extract_body_from_payload(payload)
-    body_attribute = payload.fetch('details').fetch('body')
-
-    case body_attribute
-    when Array
-      govspeak_body = body_attribute.detect do |body_hash|
-        body_hash['content_type'] == 'text/govspeak'
-      end
-      govspeak_body['content']
-    when String
-      body_attribute
-    end
-  end
-
-  def self.set_update_type(document, payload)
-    if document.temporary_update_type?
-      document.update_type = nil
-      document.temporary_update_type = false
-    elsif document.published? || document.unpublished?
-      document.update_type = nil
-    elsif document.first_draft?
-      document.update_type = 'major'
-    else
-      document.update_type = payload["update_type"]
-    end
-  end
-
   def self.from_publishing_api(payload)
-    document = self.new(
-      base_path: payload['base_path'],
-      content_id: payload['content_id'],
-      title: payload['title'],
-      summary: payload['description'],
-      body: extract_body_from_payload(payload),
-      publication_state: payload['publication_state'],
-      state_history: payload['state_history'],
-      public_updated_at: payload['public_updated_at'],
-      first_published_at: payload['first_published_at'],
-      bulk_published: payload['details']['metadata']['bulk_published'],
-      change_history: ChangeHistory.parse(payload['details']['change_history']),
-      previous_version: payload['previous_version'],
-      temporary_update_type: payload['details']['temporary_update_type'],
-      warnings: payload['warnings'] || {}
-    )
-
-    set_update_type(document, payload)
-
-    document.attachments = Attachment.all_from_publishing_api(payload)
-
-    document.format_specific_fields.each do |field|
-      document.public_send(:"#{field.to_s}=", payload['details']['metadata'][field.to_s])
-    end
-
-    document.body = SpecialistPublisherBodyPresenter.present(document)
-    document
+    DocumentBuilder.build(self, payload)
   end
 
   def self.all(page, per_page, q: nil)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -175,23 +175,7 @@ class Document
   end
 
   def self.all(page, per_page, q: nil)
-    params = {
-      publishing_app: "specialist-publisher",
-      document_type: self.document_type,
-      fields: [
-        :base_path,
-        :content_id,
-        :last_edited_at,
-        :title,
-        :publication_state,
-        :state_history,
-      ],
-      page: page,
-      per_page: per_page,
-      order: "-last_edited_at",
-    }
-    params[:q] = q if q.present?
-    Services.publishing_api.get_content_items(params)
+    AllDocumentsFinder.all(page, per_page, q, self.document_type)
   end
 
   def self.find(content_id)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -185,15 +185,8 @@ class Document
   def save(validate: true)
     return false if validate && !self.valid?
 
-    self.update_type = 'major' if first_draft?
-
-    presented_document = DocumentPresenter.new(self)
-    presented_links = DocumentLinksPresenter.new(self)
-
     handle_remote_error do
-      set_errors_on(self)
-      Services.publishing_api.put_content(self.content_id, presented_document.to_json)
-      Services.publishing_api.patch_links(self.content_id, presented_links.to_json)
+      DocumentSaver.save(self)
     end
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -230,10 +230,7 @@ class Document
 
   def unpublish
     handle_remote_error do
-      Services.publishing_api.unpublish(content_id, type: 'gone')
-
-      AttachmentDeleteWorker.perform_async(content_id)
-      RummagerDeleteWorker.perform_async(base_path)
+      DocumentUnpublisher.unpublish(content_id, base_path)
     end
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -179,26 +179,8 @@ class Document
   end
 
   def self.find(content_id)
-    begin
-      response = Services.publishing_api.get_content(content_id)
-    rescue GdsApi::HTTPNotFound
-      raise RecordNotFound, "Document: #{content_id}"
-    end
-
-    attributes = response.to_hash
-    document_type = attributes.fetch("document_type")
-    document_class = document_type.camelize.constantize
-
-    if [document_class, Document].include?(self)
-      document_class.from_publishing_api(response.to_hash)
-    else
-      message = "#{self}.find('#{content_id}') returned the wrong type: '#{document_class}'"
-      raise TypeMismatchError, message
-    end
+    DocumentFinder.find(self, content_id)
   end
-
-  class RecordNotFound < StandardError; end
-  class TypeMismatchError < StandardError; end
 
   def save(validate: true)
     return false if validate && !self.valid?

--- a/app/services/all_documents_finder.rb
+++ b/app/services/all_documents_finder.rb
@@ -1,3 +1,4 @@
+# Request all documents for a certain document type, paginated
 class AllDocumentsFinder
   def self.all(page, per_page, q, document_type)
     params = {

--- a/app/services/all_documents_finder.rb
+++ b/app/services/all_documents_finder.rb
@@ -1,0 +1,22 @@
+class AllDocumentsFinder
+  def self.all(page, per_page, q, document_type)
+    params = {
+      publishing_app: "specialist-publisher",
+      document_type: document_type,
+      fields: [
+        :base_path,
+        :content_id,
+        :last_edited_at,
+        :title,
+        :publication_state,
+        :state_history,
+      ],
+      page: page,
+      per_page: per_page,
+      order: "-last_edited_at",
+    }
+    params[:q] = q if q.present?
+
+    Services.publishing_api.get_content_items(params)
+  end
+end

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -1,0 +1,59 @@
+# Build a `Document` from the publishing-api payload
+class DocumentBuilder
+  def self.build(klass, payload)
+    document = klass.new(
+      base_path: payload['base_path'],
+      content_id: payload['content_id'],
+      title: payload['title'],
+      summary: payload['description'],
+      body: extract_body_from_payload(payload),
+      publication_state: payload['publication_state'],
+      state_history: payload['state_history'],
+      public_updated_at: payload['public_updated_at'],
+      first_published_at: payload['first_published_at'],
+      bulk_published: payload['details']['metadata']['bulk_published'],
+      change_history: ChangeHistory.parse(payload['details']['change_history']),
+      previous_version: payload['previous_version'],
+      temporary_update_type: payload['details']['temporary_update_type'],
+      warnings: payload['warnings'] || {}
+    )
+
+    set_update_type(document, payload)
+
+    document.attachments = Attachment.all_from_publishing_api(payload)
+
+    document.format_specific_fields.each do |field|
+      document.public_send(:"#{field.to_s}=", payload['details']['metadata'][field.to_s])
+    end
+
+    document.body = SpecialistPublisherBodyPresenter.present(document)
+    document
+  end
+
+  def self.extract_body_from_payload(payload)
+    body_attribute = payload.fetch('details').fetch('body')
+
+    case body_attribute
+    when Array
+      govspeak_body = body_attribute.detect do |body_hash|
+        body_hash['content_type'] == 'text/govspeak'
+      end
+      govspeak_body['content']
+    when String
+      body_attribute
+    end
+  end
+
+  def self.set_update_type(document, payload)
+    if document.temporary_update_type?
+      document.update_type = nil
+      document.temporary_update_type = false
+    elsif document.published? || document.unpublished?
+      document.update_type = nil
+    elsif document.first_draft?
+      document.update_type = 'major'
+    else
+      document.update_type = payload["update_type"]
+    end
+  end
+end

--- a/app/services/document_finder.rb
+++ b/app/services/document_finder.rb
@@ -1,3 +1,4 @@
+# Find a document of a certain type by content_id. Returns a `Document` object.
 class DocumentFinder
   def self.find(klass, content_id)
     begin

--- a/app/services/document_finder.rb
+++ b/app/services/document_finder.rb
@@ -1,0 +1,23 @@
+class DocumentFinder
+  def self.find(klass, content_id)
+    begin
+      response = Services.publishing_api.get_content(content_id)
+    rescue GdsApi::HTTPNotFound
+      raise RecordNotFound, "Document: #{content_id}"
+    end
+
+    attributes = response.to_hash
+    document_type = attributes.fetch("document_type")
+    document_class = document_type.camelize.constantize
+
+    if [document_class, Document].include?(klass)
+      document_class.from_publishing_api(response.to_hash)
+    else
+      message = "#{self}.find('#{content_id}') returned the wrong type: '#{document_class}'"
+      raise TypeMismatchError, message
+    end
+  end
+
+  class RecordNotFound < StandardError; end
+  class TypeMismatchError < StandardError; end
+end

--- a/app/services/document_publisher.rb
+++ b/app/services/document_publisher.rb
@@ -1,3 +1,5 @@
+# Publish a draft document. Also sends out emails and indexes the document
+# in search.
 class DocumentPublisher
   def self.publish(document)
     if document.first_draft?

--- a/app/services/document_publisher.rb
+++ b/app/services/document_publisher.rb
@@ -1,0 +1,33 @@
+class DocumentPublisher
+  def self.publish(document)
+    if document.first_draft?
+      document.change_note = "First published."
+      document.update_type = 'major'
+      document.save
+    end
+
+    Services.publishing_api.publish(document.content_id, document.update_type)
+
+    published_document = document.class.find(document.content_id)
+    indexable_document = SearchPresenter.new(published_document)
+
+    RummagerWorker.perform_async(
+      document.search_document_type,
+      document.base_path,
+      indexable_document.to_json,
+    )
+
+    if document.send_email_on_publish?
+      EmailAlertApiWorker.perform_async(EmailAlertPresenter.new(document).to_json)
+    end
+
+    if previously_unpublished?(document)
+      AttachmentRestoreWorker.perform_async(document.content_id)
+    end
+  end
+
+  def self.previously_unpublished?(document)
+    ordered_states = document.state_history.sort.to_h.values
+    ordered_states.last(2) == %w(unpublished draft)
+  end
+end

--- a/app/services/document_saver.rb
+++ b/app/services/document_saver.rb
@@ -1,3 +1,4 @@
+# Save a document as draft to the publishing-api
 class DocumentSaver
   def self.save(document)
     document.update_type = 'major' if document.first_draft?

--- a/app/services/document_saver.rb
+++ b/app/services/document_saver.rb
@@ -1,0 +1,13 @@
+class DocumentSaver
+  def self.save(document)
+    document.update_type = 'major' if document.first_draft?
+
+    presented_document = DocumentPresenter.new(document)
+    presented_links = DocumentLinksPresenter.new(document)
+
+    document.set_errors_on(document)
+
+    Services.publishing_api.put_content(document.content_id, presented_document.to_json)
+    Services.publishing_api.patch_links(document.content_id, presented_links.to_json)
+  end
+end

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -1,3 +1,4 @@
+# Unpublish a document. Also removes attachments and removes it from search.
 class DocumentUnpublisher
   def self.unpublish(content_id, base_path)
     Services.publishing_api.unpublish(content_id, type: 'gone')

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -1,0 +1,7 @@
+class DocumentUnpublisher
+  def self.unpublish(content_id, base_path)
+    Services.publishing_api.unpublish(content_id, type: 'gone')
+    AttachmentDeleteWorker.perform_async(content_id)
+    RummagerDeleteWorker.perform_async(base_path)
+  end
+end


### PR DESCRIPTION
This PR extracts all methods with "external" side effects (communicating with an API) into separate classes.

It's an attempt to make the class more easily digestible for the uninitiated. It reduces the number of lines in `Document` from 420 to about 300.

I've tried to keep code changes to a minimum, so all the classes have just one or two class methods. I actually prefer initialisers and instance methods ([because think piece](http://blog.codeclimate.com/blog/2012/11/14/why-ruby-class-methods-resist-refactoring/)) but this was the smallest change that would still make a difference. Further refactoring is left as an exercise to the reader.  