### PR TITLE
Tweak email summary text for the CMA finder content item

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -18,8 +18,8 @@
     "competition/regulatory-appeals-references"
   ],
   "subscription_list_title_prefix": {
-    "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-    "plural": "Competition and Markets Authority (CMA) cases with the following case types: "
+    "singular": "CMA cases with the following case type: ",
+    "plural": "CMA cases with the following case types: "
   },
   "email_filter_by": "case_type",
   "email_signup_choice": [


### PR DESCRIPTION
When a new email alert subscription is created, a short name is generated describing the subscription. If enough subscription items are chosen by the user, the short name becomes longer than 255 characters, which is the GovDelivery limit for this field.

This commit tweaks the text for the CMA finder content item to keep the short text under 255 characters.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters