### PR TITLE
Remove validation for EAT finder sub-category

### DIFF
--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -2,7 +2,6 @@ class EmploymentAppealTribunalDecision < Document
   validates :tribunal_decision_categories, presence: true
   validates :tribunal_decision_decision_date, presence: true, date: true
   validates :tribunal_decision_landmark, presence: true
-  validates :tribunal_decision_sub_categories, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
     hidden_indexable_content

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
       expect(page).to have_content("Summary can't be blank")
       expect(page).to have_content("Body can't be blank")
       expect(page).to have_content("Tribunal decision categories can't be blank")
-      expect(page).to have_content("Tribunal decision sub categories can't be blank")
+      expect(page).not_to have_content("Tribunal decision sub categories can't be blank")
       expect(page).to have_content("Tribunal decision decision date")
 
       expect(page).to_not have_content("Hidden indexable content can't be blank")


### PR DESCRIPTION
Some EAT categories don't have associated sub-categories. To avoid problems validation has been removed for the sub category field.

Note: this amend had previously been done in alphagov/manuals-publisher#670, but it looks like the validation was re-introduced at some point, perhaps in response to refactoring.