### PR TITLE
Add task to publishing special routes for Finder Frontend site search

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,0 +1,43 @@
+require 'gds_api/publishing_api/special_route_publisher'
+
+class SpecialRoutePublisher
+  def initialize(publisher_options)
+    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+  end
+
+  def publish(route)
+    payload = route.merge(
+      format: "special_route",
+      publishing_app: "finder-frontend",
+      rendering_app: "finder-frontend",
+      type: route_type,
+      public_updated_at: Time.zone.now.iso8601,
+      update_type: "major",
+    )
+
+    @publisher.publish(payload)
+  rescue GdsApi::TimedOutException
+    puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
+  rescue GdsApi::HTTPServerError => e
+    puts "WARNING: publishing-api errored out when trying to publish route #{payload.inspect}\n\nError: #{e.inspect}"
+  end
+
+  def self.routes
+    [
+      {
+        content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",
+        base_path: "/test-search/search",
+        title: "GOV.UK search results API",
+        description: "Sitewide search results are displayed in JSON format here.",
+        type: 'exact',
+      },
+      {
+        content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",
+        base_path: "/test-search/search.json",
+        title: "GOV.UK search results API",
+        description: "Sitewide search results are displayed in JSON format here.",
+        type: 'exact',
+      }
+    ]
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,4 +12,18 @@ namespace :publishing_api do
       puts "Error publishing finder: #{e.inspect}"
     end
   end
+
+  desc "Publish special routes"
+  task publish_special_routes: :environment do
+    logger = Logger.new(STDOUT)
+
+    publisher = SpecialRoutePublisher.new(
+      logger: logger,
+      publishing_api: Services.publishing_api
+    )
+
+    SpecialRoutePublisher.routes.each do |route|
+      publisher.publish(route)
+    end
+  end
 end


### PR DESCRIPTION
We are adding site search to Finder Frontend. As these are published using Specialist Publisher to manage the special route as it already talks to the Publishing API.

https://trello.com/c/lxKbO5Xw