### PR TITLE
Make GDS the owning organisation for service_standard_report

### DIFF
--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -6,6 +6,7 @@
   "description": "A list of service assessments and self certifications",
   "show_summaries": true,
   "pre_production": true,
+  "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
   "document_noun": "report",
   "filter": {
     "document_type": "service_standard_report"


### PR DESCRIPTION
- Changed the schema for service_standard_report to add GDS as the owning
organisation.
- This is done so that Pundit can be used to manage access to the
service standard report pages.