### PR TITLE
Add assessment_date to service_standard_report schema

### DIFF
--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -12,5 +12,14 @@
     "document_type": "service_standard_report"
   },
   "facets": [
+    {
+      "key": "assessment_date",
+      "name": "Assessment date",
+      "short_name": "Assessed",
+      "type": "date",
+      "preposition": "assessed",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
   ]
 }


### PR DESCRIPTION
- Added the assessment date as a facet to the service standard report
schema to allow this to be displayed.

Trello: https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document

Paired with @Davidslv and @tijmenb 

![screen shot 2016-12-15 at 12 37 29](https://cloud.githubusercontent.com/assets/12881990/21224291/62d5ed2a-c2c3-11e6-9fce-30c686e03085.png)
