### PR TITLE
Add Service Standard Report

### DIFF
--- a/app/models/service_standard_report.rb
+++ b/app/models/service_standard_report.rb
@@ -1,0 +1,5 @@
+class ServiceStandardReport < Document
+  def self.title
+    "Service Standard Report"
+  end
+end

--- a/app/views/metadata_fields/_service_standard_reports.html.erb
+++ b/app/views/metadata_fields/_service_standard_reports.html.erb
@@ -1,0 +1,1 @@
+<%# TODO: There's no metadata at the moment.%>

--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -1,0 +1,15 @@
+{
+  "content_id": "da025a9f-8293-4fef-869c-12445d364696",
+  "base_path": "/service-standard-reports",
+  "name": "Service Standard Reports",
+  "format_name": "Service Assessment and Self Certification",
+  "description": "A list of service assessments and self certifications",
+  "show_summaries": true,
+  "pre_production": true,
+  "document_noun": "report",
+  "filter": {
+    "document_type": "service_standard_report"
+  },
+  "facets": [
+  ]
+}

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,11 @@
+task import: [:environment] do
+  file = RestClient.get(ENV['URL_TO_REPORTS_JSON'])
+  reports = JSON.parse(file)
+  reports.each do |report|
+    ServiceStandardReport.new(
+      body: report.fetch("body"),
+      title: report.fetch("title"),
+      summary: report.fetch("summary"),
+    ).save
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -165,6 +165,17 @@ FactoryGirl.define do
     end
   end
 
+  factory :service_standard_report, parent: :document do
+    base_path "/service-standard-reports/example-document"
+    document_type "service_standard_report"
+
+    transient do
+      default_metadata do
+        {}
+      end
+    end
+  end
+
   factory :asylum_support_decision, parent: :document do
     base_path "/asylum-support-tribunal-decisions/example-document"
     document_type "asylum_support_decision"

--- a/spec/models/service_standard_report_spec.rb
+++ b/spec/models/service_standard_report_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'models/valid_against_schema'
+
+RSpec.describe ServiceStandardReport do
+  let(:payload) { FactoryGirl.create(:service_standard_report) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+end


### PR DESCRIPTION
Finding Things team is moving the Service Assessments & Self Certification documents from the [GDS Data blog](https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/) into finders.

This commit adds the possibility to publish Service Standard Report documents.

Trello: https://trello.com/c/lFZnNhs4/349-create-a-service-assessment-finder

Paired with @klssmith & @tijmenb 