### PR TITLE
Fix deprecation warnings for gds-sso and factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem "capybara"
   gem 'capybara-webkit'
   gem 'database_cleaner'
-  gem 'factory_girl'
+  gem 'factory_bot'
   gem 'foreman'
   gem 'govuk-content-schema-test-helpers'
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     erubi (1.6.1)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -402,7 +402,7 @@ DEPENDENCIES
   capybara
   capybara-webkit
   database_cleaner
-  factory_girl
+  factory_bot
   foreman
   gds-api-adapters (~> 50.8.0)
   gds-sso (= 13.5.0)
@@ -435,4 +435,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include Pundit
 
-  before_action :require_signin_permission!
   before_action :set_authenticated_user_header
-  after_action :verify_authorized
+  before_action :authenticate_user!
 
   helper_method :current_format
   helper_method :formats_user_can_access

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe AttachmentsController, type: :controller do
   let(:cma_case) {
-    FactoryGirl.create(:cma_case,
+    FactoryBot.create(:cma_case,
       details: {
         "attachments" => [
           {

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe DocumentsController, type: :controller do
   render_views
 
-  let(:payload) { FactoryGirl.create(:cma_case) }
+  let(:payload) { FactoryBot.create(:cma_case) }
 
   before do
     log_in_as_gds_editor

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     }
   end
 
-  let(:cma_case) { FactoryGirl.create(:cma_case) }
+  let(:cma_case) { FactoryBot.create(:cma_case) }
   let(:content_id) { cma_case['content_id'] }
   let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
 

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature "Creating a DFID Research Output", type: :feature do
   let(:fields)            { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
-  let(:research_output)   { FactoryGirl.create(:dfid_research_output) }
+  let(:research_output)   { FactoryBot.create(:dfid_research_output) }
   let(:content_id)        { research_output['content_id'] }
   let(:public_updated_at) { research_output['public_updated_at'] }
 

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature do
   let(:fields)            { [:base_path, :content_id, :public_updated_at, :title, :publication_state] }
-  let(:research_output)   { FactoryGirl.create(:employment_appeal_tribunal_decision) }
+  let(:research_output)   { FactoryBot.create(:employment_appeal_tribunal_decision) }
   let(:content_id)        { research_output['content_id'] }
   let(:public_updated_at) { research_output['public_updated_at'] }
 

--- a/spec/features/discarding_a_draft_cma_case_spec.rb
+++ b/spec/features/discarding_a_draft_cma_case_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Discarding a draft CMA Case", type: :feature do
 
   context "a draft document" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         title: "Example CMA Case",
         publication_state: "draft")
     }
@@ -43,7 +43,7 @@ RSpec.feature "Discarding a draft CMA Case", type: :feature do
 
   context "a published document with no draft" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         title: "Example CMA Case",
         publication_state: "published")
     }

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature "Editing a CMA case", type: :feature do
   let(:cma_case) {
-    FactoryGirl.create(:cma_case, title: "Example CMA Case", state_history: { "1" => "draft" })
+    FactoryBot.create(:cma_case, title: "Example CMA Case", state_history: { "1" => "draft" })
   }
   let(:content_id) { cma_case['content_id'] }
   let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
@@ -73,7 +73,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
   context "a published case" do
     let(:cma_case) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         :published,
         title: "Example CMA Case",
         description: "Summary with a typox",
@@ -129,7 +129,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     context "when a document already has a change note" do
       let(:cma_case) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :cma_case,
           update_type: "major",
           first_published_at: "2016-01-01",
@@ -226,7 +226,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     %i(draft published).each do |publication_state|
       let(:cma_case) {
-        FactoryGirl.create(
+        FactoryBot.create(
           :cma_case,
           publication_state,
           title: "Example CMA Case",
@@ -297,7 +297,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
       end
 
       context "when the document is in an invalid state" do
-        let(:cma_case) { FactoryGirl.create(:cma_case, details: { body: "" }) }
+        let(:cma_case) { FactoryBot.create(:cma_case, details: { body: "" }) }
 
         scenario "successfully adding an attachment to the invalid document" do
           click_link "Add attachment"
@@ -391,7 +391,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
   context "an unpublished document" do
     let(:cma_case) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :unpublished,
         title: "Example CMA Case",

--- a/spec/features/editing_a_dfid_research_output_spec.rb
+++ b/spec/features/editing_a_dfid_research_output_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.feature "Editing a DFID Research Output", type: :feature do
-  let(:research_output)   { FactoryGirl.create(:dfid_research_output) }
+  let(:research_output)   { FactoryBot.create(:dfid_research_output) }
   let(:content_id)        { research_output['content_id'] }
   let(:public_updated_at) { research_output['public_updated_at'] }
 

--- a/spec/features/exporting_a_csv_spec.rb
+++ b/spec/features/exporting_a_csv_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.feature 'Exporting a list of documents as CSV' do
   let(:documents) {
     3.times.map do |i|
-      FactoryGirl.create(
+      FactoryBot.create(
         :business_finance_support_scheme,
         base_path: "/bfss/#{i}",
         title: "Scheme ##{i}"
       )
     end
   }
-  let(:user) { FactoryGirl.create(:gds_editor) }
+  let(:user) { FactoryBot.create(:gds_editor) }
   let(:expected_csv) {
     CSV.generate do |csv|
       csv << BusinessFinanceSupportSchemeExportPresenter.header_row

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when the document is a new draft" do
     let(:item) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
           title: "Example CMA Case",
           base_path: "/cma-cases/example-cma-case",
@@ -33,7 +33,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
     }
 
     let(:published_item) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
           :published,
           content_id: content_id,
@@ -94,7 +94,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when the document is already published" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         :published,
         title: "Live Item")
     }
@@ -112,7 +112,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when there is a redrafted document with a major update" do
     let(:item) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :redrafted,
         title: "Major Update Case",
@@ -162,7 +162,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when there is a redrafted document with a minor update" do
     let(:item) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :redrafted,
         title: "Minor Update Case",
@@ -207,7 +207,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
 
   context "when the document is unpublished" do
     let(:item) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :published,
         title: "Unpublished Item",

--- a/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
+++ b/spec/features/publishing_a_previously_unpublished_cma_case_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Publishing a previously unpublished CMA Case", type: :feature do
   let(:existing_attachments) { [] }
 
   let(:item) do
-    FactoryGirl.create(:cma_case,
+    FactoryBot.create(:cma_case,
                        :unpublished,
                        title: "Example CMA Case",
                        publication_state: "draft",

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Searching and filtering", type: :feature do
   let(:test_date) { Date.new(2016, 1, 11) }
   let(:cma_cases) {
     ten_example_cases = 10.times.collect do |n|
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         "title" => "Example CMA Case #{n}",
         "description" => "This is the summary of example CMA case #{n}",
         "base_path" => "/cma-cases/example-cma-case-#{n}",

--- a/spec/features/temporary_update_type_spec.rb
+++ b/spec/features/temporary_update_type_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/asset_manager"
 RSpec.feature "Temporary update types, relating to attachments", type: :feature do
   include GdsApi::TestHelpers::AssetManager
 
-  let(:payload) { FactoryGirl.create(:cma_case, :published) }
+  let(:payload) { FactoryBot.create(:cma_case, :published) }
   let(:content_id) { payload.fetch("content_id") }
 
   before do
@@ -27,7 +27,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
   end
 
   context "when the update_type was not set by a user" do
-    let(:payload) { FactoryGirl.create(:cma_case, :published) }
+    let(:payload) { FactoryBot.create(:cma_case, :published) }
 
     scenario "setting temporary_update_type to true and using a minor update_type" do
       add_attachment_to_document
@@ -43,7 +43,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
 
   context "when the update_type was set by a user" do
     let(:payload) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :redrafted,
         update_type: "major",
@@ -66,7 +66,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
 
   context "when temporary_update_type was previously set" do
     let(:payload) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         :redrafted,
         update_type: "minor",
@@ -101,7 +101,7 @@ RSpec.feature "Temporary update types, relating to attachments", type: :feature 
 
   context "when the document is a draft" do
     let(:payload) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :cma_case,
         publication_state: "draft",
       )

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
 
   context "a published document" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         title: "Example CMA Case",
         publication_state: "published")
     }
@@ -88,7 +88,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
       }
 
       let(:item) {
-        FactoryGirl.create(
+        FactoryBot.create(
           :cma_case,
           :published,
           title: "Example CMA Case",
@@ -118,7 +118,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
 
   context "publishing-api returns error" do
     let(:item) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         title: "Example CMA Case",
         publication_state: "published")
     }

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
   let(:message) { "You have unsaved changes that will be lost if you leave this page." }
-  let(:cma_case) { FactoryGirl.create(:cma_case) }
+  let(:cma_case) { FactoryBot.create(:cma_case) }
   let(:content_id) { cma_case['content_id'] }
 
   before do

--- a/spec/features/viewing_a_specific_cma_case_spec.rb
+++ b/spec/features/viewing_a_specific_cma_case_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
   context "from the index" do
     let(:cma_cases) {
       [
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example CMA Case",
           description: "This is the summary of example CMA case",
           publication_state: "draft",
@@ -70,7 +70,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
   context "bulk publishing" do
     let(:cma_cases) {
       [
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Bulk published CMA Case",
           details: {
             "metadata" => {
@@ -91,18 +91,18 @@ RSpec.feature "Viewing a specific case", type: :feature do
   context "attachments" do
     let(:cma_cases) {
       [
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "CMA Case without attachments",
           details: { attachments: [] }),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "CMA Case with attachments",
           details: {
             attachments: [
-              FactoryGirl.create(:attachment_payload,
+              FactoryBot.create(:attachment_payload,
                 title: 'first attachment',
                 created_at: "2015-12-01T10:12:26+00:00",
                 updated_at: "2015-12-02T10:12:26+00:00"),
-              FactoryGirl.create(:attachment_payload,
+              FactoryBot.create(:attachment_payload,
                 title: 'second attachment',
                 created_at: "2015-12-03T10:12:26+00:00",
                 updated_at: "2015-12-04T10:12:26+00:00"),
@@ -137,36 +137,36 @@ RSpec.feature "Viewing a specific case", type: :feature do
   context "Viewing publication states" do
     let(:cma_cases) {
       [
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example Draft",
           publication_state: "draft",
           state_history: { "1" => "draft" }
                           ),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example Published",
           publication_state: "published",
           state_history: { "1" => "published" }
                           ),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example Unpublished",
           publication_state: "unpublished",
           state_history: { "1" => "unpublished" }
                           ),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example Published with new draft",
           publication_state: "draft",
           state_history: {
             "1" => "published",
             "2" => "draft"
           }),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "Example Unpublished with new draft",
           publication_state: "draft",
           state_history: {
             "1" => "unpublished",
             "2" => "draft"
           }),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "More states",
           publication_state: "draft",
           state_history: {
@@ -174,7 +174,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
             "2" => "published",
             "3" => "draft"
           }),
-        FactoryGirl.create(:cma_case,
+        FactoryBot.create(:cma_case,
           title: "More states Published",
           publication_state: "published",
           state_history: {
@@ -256,7 +256,7 @@ RSpec.feature "Viewing a specific case", type: :feature do
 
   context "when a published item exists with the same base path" do
     let(:content_id) { SecureRandom.uuid }
-    let(:draft) { FactoryGirl.create(:cma_case, content_id: content_id, title: "Example draft", base_path: "/cma-cases/foo") }
+    let(:draft) { FactoryBot.create(:cma_case, content_id: content_id, title: "Example draft", base_path: "/cma-cases/foo") }
 
     scenario "displays warnings" do
       stub_request(:get, %r{/v2/content/#{content_id}})

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }

--- a/spec/lib/ops_tasks_spec.rb
+++ b/spec/lib/ops_tasks_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api"
 RSpec.describe OpsTasks do
   include GdsApi::TestHelpers::PublishingApi
 
-  let(:payload) { FactoryGirl.create(:cma_case) }
+  let(:payload) { FactoryBot.create(:cma_case) }
   let(:content_id) { payload["content_id"] }
 
   before do
@@ -34,7 +34,7 @@ RSpec.describe OpsTasks do
   describe "#set_public_updated_at" do
     describe "when the document is live" do
       let(:payload) {
-        FactoryGirl.create(:cma_case, publication_state: "published")
+        FactoryBot.create(:cma_case, publication_state: "published")
       }
 
       before do
@@ -73,7 +73,7 @@ RSpec.describe OpsTasks do
 
     describe "when the document is not live" do
       let(:payload) {
-        FactoryGirl.create(:cma_case, publication_state: "draft")
+        FactoryBot.create(:cma_case, publication_state: "draft")
       }
 
       it "throws a helpful error" do

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe NotificationsMailer, type: :mailer do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
   let(:csv) { "Header one,Header two\nrow a value one,row a value two\nrow b value one,row b value two\n" }
   describe "document_list without a query" do
     let(:mail) { described_class.document_list(csv, user, BusinessFinanceSupportScheme, nil) }

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe AaibReport do
-  let(:payload) { FactoryGirl.create(:aaib_report) }
+  let(:payload) { FactoryBot.create(:aaib_report) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/asylum_support_decision_spec.rb
+++ b/spec/models/asylum_support_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe AsylumSupportDecision do
-  let(:payload) { FactoryGirl.create(:asylum_support_decision) }
+  let(:payload) { FactoryBot.create(:asylum_support_decision) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Attachment do
 
   describe ".all_from_publishing_api" do
     context "when the payload has attachments in details" do
-      let(:attachment_payload) { FactoryGirl.create(:attachment_payload) }
+      let(:attachment_payload) { FactoryBot.create(:attachment_payload) }
 
       let(:payload) do
         { "details" => { "attachments" => [attachment_payload] } }
@@ -28,7 +28,7 @@ RSpec.describe Attachment do
 
       context "when a content id is not provided" do
         let(:attachment_payload) {
-          FactoryGirl.create(:attachment_payload, content_id: nil)
+          FactoryBot.create(:attachment_payload, content_id: nil)
         }
 
         it "generates a content id" do

--- a/spec/models/business_finance_support_scheme_spec.rb
+++ b/spec/models/business_finance_support_scheme_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe BusinessFinanceSupportScheme do
-  let(:payload) { FactoryGirl.create(:business_finance_support_scheme) }
+  let(:payload) { FactoryBot.create(:business_finance_support_scheme) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is exportable' do

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe CmaCase do
-  let(:payload) { FactoryGirl.create(:cma_case) }
+  let(:payload) { FactoryBot.create(:cma_case) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/countryside_stewardship_grant_spec.rb
+++ b/spec/models/countryside_stewardship_grant_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe CountrysideStewardshipGrant do
-  let(:payload) { FactoryGirl.create(:countryside_stewardship_grant) }
+  let(:payload) { FactoryBot.create(:countryside_stewardship_grant) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/dfid_research_output_spec.rb
+++ b/spec/models/dfid_research_output_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe DfidResearchOutput do
-  let(:payload) { FactoryGirl.create(:dfid_research_output) }
+  let(:payload) { FactoryBot.create(:dfid_research_output) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Document do
       }
     }
   }
-  let(:payload) { FactoryGirl.create(:document, payload_attributes) }
+  let(:payload) { FactoryBot.create(:document, payload_attributes) }
   let(:document) { MyDocumentType.from_publishing_api(payload) }
 
   before do
@@ -128,7 +128,7 @@ RSpec.describe Document do
 
   describe ".from_publishing_api" do
     context "for a published document" do
-      let(:payload) { FactoryGirl.create(:document, :published, payload_attributes) }
+      let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
 
       it "sets the top-level attributes on a document" do
         expect(document.base_path).to eq(payload['base_path'])
@@ -214,7 +214,7 @@ RSpec.describe Document do
 
     context "when the document is redrafted" do
       let(:payload) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :document,
           :redrafted,
           payload_attributes.merge(update_type: "minor"),
@@ -236,7 +236,7 @@ RSpec.describe Document do
   end
 
   context "successful #publish" do
-    let(:payload) { FactoryGirl.create(:document, :published, payload_attributes) }
+    let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
     before do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
@@ -270,7 +270,7 @@ RSpec.describe Document do
     context "document is redrafted with a minor edit" do
       let(:minor_change_document) {
         MyDocumentType.from_publishing_api(
-          FactoryGirl.create(:document,
+          FactoryBot.create(:document,
             payload_attributes.merge(
               publication_state: 'published',
               update_type: 'minor',
@@ -289,7 +289,7 @@ RSpec.describe Document do
     context "document has never been published" do
       let(:unpublished_document) {
         MyDocumentType.from_publishing_api(
-          FactoryGirl.create(:document,
+          FactoryBot.create(:document,
             payload_attributes.merge(
               first_published_at: nil,
               publication_state: 'draft',
@@ -328,7 +328,7 @@ RSpec.describe Document do
     shared_examples_for 'publishing changes to a document that has previously been published' do
       let(:published_document) {
         MyDocumentType.from_publishing_api(
-          FactoryGirl.create(:document,
+          FactoryBot.create(:document,
             :published,
             payload_attributes.merge(
               publication_state: publication_state,
@@ -366,7 +366,7 @@ RSpec.describe Document do
   end
 
   context "unsuccessful #publish" do
-    let(:payload) { FactoryGirl.create(:document, :published, payload_attributes) }
+    let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
 
     it "notifies GovukError and returns false if publishing-api does not return status 200" do
       expect(GovukError).to receive(:notify)
@@ -472,7 +472,7 @@ RSpec.describe Document do
       subject { Document.from_publishing_api(payload) }
 
       context "when the document is a draft" do
-        let(:payload) { FactoryGirl.create(:document) }
+        let(:payload) { FactoryBot.create(:document) }
 
         it "does not require an update_type" do
           subject.update_type = ""
@@ -487,7 +487,7 @@ RSpec.describe Document do
 
       context "when the document is published" do
         let(:payload) {
-          FactoryGirl.create(:document, :published, state_history: { "1" => "published" })
+          FactoryBot.create(:document, :published, state_history: { "1" => "published" })
         }
 
         it "requires an update_type" do
@@ -507,7 +507,7 @@ RSpec.describe Document do
 
       context "when the document is unpublished" do
         let(:payload) {
-          FactoryGirl.create(:document, :unpublished, state_history: { "1" => "published", "2" => "unpublished" })
+          FactoryBot.create(:document, :unpublished, state_history: { "1" => "published", "2" => "unpublished" })
         }
 
         it "requires an update_type" do
@@ -726,7 +726,7 @@ RSpec.describe Document do
 
   context "a draft where a published item has the same base_path" do
     let(:content_id) { SecureRandom.uuid }
-    let(:published) { FactoryGirl.create(:document, document_type: "my_document_type", content_id: content_id) }
+    let(:published) { FactoryBot.create(:document, document_type: "my_document_type", content_id: content_id) }
 
     before do
       stub_request(:get, %r{/v2/content/#{content_id}})

--- a/spec/models/drug_safety_update_spec.rb
+++ b/spec/models/drug_safety_update_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe DrugSafetyUpdate do
-  let(:payload) { FactoryGirl.create(:drug_safety_update) }
+  let(:payload) { FactoryBot.create(:drug_safety_update) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do
@@ -11,7 +11,7 @@ RSpec.describe DrugSafetyUpdate do
 
   context "#publish" do
     let(:payload) {
-      FactoryGirl.create(
+      FactoryBot.create(
         :drug_safety_update,
           :published,
           update_type: "major",)

--- a/spec/models/employment_appeal_tribunal_decision_spec.rb
+++ b/spec/models/employment_appeal_tribunal_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe EmploymentAppealTribunalDecision do
-  let(:payload) { FactoryGirl.create(:employment_appeal_tribunal_decision) }
+  let(:payload) { FactoryBot.create(:employment_appeal_tribunal_decision) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/employment_tribunal_decision_spec.rb
+++ b/spec/models/employment_tribunal_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe EmploymentTribunalDecision do
-  let(:payload) { FactoryGirl.create(:employment_tribunal_decision) }
+  let(:payload) { FactoryBot.create(:employment_tribunal_decision) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/esi_fund_spec.rb
+++ b/spec/models/esi_fund_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe EsiFund do
-  let(:payload) { FactoryGirl.create(:esi_fund) }
+  let(:payload) { FactoryBot.create(:esi_fund) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/international_development_fund_spec.rb
+++ b/spec/models/international_development_fund_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe InternationalDevelopmentFund do
-  let(:payload) { FactoryGirl.create(:international_development_fund) }
+  let(:payload) { FactoryBot.create(:international_development_fund) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/maib_report_spec.rb
+++ b/spec/models/maib_report_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe MaibReport do
-  let(:payload) { FactoryGirl.create(:maib_report) }
+  let(:payload) { FactoryBot.create(:maib_report) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/medical_safety_alert_spec.rb
+++ b/spec/models/medical_safety_alert_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe MedicalSafetyAlert do
-  let(:payload) { FactoryGirl.create(:medical_safety_alert) }
+  let(:payload) { FactoryBot.create(:medical_safety_alert) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/raib_report_spec.rb
+++ b/spec/models/raib_report_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe RaibReport do
-  let(:payload) { FactoryGirl.create(:raib_report) }
+  let(:payload) { FactoryBot.create(:raib_report) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/service_standard_report_spec.rb
+++ b/spec/models/service_standard_report_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe ServiceStandardReport do
-  let(:payload) { FactoryGirl.create(:service_standard_report) }
+  let(:payload) { FactoryBot.create(:service_standard_report) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/tax_tribunal_decision_spec.rb
+++ b/spec/models/tax_tribunal_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe TaxTribunalDecision do
-  let(:payload) { FactoryGirl.create(:tax_tribunal_decision) }
+  let(:payload) { FactoryBot.create(:tax_tribunal_decision) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/models/utaac_decision_spec.rb
+++ b/spec/models/utaac_decision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'models/valid_against_schema'
 
 RSpec.describe UtaacDecision do
-  let(:payload) { FactoryGirl.create(:utaac_decision) }
+  let(:payload) { FactoryBot.create(:utaac_decision) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it 'is not exportable' do

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 RSpec.describe ActionsPresenter do
   include AuthenticationControllerHelpers
 
-  let(:payload) { FactoryGirl.create(:cma_case) }
+  let(:payload) { FactoryBot.create(:cma_case) }
   let(:content_id) { payload["content_id"] }
 
   let(:document) { CmaCase.from_publishing_api(payload) }
-  let(:user) { FactoryGirl.create(:cma_editor) }
+  let(:user) { FactoryBot.create(:cma_editor) }
   let(:policy) { DocumentPolicy.new(user, CmaCase) }
 
   subject { described_class.new(document, policy) }
@@ -20,22 +20,22 @@ RSpec.describe ActionsPresenter do
     specify { expect(subject.publish_button_visible?).to eq(true) }
 
     context "when the user does not have editor permissions" do
-      let(:user) { FactoryGirl.create(:cma_writer) }
+      let(:user) { FactoryBot.create(:cma_writer) }
       specify { expect(subject.publish_button_visible?).to eq(false) }
     end
 
     context "when the document is already published" do
-      let(:payload) { FactoryGirl.create(:cma_case, :published) }
+      let(:payload) { FactoryBot.create(:cma_case, :published) }
       specify { expect(subject.publish_button_visible?).to eq(false) }
 
       context "and the update_type is republish" do
-        let(:payload) { FactoryGirl.create(:cma_case, :published, update_type: "republish") }
+        let(:payload) { FactoryBot.create(:cma_case, :published, update_type: "republish") }
         specify { expect(subject.publish_button_visible?).to eq(false) }
       end
     end
 
     context "when the document is unpublished" do
-      let(:payload) { FactoryGirl.create(:cma_case, :unpublished) }
+      let(:payload) { FactoryBot.create(:cma_case, :unpublished) }
       specify { expect(subject.publish_button_visible?).to eq(false) }
     end
   end
@@ -45,33 +45,33 @@ RSpec.describe ActionsPresenter do
     specify { expect(subject.publish_text).not_to include("major edit") }
 
     context "when the user does not have editor permissions" do
-      let(:user) { FactoryGirl.create(:cma_writer) }
+      let(:user) { FactoryBot.create(:cma_writer) }
       specify { expect(subject.publish_text).to include("don't have permission to publish") }
     end
 
     context "when the document is already published" do
-      let(:payload) { FactoryGirl.create(:cma_case, :published) }
+      let(:payload) { FactoryBot.create(:cma_case, :published) }
       specify { expect(subject.publish_text).to include("no changes") }
 
       context "and the update_type is republish" do
-        let(:payload) { FactoryGirl.create(:cma_case, :published, update_type: "republish") }
+        let(:payload) { FactoryBot.create(:cma_case, :published, update_type: "republish") }
         specify { expect(subject.publish_text).to include("no changes") }
       end
     end
 
     context "when the document is unpublished" do
-      let(:payload) { FactoryGirl.create(:cma_case, :unpublished) }
+      let(:payload) { FactoryBot.create(:cma_case, :unpublished) }
       specify { expect(subject.publish_text).to include("create a new draft") }
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, :redrafted) }
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
       specify { expect(subject.publish_text).to include("major edit") }
       specify { expect(subject.publish_text).to include("will email subscribers") }
     end
 
     context "when the document is redrafted and the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, :redrafted, update_type: "minor") }
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
       specify { expect(subject.publish_text).to include("minor edit") }
       specify { expect(subject.publish_text).not_to include("will email subscribers") }
     end
@@ -81,7 +81,7 @@ RSpec.describe ActionsPresenter do
     specify { expect(subject.publish_alert).to include("will email subscribers to CMA Cases") }
 
     context "when the update_type is minor" do
-      let(:payload) { FactoryGirl.create(:cma_case, :redrafted, update_type: "minor") }
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
       specify { expect(subject.publish_alert).to include("minor edit") }
     end
   end
@@ -91,48 +91,48 @@ RSpec.describe ActionsPresenter do
   end
 
   describe "unpublish_button_visible?" do
-    let(:payload) { FactoryGirl.create(:cma_case, :published) }
+    let(:payload) { FactoryBot.create(:cma_case, :published) }
 
     specify { expect(subject.unpublish_button_visible?).to eq(true) }
 
     context "when the document is a draft" do
-      let(:payload) { FactoryGirl.create(:cma_case) }
+      let(:payload) { FactoryBot.create(:cma_case) }
       specify { expect(subject.unpublish_button_visible?).to eq(false) }
     end
 
     context "when the user does not have editor permissions" do
-      let(:user) { FactoryGirl.create(:cma_writer) }
+      let(:user) { FactoryBot.create(:cma_writer) }
       specify { expect(subject.unpublish_button_visible?).to eq(false) }
     end
 
     context "when the document is already unpublished" do
-      let(:payload) { FactoryGirl.create(:cma_case, :unpublished) }
+      let(:payload) { FactoryBot.create(:cma_case, :unpublished) }
       specify { expect(subject.unpublish_button_visible?).to eq(false) }
     end
   end
 
   describe "unpublish_text" do
-    let(:payload) { FactoryGirl.create(:cma_case, :published) }
+    let(:payload) { FactoryBot.create(:cma_case, :published) }
 
     specify { expect(subject.unpublish_text).to include("removed from the site") }
 
     context "when the document is a draft" do
-      let(:payload) { FactoryGirl.create(:cma_case) }
+      let(:payload) { FactoryBot.create(:cma_case) }
       specify { expect(subject.unpublish_text).to include("never been published") }
     end
 
     context "when the document is redrafted" do
-      let(:payload) { FactoryGirl.create(:cma_case, :redrafted) }
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
       specify { expect(subject.unpublish_text).to include("publish the draft first") }
     end
 
     context "when the document is already unpublished" do
-      let(:payload) { FactoryGirl.create(:cma_case, publication_state: "unpublished") }
+      let(:payload) { FactoryBot.create(:cma_case, publication_state: "unpublished") }
       specify { expect(subject.unpublish_text).to include("already unpublished") }
     end
 
     context "when the user does not have editor permissions" do
-      let(:user) { FactoryGirl.create(:cma_writer) }
+      let(:user) { FactoryBot.create(:cma_writer) }
       specify { expect(subject.unpublish_text).to include("don't have permission to unpublish") }
     end
   end

--- a/spec/presenters/business_finance_support_scheme_export_presenter_spec.rb
+++ b/spec/presenters/business_finance_support_scheme_export_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BusinessFinanceSupportSchemeExportPresenter do
-  let(:document) { BusinessFinanceSupportScheme.from_publishing_api(FactoryGirl.create(:business_finance_support_scheme)) }
+  let(:document) { BusinessFinanceSupportScheme.from_publishing_api(FactoryBot.create(:business_finance_support_scheme)) }
   subject { described_class.new(document) }
 
   describe '.header_row' do

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DocumentPresenter do
 
   describe "#to_json without attachments" do
     let(:payload) {
-      FactoryGirl.create(:cma_case).tap { |p| p["details"].delete("attachments") }
+      FactoryBot.create(:cma_case).tap { |p| p["details"].delete("attachments") }
     }
 
     it "is valid against the content schemas" do
@@ -35,7 +35,7 @@ RSpec.describe DocumentPresenter do
 
   describe "#to_json with attachments" do
     let(:payload) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         details: {
           attachments: [
             {
@@ -75,7 +75,7 @@ RSpec.describe DocumentPresenter do
 
   describe '#to_json with headers' do
     let(:payload) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         details: {
           body: [
             {
@@ -99,7 +99,7 @@ RSpec.describe DocumentPresenter do
 
   describe '#to_json with nested headers' do
     let(:payload) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         details: {
           body: [
             {
@@ -129,7 +129,7 @@ RSpec.describe DocumentPresenter do
 
   describe '#to_json without headers' do
     let(:payload) {
-      FactoryGirl.create(:cma_case).tap { |p| p["details"].delete("headers") }
+      FactoryBot.create(:cma_case).tap { |p| p["details"].delete("headers") }
     }
 
     it 'is valid against the content schemas' do
@@ -143,7 +143,7 @@ RSpec.describe DocumentPresenter do
 
   describe '#to_json with format_specific_fields' do
     let(:payload) {
-      FactoryGirl.create(:cma_case,
+      FactoryBot.create(:cma_case,
         details: {
           metadata: {
             case_state: "open",

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe EmailAlertPresenter do
-  let(:cma_case_payload) { FactoryGirl.create(:cma_case) }
-  let(:medical_safety_payload) { FactoryGirl.create(:medical_safety_alert) }
-  let(:cma_case_redrafted_payload) { FactoryGirl.create(:cma_case, :redrafted, title: "updated") }
+  let(:cma_case_payload) { FactoryBot.create(:cma_case) }
+  let(:medical_safety_payload) { FactoryBot.create(:medical_safety_alert) }
+  let(:cma_case_redrafted_payload) { FactoryBot.create(:cma_case, :redrafted, title: "updated") }
 
   describe "#to_json" do
     context "any finders document" do

--- a/spec/services/all_documents_finder_spec.rb
+++ b/spec/services/all_documents_finder_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe AllDocumentsFinder do
 
     it "yields each document from the publishing api response" do
       documents = [
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/1',
           title: 'Scheme #1'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/2',
           title: 'Scheme #2'
@@ -44,22 +44,22 @@ RSpec.describe AllDocumentsFinder do
 
     it "fetches each page of documents and yields all of them" do
       documents = [
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/1',
           title: 'Scheme #1'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/2',
           title: 'Scheme #2'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/3',
           title: 'Scheme #3'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/4',
           title: 'Scheme #4'
@@ -94,12 +94,12 @@ RSpec.describe AllDocumentsFinder do
 
     it 'respects the query parameter if provided and sends it to publishing api when fetching documents' do
       documents = [
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/1',
           title: 'Scheme #1'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/2',
           title: 'Scheme #2'

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -9,7 +9,7 @@ module AuthenticationControllerHelpers
   end
 
   def log_in_as_gds_editor
-    log_in_as FactoryGirl.create(:gds_editor)
+    log_in_as FactoryBot.create(:gds_editor)
   end
 end
 RSpec.configuration.include AuthenticationControllerHelpers, type: :controller
@@ -20,7 +20,7 @@ module AuthenticationFeatureHelpers
   end
 
   def log_in_as_editor(user_type)
-    log_in_as FactoryGirl.create(user_type)
+    log_in_as FactoryBot.create(user_type)
   end
 end
 RSpec.configuration.include AuthenticationFeatureHelpers, type: :feature

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -1,6 +1,6 @@
 module PublishingApiHelpers
   def write_payload(document)
-    copy = FactoryGirl.create(document["document_type"], document)
+    copy = FactoryBot.create(document["document_type"], document)
     copy.delete("content_id")
     copy.delete("last_edited_at")
     copy.delete("publication_state")

--- a/spec/workers/attachment_delete_worker_spec.rb
+++ b/spec/workers/attachment_delete_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AttachmentDeleteWorker do
   let(:content_id) { SecureRandom.uuid }
 
   let!(:document) do
-    FactoryGirl.create(:cma_case,
+    FactoryBot.create(:cma_case,
                        :published,
                        content_id: content_id)
   end

--- a/spec/workers/attachment_restore_worker_spec.rb
+++ b/spec/workers/attachment_restore_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AttachmentRestoreWorker do
   let(:content_id) { SecureRandom.uuid }
 
   let!(:document) do
-    FactoryGirl.create(:cma_case,
+    FactoryBot.create(:cma_case,
                        :published,
                        content_id: content_id)
   end

--- a/spec/workers/document_list_export_worker_spec.rb
+++ b/spec/workers/document_list_export_worker_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe DocumentListExportWorker do
   describe "perform" do
-    let(:user) { FactoryGirl.create(:gds_editor) }
+    let(:user) { FactoryBot.create(:gds_editor) }
     let(:documents) do
       [
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/1',
           title: 'Scheme #1'
         ),
-        FactoryGirl.create(
+        FactoryBot.create(
           :business_finance_support_scheme,
           base_path: '/bfss/2',
           title: 'Scheme #2'

--- a/spec/workers/publish_worker_spec.rb
+++ b/spec/workers/publish_worker_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PublishWorker do
-  let(:document) { FactoryGirl.create(:utaac_decision) }
+  let(:document) { FactoryBot.create(:utaac_decision) }
   let(:content_id) { document["content_id"] }
 
   let(:uses_publish_update_type) {
@@ -16,7 +16,7 @@ RSpec.describe PublishWorker do
 
   context "when the publication_state is 'draft'" do
     let(:document) {
-      FactoryGirl.create(:utaac_decision, :draft)
+      FactoryBot.create(:utaac_decision, :draft)
     }
 
     it "publishes the document" do
@@ -27,7 +27,7 @@ RSpec.describe PublishWorker do
 
   context "when the document is in any other state" do
     let(:document) {
-      FactoryGirl.create(:utaac_decision, :published)
+      FactoryBot.create(:utaac_decision, :published)
     }
 
     it "does not publish the document" do

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RepublishWorker do
-  let(:document) { FactoryGirl.create(:cma_case) }
+  let(:document) { FactoryBot.create(:cma_case) }
   let(:content_id) { document["content_id"] }
 
   let(:uses_republish_update_type) {
@@ -21,7 +21,7 @@ RSpec.describe RepublishWorker do
   %i(draft redrafted).each do |publication_state|
     context "when the publication_state is '#{publication_state}'" do
       let(:document) {
-        FactoryGirl.create(:cma_case, publication_state)
+        FactoryBot.create(:cma_case, publication_state)
       }
 
       it "sends the document to the publishing api" do
@@ -47,7 +47,7 @@ RSpec.describe RepublishWorker do
 
   context "when the document is published" do
     let(:document) {
-      FactoryGirl.create(:cma_case, :published)
+      FactoryBot.create(:cma_case, :published)
     }
 
     it "sends the document to the publishing api" do
@@ -72,7 +72,7 @@ RSpec.describe RepublishWorker do
 
   context "when the document is unpublished" do
     let(:document) {
-      FactoryGirl.create(:cma_case, :unpublished)
+      FactoryBot.create(:cma_case, :unpublished)
     }
 
     it "skips republishing of the document" do
@@ -88,7 +88,7 @@ RSpec.describe RepublishWorker do
 
   context "when the document is in any other state" do
     let(:document) {
-      FactoryGirl.create(:cma_case, publication_state: "unrecognised")
+      FactoryBot.create(:cma_case, publication_state: "unrecognised")
     }
 
     it "skips republishing of the document" do


### PR DESCRIPTION
Remove defunct call to `require_signin_permission!`, gds-sso always checks for signin permission now.
Replace `factory_girl` with `factory_bot`. Only factory_bot will receive updates from now on. See
https://robots.thoughtbot.com/factory_bot