### PR TITLE
Add new jurisdiction code to employment tribunal decisions

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -142,6 +142,10 @@
           "value": "national-security"
         },
         {
+          "label": "Notice Appeal",
+          "value": "notice-appeal"
+        },
+        {
           "label": "Parental and Maternity Leave",
           "value": "parental-and-maternity-leave"
         },


### PR DESCRIPTION
The new jurisdiction code of 'Notice Appeal' has been added to the
Employment Tribunal Decisions finder.

The following rake tasks will also need to be run:
- [ ] `rake publishing_api:publish_finders`
- [ ] `rake rummager:publish_finders`

[Trello card](https://trello.com/c/oz9hqJcn/997-add-new-jurisdiction-code-to-specialist-publisher-2)