### PR TITLE
Add `republish:many` rake task to process multiple content items

### DIFF
--- a/lib/republisher.rb
+++ b/lib/republisher.rb
@@ -17,6 +17,12 @@ module_function
     RepublishWorker.new.perform(content_id)
   end
 
+  def republish_many(content_ids)
+    content_ids.split(',').each do |content_id|
+      RepublishWorker.new.perform(content_id)
+    end
+  end
+
   def all_content_ids
     document_types.flat_map { |t| content_ids_for_document_type(t) }
   end

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -18,4 +18,9 @@ namespace :republish do
   task :one, [:content_id] => :environment do |_, args|
     Republisher.republish_one(args.content_id)
   end
+
+  desc "republish a many document"
+  task :many, [:content_ids] => :environment do |_, args|
+    Republisher.republish_many(args.content_ids)
+  end
 end

--- a/spec/lib/republisher_spec.rb
+++ b/spec/lib/republisher_spec.rb
@@ -56,4 +56,24 @@ RSpec.describe Republisher do
       subject.republish_one("content-id")
     end
   end
+
+  describe ".republish_many" do
+    it "immediately runs the job rather than enqueueing it" do
+      expect(RepublishWorker).not_to receive(:perform_async)
+
+      expect_any_instance_of(RepublishWorker).to receive(:perform).with("content-id")
+      expect_any_instance_of(RepublishWorker).not_to receive(:perform).with("raib-1")
+
+      subject.republish_many("content-id")
+    end
+
+    it "can run multiple content items from a comma separated list" do
+      republish_worker = double
+      allow(RepublishWorker).to receive(:new).and_return(republish_worker)
+      expect(republish_worker).to receive(:perform).with("content-id-1")
+      expect(republish_worker).to receive(:perform).with("content-id-2")
+
+      subject.republish_many("content-id-1,content-id-2")
+    end
+  end
 end


### PR DESCRIPTION
Allow a comma separated list of content items to be passed in for republishing.