### PR TITLE
Add residential property tribunal decision specialist document

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -11,8 +11,9 @@ jQuery(function($) {
 
   ////
   // Add "select all"/"clear all" buttons to each select2 dropdown menu
+  // but exclude those that aren't for multiple selection
   var dropdownSelectAll = new GOVUKAdmin.Modules.DropdownSelectAll();
-  dropdownSelectAll.start($("select.select2"));
+  dropdownSelectAll.start($("select.select2[multiple]"));
 
   ////
   // Make a select2 that will create new values on return as you type them

--- a/app/models/residential_property_tribunal_decision.rb
+++ b/app/models/residential_property_tribunal_decision.rb
@@ -1,0 +1,22 @@
+class ResidentialPropertyTribunalDecision < Document
+  validates :tribunal_decision_category, presence: true
+  validates :tribunal_decision_sub_category, presence: true, residential_property_tribunal_decision_sub_category: true
+  validates :tribunal_decision_decision_date, presence: true, date: true
+
+  FORMAT_SPECIFIC_FIELDS = %i(
+    hidden_indexable_content
+    tribunal_decision_category
+    tribunal_decision_sub_category
+    tribunal_decision_decision_date
+  ).freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def self.title
+    "Residential Property Tribunal Decision"
+  end
+end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,5 +1,6 @@
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    return if value.blank?
     Date.parse(value)
     Date.strptime(value, '%Y-%m-%d')
   rescue ArgumentError, RangeError

--- a/app/validators/residential_property_tribunal_decision_sub_category_validator.rb
+++ b/app/validators/residential_property_tribunal_decision_sub_category_validator.rb
@@ -1,0 +1,17 @@
+class ResidentialPropertyTribunalDecisionSubCategoryValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if [record.tribunal_decision_category, value].any?(&:blank?)
+    record.errors.add(attribute, error_message) unless related_sub_category?(record.tribunal_decision_category, value)
+  end
+
+private
+
+  def related_sub_category?(category, sub_category)
+    category_from_sub_category, _sub_category_from_sub_category = sub_category&.split('---', 2)
+    category == category_from_sub_category
+  end
+
+  def error_message
+    options[:message] || "must belong to the selected tribunal decision category"
+  end
+end

--- a/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
@@ -1,0 +1,19 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_category } do %>
+  <%= f.select :tribunal_decision_category,
+      f.object.facet_options(:tribunal_decision_category),
+      { label: "Category", include_blank: 'Select category' },
+      { class: 'form-control' }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_sub_category } do %>
+  <%= f.select :tribunal_decision_sub_category,
+      f.object.facet_options(:tribunal_decision_sub_category),
+      { label: "Sub-category", include_blank: true },
+      { class: 'select2 form-control', data: { placeholder: 'Select sub-category' } }
+  %>
+<% end %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :tribunal_decision_decision_date, format: :residential_property_tribunal_decision } do %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :hidden_indexable_content } do %>
+  <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
+<% end %>

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -1,0 +1,257 @@
+{
+  "content_id": "ce2c1353-2fcb-4c85-ac35-a1c8c3e990cf",
+  "base_path": "/residential-property-tribunal-decisions",
+  "format_name": "Residential property tribunal decision",
+  "name": "Residential property tribunal decisions",
+  "description": "Find decisions on Residential Property Tribunal cases in England, Wales and Scotland.",
+  "phase": "beta",
+  "pre_production": true,
+  "filter": {
+    "document_type": "residential_property_tribunal_decision"
+  },
+  "show_summaries": true,
+  "organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "bb2b028f-efaa-44fd-b3f8-971b25cb51a2"
+  ],
+  "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",
+  "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
+  "subscription_list_title_prefix": "Residential property tribunal decisions",
+  "summary": "<p>Find decisions on Residential Property Tribunal cases in England, Wales and Scotland from January 2018 onwards.</p><p>If the decision was made before March 2018, visit the <a href=\"http://www.residential-property.judiciary.gov.uk/search/decision_search.jsp\" rel=\"external\">Residential Property Tribunal Judiciary</a>.</p>",
+  "document_noun": "decision",
+  "facets": [
+    {
+      "key": "tribunal_decision_category",
+      "name": "Category",
+      "type": "text",
+      "preposition": "categorised as",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016",
+          "value": "housing-act-2004-housing-and-planning-act-2016"
+        },
+        {
+          "label": "Leasehold Disputes (Management)",
+          "value": "leasehold-disputes-Management"
+        },
+        {
+          "label": "Leasehold Enfranchisement & Extension",
+          "value": "leasehold-enfranchisement-extension"
+        },
+        {
+          "label": "Park Homes",
+          "value": "park-homes"
+        },
+        {
+          "label": "Rents",
+          "value": "rents"
+        },
+        {
+          "label": "Right-to-buy",
+          "value": "right-to-buy"
+        },
+        {
+          "label": "Tenant Associations",
+          "value": "tenant-associations"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_sub_category",
+      "name": "Sub-category",
+      "type": "text",
+      "preposition": "sub-categorised as",
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "allowed_values": [
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Rent Repayment Order",
+          "value": "housing-act-2004-housing-and-planning-act-2016---rent-repayment-order"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Improvement Notices",
+          "value": "housing-act-2004-housing-and-planning-act-2016---improvement-notices"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Prohibition Orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---prohibition-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Demolition and Closing Orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---demolition-and-closing-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Emergency Notices and Orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---emergency-notices-and-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Empty Dwelling Management Orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---empty-dwelling-management-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Houses in Multiple Occupation Licensing",
+          "value": "housing-act-2004-housing-and-planning-act-2016---houses-in-multiple-occupation-licensing"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Selective Licensing",
+          "value": "housing-act-2004-housing-and-planning-act-2016---selective-licensing"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Banning orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---banning-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Civil Financial Penalties",
+          "value": "housing-act-2004-housing-and-planning-act-2016---civil-financial-penalties"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Management Orders",
+          "value": "housing-act-2004-housing-and-planning-act-2016---management-orders"
+        },
+        {
+          "label": "Housing Act 2004 & Housing and Planning Act 2016 - Overcrowding Notices",
+          "value": "housing-act-2004-housing-and-planning-act-2016---overcrowding-notices"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Service Charges",
+          "value": "leasehold-disputes-management---service-charges"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Administration Charges",
+          "value": "leasehold-disputes-management---administration-charges"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Appointment of Manager",
+          "value": "leasehold-disputes-management---appointment-of-manager"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Right to Manage",
+          "value": "leasehold-disputes-management---right-to-manage"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Variation of Leases",
+          "value": "leasehold-disputes-management---variation-of-leases"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Breach of Lease/Forfeiture",
+          "value": "leasehold-disputes-management---breach-of-lease-forfeiture"
+        },
+        {
+          "label": "Leasehold Disputes (Management) - Estate Charges/Estate Management Schemes",
+          "value": "leasehold-disputes-management---estate-charges-estate-management-schemes"
+        },
+        {
+          "label": "Leasehold Enfranchisement & Extension - Flats - Lease Extension ",
+          "value": "leasehold-enfranchisement-extension---flats-lease-extension-"
+        },
+        {
+          "label": "Leasehold Enfranchisement & Extension - Houses - Enfranchisement",
+          "value": "leasehold-enfranchisement-extension---houses-enfranchisement"
+        },
+        {
+          "label": "Leasehold Enfranchisement & Extension - Flats - Collective Enfranchisement",
+          "value": "leasehold-enfranchisement-extension---flats-collective-enfranchisement"
+        },
+        {
+          "label": "Leasehold Enfranchisement & Extension - Right of First Refusal",
+          "value": "leasehold-enfranchisement-extension---right-of-first-refusal"
+        },
+        {
+          "label": "Park Homes - Pitch Fee",
+          "value": "park-homes---pitch-fee"
+        },
+        {
+          "label": "Park Homes - Section 4 - Any Question Under Act or Agreement",
+          "value": "park-homes---section-4-any-question-under-act-or-agreement"
+        },
+        {
+          "label": "Park Homes - Local Authority Compliance Notice",
+          "value": "park-homes---local-authority-compliance-notice"
+        },
+        {
+          "label": "Park Homes - Appeal Against/Alteration of a Site Licence Condition",
+          "value": "park-homes---appeal-against-alteration-of-a-site-licence-condition"
+        },
+        {
+          "label": "Park Homes - Local Authority Decision - Emergency Action",
+          "value": "park-homes---local-authority-decision-emergency-action"
+        },
+        {
+          "label": "Park Homes - Local Authority Site Licence Refusal/Refusal to Transfer",
+          "value": "park-homes---local-authority-site-licence-refusal-refusal-to-transfer"
+        },
+        {
+          "label": "Park Homes - Site Owner's Failure To Deposit Site Rules with LA",
+          "value": "park-homes---site-owners-failure-to-deposit-site-rules with la"
+        },
+        {
+          "label": "Park Homes - Site Rule Change - Consultation Response",
+          "value": "park-homes---site-rule-change-consultation-response"
+        },
+        {
+          "label": "Park Homes - Park Home Having a Detrimental Effect",
+          "value": "park-homes---park-home-having-a-detrimental-effect"
+        },
+        {
+          "label": "Park Homes - Order relating to implied and express terms",
+          "value": "park-homes---order-relating-to-implied-and-express-terms"
+        },
+        {
+          "label": "Park Homes - Recognition of Residents Association",
+          "value": "park-homes---recognition-of-residents-association"
+        },
+        {
+          "label": "Park Homes - Refusal Orders against Giving/Assigning home",
+          "value": "park-homes---refusal-orders-against-giving-assigning-home"
+        },
+        {
+          "label": "Park Homes - Site Licence - Payment of Annual Fee",
+          "value": "park-homes---site-licence-payment-of-annual-fee"
+        },
+        {
+          "label": "Park Homes - Order Requiring Written Statement of Terms",
+          "value": "park-homes---order-requiring-written-statement-of-terms"
+        },
+        {
+          "label": "Park Homes - Temporary Re-Siting/Return of Resited Park Home",
+          "value": "park-homes---temporary-re-siting-return-of-resited-park-home"
+        },
+        {
+          "label": "Park Homes - Entitlement to terminate an agreement for occupation",
+          "value": "park-homes---entitlement-to-terminate-an-agreement-for-occupation"
+        },
+        {
+          "label": "Rents - Market Rent (Assured Shorthold Tenancy)",
+          "value": "rents---market-rent-assured-shorthold-tenancy"
+        },
+        {
+          "label": "Rents - Fair Rent",
+          "value": "rents---fair-rent"
+        },
+        {
+          "label": "Right-to-buy - RTB appeals - Elderly persons",
+          "value": "right-to-buy---rtb-appeals-elderly-persons"
+        },
+        {
+          "label": "Tenant Associations - Recognition of tenants association",
+          "value": "tenant-associations---recognition-of-tenants-association"
+        },
+        {
+          "label": "Tenant Associations - Request for information",
+          "value": "tenant-associations---request-for-information"
+        }
+      ]
+    },
+    {
+      "key": "tribunal_decision_decision_date",
+      "name": "Decision date",
+      "short_name": "Decided",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/features/creating_a_residential_property_tribunal_decision_spec.rb
+++ b/spec/features/creating_a_residential_property_tribunal_decision_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+RSpec.feature "Creating a residential property tribunal decision", type: :feature do
+  let(:tribunal_decision) { FactoryBot.create(:residential_property_tribunal_decision) }
+  let(:content_id)        { tribunal_decision['content_id'] }
+  let(:public_updated_at) { tribunal_decision['public_updated_at'] }
+
+  before do
+    log_in_as_editor(:moj_editor)
+
+    Timecop.freeze(Time.parse(public_updated_at))
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    publishing_api_has_item(tribunal_decision)
+  end
+
+  scenario "with valid data" do
+    visit "/residential-property-tribunal-decisions/new"
+    title = "Example Residential property tribunal decision"
+    summary = "This is the summary of an example Residential property tribunal decision"
+
+    expect(page.status_code).to eq(200)
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: summary
+    fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example Residential property tribunal decision" * 10))
+    select "Park Homes", from: "Tribunal decision category"
+    select "Park Homes - Site Licence - Payment of Annual Fee", from: "Tribunal decision sub category"
+    fill_in "[residential_property_tribunal_decision]tribunal_decision_decision_date(1i)", with: "2018"
+    fill_in "[residential_property_tribunal_decision]tribunal_decision_decision_date(2i)", with: "01"
+    fill_in "[residential_property_tribunal_decision]tribunal_decision_decision_date(3i)", with: "01"
+    fill_in "Hidden indexable content", with: "hidden text goes here"
+
+    expect(page).to have_css('div.govspeak-help')
+    expect(page).to have_content('To add an attachment, please save the draft first.')
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(200)
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example Residential property tribunal decision")
+  end
+
+  scenario "with no data" do
+    visit "/residential-property-tribunal-decisions/new"
+
+    expect(page.status_code).to eq(200), page.html
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+    expect(page).to have_content("Tribunal decision category can't be blank")
+    expect(page).to have_content("Tribunal decision sub category can't be blank")
+    expect(page).to have_content("Tribunal decision decision date can't be blank")
+
+    expect(page).to_not have_content("Hidden indexable content can't be blank")
+  end
+
+  scenario "with invalid data" do
+    visit "/residential-property-tribunal-decisions/new"
+
+    expect(page.status_code).to eq(200)
+
+    fill_in "Title", with: "Example Residential property tribunal decision"
+    fill_in "Summary", with: "This is the summary of an example Residential property tribunal decision"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+    select "Rents", from: "Tribunal decision category"
+    select "Park Homes - Site Licence - Payment of Annual Fee", from: "Tribunal decision sub category"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+    expect(page).to have_content("Tribunal decision sub category must belong to the selected tribunal decision category")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -402,6 +402,22 @@ FactoryBot.define do
     end
   end
 
+  factory :residential_property_tribunal_decision, parent: :document do
+    base_path "/residential-property-tribunal-decisions/example-document"
+    document_type "residential_property_tribunal_decision"
+
+    transient do
+      default_metadata {
+        {
+          "tribunal_decision_category" => "leasehold-disputes-management",
+          "tribunal_decision_sub_category" => "leasehold-disputes-management---appointment-of-manager",
+          "tribunal_decision_decision_date" => "2018-01-17",
+          "hidden_indexable_content" => "some hidden content",
+        }
+      }
+    end
+  end
+
   factory :tax_tribunal_decision, parent: :document do
     base_path "/tax-and-chancery-tribunal-decisions/example-document"
     document_type "tax_tribunal_decision"

--- a/spec/models/residential_property_tribunal_decision_spec.rb
+++ b/spec/models/residential_property_tribunal_decision_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'models/valid_against_schema'
+
+RSpec.describe ResidentialPropertyTribunalDecision do
+  let(:payload) { FactoryBot.create(:residential_property_tribunal_decision) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+  subject(:tribunal_decision) { described_class.from_publishing_api(payload) }
+
+  it 'is not exportable' do
+    expect(described_class).not_to be_exportable
+  end
+
+  context 'validations' do
+    it 'is valid from the payload' do
+      expect(tribunal_decision).to be_valid
+    end
+
+    it 'is invalid if the tribunal decision category is missing' do
+      tribunal_decision.tribunal_decision_category = nil
+      expect(tribunal_decision).not_to be_valid
+    end
+
+    it 'is invalid if the tribunal decision decision date is missing' do
+      tribunal_decision.tribunal_decision_decision_date = nil
+      expect(tribunal_decision).not_to be_valid
+    end
+
+    it 'is invalid if the tribunal decision sub category is missing' do
+      tribunal_decision.tribunal_decision_sub_category = nil
+      expect(tribunal_decision).not_to be_valid
+    end
+
+    it "is invalid if the tribunal decision sub category does not match up to the tribunal decision category" do
+      tribunal_decision.tribunal_decision_category = 'rents'
+      tribunal_decision.tribunal_decision_sub_category = 'tenant-associations---request-for-information'
+      expect(tribunal_decision).not_to be_valid
+    end
+  end
+end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe DateValidator do
 
     subject { described_class.new(attributes: [:dob]) }
 
+    it "assumes presence: true validation will be used to detect nils if we don't allow them for this attribute so doesn't add an error if the date value is blank" do
+      subject.validate_each(record, :dob, nil)
+      expect(record.errors[:dob]).to be_empty
+    end
+
     it "adds an error to the record if the date value is unparseable" do
       subject.validate_each(record, :dob, "31-02-2013")
       expect(record.errors[:dob]).to eq(["is not a valid date"])

--- a/spec/validators/residential_property_tribunal_decision_sub_category_validator_spec.rb
+++ b/spec/validators/residential_property_tribunal_decision_sub_category_validator_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+RSpec.describe ResidentialPropertyTribunalDecisionSubCategoryValidator do
+  describe "#validate_each" do
+    let(:record) { double(:record) }
+    let(:errors) { ActiveModel::Errors.new(record) }
+    before { allow(record).to receive(:errors).and_return(errors) }
+
+    subject { described_class.new(attributes: [:sub_category]) }
+
+    context "nil values are ignored on the assumption that presence: true validations will be used to detect them so" do
+      it "doesn't add an error to the record if the category on the record is blank" do
+        allow(record).to receive(:tribunal_decision_category).and_return(nil)
+        subject.validate_each(record, :sub_category, "foo---bar")
+        expect(record.errors[:sub_category]).to be_empty
+      end
+
+      it "doesn't add an error to the record if the sub_category on the record is blank" do
+        allow(record).to receive(:tribunal_decision_category).and_return('foo')
+        subject.validate_each(record, :sub_category, nil)
+        expect(record.errors[:sub_category]).to be_empty
+      end
+    end
+
+    it "adds an error to the record if the category suffixed by '---' is not a prefix of the sub_category" do
+      allow(record).to receive(:tribunal_decision_category).and_return('foo')
+      subject.validate_each(record, :sub_category, 'foo-bar')
+      expect(record.errors[:sub_category]).to eq(["must belong to the selected tribunal decision category"])
+    end
+
+    it "does not add an error to the record if the category suffixed by '---' is a prefix of the sub_category" do
+      allow(record).to receive(:tribunal_decision_category).and_return('foo')
+      subject.validate_each(record, :sub_category, 'foo---bar')
+      expect(record.errors[:sub_category]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder

We add a new finder, and support in the UI for manipulating these documents.  The documents are decisions from the residential property tribunal.  The finder is marked as pre_production so we can merge + ship it to staging and allow for testing without deploying it to production.

This PR relies on alphagov/govuk-content-schemas#705 to define the schemas for the new document type.