### PR TITLE
Make the business finance support schemes finder live

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -1,7 +1,6 @@
 {
   "content_id": "12fecc5b-c02a-405e-b96e-7aa32ceaf504",
   "base_path": "/business-finance-support",
-  "pre_production": true,
   "format_name": "Business finance support scheme",
   "name": "Finance and support for your business",
   "description": "Find government-backed support and finance for business",


### PR DESCRIPTION
This commit makes the business finance support schemes finder live so that it can be published in production.

Trello: https://trello.com/c/QLmSU4iF/490-publish-new-business-support-finder-documents

- [x] Deploy specialist-publisher
- [x] Run the rake tasks `publishing_api:publish_finders` and `rummager:publish_finders` to publish the new business finance support schemes finder