### PR TITLE
Make hidden_indexable_content indexable

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -22,7 +22,8 @@ class SearchPresenter
   end
 
   def indexable_content
-    Govspeak::Document.new(document.body).to_text
+    hidden_content = defined?(document.hidden_indexable_content) ? " " + document.hidden_indexable_content : ""
+    Govspeak::Document.new(document.body).to_text + hidden_content
   end
 
 private

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -4,22 +4,38 @@ RSpec.describe SearchPresenter do
   subject(:presenter) { SearchPresenter.new(document) }
 
   context 'a complete document is given' do
+    let(:document_fields) do
+      {
+          title: 'A Title',
+          summary: 'A summary',
+          base_path: '/some-finder/a-title',
+          public_updated_at: Time.now,
+          first_published_at: Time.now,
+          body: '## A Title',
+          format_specific_metadata: { country: ['GB'], blank_value: '' }
+      }
+    end
+
     let(:document) do
       double(
         'Document',
-        title:                    'A Title',
-        summary:                  'A summary',
-        base_path:                '/some-finder/a-title',
-        public_updated_at:        Time.now,
-        first_published_at:       Time.now,
-        body:                     '## A Title',
-        format_specific_metadata: { country: ['GB'], blank_value: '' }
+          document_fields
       )
+    end
+
+    let(:document_with_hidden_content) do
+      double(
+        'Document',
+          document_fields.merge(hidden_indexable_content: 'hidden content'))
     end
 
     describe '#indexable_content' do
       it 'indexes the body alone' do
         expect(presenter.indexable_content).to eql('A Title')
+      end
+
+      it 'includes hidden_indexable_content when present in document' do
+        expect(SearchPresenter.new(document_with_hidden_content).indexable_content).to eql('A Title' + ' ' + 'hidden content')
       end
     end
 


### PR DESCRIPTION
All MOJ finders use a hidden_indexable_field which should be indexed by
Rummger but currently isn't.  This PR adds code that includes the field
in a document's indexable content, when the field is present.

NOTE: This functionality used to work so likely it is a regression
introduced when specialist publisher was rebuilt.