### PR TITLE
Cater for nil hidden_indexable_content

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -22,11 +22,18 @@ class SearchPresenter
   end
 
   def indexable_content
-    hidden_content = defined?(document.hidden_indexable_content) ? " " + document.hidden_indexable_content : ""
     Govspeak::Document.new(document.body).to_text + hidden_content
   end
 
 private
+
+  def hidden_content
+    has_hidden_content? ? " #{document.hidden_indexable_content}" : ""
+  end
+
+  def has_hidden_content?
+    defined?(document.hidden_indexable_content) && document.hidden_indexable_content
+  end
 
   attr_reader :document
 end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe SearchPresenter do
           document_fields.merge(hidden_indexable_content: 'hidden content'))
     end
 
+    let(:document_with_undefined_hidden_content) do
+      double(
+        'Document',
+          document_fields.merge(hidden_indexable_content: nil))
+    end
+
     describe '#indexable_content' do
       it 'indexes the body alone' do
         expect(presenter.indexable_content).to eql('A Title')
@@ -36,6 +42,10 @@ RSpec.describe SearchPresenter do
 
       it 'includes hidden_indexable_content when present in document' do
         expect(SearchPresenter.new(document_with_hidden_content).indexable_content).to eql('A Title' + ' ' + 'hidden content')
+      end
+
+      it 'handles hidden_indexable_content when nil in document' do
+        expect(SearchPresenter.new(document_with_undefined_hidden_content).indexable_content).to eql('A Title')
       end
     end
 


### PR DESCRIPTION
When we introduced `hidden_indexable_content` we catered for the scenario where
the document didn't have the field.  If the document does have the field, but
it is undefined we run into problems.