### PR TITLE
Add 'Reasonable Adjustment' sub-category

### DIFF
--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -274,6 +274,10 @@
           "value": "contract-of-employment-wrongful-dismissal"
         },
         {
+          "label": "Disability Discrimination - Reasonable Adjustment",
+          "value": "disability-discrimination-reasonable-adjustment"
+        },
+        {
           "label": "Equal Pay Act - Article 141/European law",
           "value": "equal-pay-act-article-141-european-law"
         },


### PR DESCRIPTION
This is a sub-category of 'Disability Discrimination'.

[Trello Card](https://trello.com/c/8li9QhUC/1046-1-add-reasonable-adjustment-as-a-sub-category-to-the-employment-appeal-tribunal-eat-finder)