### PR TITLE
Add business finance support scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Publishing App for Specialist Documents.
 ## Live examples
 
 - [AAIB Reports](https://www.gov.uk/aaib-reports)
+- [Business Finance Support Schemes](https://www.gov.uk/business-finance-support)
 - [CMA Cases](https://www.gov.uk/cma-cases)
 - [Countryside Stewardship Grants](https://www.gov.uk/countryside-stewardship-grants)
 - [DFID Research Outputs](https://www.gov.uk/dfid-research-outputs)

--- a/app/models/business_finance_support_scheme.rb
+++ b/app/models/business_finance_support_scheme.rb
@@ -1,0 +1,26 @@
+class BusinessFinanceSupportScheme < Document
+  validates :business_sizes, presence: true
+  validates :business_stages, presence: true
+  validates :continuation_link, presence: true
+  validates :industries, presence: true
+  validates :types_of_support, presence: true
+
+  FORMAT_SPECIFIC_FIELDS = %i(
+    business_sizes
+    business_stages
+    continuation_link
+    industries
+    types_of_support
+    will_continue_on
+  ).freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def self.title
+    "Business Finance Support Scheme"
+  end
+end

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -53,6 +53,7 @@ private
     {
       "aaib_report" => "Air Accidents Investigation Branch reports",
       "asylum_support_decision" => "Asylum Support Decision",
+      "business_finance_support_scheme" => "Business finance support scheme",
       "cma_case" => "Competition and Markets Authority cases",
       "countryside_stewardship_grant" => "Countryside Stewardship Grants",
       "employment_appeal_tribunal_decision" => "Employment appeal tribunal decisions",
@@ -72,6 +73,7 @@ private
     {
       "aaib_report" => "report",
       "asylum_support_decision" => "decision",
+      "business_finance_support_scheme" => "scheme",
       "cma_case" => "case",
       "countryside_stewardship_grant" => "grant",
       "employment_appeal_tribunal_decision" => "decision",

--- a/app/views/metadata_fields/_business_finance_support_schemes.html.erb
+++ b/app/views/metadata_fields/_business_finance_support_schemes.html.erb
@@ -1,0 +1,62 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :continuation_link } do %>
+  <%= f.url_field :continuation_link, class: 'form-control' %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on } do %>
+  <%= f.text_field :will_continue_on, class: 'form-control' %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :types_of_support, label: 'Types of support offered' } do %>
+  <%= f.select :types_of_support,
+      facet_options(f, :types_of_support),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select types of support offered'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :business_sizes } do %>
+  <%= f.select :business_sizes,
+      facet_options(f, :business_sizes),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select business sizes'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :industries } do %>
+  <%= f.select :industries,
+      facet_options(f, :industries),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select industries'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :business_stages } do %>
+  <%= f.select :business_stages,
+      facet_options(f, :business_stages),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select business stages'
+        }
+      }
+  %>
+<% end %>

--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -1,0 +1,93 @@
+{
+  "content_id": "12fecc5b-c02a-405e-b96e-7aa32ceaf504",
+  "base_path": "/business-finance-support",
+  "pre_production": true,
+  "format_name": "Business finance support scheme",
+  "name": "Finance and support for your business",
+  "description": "Find government-backed support and finance for business",
+  "filter": {
+    "document_type": "business_finance_support_scheme"
+  },
+  "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",
+  "signup_copy": "You'll get an email each time a scheme is updated or a new scheme is published.",
+  "organisations": ["2bde479a-97f2-42b5-986a-287a623c2a1c"],
+  "topics": [
+
+  ],
+  "subscription_list_title_prefix": "Business finance support schemes",
+  "document_noun": "scheme",
+  "facets": [
+    {
+        "key": "types_of_support",
+        "name": "Type of support",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {"label": "Finance", "value": "finance"},
+          {"label": "Equity", "value": "equity"},
+          {"label": "Grant", "value": "grant"},
+          {"label": "Loan", "value": "loan"},
+          {"label": "Expertise and advice", "value": "expertise-and-advice"},
+          {"label": "Recognition awards", "value": "recognition-award"}
+        ]
+    },
+
+    {
+      "key": "business_stages",
+      "name": "Business stage",
+      "type": "text",
+      "preposition": "for businesses which are",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Not yet trading", "value": "not-yet-trading"},
+        {"label": "Start-ups (1-2 years trading)", "value": "start-up"},
+        {"label": "Established", "value": "established"}
+      ]
+    },
+
+    {
+      "key": "industries",
+      "name": "Industry",
+      "type": "text",
+      "preposition": "for businesses in",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Agriculture and food", "value": "agriculture-and-food"},
+        {"label": "Business and finance", "value": "business-and-finance"},
+        {"label": "Construction", "value": "construction"},
+        {"label": "Education", "value": "education"},
+        {"label": "Health", "value": "health"},
+        {"label": "Hospitality and catering", "value": "hospitality-and-catering"},
+        {"label": "IT, digital and creative", "value": "information-technology-digital-and-creative"},
+        {"label": "Manufacturing", "value": "manufacturing"},
+        {"label": "Mining", "value": "mining"},
+        {"label": "Real estate and property", "value": "real-estate-and-property"},
+        {"label": "Science and technology", "value": "science-and-technology"},
+        {"label": "Service industries", "value": "service-industries"},
+        {"label": "Transport and distribution", "value": "transport-and-distribution"},
+        {"label": "Travel and leisure", "value": "travel-and-leisure"},
+        {"label": "Utilities providers", "value": "utilities-providers"},
+        {"label": "Wholesale and retail", "value": "wholesale-and-retail"}
+      ]
+    },
+
+    {
+      "key": "business_sizes",
+      "name": "Number of employees",
+      "type": "text",
+      "preposition": "for businesses with",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "0 to 9 employees", "value": "under-10"},
+        {"label": "10 to 249 employees", "value": "between-10-and-249"},
+        {"label": "250 to 500 employees", "value": "between-250-and-500"},
+        {"label": "More than 500 employees", "value": "over-500"}
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -197,6 +197,24 @@ FactoryGirl.define do
     end
   end
 
+  factory :business_finance_support_scheme, parent: :document do
+    base_path "/business-finance-support/example-document"
+    document_type "business_finance_support_scheme"
+
+    transient do
+      default_metadata do
+        {
+          "business_sizes" => ["under-10", "between-10-and-249"],
+          "business_stages" => ["start-up"],
+          "continuation_link" => "https://www.gov.uk",
+          "industries" => ["information-technology-digital-and-creative"],
+          "types_of_support" => ["finance"],
+          "will_continue_on" => "on GOV.UK",
+        }
+      end
+    end
+  end
+
   factory :cma_case, parent: :document do
     base_path "/cma-cases/example-document"
     document_type "cma_case"

--- a/spec/models/business_finance_support_scheme_spec.rb
+++ b/spec/models/business_finance_support_scheme_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'models/valid_against_schema'
+
+RSpec.describe BusinessFinanceSupportScheme do
+  let(:payload) { FactoryGirl.create(:business_finance_support_scheme) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+end


### PR DESCRIPTION
This commit adds support to specialist-publisher for business finance support schemes, which will be imported from the current business-support-finder, and the related finder.

Trello: https://trello.com/c/6q9hCkPK/492-add-business-finance-support-schemes-as-a-document-type-in-specialist-publisher

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake tasks `publishing_api:publish_finders` and `rummager:publish_finders` to publish the new business finance support schemes finder (pre-production)

![screencapture-specialist-publisher-dev-gov-uk-business-finance-support-schemes-new-1487849074057](https://cloud.githubusercontent.com/assets/444232/23257218/cd58a722-f9ba-11e6-969c-fe595e4869cc.png)

![screencapture-dev-gov-uk-business-finance-support-1487846327515](https://cloud.githubusercontent.com/assets/444232/23255645/56673512-f9b4-11e6-8d95-26eeabe0bea6.png)
