### PR TITLE
Make date field in DocumentSearch optional

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -21,7 +21,7 @@ class SearchPresenter
   end
 
   def format_date(timestamp)
-    raise ArgumentError, "Timestamp is blank" if timestamp.blank?
+    return nil if timestamp.blank?
     timestamp.to_datetime.rfc3339
   end
 


### PR DESCRIPTION
Due to a problem with the republish task documents are being returned
without a public_updated_at value. Instead of creating am error during
rummager republishing, these will now be republished to ES with the
field being nil.