### PR TITLE
Sort business finance support schemes in alphabetical order

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -16,6 +16,7 @@
   ],
   "subscription_list_title_prefix": "Business finance support schemes",
   "document_noun": "scheme",
+  "default_order": "title",
   "facets": [
     {
         "key": "types_of_support",


### PR DESCRIPTION
This commit changes the sort order for business finance support schemes to alphabetical to match the behaviour of the old finder.

Deployment checklist:

- [x] Deploy specialist-publisher
- [x] Run the rake tasks `publishing_api:publish_finders` and `rummager:publish_finders` to apply the changes