### PR TITLE
Publish email_filter_name to publishing-api

### DIFF
--- a/app/presenters/finders/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finders/finder_signup_content_item_presenter.rb
@@ -67,6 +67,7 @@ private
       "beta" => schema.fetch("signup_beta", false),
       "email_signup_choice" => schema.fetch("email_signup_choice", []),
       "email_filter_by" => schema.fetch("email_filter_by", nil),
+      "email_filter_name" => schema.fetch("email_filter_name", nil),
       "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", {})
     }
   end


### PR DESCRIPTION
https://github.com/alphagov/specialist-publisher/pull/986 added a new `email_filter_name` field to the various finder signup page schemas. This commit changes the relevant presenter to send this new field to the publishing-api whenever the content items are re-published.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake task `publishing_api:publish_finders` to re-publish all the finders