### PR TITLE
Add content_store_document_type into SearchPresenter

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -8,9 +8,13 @@ class SearchPresenter
   def to_json
     {
       title: document.title,
+      content_id: document.content_id,
+      content_store_document_type: document.document_type,
       description: document.summary,
       link: document.base_path,
       indexable_content: indexable_content,
+      publishing_app: 'specialist-publisher',
+      rendering_app: 'specialist-frontend',
       public_timestamp: format_date(document.public_updated_at),
       first_published_at: format_date(document.first_published_at),
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe SearchPresenter do
     let(:document_fields) do
       {
           title: 'A Title',
+          content_id: 'content-id',
+          document_type: 'aaib_report',
           summary: 'A summary',
           base_path: '/some-finder/a-title',
+          publishing_app: 'specialist-publisher',
+          rendering_app: 'specialist-frontend',
           public_updated_at: Time.now,
           first_published_at: Time.now,
           body: '## A Title',
@@ -49,6 +53,19 @@ RSpec.describe SearchPresenter do
 
       it 'includes format-specific metadata' do
         expect(json[:country]).to eql(['GB'])
+      end
+
+      it 'includes content_id' do
+        expect(json[:content_id]).to eql('content-id')
+      end
+
+      it 'includes content_store_document_type' do
+        expect(json[:content_store_document_type]).to eql('aaib_report')
+      end
+
+      it 'includes publishing and rendering apps' do
+        expect(json[:publishing_app]).to eql('specialist-publisher')
+        expect(json[:rendering_app]).to eql('specialist-frontend')
       end
 
       it 'does not include blank values' do


### PR DESCRIPTION
Finding Things has been working into adding a new field in rummager
called content_store_document_type.

This commit also adds `content_id`, `rendering_app` and `publishing_app`

Superseeds https://github.com/alphagov/specialist-publisher/pull/996

Trello:
https://trello.com/c/iMotNdUv/461-add-more-document-type-to-search