### PR TITLE
Revert "Make date field in DocumentSearch optional"

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -21,7 +21,7 @@ class SearchPresenter
   end
 
   def format_date(timestamp)
-    return nil if timestamp.blank?
+    raise ArgumentError, "Timestamp is blank" if timestamp.blank?
     timestamp.to_datetime.rfc3339
   end
 


### PR DESCRIPTION
This reverts commit 230461613f1a51d4cb93d415e27001c4dd66c748.

Date fields were made optional because of a problem in a publishing API republishing task which was not saving the dates correctly. This caused errors in finder-frontend because Atom feeds for finders rely on the `public_timestamp` field).

The original publishing API issue has now been fixed so specialist publisher should no longer send blank date fields to the search API.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents