### PR TITLE
Faster AttachmentReporter report

### DIFF
--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -36,8 +36,8 @@ class GovspeakPresenter
   end
 
   def snippets_match?(a, b)
-    a = sanitise(a)
-    b = sanitise(b)
+    a = sanitise_snippet(a)
+    b = sanitise_snippet(b)
 
     (a == b) && a.present?
   end
@@ -50,14 +50,7 @@ class GovspeakPresenter
     )
   end
 
-private
-
-  def replace_with_markdown_links(body, body_snippet, attachment)
-    markdown_link = "[#{attachment.title}](#{attachment.url})"
-    body.gsub(body_snippet, markdown_link)
-  end
-
-  def sanitise(snippet)
+  def sanitise_snippet(snippet)
     snippet = CGI::unescape(snippet)
     path = snippet[/\[\s*InlineAttachment\s*:\s*(.*?)\s*\]/, 1]
     return unless path
@@ -68,5 +61,12 @@ private
     filename = filename.gsub(special_chars, "_")
 
     "[InlineAttachment:#{filename}]"
+  end
+
+private
+
+  def replace_with_markdown_links(body, body_snippet, attachment)
+    markdown_link = "[#{attachment.title}](#{attachment.url})"
+    body.gsub(body_snippet, markdown_link)
   end
 end

--- a/app/reporters/attachment_reporter.rb
+++ b/app/reporters/attachment_reporter.rb
@@ -29,42 +29,73 @@ private
   attr_accessor :document
 
   def build_report_data
-    used = []
-    matched = []
-    unmatched = []
+    sanitised_attachment_snippets = attachment_snippets.map { |s| s[:sanitised_snippet] }
+    sanitised_body_snippets = body_snippets.map { |s| s[:sanitised_snippet] }
 
-    body_snippets.each do |b|
-      match = false
+    unused_sanitised_attachment_snippets = sanitised_attachment_snippets - sanitised_body_snippets
+    unused_sanitised_body_snippets = sanitised_body_snippets - sanitised_attachment_snippets
 
-      attachment_snippets.each do |a|
-        if presenter.snippets_match?(a, b)
-          matched.push(b)
-          used |= [a]
-          match = true
-        end
-      end
+    used = used_attachments(attachment_snippets, sanitised_attachment_snippets - unused_sanitised_attachment_snippets)
+    unused = unused_attachments(attachment_snippets, unused_sanitised_attachment_snippets)
 
-      unmatched.push(b) unless match
-    end
-    unused = attachment_snippets - used
+    matched = match_snippets(body_snippets, sanitised_body_snippets - unused_sanitised_body_snippets)
+    unmatched = match_snippets(body_snippets, unused_sanitised_body_snippets)
 
-    filenames_only([used, unused, matched, unmatched])
+    [used, unused, matched, unmatched].map { |arr| filenames_only(arr) }
   end
 
   def body_snippets
-    @body_snippets ||= presenter.snippets_in_body
+    @body_snippets ||= presenter.snippets_in_body.map do |snippet|
+      {
+        snippet: snippet,
+        sanitised_snippet: sanitise_snippet(snippet),
+        filename: filename_from_snippet(snippet)
+      }
+    end
   end
 
   def attachment_snippets
-    @attachment_snippets ||= document.attachments.map(&:snippet)
+    @attachment_snippets ||= document.attachments.map do |attachment|
+      {
+        snippet: attachment.snippet,
+        sanitised_snippet: sanitise_snippet(attachment.snippet),
+        filename: filename_from_snippet(attachment.snippet)
+      }
+    end
   end
 
-  def filenames_only(arrays)
-    arrays.map do |array|
-      array.map do |snippet|
-        snippet[/\[InlineAttachment:(.*?)\]/, 1]
-      end
+  def sanitise_snippet(snippet)
+    presenter.sanitise_snippet(snippet)
+  end
+
+  def used_attachments(attachment_snippets, matched_sanitised_snippets)
+    # only match first instance of an attachment with a non-unique sanitised
+    # snippet, as latter ones will be ignored.
+    first_attachments = attachment_snippets.uniq { |a| a[:sanitised_snippet] }
+    match_snippets(first_attachments, matched_sanitised_snippets)
+  end
+
+  def unused_attachments(attachment_snippets, matched_sanitised_snippets)
+    # include attachments that have a non-unique sanitised snippet ignoring
+    # their first occurence as they won't be matched.
+    occurences = Hash.new(0)
+    attachment_snippets.select do |s|
+      sanitised_snippet = s[:sanitised_snippet]
+      occurences[sanitised_snippet] += 1
+      matched_sanitised_snippets.include?(sanitised_snippet) || occurences[sanitised_snippet] > 1
     end
+  end
+
+  def match_snippets(snippets, matched_sanitised_snippets)
+    snippets.select { |s| matched_sanitised_snippets.include?(s[:sanitised_snippet]) }
+  end
+
+  def filenames_only(snippets)
+    snippets.map { |s| s[:filename] }
+  end
+
+  def filename_from_snippet(snippet)
+    snippet[/\[InlineAttachment:(.*?)\]/, 1]
   end
 
   def presenter

--- a/spec/reporters/attachment_reporter_spec.rb
+++ b/spec/reporters/attachment_reporter_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe AttachmentReporter do
     Some of the attachments are referenced more than once:
       [InlineAttachment:bar.pdf]
       [InlineAttachment:bar.pdf]
-      [InlineAttachment:baz.pdf]
-      [InlineAttachment:baz.pdf]
-      [InlineAttachment:baz.pdf]
+      [InlineAttachment:baz-1.pdf]
+      [InlineAttachment:baz-1.pdf]
+      [InlineAttachment:baz-1.pdf]
 
     This one is used, but is missing from the document:
       [InlineAttachment:missing.pdf]
@@ -25,7 +25,8 @@ RSpec.describe AttachmentReporter do
     [
       double(:attachment, snippet: "[InlineAttachment:foo.pdf]"),
       double(:attachment, snippet: "[InlineAttachment:bar.pdf]"),
-      double(:attachment, snippet: "[InlineAttachment:baz.pdf]"),
+      double(:attachment, snippet: "[InlineAttachment:baz-1.pdf]"),
+      double(:attachment, snippet: "[InlineAttachment:baz_1.pdf]"),
       double(:attachment, snippet: "[InlineAttachment:unused.pdf]"),
     ]
   }
@@ -36,13 +37,13 @@ RSpec.describe AttachmentReporter do
     expect(report).to eq(
       attachment_counts: {
         used: 3,
-        unused: 1,
+        unused: 2,
       },
       snippet_counts: {
         matched: 6,
         unmatched: 2,
       },
-      unused_attachments: %w(unused.pdf),
+      unused_attachments: %w(baz_1.pdf unused.pdf),
       unmatched_snippets: %w(missing.pdf missing.pdf)
     )
   end


### PR DESCRIPTION
This refactors the AttachmentReporter to no longer have a nested loop
and instead use ruby array methods to compare arrays. It is
substantially quicker than the previous code and thus should resolve the
timeout errors that have been occurring.

We also make more clear attachments that have matching snippets.