### PR TITLE
Add finder links to specialist documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -23,7 +23,8 @@ class Document
     :previous_version,
     :temporary_update_type,
     :update_type,
-    :warnings
+    :warnings,
+    :links,
   )
 
   def temporary_update_type
@@ -68,6 +69,10 @@ class Document
     keys.each do |key|
       public_send(:"#{clean_key(key.to_s)}=", param_value(attrs, key))
     end
+  end
+
+  def to_h
+    super.merge(links: links)
   end
 
   def bulk_published
@@ -274,6 +279,12 @@ class Document
 
   def self.finder_schema
     @finder_schema ||= FinderSchema.new(document_type.pluralize)
+  end
+
+  def links
+    {
+      "finder": [finder_schema.content_id]
+    }
   end
 
 private

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -26,6 +26,7 @@ class DocumentPresenter
       ],
       redirects: [],
       update_type: document.update_type,
+      links: document.links,
     }.compact
   end
 

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -84,6 +84,9 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "routes" => [{ "path" => "/cma-cases/example-cma-case", "type" => "exact" }],
       "redirects" => [],
       "update_type" => "major",
+      "links" => {
+        "finder" => ["fef4ac7c-024a-4943-9f19-e85a8369a1f3"]
+      }
     }
 
     assert_publishing_api_put_content(content_id, expected_sent_payload)
@@ -326,6 +329,9 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "routes" => [{ "path" => "/cma-cases/at-veroeos-et-accusamus-et-iusto-odio-dignissimos-ducimus-qui-blanditiis-praesentium-voluptatum-deleniti-atque-corrupti-quos-dolores-et-quas-molestias-excepturi-sint-occaecati-cupiditate-non-provident-similique-sunt-in-culpa-qui-officia-de", "type" => "exact" }],
       "redirects" => [],
       "update_type" => "major",
+      "links" => {
+        "finder" => ["fef4ac7c-024a-4943-9f19-e85a8369a1f3"]
+      }
     }
     assert_publishing_api_put_content(content_id, expected_sent_payload)
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -66,6 +66,7 @@ FactoryGirl.define do
     title "Example document"
     description "This is the summary of example document"
     schema_name "specialist_document"
+    document_type nil
     publishing_app "specialist-publisher"
     rendering_app "specialist-frontend"
     locale "en"
@@ -79,6 +80,7 @@ FactoryGirl.define do
     state_history {
       { "1": "draft" }
     }
+    links {}
 
     routes {
       [
@@ -110,7 +112,15 @@ FactoryGirl.define do
 
     initialize_with {
       merged_details = default_details.deep_stringify_keys.deep_merge(details.deep_stringify_keys)
-      attributes.merge(details: merged_details)
+      result = attributes.merge(details: merged_details)
+
+      result = result.merge(
+        links: {
+          finder: [FinderSchema.new(document_type.pluralize).content_id]
+        },
+      ) if document_type
+
+      result
     }
 
     # This is the default document state.

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -78,13 +78,19 @@ RSpec.describe Document do
     end
   end
 
+  before(:all) do
+    # this value is cached in the Document as a class variable, so we need it
+    # to not change between tests
+    @finder_content_id = SecureRandom.uuid
+  end
+
   let(:finder_schema) {
     {
       base_path: "/my-document-types",
       filter: {
         document_type: "my_document_type",
       },
-      content_id: SecureRandom.uuid
+      content_id: @finder_content_id
     }.deep_stringify_keys
   }
 
@@ -106,6 +112,9 @@ RSpec.describe Document do
           field2: "open",
           field3: %w(x y z),
         }
+      },
+      links: {
+        finder: [@finder_content_id]
       }
     }
   }


### PR DESCRIPTION
Add edition links to the finder of a specialist document when saving.

Although this works, it shouldn't be merged until govuk-content-schemas#539 is merged. The reason why it currently passes schema validation checks is that [the schema for edition links is very lax](https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/specialist_document/publisher_v2/schema.json#L125).