### PR TITLE
Use Rails.root to remove relative resolution of path

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -111,7 +111,7 @@ private
   end
 
   def view_renderer
-    ActionView::Base.new("app/views")
+    ActionView::Base.new(Rails.root.join("app/views"))
   end
 
   def header


### PR DESCRIPTION
Without using Rails.root this will based off of the working directory of
the application. The reason this hasn't presented any problems before is
because this is nearly always the value of the Rails root.

However if we utilise the rails server feature of running this as a
daemon the value of the working directory is "/" which causes this path
to be looked for in the wrong place.