### PR TITLE
Add log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-log
+/log/*
+!/log/.keep
 tmp
 coverage
 /coverage


### PR DESCRIPTION
This prevents errors like "No such file or directory @ rb_sysopen - ./log/sidekiq.json.log" when you start specialist publisher.