### PR TITLE
Test for email alert summaries over 255 characters

### DIFF
--- a/spec/finders/email_alert_configuration_spec.rb
+++ b/spec/finders/email_alert_configuration_spec.rb
@@ -9,18 +9,37 @@ RSpec.describe "Email alert configuration" do
     describe "Finder configuration for #{finder['name']}" do
       next unless finder["email_filter_by"]
 
-      it "only allows people to sign up to alerts that exist" do
-        facet_used_to_email_things = finder["facets"].find do |facet|
+      before do
+        @facet_used_to_email_things = finder["facets"].find do |facet|
           facet["key"] == finder["email_filter_by"]
         end
+      end
 
-        actually_possible_keys_for_which_emails_will_be_sent = facet_used_to_email_things["allowed_values"].map do |allowed_value|
+      it "only allows people to sign up to alerts that exist" do
+        actually_possible_keys_for_which_emails_will_be_sent = @facet_used_to_email_things["allowed_values"].map do |allowed_value|
           allowed_value["value"]
         end
 
         finder["email_signup_choice"].each do |choice|
           expect(choice["key"]).to be_in(actually_possible_keys_for_which_emails_will_be_sent)
         end
+      end
+
+      # This is a GovDelivery maximum limit
+      # finder-frontend detects generated strings that are too long and
+      # changes them, but this assumes that the combination of the prefix
+      # and suffix does not already breach the limit, which we test here
+      it "doesn't have a combined prefix and suffix longer than 255 characters" do
+        next unless finder["subscription_list_title_prefix"] &&
+            finder["subscription_list_title_prefix"]["many"] &&
+            finder["email_filter_name"] &&
+            finder["email_filter_name"]["plural"]
+
+        short_name = finder["subscription_list_title_prefix"]["many"] +
+          @facet_used_to_email_things["allowed_values"].length.to_s + " " +
+          finder["email_filter_name"]["plural"]
+
+        expect(short_name.length).to be <= 255
       end
     end
   end


### PR DESCRIPTION
When a new email alert subscription is created, a short name is generated describing the subscription. If enough subscription items are chosen by the user, the short name becomes longer than 255 characters, which is the GovDelivery limit for this field.

This commit adds a test to catch cases where adding a new item takes the short name over 255 characters, so that it can be fixed.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters