### PR TITLE
Ensure schema tests are run against the right version of the schemas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ node {
     }
 
     stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 


### PR DESCRIPTION
This build can be triggered by changes to the schema tests, so we need to make sure that we check out the correct branch of the content schemas to test against, rather than always testing against `deployed-to-production`, which is the default.

This fix adds a missing branch parameter when checking out the content schemas.