### PR TITLE
Allow a SECRET_KEY_BASE env var to set secret_key_base

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,4 +19,4 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_TOKEN"] %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] || ENV["SECRET_TOKEN"] %>


### PR DESCRIPTION
This is to fix an inconsistency between this app and other GOV.UK Rails
apps which use a SECRET_KEY_BASE env var.