### PR TITLE
Make rummager finder task consistent with Publishing API task

### DIFF
--- a/lib/finder_loader.rb
+++ b/lib/finder_loader.rb
@@ -1,6 +1,6 @@
 require "multi_json"
 
-class PublishingApiFinderLoader
+class FinderLoader
   def finders
     files.map do |file|
       {

--- a/lib/rummager_finder_publisher.rb
+++ b/lib/rummager_finder_publisher.rb
@@ -31,6 +31,9 @@ private
 
   def export_finder(schema)
     presenter = FinderRummagerPresenter.new(schema[:file], schema[:timestamp])
-    RummagerWorker.perform_async(presenter.type, presenter.id, presenter.to_json)
+
+    logger.info("Publishing '#{schema[:file]['name']}' finder")
+
+    Services.rummager.add_document(presenter.type, presenter.id, presenter.to_json)
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,10 +1,10 @@
 namespace :publishing_api do
   desc "Publish all Finders to the Publishing API"
   task publish_finders: :environment do
+    require "finder_loader"
     require "publishing_api_finder_publisher"
-    require "publishing_api_finder_loader"
 
-    finder_loader = PublishingApiFinderLoader.new
+    finder_loader = FinderLoader.new
 
     begin
       PublishingApiFinderPublisher.new(finder_loader.finders).call

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,17 +1,15 @@
 namespace :rummager do
   desc "Publish all Finders to Rummager"
   task publish_finders: :environment do
+    require "finder_loader"
     require "rummager_finder_publisher"
 
-    require "multi_json"
+    finder_loader = FinderLoader.new
 
-    schemas = Dir.glob("lib/documents/schemas/*.json").map do |file_path|
-      {
-        file: MultiJson.load(File.read(file_path)),
-        timestamp: File.mtime(file_path)
-      }
+    begin
+      RummagerFinderPublisher.new(finder_loader.finders).call
+    rescue GdsApi::HTTPServerError => e
+      puts "Error publishing finder: #{e.inspect}"
     end
-
-    RummagerFinderPublisher.new(schemas).call
   end
 end

--- a/spec/lib/finder_loader_spec.rb
+++ b/spec/lib/finder_loader_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require "publishing_api_finder_loader"
+require "finder_loader"
 
-RSpec.describe PublishingApiFinderLoader do
+RSpec.describe FinderLoader do
   before do
     expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w{
       lib/documents/schemas/format-1.json
@@ -20,7 +20,7 @@ RSpec.describe PublishingApiFinderLoader do
     expect(File).to receive(:mtime).with("lib/documents/schemas/format-2.json")
       .and_return("today")
 
-    loader = PublishingApiFinderLoader.new
+    loader = FinderLoader.new
     expect(loader.finders).to match_array([
       {
         file: { "name" => "format-1" },


### PR DESCRIPTION
This commit makes the publishing-api finder loader more generic so that it can also be used by the rummager finder publishing task. It also makes the rummager finder publishing task more consistent with its publishing-api equivalent, and changes it to send to rummager immediately instead of placing changes in a queue.

This is what the publishing-api task does, and since these tasks are called manually, it makes sense for their results to be immediately available.