### PR TITLE
Removes pre-prod marker for residential tribunal

### DIFF
--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -5,7 +5,6 @@
   "name": "Residential property tribunal decisions",
   "description": "Find decisions on Residential Property Tribunal cases in England, Wales and Scotland.",
   "phase": "beta",
-  "pre_production": true,
   "filter": {
     "document_type": "residential_property_tribunal_decision"
   },


### PR DESCRIPTION
In order to be able to deploy this to production, we need to remove the "pre-production" marker.

For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder