### PR TITLE
Add fallback OAuth ID and secret

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,9 +2,9 @@ GDS::SSO.config do |config|
   config.user_model   = 'User'
 
   # set up ID and Secret in a way which doesn't require it to be checked in to source control...
-  config.oauth_id     = ENV['OAUTH_ID']
-  config.oauth_secret = ENV['OAUTH_SECRET']
+  config.oauth_id     = ENV['OAUTH_ID'] || "abcdefg"
+  config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
 
-  # optional config for location of signonotron2
+  # optional config for location of signon
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
This commit adds a fallback OAuth ID and secret. This will allow the signon-munging script for development to configure signon for this app locally.