### PR TITLE
Change label for "will continue on" metadata field

### DIFF
--- a/app/views/metadata_fields/_business_finance_support_schemes.html.erb
+++ b/app/views/metadata_fields/_business_finance_support_schemes.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :continuation_link } do %>
   <%= f.url_field :continuation_link, class: 'form-control' %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on, label: 'Will continue' } do %>
   <%= f.text_field :will_continue_on, class: 'form-control' %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :types_of_support, label: 'Types of support offered' } do %>


### PR DESCRIPTION
This commit changes the label for the "will continue on" metadata field to "will continue" to prevent users from thinking that "on" will be prepended to the text they enter in the field.

Requested by Constance from the Content Team.