### PR TITLE
Enable ET and AST finders in production

### DIFF
--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -47,7 +47,7 @@
     }
   ],
   "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
-  "pre_production": true,
+  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -341,7 +341,7 @@
     }
   ],
   "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
-  "pre_production": true,
+  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {


### PR DESCRIPTION
We want to enable the Employment Tribunal Decisions and Asylum Support
Decisions finders in production.

This should not be merged until 8th Feb 2017 as this is go live date.

[Trello card](https://trello.com/c/yIqEcIQi/637-publish-et-decisions-and-asylum-support-decisions-finders)