### PR TITLE
Assign emails as high priority

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -20,7 +20,8 @@ class EmailAlertPresenter
       content_id: content_id,
       public_updated_at: public_updated_at,
       publishing_app: "specialist-publisher",
-      base_path: base_path
+      base_path: base_path,
+      priority: priority,
     }.merge(extra_options)
   end
 
@@ -118,6 +119,10 @@ private
 
   def urgent
     document.urgent
+  end
+
+  def priority
+    urgent ? "high" : "normal"
   end
 
   def public_updated_at

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -37,11 +37,13 @@ RSpec.describe EmailAlertPresenter do
         expect(presented_data[:base_path]).to include(cma_case_payload["base_path"])
         expect(presented_data[:footer]).to include("SUBSCRIBER_PREFERENCES_URL")
         expect(presented_data[:header]).to include("govuk-email-header")
+        expect(presented_data[:priority]).to eq("normal")
 
         expect(presented_data.keys).to match_array(%i(
           title description change_note subject body tags document_type
           email_document_supertype government_document_supertype content_id
           public_updated_at publishing_app base_path urgent header footer
+          priority
         ))
       end
     end
@@ -60,6 +62,7 @@ RSpec.describe EmailAlertPresenter do
 
         expect(presented_data[:body]).to include(mhra_email_address)
         expect(presented_data[:document_type]).to eq("medical_safety_alert")
+        expect(presented_data[:priority]).to eq("high")
       end
     end
   end


### PR DESCRIPTION
This means that the emails will be sent with a higher priority than other kinds of emails.

Depends on https://github.com/alphagov/email-alert-api/pull/382

[Trello Card](https://trello.com/c/mHXNdskh/550-setup-delivery-priorities)