### PR TITLE
Present all necessary fields to email-alert-api

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -7,12 +7,25 @@ class EmailAlertPresenter
 
   def to_json
     {
+      title: title,
+      description: summary,
+      change_note: change_note,
       subject: subject,
       body: body,
       tags: tags,
       urgent: urgent,
       document_type: document.document_type,
+      email_document_supertype: "other",
+      government_document_supertype: "other",
+      content_id: content_id,
+      public_updated_at: public_updated_at,
+      publishing_app: "specialist-publisher",
+      base_path: base_path
     }.merge(extra_options)
+  end
+
+  def content_id
+    document.content_id
   end
 
 private
@@ -89,12 +102,32 @@ private
     }
   end
 
-  def subject
+  def title
     redrafted? ? document.title + " updated" : document.title
+  end
+
+  def summary
+    document.summary
+  end
+
+  def change_note
+    document.change_note
+  end
+
+  def subject
+    title
   end
 
   def urgent
     document.urgent
+  end
+
+  def public_updated_at
+    document.public_updated_at
+  end
+
+  def base_path
+    document.base_path
   end
 
   def updated_or_published

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe EmailAlertPresenter do
         email_alert_presenter_redrafted = EmailAlertPresenter.new(redrafted_cma_case)
         presented_data_redrafted = email_alert_presenter_redrafted.to_json
 
+        expect(presented_data[:title]).to include(cma_case_payload["title"])
+        expect(presented_data[:description]).to include(cma_case_payload["description"])
         expect(presented_data[:subject]).to include(cma_case_payload["title"])
         expect(presented_data[:subject]).not_to include("updated")
         expect(presented_data_redrafted[:subject]).to include("updated")
@@ -31,8 +33,16 @@ RSpec.describe EmailAlertPresenter do
         expect(presented_data[:tags][:format]).to eq(cma_case_payload["document_type"])
         expect(presented_data[:tags][:case_type]).to eq(cma_case_payload["details"]["metadata"]["case_type"])
         expect(presented_data[:document_type]).to eq(cma_case_payload["document_type"])
+        expect(presented_data[:public_updated_at]).to include(cma_case_payload["public_updated_at"])
+        expect(presented_data[:base_path]).to include(cma_case_payload["base_path"])
         expect(presented_data[:footer]).to include("SUBSCRIBER_PREFERENCES_URL")
         expect(presented_data[:header]).to include("govuk-email-header")
+
+        expect(presented_data.keys).to match_array(%i(
+          title description change_note subject body tags document_type
+          email_document_supertype government_document_supertype content_id
+          public_updated_at publishing_app base_path urgent header footer
+        ))
       end
     end
 


### PR DESCRIPTION
These new fields are required by the API for GOV.UK Notify integration.

Trello: https://trello.com/c/02JCCXB6/185-tap-and-specialist-publisher-should-match-service-regarding-what-they-send-to-the-api