### PR TITLE
Downgrade select2-rails to fix broken form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'logstasher', '1.2.2'
 gem 'mongoid', '~> 6.0.0'
 gem 'pundit'
 gem 'sass-rails', '~> 5.0.4'
-gem 'select2-rails', '~> 4.0.3'
+gem 'select2-rails', '~> 3.5.10'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '~> 5.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    select2-rails (4.0.3)
+    select2-rails (3.5.10)
       thor (~> 0.14)
     sentry-raven (2.6.3)
       faraday (>= 0.7.6, < 1.0)
@@ -426,7 +426,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0.4)
-  select2-rails (~> 4.0.3)
+  select2-rails (~> 3.5.10)
   simplecov
   simplecov-rcov
   timecop


### PR DESCRIPTION
The recent upgrade of select2-rails from version 3 to 4 broke the Authors field: authors were appearing as a single string rather than in separate boxes with a delete button. JS errors also stopped Body preview from working.

We can't use select2's backwards-compatibility mode (called select2-full) because it's not completely compatible with the Authors field: it doesn't allow users to enter names which don't match the autocomplete values.

Instead, this just downgrades select2-rails back to the working version until we can follow the full upgrade path: https://select2.org/upgrading/migrating-from-35

This fixes https://govuk.zendesk.com/agent/tickets/2545435