### PR TITLE
Use search_document_type for search indexing

### DIFF
--- a/app/workers/republish_worker.rb
+++ b/app/workers/republish_worker.rb
@@ -58,6 +58,6 @@ private
 
   def rummager_add_document(document)
     payload = SearchPresenter.new(document).to_json
-    Services.rummager.add_document(document.document_type, document.base_path, payload)
+    Services.rummager.add_document(document.search_document_type, document.base_path, payload)
   end
 end


### PR DESCRIPTION
Use `search_document_type` instead of `document_type` when indexing a
document during republishing.

This is consistent with how we index documents in document_publisher.rb

```ruby
RummagerWorker.perform_async(
  document.search_document_type,
  document.base_path,
  indexable_document.to_json,
)
```

This app has two "document type" concepts:

- `document.search_document_type` which is used for filtering in
rummager. This is defined in the finder schema JSON.
- `document.document_type` which is used for the `document_type` in the
content item. It is derived from the class name.

ESI fund documents are the only finder type where the two are different
`document.search_document_type` is
"european_structural_investment_fund" and `document.document_type` is
`esi_fund`.

See also commit 713174e1a5289b3279d81d6a44bf9acb27d44a2e

Trello: https://trello.com/c/YKFN6UvQ/471-specialist-publisher-is-indexing-with-document-type-esi-fund-which-doesn-t-exist