### PR TITLE
Provide rake task to generate report for Content Operating Model team

### DIFF
--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -6,13 +6,14 @@ class FinderSchema
     end
   end
 
-  attr_reader :base_path, :organisations, :document_type_filter
+  attr_reader :base_path, :organisations, :document_type_filter, :content_id
 
   def initialize(schema_type)
     @schema ||= load_schema_for(schema_type)
     @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
     @document_type_filter = schema.fetch("filter", {}).fetch("document_type")
+    @content_id = schema.fetch("content_id")
   end
 
   def facets

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,5 +1,5 @@
-desc "validate inline attachments snippets for all documents of a class"
 namespace :report do
+  desc "validate inline attachments snippets for all documents of a class"
   task :attachments, [:class_name] => :environment do |_, args|
     if args.class_name.blank? || args.class_name == "all"
       Rails.application.eager_load!
@@ -58,5 +58,86 @@ namespace :report do
     end
 
     puts
+  end
+
+  desc "generate a report on all documents to help the Content Operating Model team"
+  task content_operating_model: :environment do
+    def all_document_classes
+      @_all_document_classes ||= FinderSchema.schema_names.map do |schema_name|
+        schema_name.singularize.camelize.constantize
+      end
+    end
+
+    def public_url_for(document)
+      URI.join(Plek.new.website_root, document['base_path']).to_s
+    end
+
+    class Paginator
+      def initialize(document_class)
+        @document_class = document_class
+      end
+
+      def document_type
+        @document_type ||= @document_class.document_type
+      end
+
+      def params(page)
+        {
+          publishing_app: "specialist-publisher",
+          document_type: document_type,
+          fields: [
+            :base_path,
+            :content_id,
+            :publication_state,
+            :first_published_at,
+          ],
+          page: page,
+          per_page: 100,
+          order: "-last_edited_at",
+        }
+      end
+
+      def each(&block)
+        page = 1
+        loop do
+          response = Services.publishing_api.get_content_items(params(page))
+          break if response['results'].empty?
+          response['results'].each(&block)
+          break if response['current_page'] >= response['pages']
+          page += 1
+        end
+      end
+    end
+
+    def each_document(document_class, &block)
+      Paginator.new(document_class).each(&block)
+    end
+
+    def organisations_for_document_class(document_class)
+      org_ids = document_class.finder_schema.organisations
+      org_ids.map do |org_id|
+        Services.publishing_api.get_content(org_id)['title']
+      end
+    end
+
+    require 'csv'
+
+    output_filename = Rails.root.join("content-operating-report-#{Time.zone.today.strftime('%Y-%m-%d')}.csv")
+
+    CSV.open(output_filename, 'w') do |csv|
+      csv << ["URL", "Organisation(s)", "Finder", "Status", "First published at"]
+      all_document_classes.each do |document_class|
+        organisations_for_csv = organisations_for_document_class(document_class).join(', ')
+        each_document(document_class) do |document_hash|
+          csv << [
+            public_url_for(document_hash),
+            organisations_for_csv,
+            document_class.title,
+            document_hash['publication_state'],
+            document_hash['first_published_at'] || "Never published to GOV.UK",
+          ]
+        end
+      end
+    end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe Document do
       base_path: "/my-document-types",
       filter: {
         document_type: "my_document_type",
-      }
+      },
+      content_id: SecureRandom.uuid
     }.deep_stringify_keys
   }
 


### PR DESCRIPTION
The report is to show the organisation(s), url, finder, status and
first published date for all the documents in the system.

We expect that this is a one-off, but it might be useful for the code
that generates it to persist as this kind of report could be needed
again, or could be used as a jumping off point for future reports.

The trello card describing the report is: https://trello.com/c/e3nDUdE2/88-report-for-content-operating-model