### PR TITLE
Display service standard reports ordered by assessment date

### DIFF
--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -8,6 +8,7 @@
   "pre_production": true,
   "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
   "document_noun": "report",
+  "default_order": "-assessment_date",
   "filter": {
     "document_type": "service_standard_report"
   },


### PR DESCRIPTION
- Service standard reports are displayed with most recent reports shown first.
- Depends on https://github.com/alphagov/rummager/pull/729

Trello: https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document