### PR TITLE
Match the Dockerfile ruby image version to .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 
 # for capybara-webkit


### PR DESCRIPTION
Following on from #1069 

Dockerfile gets used by the publishing end-to-end tests.  We don't
want the version tested against to be different to the version
in production.
