### PR TITLE
Add rake task to publish a single finder

### DIFF
--- a/lib/finder_loader.rb
+++ b/lib/finder_loader.rb
@@ -2,11 +2,24 @@ require "multi_json"
 
 class FinderLoader
   def finders
-    files.map do |file|
+    files.map do |json_schema|
       {
-        file: MultiJson.load(File.read(file)),
-        timestamp: File.mtime(file)
+        file: MultiJson.load(File.read(json_schema)),
+        timestamp: File.mtime(json_schema)
       }
+    end
+  end
+
+  def finder(name)
+    json_schema = "lib/documents/schemas/#{name}.json"
+
+    if File.exist?(json_schema)
+      [{
+        file: MultiJson.load(File.read(json_schema)),
+        timestamp: File.mtime(json_schema)
+      }]
+    else
+      raise "Could not find file: #{json_schema}"
     end
   end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,4 +12,25 @@ namespace :publishing_api do
       puts "Error publishing finder: #{e.inspect}"
     end
   end
+
+  desc "Publish a single Finder to the Publishing API"
+  task :publish_finder, [:name] => :environment do |_, args|
+    require "finder_loader"
+    require "publishing_api_finder_publisher"
+
+    begin
+      finder_loader = FinderLoader.new
+      finder = finder_loader.finder(args.name)
+    rescue StandardError => e
+      puts "Error: #{e.inspect}"
+    end
+
+    if finder
+      begin
+        PublishingApiFinderPublisher.new(finder).call
+      rescue GdsApi::HTTPServerError => e
+        puts "Error publishing finder: #{e.inspect}"
+      end
+    end
+  end
 end

--- a/spec/lib/finder_loader_spec.rb
+++ b/spec/lib/finder_loader_spec.rb
@@ -3,20 +3,18 @@ require "finder_loader"
 
 RSpec.describe FinderLoader do
   before do
+    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
+                      .and_return('{"name":"format-1"}')
+    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
+                      .and_return("yesterday")
+  end
+  it "returns matching finder data objects" do
     expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w{
       lib/documents/schemas/format-1.json
       lib/documents/schemas/format-2.json
     })
-  end
-
-  it "returns matching finder data objects" do
-    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
-      .and_return('{"name":"format-1"}')
     expect(File).to receive(:read).with("lib/documents/schemas/format-2.json")
       .and_return('{"name":"format-2"}')
-
-    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
-      .and_return("yesterday")
     expect(File).to receive(:mtime).with("lib/documents/schemas/format-2.json")
       .and_return("today")
 
@@ -30,6 +28,19 @@ RSpec.describe FinderLoader do
 
         file: { "name" => "format-2" },
         timestamp: "today"
+      }
+    ])
+  end
+
+  it "returns one matching finder data object" do
+    expect(File).to receive(:exist?).with("lib/documents/schemas/format-1.json")
+                      .and_return(true)
+
+    loader = FinderLoader.new
+    expect(loader.finder('format-1')).to match_array([
+      {
+        file: { "name" => "format-1" },
+        timestamp: "yesterday"
       }
     ])
   end


### PR DESCRIPTION
For: https://trello.com/c/bogvHiGv/53-add-a-rake-task-for-publishing-a-single-finder-to-specialist-publisher

To publish a single finder:

```
bundle exec rake publishing_api:publish_finder["residential_property_tribunal_decisions"]
```

The parameter is the name of the json schema in ```lib/documents/schemas/```