### PR TITLE
Update Employment Tribunal Decisions finder description to include information about older decisions

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -17,7 +17,7 @@
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment tribunal decisions",
-  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-tribunal-hearing-centre-eagle-building'>Glasgow Tribunal Hearing Centre</a> for cases in Scotland.</p>",
   "document_noun": "decision",
   "facets": [
     {


### PR DESCRIPTION
We've been notified by Lis Ramsay (HMCTS) about users contacting them about older decisions
and that they can't be found.

Zendesk for context: https://govuk.zendesk.com/agent/tickets/2266400

Tested on integration by deploying this branch and running the rake task `publishing_api:publish_finders`

![screen shot 2017-10-23 at 16 22 34](https://user-images.githubusercontent.com/2445413/31897474-68783346-b80e-11e7-80f1-73399b6064f7.png)
