### PR TITLE
Use eager_load_paths to include lib directory.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module SpecialistPublisher
     # config.time_zone = 'Central Time (US & Canada)'
     config.time_zone = 'London'
 
-    config.autoload_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join('lib')
   end
 
   mattr_accessor :publish_pre_production_finders

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3123
+bundle exec rails s -p 3064


### PR DESCRIPTION
Fixes issue with constants not found in production only.