### PR TITLE
Change default MongoDB values to use ENV vars

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   clients:
     default:
-      uri: mongodb://localhost/govuk_content_development
+      uri: <%= ENV["MONGODB_URI"] || "mongodb://localhost/govuk_content_development" %>
       options:
         write:
           w: 1
@@ -9,7 +9,7 @@ development:
 test:
   clients:
     default:
-      uri: mongodb://localhost/specialist_publisher_rebuild_test
+      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/specialist_publisher_rebuild_test" %>
       options:
         write:
           w: 1
@@ -17,7 +17,7 @@ test:
 production:
   clients:
     default:
-      uri: <%= ENV['MONGODB_URI'] %>
+      uri: <%= ENV["MONGODB_URI"] %>
       options:
         write:
           w: majority


### PR DESCRIPTION
Falls back to the defaults when ENV vars are not available. The TEST_*
prefix naming format is based on the TEST_DATABASE_URL one used in
Publishing API.