### PR TITLE
Remove beta banner for AAIB reports finder

### DIFF
--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -4,7 +4,7 @@
   "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "description": "Find reports of AAIB investigations into air accidents and incidents",
-  "phase": "beta",
+  "phase": "live",
   "filter": {
     "document_type": "aaib_report"
   },


### PR DESCRIPTION
AAIB reports are now live, so remove the beta banner.

Trello: https://trello.com/c/qf1e01pP/366-remove-beta-banner-from-aaib-reports

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake task `publishing_api:publish_finders` to republish the finder