### PR TITLE
Downgrade airbrake to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '5.0.0.1'
 
-gem 'airbrake', '~> 5.5'
-gem 'airbrake-ruby', '1.5'
+gem 'airbrake', '~> 4.0'
 gem 'logstasher', '0.6.2'
 gem 'unicorn', '~> 4.9.0'
 gem 'sass-rails', '~> 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (5.5.0)
-      airbrake-ruby (~> 1.5)
-    airbrake-ruby (1.5.0)
+    airbrake (4.3.8)
+      builder
+      multi_json
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.5.1.1)
@@ -370,8 +370,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.5)
-  airbrake-ruby (= 1.5)
+  airbrake (~> 4.0)
   better_errors (~> 2.1.1)
   binding_of_caller (~> 0.7.2)
   bootstrap-kaminari-views (= 0.0.5)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.project_key = ENV['ERRBIT_API_KEY']
-    config.project_id = 1 # dummy, not used in Errbit
-    config.host = errbit_uri.to_s
-    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
   end
 end


### PR DESCRIPTION
Our errbit installation doesn't like the airbrake 5.x gem and so deploys
don't get notified properly.  Downgrading to 4.x will fix this.