### PR TITLE
Remove business finance support finder metadata

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -23,7 +23,7 @@
         "name": "Type of support",
         "type": "text",
         "preposition": "of type",
-        "display_as_result_metadata": true,
+        "display_as_result_metadata": false,
         "filterable": true,
         "allowed_values": [
           {"label": "Finance", "value": "finance"},
@@ -40,7 +40,7 @@
       "name": "Business stage",
       "type": "text",
       "preposition": "for businesses which are",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "Not yet trading", "value": "not-yet-trading"},
@@ -54,7 +54,7 @@
       "name": "Industry",
       "type": "text",
       "preposition": "for businesses in",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "Agriculture and food", "value": "agriculture-and-food"},
@@ -81,7 +81,7 @@
       "name": "Number of employees",
       "type": "text",
       "preposition": "for businesses with",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "0 to 9 employees", "value": "under-10"},


### PR DESCRIPTION
This commit removes the metadata from the business finance support finder.

Asked for by the content design team.

Deployment checklist:

- [ ] Deploy specialist-publisher
- [ ] Run the rake tasks `publishing_api:publish_finders` and `rummager:publish_finders` to republish the finder

Before:

![screen shot 2017-03-27 at 10 49 20](https://cloud.githubusercontent.com/assets/444232/24351112/6fb5f1b6-12dc-11e7-878b-33985b6ec3da.png)

After:

![screen shot 2017-03-27 at 10 58 33](https://cloud.githubusercontent.com/assets/444232/24351119/741f937e-12dc-11e7-81c3-11d4d616b3c1.png)
