### PR TITLE
Paginate specialist document finders

### DIFF
--- a/app/presenters/finders/finder_content_item_presenter.rb
+++ b/app/presenters/finders/finder_content_item_presenter.rb
@@ -46,6 +46,7 @@ private
       summary: file.fetch("summary", nil),
       facets: file.fetch("facets", nil),
       default_order: file.fetch("default_order", nil),
+      default_documents_per_page: 50,
     }.reject { |_, value| value.nil? }
   end
 


### PR DESCRIPTION
The finders published by this application have a lot of documents in them, but aren't paginated. The number 50 is a bit arbitrary, but seems alright for specialist users. We'll probably do more user research into finder behaviour later next year, which might influence the number of results.

From Tara:

> As they're more specialist, maybe 50 would be better than 20, to help the type of users who want to see everything about a thing. But we've got no analytics evidence unless we either track the positions or work them out from the URLs clicked.

https://trello.com/c/VKqW8wEV