### PR TITLE
Add “select all”/“clear all” buttons to dropdown menus

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require select2
+//= require dropdown_select_all
 //= require length_counter
 //= require form_change_protection
 
@@ -7,6 +8,11 @@ jQuery(function($) {
   $(".select2").select2({
     placeholder: $(this).data('placeholder')
   });
+
+  ////
+  // Add "select all"/"clear all" buttons to each select2 dropdown menu
+  var dropdownSelectAll = new GOVUKAdmin.Modules.DropdownSelectAll();
+  dropdownSelectAll.start($("select.select2"));
 
   ////
   // Make a select2 that will create new values on return as you type them

--- a/app/assets/javascript/dropdown_select_all.js
+++ b/app/assets/javascript/dropdown_select_all.js
@@ -1,0 +1,32 @@
+(function(Modules) {
+  "use strict";
+  Modules.DropdownSelectAll = function() {
+    var that = this;
+    that.start = function(elements) {
+      elements.each(function() {
+        var selectId = $(this).attr("id");
+        $(this).parent()
+          .append('<a href="#" class="dropdown-select-all" data-select-id="#' + selectId  + '">Select all</a>')
+          .append('<a href="#" class="dropdown-clear-all" data-select-id="#' + selectId + '">Clear all</a>');
+      });
+
+      $(".dropdown-select-all").click(function() {
+        var selectId = $(this).data("select-id");
+        $(selectId + " option:not(:selected)")
+          .prop("selected", true)
+          .parent()
+          .trigger("change");
+        return false;
+      });
+
+      $(".dropdown-clear-all").click(function() {
+        var selectId = $(this).data("select-id");
+        $(selectId + " option:selected")
+          .prop("selected", false)
+          .parent()
+          .trigger("change");
+        return false;
+      });
+    };
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -18,6 +18,12 @@ form {
     width: 100%;
   }
 
+  .dropdown-select-all,
+  .dropdown-clear-all {
+    margin-top: 10px;
+    margin-right: 10px;
+  }
+
   .short-textarea {
     height: 50px;
   }


### PR DESCRIPTION
This commit adds “select all”/“clear all” buttons to dropdown menus. These buttons allow a user to quickly select or clear all options in a dropdown menu with one action, which is useful if there are many options that are often all selected.

The buttons require JavaScript and are also added using JavaScript, so they won’t appear if the browser has JavaScript disabled.

This change was requested by content designers working on the migration of the business finance support schemes, but can be useful elsewhere due to its generic nature.

Trello: https://trello.com/c/3Dnak3do/515-add-select-all-clear-all-buttons-for-select-fields-in-specialist-publisher

![out](https://cloud.githubusercontent.com/assets/444232/23398807/dd2103b4-fd95-11e6-8a6e-3ff782c48aa0.gif)
