### PR TITLE
Explicitly use external URLs where appropriate

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -102,7 +102,7 @@ class DocumentsController < ApplicationController
 private
 
   def unknown_error_message
-    support_url = Plek.find('support') + "/technical_fault_report/new"
+    support_url = Plek.new.external_url_for('support') + "/technical_fault_report/new"
 
     "Something has gone wrong. Please try again and see if it works. <a href='#{support_url}'>Let us know</a>
     if the problem happens again and a developer will look into it.".html_safe

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -12,7 +12,7 @@ module UrlHelper
   end
 
   def draft_url_for(document)
-    URI.join(Plek.current.find("draft-origin"), document.base_path, cachebust_query_string).to_s
+    URI.join(Plek.new.external_url_for("draft-origin"), document.base_path, cachebust_query_string).to_s
   end
 
   def cachebust_query_string

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -6,5 +6,5 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
 
   # optional config for location of signon
-  config.oauth_root_url = Plek.current.find("signon")
+  config.oauth_root_url = Plek.new.external_url_for("signon")
 end


### PR DESCRIPTION
By using the new external_url_for method in Plek.