### PR TITLE
Use model names from schemas

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,24 +36,9 @@ private
   end
 
   def document_models
-    [
-      AaibReport,
-      AsylumSupportDecision,
-      CmaCase,
-      CountrysideStewardshipGrant,
-      DfidResearchOutput,
-      DrugSafetyUpdate,
-      EmploymentAppealTribunalDecision,
-      EsiFund,
-      EmploymentTribunalDecision,
-      InternationalDevelopmentFund,
-      MaibReport,
-      MedicalSafetyAlert,
-      RaibReport,
-      TaxTribunalDecision,
-      UtaacDecision,
-      VehicleRecallsAndFaultsAlert,
-    ]
+    @document_models ||= FinderSchema.schema_names.map do |schema_name|
+      schema_name.singularize.camelize.constantize
+    end
   end
 
   def set_authenticated_user_header

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -1,4 +1,11 @@
 class FinderSchema
+  # Pluralized names of all document types
+  def self.schema_names
+    Dir.glob(Rails.root.join("lib/documents/schemas/*.json")).map do |f|
+      File.basename(f).gsub('.json', '')
+    end
+  end
+
   attr_reader :base_path, :organisations, :document_type_filter
 
   def initialize(schema_type)

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 require 'finder_schema'
 
 RSpec.describe FinderSchema do
+  describe '.schema_names' do
+    it 'returns schema names' do
+      expect(FinderSchema.schema_names).to include('aaib_reports')
+    end
+  end
+
   let(:schema) { FinderSchema.new('dfid_research_outputs') }
 
   describe '#humanized_facet_value' do


### PR DESCRIPTION
This automatically generate the model names from the schemas. 

Makes it easier to add a new specialist document type.