### PR TITLE
Use space separated list of republish:many rake task

### DIFF
--- a/lib/republisher.rb
+++ b/lib/republisher.rb
@@ -18,7 +18,7 @@ module_function
   end
 
   def republish_many(content_ids)
-    content_ids.split(',').each do |content_id|
+    content_ids.split(' ').each do |content_id|
       RepublishWorker.perform_async(content_id)
     end
   end

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -19,7 +19,7 @@ namespace :republish do
     Republisher.republish_one(args.content_id)
   end
 
-  desc "republish a many document"
+  desc "republish a many document (space separated list of content IDs)"
   task :many, [:content_ids] => :environment do |_, args|
     Republisher.republish_many(args.content_ids)
   end

--- a/spec/lib/republisher_spec.rb
+++ b/spec/lib/republisher_spec.rb
@@ -65,11 +65,11 @@ RSpec.describe Republisher do
       subject.republish_many("content-id")
     end
 
-    it "can run multiple content items from a comma separated list" do
+    it "can run multiple content items from a space separated list" do
       expect(RepublishWorker).to receive(:perform_async).with("content-id-1")
       expect(RepublishWorker).to receive(:perform_async).with("content-id-2")
 
-      subject.republish_many("content-id-1,content-id-2")
+      subject.republish_many("content-id-1 content-id-2")
     end
   end
 end


### PR DESCRIPTION
This is required as comma separated list parse out each content_id as a
separate arg which can't be easily captured in rake.