### PR TITLE
[Don't merge] Search by elasticsearch_type

### DIFF
--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -6,7 +6,7 @@
   "description": "Find reports of AAIB investigations into air accidents and incidents",
   "phase": "beta",
   "filter": {
-    "document_type": "aaib_report"
+    "elasticsearch_type": "aaib_report"
   },
   "show_summaries": true,
   "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"],

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -6,7 +6,7 @@
   "description": "Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).",
   "phase": "beta",
   "filter": {
-    "document_type": "asylum_support_decision"
+    "elasticsearch_type": "asylum_support_decision"
   },
   "show_summaries": true,
   "organisations": [

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -5,7 +5,7 @@
   "name": "Competition and Markets Authority cases",
   "description": "Find reports and updates on current and historical CMA investigations",
   "filter": {
-    "document_type": "cma_case"
+    "elasticsearch_type": "cma_case"
   },
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",

--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -6,7 +6,7 @@
   "description": "Find information about Countryside Stewardship options, capital items and supplements",
   "beta": true,
   "filter": {
-    "document_type": "countryside_stewardship_grant"
+    "elasticsearch_type": "countryside_stewardship_grant"
   },
   "organisations": [
     "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -6,7 +6,7 @@
   "description": "Find outputs from Research for Development projects",
   "pre_production": false,
   "filter": {
-    "document_type": "dfid_research_output"
+    "elasticsearch_type": "dfid_research_output"
   },
   "signup_content_id": "a062704c-f49d-4942-aaf4-c06d81ada3b8",
   "signup_copy": "You'll get an email each time an output is updated or a new output is published.",

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -5,7 +5,7 @@
   "name": "Drug Safety Update",
   "description": "Find drug safety updates issued by MHRA",
   "filter": {
-    "document_type": "drug_safety_update"
+    "elasticsearch_type": "drug_safety_update"
   },
   "show_summaries": true,
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -6,7 +6,7 @@
   "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
   "phase": "beta",
   "filter": {
-    "document_type": "employment_appeal_tribunal_decision"
+    "elasticsearch_type": "employment_appeal_tribunal_decision"
   },
   "show_summaries": true,
   "organisations": [

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -6,7 +6,7 @@
   "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
   "phase": "beta",
   "filter": {
-    "document_type": "employment_tribunal_decision"
+    "elasticsearch_type": "employment_tribunal_decision"
   },
   "show_summaries": true,
   "organisations": [

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -7,7 +7,7 @@
   "beta": true,
   "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.dfpni.gov.uk/topics/finance/european-funding-2014-2020\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
   "filter": {
-    "document_type": "european_structural_investment_fund"
+    "elasticsearch_type": "european_structural_investment_fund"
   },
   "default_order": "-closing_date",
   "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -5,7 +5,7 @@
   "name": "International development funding",
   "description": "Find and apply for funds to run international development projects",
   "filter": {
-    "document_type": "international_development_fund"
+    "elasticsearch_type": "international_development_fund"
   },
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -5,7 +5,7 @@
   "name": "Marine Accident Investigation Branch reports",
   "description": "Find reports of MAIB investigations into marine accidents and incidents",
   "filter": {
-    "document_type": "maib_report"
+    "elasticsearch_type": "maib_report"
   },
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -5,7 +5,7 @@
   "name": "Alerts and recalls for drugs and medical devices",
   "description": "Find alerts and recalls issued by MHRA",
   "filter": {
-    "document_type": "medical_safety_alert"
+    "elasticsearch_type": "medical_safety_alert"
   },
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_title": "Drug alerts and medical device alerts",

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -5,7 +5,7 @@
   "name": "Rail Accident Investigation Branch reports",
   "description": "Find reports of RAIB investigations into rail accidents and incidents",
   "filter": {
-    "document_type": "raib_report"
+    "elasticsearch_type": "raib_report"
   },
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -6,7 +6,7 @@
   "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
   "phase": "beta",
   "filter": {
-    "document_type": "tax_tribunal_decision"
+    "elasticsearch_type": "tax_tribunal_decision"
   },
   "default_order": "-tribunal_decision_decision_date",
   "show_summaries": true,

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -5,7 +5,7 @@
   "name": "Administrative appeals tribunal decision",
   "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
   "filter": {
-    "document_type": "utaac_decision"
+    "elasticsearch_type": "utaac_decision"
   },
   "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",

--- a/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
+++ b/lib/documents/schemas/vehicle_recalls_and_faults_alerts.json
@@ -7,7 +7,7 @@
   "pre_production": true,
   "summary": "<p>Find out if your vehicle has been recalled by the manufacturer or has a fault. You can also search for child car seats, tyres and other vehicle parts.</p>",
   "filter": {
-    "document_type": "vehicle_recalls_and_faults_alert"
+    "elasticsearch_type": "vehicle_recalls_and_faults_alert"
   },
   "organisations": [
     "d39237a5-678b-4bb5-a372-eb2cb036933d"


### PR DESCRIPTION
We are trying to remove usage of `document_type` in rummager, because
it's easily confused with the `document_type` in the content-store.

https://github.com/alphagov/rummager/pull/722 allows searching with `elasticsearch_type`. This PR can be merged after that is deployed.

https://trello.com/c/C8A9bnuO/344-work-on-making-the-document-type-concept-clearer