### PR TITLE
Allow republishing to search only

### DIFF
--- a/lib/republisher.rb
+++ b/lib/republisher.rb
@@ -18,8 +18,16 @@ module_function
   end
 
   def republish_many(content_ids)
-    content_ids.split(' ').each do |content_id|
+    content_ids.each do |content_id|
       RepublishWorker.perform_async(content_id)
+    end
+  end
+
+  def republish_search_sync(content_ids)
+    content_ids.each do |content_id|
+      document = Document.find(content_id)
+      payload = SearchPresenter.new(document).to_json
+      Services.rummager.add_document(document.search_document_type, document.base_path, payload)
     end
   end
 

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -19,8 +19,13 @@ namespace :republish do
     Republisher.republish_one(args.content_id)
   end
 
-  desc "republish a many document (space separated list of content IDs)"
+  desc "republish many documents (space separated list of content IDs)"
   task :many, [:content_ids] => :environment do |_, args|
-    Republisher.republish_many(args.content_ids)
+    Republisher.republish_many(args.content_ids.split(' '))
+  end
+
+  desc "synchronously republish documents to rummager (space separated list of content IDs)"
+  task :search, [:content_ids] => :environment do |_, args|
+    Republisher.republish_search_sync(args.content_ids.split(' '))
   end
 end

--- a/spec/lib/republisher_spec.rb
+++ b/spec/lib/republisher_spec.rb
@@ -59,17 +59,11 @@ RSpec.describe Republisher do
 
   describe ".republish_many" do
     it "enqueues a republish job for the given content ids" do
-      expect(RepublishWorker).to receive(:perform_async).with("content-id")
-      expect(RepublishWorker).not_to receive(:perform_async).with("raib-1")
-
-      subject.republish_many("content-id")
-    end
-
-    it "can run multiple content items from a space separated list" do
       expect(RepublishWorker).to receive(:perform_async).with("content-id-1")
       expect(RepublishWorker).to receive(:perform_async).with("content-id-2")
+      expect(RepublishWorker).not_to receive(:perform_async).with("raib-1")
 
-      subject.republish_many("content-id-1 content-id-2")
+      subject.republish_many(["content-id-1", "content-id-2"])
     end
   end
 end


### PR DESCRIPTION
Due to issues with republishing to publisher-api we have extracted the
code to republish search to a separate rake ask `republish:search`