### PR TITLE
Fix asylum finder category config

### DIFF
--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -6,7 +6,7 @@
          class: 'select2 form-control',
          multiple: true,
          data: {
-             placeholder: 'Select judges'
+             placeholder: 'Select categories'
          }
      }
   %>
@@ -19,7 +19,7 @@
          class: 'select2 form-control',
          multiple: true,
          data: {
-             placeholder: 'Select judges'
+             placeholder: 'Select sub categories'
          }
      }
   %>

--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -1,5 +1,5 @@
-<%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_category} do %>
-  <%= f.select :tribunal_decision_category,
+<%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_categories} do %>
+  <%= f.select :tribunal_decision_categories,
      f.object.facet_options(:tribunal_decision_categories),
      {},
      {
@@ -11,8 +11,8 @@
      }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_sub_category} do %>
-  <%= f.select :tribunal_decision_sub_category,
+<%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_sub_categories} do %>
+  <%= f.select :tribunal_decision_sub_categories,
      f.object.facet_options(:tribunal_decision_sub_categories),
      {},
      {

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -46,7 +46,7 @@
   "document_noun": "decision",
   "facets": [
     {
-      "key": "tribunal_decision_category",
+      "key": "tribunal_decision_categories",
       "name": "Category",
       "type": "text",
       "preposition": "categorised as",
@@ -75,7 +75,7 @@
       "filterable": false
     },
     {
-      "key": "tribunal_decision_sub_category",
+      "key": "tribunal_decision_sub_categories",
       "name": "Sub-category",
       "type": "text",
       "preposition": "sub-categorised as",

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -20,7 +20,7 @@
     "singular": "First-tier Tribunal (Asylum Support) decisions with the following category: ",
     "plural": "First-tier Tribunal (Asylum Support) decisions with the following categories: "
   },
-  "email_filter_by": "tribunal_decision_category",
+  "email_filter_by": "tribunal_decision_categories",
   "email_signup_choice": [
     {
       "key": "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",


### PR DESCRIPTION
The asylum finder schema was still refering to the older *_category
fields rather than the new multi select *_categories variants.

Follow up to https://github.com/alphagov/specialist-publisher/pull/927.