### PR TITLE
Add more text options for email alerts

### DIFF
--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -18,9 +18,14 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": {
     "singular": "First-tier Tribunal (Asylum Support) decisions with the following category: ",
-    "plural": "First-tier Tribunal (Asylum Support) decisions with the following categories: "
+    "plural": "First-tier Tribunal (Asylum Support) decisions with the following categories: ",
+    "many": "First-tier Tribunal (Asylum Support) decisions: "
   },
   "email_filter_by": "tribunal_decision_categories",
+  "email_filter_name": {
+    "singular": "category",
+    "plural": "categories"
+  },
   "email_signup_choice": [
     {
       "key": "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -18,10 +18,15 @@
     "competition/regulatory-appeals-references"
   ],
   "subscription_list_title_prefix": {
-    "singular": "CMA cases with the following case type: ",
-    "plural": "CMA cases with the following case types: "
+    "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
+    "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
+    "many": "Competition and Markets Authority (CMA) cases: "
   },
   "email_filter_by": "case_type",
+  "email_filter_name": {
+    "singular": "case type",
+    "plural": "case types"
+  },
   "email_signup_choice": [
     {
       "key": "ca98-and-civil-cartels",

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -18,9 +18,14 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": {
     "singular": "Employment Appeal Tribunal decisions with the following category: ",
-    "plural": "Employment Appeal Tribunal decisions with the following categories: "
+    "plural": "Employment Appeal Tribunal decisions with the following categories: ",
+    "many": "Employment Appeal Tribunal decisions: "
   },
   "email_filter_by": "tribunal_decision_categories",
+  "email_filter_name": {
+    "singular": "category",
+    "plural": "categories"
+  },
   "email_signup_choice": [
     {
       "key": "age-discrimination",

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -18,9 +18,14 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": {
     "singular": "Employment tribunal decisions with the following jurisdiction code: ",
-    "plural": "Employment tribunal decisions with the following jurisdiction codes: "
+    "plural": "Employment tribunal decisions with the following jurisdiction codes: ",
+    "many": "Employment tribunal decisions: "
   },
   "email_filter_by": "tribunal_decision_categories",
+  "email_filter_name": {
+    "singular": "jurisdiction code",
+    "plural": "jurisdiction codes"
+  },
   "email_signup_choice": [
     {
       "key": "age-discrimination",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -19,10 +19,15 @@
     "e8fae147-6232-4163-a3f1-1c15b755a8a4"
   ],
   "subscription_list_title_prefix": {
-    "singular": "European Structural and Investment Fund",
-    "plural": "European Structural and Investment Funds"
+    "singular": "European Structural and Investment Fund with the following location: ",
+    "plural": "European Structural and Investment Funds with the following locations: ",
+    "many": "European Structural and Investment Funds: "
   },
   "email_filter_by": "location",
+  "email_filter_name": {
+    "singular": "location",
+    "plural": "locations"
+  },
   "email_signup_choice": [
     {
       "key": "north-east",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -13,9 +13,14 @@
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],
   "subscription_list_title_prefix": {
     "singular": "Marine Accident Investigation Branch (MAIB) reports with the following vessel type: ",
-    "plural": "Marine Accident Investigation Branch (MAIB) reports with the following vessel types: "
+    "plural": "Marine Accident Investigation Branch (MAIB) reports with the following vessel types: ",
+    "many": "Marine Accident Investigation Branch (MAIB) reports: "
   },
   "email_filter_by": "vessel_type",
+  "email_filter_name": {
+    "singular": "vessel type",
+    "plural": "vessel types"
+  },
   "email_signup_choice": [
     {
       "key": "merchant-vessel-100-gross-tons-or-over",

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -12,9 +12,14 @@
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],
   "subscription_list_title_prefix": {
     "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
-    "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: "
+    "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: ",
+    "many": "Rail Accident Investigation Branch (RAIB) reports: "
   },
   "email_filter_by": "railway_type",
+  "email_filter_name": {
+    "singular": "railway type",
+    "plural": "railway types"
+  },
   "email_signup_choice": [
     {
       "key": "heavy-rail",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -18,10 +18,15 @@
   "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": {
-    "singular": "Upper Tribunal (Tax and Chancery Chamber) with the following category: ",
-    "plural": "Upper Tribunal (Tax and Chancery Chamber) with the following categories: "
+    "singular": "Upper Tribunal (Tax and Chancery Chamber) decisions with the following category: ",
+    "plural": "Upper Tribunal (Tax and Chancery Chamber) decisions with the following categories: ",
+    "many": "Upper Tribunal (Tax and Chancery Chamber) decisions: "
   },
   "email_filter_by": "tribunal_decision_category",
+  "email_filter_name": {
+    "singular": "category",
+    "plural": "categories"
+  },
   "email_signup_choice": [
     {
       "key": "banking",

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -15,7 +15,7 @@
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
   ],
-  "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions with the following categories:",
+  "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions",
   "pre_production": false,
   "summary": "<p>Check the Courts and Tribunals Judiciary website for <a href=\"http://administrativeappeals.decisions.tribunals.gov.uk/Aspx/default.aspx\">decisions made before January 2016</a>.</p>",
   "document_noun": "decision",


### PR DESCRIPTION
This commit adds fields to most finders to define a separate email alert list title text which will be used when the normally generated string is too long (> 255 characters). It will be appended with a string of the form “x items”, where “x” is the number of selected topics and “items” is either the singular or plural string defined as `email_filter_name`.

Also reverts https://github.com/alphagov/specialist-publisher/pull/984 since this is a more comprehensive solution.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake task `publishing_api:publish_finders` to re-publish all the finders