### PR TITLE
Use the full website_root, rather than parts of it

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -8,7 +8,7 @@ module UrlHelper
   end
 
   def public_url_for(document)
-    URI.join("#{Plek.new.website_uri.scheme}://#{Plek.new.website_uri.host}", document.base_path, cachebust_query_string).to_s
+    URI.join(Plek.new.website_root, document.base_path, cachebust_query_string).to_s
   end
 
   def draft_url_for(document)


### PR DESCRIPTION
This is simpler, and more closely follows the value for website_root.