### PR TITLE
Fix email alerts for ESI funds

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -25,9 +25,11 @@ private
     end
   end
 
+  # The tags are sent to email-alert-api and matched against subscriberlists.
   def tags
     {
-      format: document.document_type
+      # This format should be the same as https://github.com/alphagov/finder-frontend/blob/2c1d5f25e7e4212795b485b6e4c290c6764c813c/app/controllers/email_alert_subscriptions_controller.rb#L41
+      format: document.search_document_type
     }.deep_merge(document.format_specific_metadata.reject { |_k, v| v.blank? })
   end
 


### PR DESCRIPTION
This app has two "document type" concepts:

- `document.search_document_type` which is used for filtering in rummager. This is defined in the finder schema JSON.
- `document.document_type` which is used for the `document_type` in the content item. It is derived from the class name.

ESI fund documents are the only finder type where the two are different `document.search_document_type` is "european_structural_investment_fund" and `document.document_type` is `esi_fund`.

This confusion has caused a bug in the email subscriptions. Finder frontend uses `european_structural_investment_fund` to subscribe people to lists when signing up, but specialist publisher sends out email alerts for `esi_fund`.

This means subscribers to the ESI Fund finder will never receive email because email-alert-api can't match the incoming notification to a subscriberlist.

This commit fixes the bug by using the same thing in both places. It doesn't need test changes because for all finders except ESI the values are the same.

https://trello.com/c/gm0k7hwj/284-email-alerts-not-being-sent-for-esif-finder