### PR TITLE
Send update_type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '~> 4.9.0'
 
 # GDS managed dependencies
-gem "gds-api-adapters", "41.5.0"
+gem "gds-api-adapters", "47.2"
 gem 'gds-sso', '13.2.0'
 gem "govspeak", "~> 5.0.1"
 gem 'govuk_admin_template', '~> 4.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    gds-api-adapters (41.5.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -230,7 +230,7 @@ GEM
       pry (>= 0.10.4)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -271,7 +271,7 @@ GEM
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.2)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -385,7 +385,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl
   foreman
-  gds-api-adapters (= 41.5.0)
+  gds-api-adapters (= 47.2)
   gds-sso (= 13.2.0)
   govspeak (~> 5.0.1)
   govuk-content-schema-test-helpers
@@ -415,4 +415,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/services/document_publisher.rb
+++ b/app/services/document_publisher.rb
@@ -7,8 +7,7 @@ class DocumentPublisher
       document.update_type = 'major'
       document.save
     end
-
-    Services.publishing_api.publish(document.content_id, document.update_type)
+    Services.publishing_api.publish(document.content_id)
 
     published_document = document.class.find(document.content_id)
     indexable_document = SearchPresenter.new(published_document)

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -47,7 +47,7 @@ private
 
     Services.publishing_api.put_content(finder_payload.content_id, finder_payload.to_json)
     Services.publishing_api.patch_links(finder_payload.content_id, links_payload.to_json)
-    Services.publishing_api.publish(finder_payload.content_id, "major")
+    Services.publishing_api.publish(finder_payload.content_id)
   end
 
   def export_signup(finder)
@@ -64,6 +64,6 @@ private
 
     Services.publishing_api.put_content(signup_payload.content_id, signup_payload.to_json)
     Services.publishing_api.patch_links(signup_payload.content_id, links_payload.to_json)
-    Services.publishing_api.publish(signup_payload.content_id, "major")
+    Services.publishing_api.publish(signup_payload.content_id)
   end
 end

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:patch_links)
           .with(finders[0][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
-          .with(finders[0][:file]["content_id"], "major")
+          .with(finders[0][:file]["content_id"])
 
         # This should be validated against an email-signup schema if one gets created
         expect(publishing_api).to receive(:put_content)
@@ -72,7 +72,7 @@ RSpec.describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:patch_links)
           .with(finders[0][:file]["signup_content_id"], anything)
         expect(publishing_api).to receive(:publish)
-          .with(finders[0][:file]["signup_content_id"], "major")
+          .with(finders[0][:file]["signup_content_id"])
 
 
         expect(publishing_api).to receive(:put_content)
@@ -80,7 +80,7 @@ RSpec.describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:patch_links)
           .with(finders[1][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
-          .with(finders[1][:file]["content_id"], "major")
+          .with(finders[1][:file]["content_id"])
 
         PublishingApiFinderPublisher.new(finders, logger: test_logger).call
       end
@@ -107,7 +107,7 @@ RSpec.describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:patch_links)
           .with(finders[0][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
-          .with(finders[0][:file]["content_id"], "major")
+          .with(finders[0][:file]["content_id"])
 
         PublishingApiFinderPublisher.new(finders, logger: test_logger).call
       end
@@ -134,7 +134,7 @@ RSpec.describe PublishingApiFinderPublisher do
         expect(publishing_api).to receive(:patch_links)
           .with(content_id, anything)
         expect(publishing_api).to receive(:publish)
-          .with(content_id, "major")
+          .with(content_id)
 
         PublishingApiFinderPublisher.new(finders, logger: test_logger).call
       end
@@ -166,7 +166,7 @@ RSpec.describe PublishingApiFinderPublisher do
           expect(publishing_api).to receive(:patch_links)
             .with(content_id, anything)
           expect(publishing_api).to receive(:publish)
-            .with(content_id, "major")
+            .with(content_id)
 
           PublishingApiFinderPublisher.new(finders, logger: test_logger).call
         end
@@ -179,7 +179,7 @@ RSpec.describe PublishingApiFinderPublisher do
           expect(publishing_api).not_to receive(:patch_links)
             .with(content_id, anything)
           expect(publishing_api).not_to receive(:publish)
-            .with(content_id, "major")
+            .with(content_id)
 
           PublishingApiFinderPublisher.new(finders, logger: test_logger).call
         end


### PR DESCRIPTION
We are deprecating sending the update_type in publish requests made to the
Publishing API, and now expect clients to send update_type in PUT requests
instead. We also upgrade gds-api-adapters to bring this app up to date with
the new expected behaviour

https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk