### PR TITLE
Add "Unmanned Aircraft Systems" Aircraft category

### DIFF
--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -24,7 +24,8 @@
         {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
         {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
         {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
-        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"}
+        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"},
+        {"label": "Unmanned Aircraft Systems (UAS)", "value": "unmanned-aircraft-systems"}
       ]
     },
     {


### PR DESCRIPTION
dependant on: https://github.com/alphagov/rummager/pull/1151 and https://github.com/alphagov/rummager/pull/1155

https://trello.com/c/7z1oGLZ1/1-2-aaib-reports-finder-add-a-new-label-to-aircraft-category

Once deployed this need to run:

```
rake publishing_api:publish_finders
```