### PR TITLE
Add documentation about `discard_draft` task in Publishing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ You can use the Jenkins rake task runner to run these tasks.
 If a document has been created in draft, it can be discarded with this task:
 `ops:discard['some-content-id']`
 
+Drafts can also be discarded by running a similar task from the Publishing API:
+
+`discard_draft['some-content-id']`
+
+See [Admin Tasks](https://github.com/alphagov/publishing-api/blob/master/doc/admin-tasks.md)
+
 ### Triggering an email notification
 
 If an email has not been sent for a document, it can be re-triggered with this task:


### PR DESCRIPTION
Trello card: https://trello.com/c/PSlBhEMi
Depends on: https://github.com/alphagov/publishing-api/pull/941

When the new discard_draft task in Publishing API is merged, the `ops:discard` task can be removed.