### PR TITLE
Faster Govspeak preview

### DIFF
--- a/app/presenters/govspeak_body_presenter.rb
+++ b/app/presenters/govspeak_body_presenter.rb
@@ -35,8 +35,12 @@ class GovspeakBodyPresenter
   end
 
   def matching_attachment(filename)
-    document.attachments.detect do |att|
-      sanitise_filename(att.url) == sanitise_filename(filename)
+    attachments_by_sanitised_filename[sanitise_filename(filename)]
+  end
+
+  def attachments_by_sanitised_filename
+    @attachments_by_sanitised_filename ||= document.attachments.each_with_object({}) do |attachment, memo|
+      memo[sanitise_filename(attachment.url)] = attachment
     end
   end
 

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -21,18 +21,14 @@ class GovspeakPresenter
   end
 
   def html_body
-    body = document.body
-
-    snippets_in_body.uniq.each do |body_snippet|
-      document.attachments.each do |attachment|
-        if snippets_match?(body_snippet, attachment.snippet)
-          body = replace_with_markdown_links(body, body_snippet, attachment)
-        end
-      end
-    end
-
     internal_hosts = PRODUCTION_HOSTS + INTEGRATION_HOSTS + DEVELOPMENT_HOSTS
-    Govspeak::Document.new(body, document_domains: internal_hosts).to_html
+    attachments = document.attachments.map { |attachment| AttachmentPresenter.new(attachment).to_json }
+    govspeak = Govspeak::Document.new(
+      govspeak_body,
+      attachments: attachments,
+      document_domains: internal_hosts
+    )
+    govspeak.to_html
   end
 
   def snippets_match?(a, b)


### PR DESCRIPTION
This improves the performance of generating a Govspeak preview and makes the rendering of the preview more consistent with Govspeak rendering.

For a large document with many attachments we're still getting around ~3s of time to render the Govspeak into HTML, to improve this we'd have to look inside the Govspeak gem and see if there are any boosts we can give it there, or it could be that kramdown itself is the bottleneck.