### PR TITLE
Update MHRA’s email address

### DIFF
--- a/app/views/email_alerts/medical_safety_alerts/publication.html.erb
+++ b/app/views/email_alerts/medical_safety_alerts/publication.html.erb
@@ -38,7 +38,7 @@
 
       <p style="color: #0B0C0C; font-family: sans-serif; font-size: 19px; line-height: 1.315789474; margin: 15px 0;">
         This is an automatically generated email, enquiries should be sent to:
-        <a href="mailto:email.support@mhra.gsi.gov.uk" style="color: #005EA5;">email.support@mhra.gsi.gov.uk</a>
+        <a href="mailto:email.support@mhra.gov.uk" style="color: #005EA5;">email.support@mhra.gov.uk</a>
       </p>
     </td>
   </tr>

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EmailAlertPresenter do
     end
 
     context "Medical Safety Alerts documents" do
-      let(:mhra_email_address) { "email.support@mhra.gsi.gov.uk" }
+      let(:mhra_email_address) { "email.support@mhra.gov.uk" }
 
       before do
         publishing_api_has_item(medical_safety_payload)


### PR DESCRIPTION
https://trello.com/c/FdvTwmGr/901-change-email-address-in-mrha-drug-alert-2016-email-footer-template

These emails are sent via a call to the `email-alert-api` from a Sidekiq worker in this app. Payloads are pre-computed when jobs are enqueued so existing messages will be sent with the old address. After the app is restarted after deploy, emails will be sent with the new address.