### PR TITLE
Add PDF reporting task

### DIFF
--- a/lib/report_document_paginator.rb
+++ b/lib/report_document_paginator.rb
@@ -1,0 +1,38 @@
+class ReportDocumentPaginator
+  def initialize(document_class, document_fields, param_options = {})
+    @document_class = document_class
+    @document_fields = document_fields
+    @params_hash = default_params.merge(param_options)
+  end
+
+  def each(&block)
+    page = 1
+    loop do
+      response = Services.publishing_api.get_content_items(params(page))
+      break if response['results'].empty?
+      response['results'].each(&block)
+      break if response['current_page'] >= response['pages']
+      page += 1
+    end
+  end
+
+private
+
+  def params(page)
+    @params_hash.merge(page: page)
+  end
+
+  def default_params
+    {
+      publishing_app: "specialist-publisher",
+      document_type: document_type,
+      fields: @document_fields,
+      per_page: 100,
+      order: "-last_edited_at",
+    }
+  end
+
+  def document_type
+    @document_type ||= @document_class.document_type
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -72,45 +72,9 @@ namespace :report do
       URI.join(Plek.new.website_root, document['base_path']).to_s
     end
 
-    class Paginator
-      def initialize(document_class)
-        @document_class = document_class
-      end
-
-      def document_type
-        @document_type ||= @document_class.document_type
-      end
-
-      def params(page)
-        {
-          publishing_app: "specialist-publisher",
-          document_type: document_type,
-          fields: [
-            :base_path,
-            :content_id,
-            :publication_state,
-            :first_published_at,
-          ],
-          page: page,
-          per_page: 100,
-          order: "-last_edited_at",
-        }
-      end
-
-      def each(&block)
-        page = 1
-        loop do
-          response = Services.publishing_api.get_content_items(params(page))
-          break if response['results'].empty?
-          response['results'].each(&block)
-          break if response['current_page'] >= response['pages']
-          page += 1
-        end
-      end
-    end
-
     def each_document(document_class, &block)
-      Paginator.new(document_class).each(&block)
+      document_field_params = [:base_path, :content_id, :publication_state, :first_published_at]
+      ReportDocumentPaginator.new(document_class, document_field_params).each(&block)
     end
 
     def organisations_for_document_class(document_class)

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -60,6 +60,105 @@ namespace :report do
     puts
   end
 
+  desc "generate a report of counts of published PDF documents per organisation to help the Content Operating Model team"
+  task pdf_content_operating_model: :environment do
+    def unique_owning_organisation_ids
+      @_owning_organisation_ids ||= all_document_classes.map { |document| document.organisations.first }.uniq
+    end
+
+    def all_document_classes
+      @_all_document_classes ||= FinderSchema.schema_names.map do |schema_name|
+        schema_name.singularize.camelize.constantize
+      end
+    end
+
+    def organisation_name_from_id(org_id)
+      Services.publishing_api.get_content(org_id)['title']
+    end
+
+    def each_document_content_id_and_state_history(document_class, &block)
+      ReportDocumentPaginator.new(document_class, [:content_id, :state_history]).each(&block)
+    end
+
+    def document_published_prior_to_date?(document, date)
+      document.public_updated_at && document.public_updated_at.to_date >= date
+    end
+
+    first_period_start_date = ENV.fetch('FIRST_PERIOD_START_DATE', Date.parse('2016-01-01'))
+    last_time_period_days = ENV.fetch('LAST_TIME_PERIOD_DAYS', 30)
+    last_time_period_start_date = last_time_period_days.days.ago
+
+    organisation_published_pdfs_total_counts_hash = Hash[unique_owning_organisation_ids.map { |o| [o, 0] }]
+    organisation_published_pdfs_since_first_period_counts_hash = Hash[unique_owning_organisation_ids.map { |o| [o, 0] }]
+    organisation_published_pdfs_since_second_period_counts_hash = Hash[unique_owning_organisation_ids.map { |o| [o, 0] }]
+
+    all_document_classes.each do |document_class|
+      each_document_content_id_and_state_history(document_class) do |document_id_and_state_hash|
+        state_history = document_id_and_state_hash['state_history']
+
+        # Ignore docs that have never been published
+        next if state_history.count == 1 && state_history['1'] == 'draft'
+
+        content_id = document_id_and_state_hash['content_id']
+
+        unique_pdf_attachment_urls_for_document = []
+
+        # Walk through the history of document versions looking for published PDF attachments
+        state_history.each_pair do |version_number, version_state|
+          next if version_state == 'draft'
+
+          response = Services.publishing_api.get_content(content_id, 'version' => version_number)
+
+          current_document_version = Document.from_publishing_api(response.parsed_content)
+
+          current_document_version.attachments.each do |attachment|
+            next if attachment.content_type != 'application/pdf'
+
+            # Uses the URL of the attachment as a way to detect if the current attachment is unique
+            # in the version history and only count it if so.
+            next if unique_pdf_attachment_urls_for_document.include? attachment.url
+
+            owning_organisation_id = document_class.organisations.first
+
+            organisation_published_pdfs_total_counts_hash[owning_organisation_id] += 1
+
+            if document_published_prior_to_date?(current_document_version, first_period_start_date)
+              organisation_published_pdfs_since_first_period_counts_hash[owning_organisation_id] += 1
+            end
+
+            if document_published_prior_to_date?(current_document_version, last_time_period_start_date)
+              organisation_published_pdfs_since_second_period_counts_hash[owning_organisation_id] += 1
+            end
+
+            unique_pdf_attachment_urls_for_document << attachment.url
+          end
+        end
+      end
+    end
+
+    document_report_filename = Rails.root.join("content-operating-report-for-pdf-documents-#{Time.zone.today.strftime('%Y-%m-%d')}.csv")
+
+    require 'csv'
+
+    CSV.open(document_report_filename, 'w') do |document_csv|
+      document_csv << [
+        "Organisation",
+        "Total published PDF attachments",
+        "#{first_period_start_date} - present PDF attachments",
+        "Last #{last_time_period_days} days PDF attachments"
+      ]
+
+      unique_owning_organisation_ids.each do |org_id|
+        document_csv << [
+          organisation_name_from_id(org_id),
+          organisation_published_pdfs_total_counts_hash[org_id],
+          organisation_published_pdfs_since_first_period_counts_hash[org_id],
+          organisation_published_pdfs_since_second_period_counts_hash[org_id]
+        ]
+      end
+    end
+  end
+
   desc "generate a report on all documents to help the Content Operating Model team"
   task content_operating_model: :environment do
     def all_document_classes

--- a/spec/lib/report_document_paginator_spec.rb
+++ b/spec/lib/report_document_paginator_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe ReportDocumentPaginator do
+  describe '.each' do
+    let(:content_fields) { [:content_id] }
+
+    let(:first_item) { { 'content_id' => 'a' } }
+    let(:second_item) { { 'content_id' => 'b' } }
+    let(:third_item) { { 'content_id' => 'c' } }
+
+    let(:all_items) { [first_item, second_item, third_item] }
+
+    before do
+      publishing_api_has_content(
+        all_items,
+        document_type: 'asylum_support_decision',
+        fields: content_fields,
+        page: 1,
+        per_page: 2,
+        order: '-last_edited_at',
+        publishing_app: 'specialist-publisher'
+      )
+
+      publishing_api_has_content(
+        all_items,
+        document_type: 'asylum_support_decision',
+        fields: content_fields,
+        page: 2,
+        per_page: 2,
+        order: '-last_edited_at',
+        publishing_app: 'specialist-publisher'
+      )
+    end
+
+    let(:subject) { described_class.new(AsylumSupportDecision, content_fields, per_page: 2) }
+
+    it 'calls the supplied block with each document hash returned from the publishing api across successive pages' do
+      expect { |b| subject.each(&b) }.to yield_successive_args(first_item, second_item, third_item)
+    end
+  end
+end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/JIT8o1Tn/90-pdf-report-for-natalie-baron-com)

This task produces a CSV of counts of published PDFs over time, grouped
by the owning organisation. This is for the Content Operating model team.

Also see (https://github.com/alphagov/manuals-publisher/pull/814) and (https://github.com/alphagov/whitehall/pull/3036).

There was a timeout problem on the integration environment when accessing a certain document category from publishing-api (on which this script relies). This was addressed in PR https://github.com/alphagov/publishing-api/pull/818.