### PR TITLE
Add support for unpublishing with a redirect

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -79,11 +79,14 @@ class DocumentsController < ApplicationController
   end
 
   def unpublish
-    if @document.unpublish
+    if @document.unpublish(params[:alternative_path])
       flash[:success] = "Unpublished #{@document.title}"
     else
       flash[:danger] = unknown_error_message
     end
+  rescue DocumentUnpublisher::AlternativeContentNotFound => e
+    flash[:danger] = e.message
+  ensure
     redirect_to document_path(current_format.slug, params[:content_id])
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -199,9 +199,9 @@ class Document
     end
   end
 
-  def unpublish
+  def unpublish(alternative_path = nil)
     handle_remote_error do
-      DocumentUnpublisher.unpublish(content_id, base_path)
+      DocumentUnpublisher.unpublish(content_id, base_path, alternative_path)
     end
   end
 

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -1,7 +1,23 @@
 # Unpublish a document. Also removes attachments and removes it from search.
 class DocumentUnpublisher
-  def self.unpublish(content_id, base_path)
-    Services.publishing_api.unpublish(content_id, type: 'gone')
+  AlternativeContentNotFound = Class.new(StandardError)
+
+  def self.unpublish(content_id, base_path, alternative_path = nil)
+    if alternative_path.blank?
+      Services.publishing_api.unpublish(content_id, type: 'gone')
+
+    elsif Services.publishing_api.lookup_content_id(base_path: alternative_path)
+      Services.publishing_api.unpublish(
+        content_id,
+        type: 'redirect',
+        alternative_path: alternative_path,
+      )
+
+    else
+      raise AlternativeContentNotFound, 'Alternative content not found at ' \
+                                          "the path '#{alternative_path}'"
+    end
+
     AttachmentDeleteWorker.perform_async(content_id)
     RummagerDeleteWorker.perform_async(base_path)
   end

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -28,10 +28,17 @@
         <%= presenter.unpublish_text %>
 
         <% if presenter.unpublish_button_visible? %>
-          <button name="submit" class="btn btn-warning"
-                  data-module="confirm"
-                  data-message="<%= presenter.unpublish_alert %>"
-                  data-disable-with="Unpublishing..." >Unpublish document</button>
+          <div class="form-group">
+            <label for="alternative_path">Redirect to alternative GOV.UK content path</label>
+            <input type="text" name="alternative_path" class="form-control">
+          </div>
+
+          <div class="form-group">
+            <button name="submit" class="btn btn-warning"
+                    data-module="confirm"
+                    data-message="<%= presenter.unpublish_alert %>"
+                    data-disable-with="Unpublishing..." >Unpublish document</button>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe Document do
     it "sends correct payload to publishing api" do
       expect(document.unpublish).to eq(true)
 
-      assert_publishing_api_unpublish(document.content_id)
+      assert_publishing_api_unpublish(document.content_id, type: 'gone')
     end
 
     it "sends a delete request to Rummager" do
@@ -442,6 +442,17 @@ RSpec.describe Document do
       expect(AttachmentDeleteWorker).to receive(:perform_async).with(payload["content_id"])
 
       document.unpublish
+    end
+
+    context "with an alternative path" do
+      it "sends correct payload to publishing api" do
+        publishing_api_has_lookups('/foo' => SecureRandom.uuid)
+        stub_publishing_api_unpublish(document.content_id, body: { type: 'redirect', alternative_path: '/foo' })
+
+        expect(document.unpublish('/foo')).to eq(true)
+
+        assert_publishing_api_unpublish(document.content_id, type: 'redirect', alternative_path: '/foo')
+      end
     end
 
     context "unsuccessful #unpublish" do


### PR DESCRIPTION
Allows for the path of alternative content to be specified when unpublishing a document.

Needed for https://trello.com/c/xm4W1SzB

Before:
<img width="766" alt="screen shot 2017-06-19 at 15 02 27" src="https://user-images.githubusercontent.com/2715/27288987-581455a0-5500-11e7-80ca-03d0a3a28f0b.png">

After:
<img width="775" alt="screen shot 2017-06-19 at 15 01 25" src="https://user-images.githubusercontent.com/2715/27288956-3bf8cde2-5500-11e7-97c6-574451f8338e.png">
