### PR TITLE
Add assessment_date for Service Standard Report

### DIFF
--- a/app/models/service_standard_report.rb
+++ b/app/models/service_standard_report.rb
@@ -1,4 +1,12 @@
 class ServiceStandardReport < Document
+  FORMAT_SPECIFIC_FIELDS = %i(assessment_date).freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
   def self.title
     "Service Standard Report"
   end

--- a/app/views/metadata_fields/_service_standard_reports.html.erb
+++ b/app/views/metadata_fields/_service_standard_reports.html.erb
@@ -1,1 +1,2 @@
-<%# TODO: There's no metadata at the moment.%>
+<%= render partial: "shared/date_fields",
+  locals: { f: f, field: :assessment_date, format: :service_standard_report } %>

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -171,7 +171,9 @@ FactoryGirl.define do
 
     transient do
       default_metadata do
-        {}
+        {
+          "assessment_date" => "2016-10-10"
+        }
       end
     end
   end


### PR DESCRIPTION
This depends on https://github.com/alphagov/govuk-content-schemas/pull/462 to be merged first in order for the test suite to be green.

We are adding `assessment_date` as part of the metadata sent to
Publishing API. This means that editors will be able to set the date of a given assessment.

This is a follow up work on moving all the service assessments and self
certification documents away from GDS Data blog
(https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/)
and move them to Specialist Publisher.

Trello:
https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document

Paired with: @klssmith