### PR TITLE
Revert "Add specialist document links to the parent"

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -287,11 +287,11 @@ class Document
     }
   end
 
+private
+
   def finder_schema
     self.class.finder_schema
   end
-
-private
 
   def param_value(params, key)
     date_param_value(params, key) || params.fetch(key, nil)

--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -7,8 +7,7 @@ class DocumentLinksPresenter
     {
       content_id: document.content_id,
       links: {
-        organisations: document.organisations,
-        parent: [parent_content_id]
+        organisations: document.organisations
       },
     }
   end
@@ -16,8 +15,4 @@ class DocumentLinksPresenter
 private
 
   attr_reader :document
-
-  def parent_content_id
-    document.finder_schema.content_id
-  end
 end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -5,8 +5,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     {
       "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
       "links" => {
-        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
-        "parent" => ["fef4ac7c-024a-4943-9f19-e85a8369a1f3"],
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
       }
     }
   end


### PR DESCRIPTION
Reverts alphagov/specialist-publisher#1014

Unfortunately the reverse links from this change cause a real pain as the finders end up with a link to every item (`children`) and we end up with huge content items. 

See https://github.com/alphagov/publishing-api/pull/835 for more info.