### PR TITLE
Change the display title of medical_specialism

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -66,7 +66,7 @@
     },
     {
       "key": "medical_specialism",
-      "name": "Medical specialism",
+      "name": "Medical speciality",
       "type": "text",
       "preposition": "about",
       "display_as_result_metadata": true,


### PR DESCRIPTION
For: https://trello.com/c/HbnBgaJd/208-rename-filter-title-in-mhra-finder

The people that care about the medical safety alerts don't talk about
specialisms they talk about specialities so we want to change the
display title of the field to match their wording.  We're leaving the
field name as is though because changing it requires schema changes and
republishing every medical safety alert document, whereas changing only
the title means we only need to republish the finder (doing so will
represent all the documents to content-store because of dependency
resolution, but that's a lesser task than republishing them all).