### PR TITLE
Catch errors during finder rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,6 +6,10 @@ namespace :publishing_api do
 
     finder_loader = PublishingApiFinderLoader.new
 
-    PublishingApiFinderPublisher.new(finder_loader.finders).call
+    begin
+      PublishingApiFinderPublisher.new(finder_loader.finders).call
+    rescue GdsApi::HTTPServerError => e
+      puts "Error publishing finder: #{e.inspect}"
+    end
   end
 end


### PR DESCRIPTION
This rake task is often run on deploy. When it fails it should not prevent the deploy from finishing.