### PR TITLE
Add a cautionary note to the republish tasks

### DIFF
--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -4,6 +4,14 @@ require 'csv'
 require 'services'
 
 namespace :republish do
+  # Caution: These tasks should be avoided in production environnments (with
+  # the exception of republish to rummager) as they change the date information
+  # of draft documents and extra superfluous history to published documents.
+  #
+  # If data is incorrect in Publishing API it should be fixed in Publishing API
+  # whereas if there is problems with the search index the republish to rummager
+  # task should be used.
+
   desc "republish all documents"
   task all: :environment do
     Republisher.republish_all


### PR DESCRIPTION
These can be quite dangerous in a production environment, even now we
have fixed bugs in the Publishing API surrounding them.