### PR TITLE
Shorten CMA email subscription list name

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -18,8 +18,8 @@
     "competition/regulatory-appeals-references"
   ],
   "subscription_list_title_prefix": {
-    "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-    "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
+    "singular": "CMA cases with the following case type: ",
+    "plural": "CMA cases with the following case types: ",
     "many": "Competition and Markets Authority (CMA) cases: "
   },
   "email_filter_by": "case_type",


### PR DESCRIPTION
The current name results in strings that are longer then 255 characters, which breaks a GovDelivery limit.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake task `publishing_api:publish_finders` to re-publish all the finders