### PR TITLE
Use async when republishing many

### DIFF
--- a/lib/republisher.rb
+++ b/lib/republisher.rb
@@ -19,7 +19,7 @@ module_function
 
   def republish_many(content_ids)
     content_ids.split(',').each do |content_id|
-      RepublishWorker.new.perform(content_id)
+      RepublishWorker.perform_async(content_id)
     end
   end
 

--- a/spec/lib/republisher_spec.rb
+++ b/spec/lib/republisher_spec.rb
@@ -58,20 +58,16 @@ RSpec.describe Republisher do
   end
 
   describe ".republish_many" do
-    it "immediately runs the job rather than enqueueing it" do
-      expect(RepublishWorker).not_to receive(:perform_async)
-
-      expect_any_instance_of(RepublishWorker).to receive(:perform).with("content-id")
-      expect_any_instance_of(RepublishWorker).not_to receive(:perform).with("raib-1")
+    it "enqueues a republish job for the given content ids" do
+      expect(RepublishWorker).to receive(:perform_async).with("content-id")
+      expect(RepublishWorker).not_to receive(:perform_async).with("raib-1")
 
       subject.republish_many("content-id")
     end
 
     it "can run multiple content items from a comma separated list" do
-      republish_worker = double
-      allow(RepublishWorker).to receive(:new).and_return(republish_worker)
-      expect(republish_worker).to receive(:perform).with("content-id-1")
-      expect(republish_worker).to receive(:perform).with("content-id-2")
+      expect(RepublishWorker).to receive(:perform_async).with("content-id-1")
+      expect(RepublishWorker).to receive(:perform_async).with("content-id-2")
 
       subject.republish_many("content-id-1,content-id-2")
     end


### PR DESCRIPTION
This will make monitoring and tracking of the processed content items easier to follow