### PR TITLE
Add content store document type attribute for search

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -8,6 +8,7 @@ class SearchPresenter
   def to_json
     {
       title: document.title,
+      content_store_document_type: document.document_type,
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -8,10 +8,13 @@ class SearchPresenter
   def to_json
     {
       title: document.title,
+      content_id: document.content_id,
       content_store_document_type: document.document_type,
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,
+      publishing_app: "specialist-publisher",
+      rendering_app: "specialist-frontend",
       public_timestamp: format_date(document.public_updated_at),
       first_published_at: format_date(document.first_published_at),
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }

--- a/app/workers/rummager_bulk_republisher_worker.rb
+++ b/app/workers/rummager_bulk_republisher_worker.rb
@@ -1,0 +1,30 @@
+class RummagerBulkRepublisherWorker
+  include Sidekiq::Worker
+
+  def perform(document_type, page, per_page)
+    Services.publishing_api.client.options[:timeout] = 30
+
+    results = Services.publishing_api.get_content_items(
+      document_type: document_type,
+      fields: [:content_id],
+      per_page: per_page,
+      page: page,
+    )["results"]
+
+    puts "found #{results.size} results for document_type: #{document_type}"
+
+    content_ids = results.map { |result| result["content_id"] }
+
+    content_ids.each do |content_id|
+      document = Document.find(content_id)
+      payload = SearchPresenter.new(document).to_json
+
+      puts "sending content_id: #{content_id} to rummager."
+      RummagerWorker.perform_async(
+        document.document_type,
+        document.base_path,
+        payload
+      )
+    end
+  end
+end

--- a/lib/rummager_republisher.rb
+++ b/lib/rummager_republisher.rb
@@ -1,0 +1,58 @@
+class RummagerRepublisher
+  class << self
+    def republish_all
+      document_types.each do |document_type|
+        pagination = publishing_api_pagination_for(document_type)
+
+        if pagination[:total_results].zero?
+          puts "skipping - could not find #{document_type}"
+          next
+        end
+
+        puts "Schedulling rummager republishing for document_type: #{document_type}"
+
+        current_page = pagination[:current_page]
+        per_page = pagination[:request_per_page]
+
+        while current_page <= pagination[:total_pages]
+          puts "Page: #{current_page} of #{pagination[:total_pages]}"
+
+          RummagerBulkRepublisherWorker.perform_async(
+            document_type,
+            current_page,
+            per_page
+          )
+
+          current_page += 1
+        end
+      end
+    end
+
+  private
+
+    def publishing_api_pagination_for(document_type)
+      response = Services.publishing_api.get_content_items(
+        document_type: document_type,
+        fields: [:content_id]
+      )
+
+      total_pages = response["pages"].zero? ? 1 : response["pages"].to_f
+      total_results = response["total"].to_f
+
+      # for console output when running the rake task.
+      puts "about to process #{total_results} results for #{document_type}."
+
+      {
+        total_results: response["total"].to_f,
+        total_pages: response["pages"].to_f,
+        current_page: response["current_page"],
+        request_per_page: (total_results / total_pages).ceil
+      }
+    end
+
+    def document_types
+      Rails.application.eager_load!
+      @document_types ||= Document.subclasses.map(&:document_type)
+    end
+  end
+end

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -18,4 +18,9 @@ namespace :republish do
   task :one, [:content_id] => :environment do |_, args|
     Republisher.republish_one(args.content_id)
   end
+
+  desc "republishes all documents to rummager"
+  task all_documents_to_rummager: :environment do
+    RummagerRepublisher.republish_all
+  end
 end

--- a/spec/lib/rummager_republisher_spec.rb
+++ b/spec/lib/rummager_republisher_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "rummager_republisher"
+
+RSpec.describe RummagerRepublisher do
+  describe '.republish_all' do
+    it 'delegates content_ids to RummagerBulkRepublisherWorker' do
+      # to load all the document types without manually typing them.
+      Rails.application.eager_load!
+      document_types ||= Document.subclasses.map(&:document_type)
+
+      expect(document_types).to_not be_empty
+
+      url = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT + "/content"
+
+      content_id = "8afc9def-7363-485f-8afc-8afc7340619b"
+      body = {
+        "total" => 1,
+        "pages" => 1,
+        "current_page" => 1,
+        "links" => [],
+        "results" => [
+          {
+            "content_id" => content_id,
+            "publishing_app" => "specialist-publisher",
+            "rendering_app" => "specialist-frontend",
+            "document_type" => "aaib_report",
+            "base_path" => "/aaib-reports/report-base-path",
+          }
+        ]
+      }
+
+      document_types.each do |document_type|
+        params = {
+          document_type: document_type,
+          fields: [:content_id]
+        }
+
+        stub_request(:get, url)
+          .with(query: params)
+          .to_return(status: 200, body: body.to_json, headers: {})
+      end
+
+      allow(
+        RummagerBulkRepublisherWorker
+      ).to receive(:perform_async).exactly(document_types.size).times
+
+      expect {
+        RummagerRepublisher.republish_all
+      }.to output(/Schedulling rummager/).to_stdout
+    end
+  end
+end

--- a/spec/lib/tasks/republish_rake_spec.rb
+++ b/spec/lib/tasks/republish_rake_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'rake'
+load File.join(Rails.root, 'Rakefile')
+load File.join(Rails.root, 'lib/tasks/republish.rake')
+
+RSpec.describe 'Republish rake task' do
+  describe 'republish:all_documents_to_rummager' do
+    it 'invokes RummagerRepublisher' do
+      allow(RummagerRepublisher).to receive(:republish_all)
+
+      Rake::Task['republish:all_documents_to_rummager'].invoke
+    end
+  end
+end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe SearchPresenter do
     let(:document_fields) do
       {
           title: 'A Title',
+          content_id: 'A-CONTENT-ID',
           document_type: 'document_type',
           summary: 'A summary',
           base_path: '/some-finder/a-title',
+          publishing_app: "specialist-publisher",
+          rendering_app: "specialist-frontend",
           public_updated_at: Time.now,
           first_published_at: Time.now,
           body: '## A Title',
@@ -51,6 +54,18 @@ RSpec.describe SearchPresenter do
       it 'has attribute "content_store_document_type" with value of "document_type"' do
         expect(json[:content_store_document_type]).to eql('document_type')
         expect(json[:content_store_document_type]).to eql(document.document_type)
+      end
+
+      it 'has rendering_app attribute' do
+        expect(json[:rendering_app]).to eql('specialist-frontend')
+      end
+
+      it 'has publishing_app attribute' do
+        expect(json[:publishing_app]).to eql('specialist-publisher')
+      end
+
+      it 'has content_id attribute' do
+        expect(json[:content_id]).to eql('A-CONTENT-ID')
       end
 
       it 'includes format-specific metadata' do

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SearchPresenter do
     let(:document_fields) do
       {
           title: 'A Title',
+          document_type: 'document_type',
           summary: 'A summary',
           base_path: '/some-finder/a-title',
           public_updated_at: Time.now,
@@ -45,6 +46,11 @@ RSpec.describe SearchPresenter do
       it 'has values that are present' do
         expect(json[:title]).to eql('A Title')
         expect(json[:link]).to eql(document.base_path)
+      end
+
+      it 'has attribute "content_store_document_type" with value of "document_type"' do
+        expect(json[:content_store_document_type]).to eql('document_type')
+        expect(json[:content_store_document_type]).to eql(document.document_type)
       end
 
       it 'includes format-specific metadata' do

--- a/spec/workers/rummager_bulk_republisher_worker_spec.rb
+++ b/spec/workers/rummager_bulk_republisher_worker_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe RummagerBulkRepublisherWorker do
+  around do |example|
+    Sidekiq::Testing.fake! { example.run }
+  end
+
+  let(:cma_case) { FactoryGirl.create(:cma_case, :published) }
+  let(:content_ids) { [cma_case["content_id"]] }
+
+  it 'delegates a document to RummagerWorker' do
+    publishing_api_has_content([cma_case], hash_including(document_type: CmaCase.document_type))
+    publishing_api_has_item(cma_case)
+
+    payload = SearchPresenter.new(
+      Document.find(cma_case["content_id"])
+    ).to_json
+
+    allow(RummagerWorker).to receive(:perform_async).with(
+      cma_case["document_type"],
+      cma_case["base_path"],
+      payload
+    )
+
+    described_class.perform_async(CmaCase.document_type, 1, 1)
+
+    expect(described_class.jobs.size).to eq(1)
+    described_class.drain
+    expect(described_class.jobs.size).to eq(0)
+  end
+
+  it 'publishes to rummager' do
+    publishing_api_has_content([cma_case], hash_including(document_type: CmaCase.document_type))
+    publishing_api_has_item(cma_case)
+    stub_any_rummager_post
+
+    described_class.perform_async(CmaCase.document_type, 1, 1)
+    described_class.drain
+    RummagerWorker.drain
+
+    assert_rummager_posted_item(
+      _type: CmaCase.document_type,
+      _id: cma_case["base_path"]
+    )
+  end
+end


### PR DESCRIPTION
Add `content_store_document_type` to be sent to rummager.

Also, currently we have in place a task to republish documents to Publishing API and
Rummager, but in some cases we only want to republish to rummager in
order to update the document.

This commit adds an extra task into the republish.rake file to republish
all documents to rummager.

And also adds `content_id`, `rendering_app` and `publishing_app`

This might be best to be reviewed commit by commit (will rebase afterwards)

Trello:
https://trello.com/c/iMotNdUv/461-add-more-document-type-to-search