### PR TITLE
Pick up change_note when building a document

### DIFF
--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -9,6 +9,7 @@ class DocumentBuilder
       body: extract_body_from_payload(payload),
       publication_state: payload['publication_state'],
       state_history: payload['state_history'],
+      change_note: payload['change_note'],
       public_updated_at: payload['public_updated_at'],
       first_published_at: payload['first_published_at'],
       bulk_published: payload['details']['metadata']['bulk_published'],


### PR DESCRIPTION
This commit adds `change_note` as a field that is extracted from `publishing-api` responses when building a document. This allows it to be available when published documents are later presented to downstream systems.