### PR TITLE
Switch rendering app to government-frontend

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -14,7 +14,7 @@ class DocumentPresenter
       change_note: document.change_note,
       schema_name: "specialist_document",
       publishing_app: "specialist-publisher",
-      rendering_app: "specialist-frontend",
+      rendering_app: "government-frontend",
       locale: "en",
       phase: document.phase,
       details: details,

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -14,7 +14,7 @@ class SearchPresenter
       link: document.base_path,
       indexable_content: indexable_content,
       publishing_app: 'specialist-publisher',
-      rendering_app: 'specialist-frontend',
+      rendering_app: 'government-frontend',
       public_timestamp: format_date(document.public_updated_at),
       first_published_at: format_date(document.first_published_at),
     }.merge(document.format_specific_metadata).reject { |_k, v| v.blank? }

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "document_type" => "cma_case",
       "schema_name" => "specialist_document",
       "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
+      "rendering_app" => "government-frontend",
       "locale" => "en",
       "phase" => "live",
       "details" => {
@@ -304,7 +304,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
       "document_type" => "cma_case",
       "schema_name" => "specialist_document",
       "publishing_app" => "specialist-publisher",
-      "rendering_app" => "specialist-frontend",
+      "rendering_app" => "government-frontend",
       "locale" => "en",
       "phase" => "live",
       "details" => {

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -68,7 +68,7 @@ FactoryGirl.define do
     schema_name "specialist_document"
     document_type nil
     publishing_app "specialist-publisher"
-    rendering_app "specialist-frontend"
+    rendering_app "government-frontend"
     locale "en"
     phase "live"
     redirects []

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SearchPresenter do
 
       it 'includes publishing and rendering apps' do
         expect(json[:publishing_app]).to eql('specialist-publisher')
-        expect(json[:rendering_app]).to eql('specialist-frontend')
+        expect(json[:rendering_app]).to eql('government-frontend')
       end
 
       it 'does not include blank values' do


### PR DESCRIPTION
Part of: https://trello.com/c/LnV838V3/193-penultimate-stage-re-publish-specialist-content-to-switch-rendering-app-1

It can be merged and deployed when government-frontend can correctly render specialist content.