### PR TITLE
Change the display title of medical_specialism

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -66,7 +66,7 @@
     },
     {
       "key": "medical_specialism",
-      "name": "Medical speciality",
+      "name": "Medical specialty",
       "type": "text",
       "preposition": "about",
       "display_as_result_metadata": true,


### PR DESCRIPTION
For: https://trello.com/c/HbnBgaJd/208-rename-filter-title-in-mhra-finder

We got it wrong in the previous commit
(78110ee1915f9c221b068ed0e873b7c8f79ec8c5 - #1051) it should be specialty, not
speciality.  Specialty is the medical term and medicine is the domain for
this finder, so that's the word we should use.