### PR TITLE
Enable EAT finder

### DIFF
--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -18,7 +18,6 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "First-tier Tribunal (Asylum Support) decisions",
   "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
-  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/dfid_research_outputs.json
+++ b/lib/documents/schemas/dfid_research_outputs.json
@@ -4,7 +4,6 @@
   "format_name": "Research for Development Output",
   "name": "Research for Development Outputs",
   "description": "Find outputs from Research for Development projects",
-  "pre_production": false,
   "filter": {
     "document_type": "dfid_research_output"
   },

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -18,7 +18,7 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment Appeal Tribunal decisions",
   "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
-  "pre_production": true,
+  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -18,7 +18,6 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment Appeal Tribunal decisions",
   "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
-  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -18,7 +18,6 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment tribunal decisions",
   "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
-  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -66,7 +66,6 @@
     }
   ],
   "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
-  "pre_production": false,
   "document_noun": "decision",
   "facets": [
     {

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -16,7 +16,6 @@
     "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
   ],
   "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions",
-  "pre_production": false,
   "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>This includes decisions made from January 2016 onwards. You can find details of <a rel=\"external\" href=\"http://administrativeappeals.decisions.tribunals.gov.uk/Aspx/default.aspx\">decisions made in 2015 or earlier</a> on the Courts and Tribunals Judiciary website.</p>",
   "document_noun": "decision",
   "facets": [


### PR DESCRIPTION
This will go live on 15th March and will be at www.gov.uk/employment-appeal-tribunal-decisions

https://trello.com/c/p5iD9WwS/686-publish-eat-decisions-finder