### PR TITLE
Add conditionals so we can run E2E tests in rails production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
+ARG COMPILE_ASSETS=false
+RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -20,4 +20,4 @@ production:
       uri: <%= ENV["MONGODB_URI"] %>
       options:
         write:
-          w: majority
+          w: <%= ENV["MONGO_WRITE_CONCERN"] || "majority" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 def seed
-  unless Rails.env.development?
+  unless Rails.env.development? || ENV["RUN_SEEDS_IN_PRODUCTION"]
     puts "Skipping because not in development"
     return
   end


### PR DESCRIPTION
These allow us to connect to single instances of Mongo rather than clusters, compile the assets for testing purposes and seed the database while still in production mode without interfering with the existing configurations.

These also allow for easily switching to run the application in development.
