### PR TITLE
Add ops manual content to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,46 @@ $ bundle exec rake
 
 👉 [Creating a new specialist document type](/docs/creating-a-new-specialist-document-type.md)
 
+## Running tasks
+
+You can use the Jenkins rake task runner to run these tasks.
+
+### Discarding a draft document
+
+If a document has been created in draft, it can be discarded with this task:
+`ops:discard['some-content-id']`
+
+### Triggering an email notification
+
+If an email has not been sent for a document, it can be re-triggered with this task:
+`ops:email['some-content-id']`
+
+### Setting the public_updated_at
+
+If a document has an incorrect public_updated_at, it can be set with this task:
+`ops:set_public_updated_at['some-content-id','2016-01-01']`
+
+This is useful if a published document is appearing with an incorrect published time on GOV.UK. This is not something users of the publishing app can set manually and so occasionally we get support requests to change this.
+
+Rails will call `DateTime.parse` on the string provided, so most formats should work. You can also pass ‘now’ to use the current time.
+
+You can’t currently set the `public_updated_at` field if a publisher has created a new draft for the document. You’ll either need to discard it or publish it first for this task to succeed.
+
+### Republishing
+
+Republishing is useful if content failed to make its way through the system. This might be the case if an error was thrown somewhere along the way. Republishing a document will notify Publishing API and Rummager of the change. It will not send email notifications.
+
+You can republish a single document with this task:
+`republish:one['some-content-id']`
+
+You can republish all documents for a document_type with this task:
+`republish:document_type['some_document_type']`
+
+You can republish all specialist documents with this task:
+`republish:all`
+
+These last two tasks place a large number of items on Specialist Publisher’s sidekiq queue. These tasks could take a very long time to complete. You can’t currently republish published documents if a publisher has created a new draft for the document.
+
 ## Phase 2 migration
 
 There is tonnes of information on our learnings from migrating this app to


### PR DESCRIPTION
As part of reviewing the documentation, we are moving content out of
the ops manual. This PR moves the content about Specialist Publisher from
the ops manual to the README.

[Trello card](https://trello.com/c/5x8NHLhf/40-merge-opsmanual-into-developer-docs)