### PR TITLE
Don't retry 409s from email-alert-api

### DIFF
--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -4,6 +4,10 @@ class EmailAlertApiWorker
   include Sidekiq::Worker
 
   def perform(payload)
-    Services.email_alert_api.send_alert(payload)
+    begin
+      Services.email_alert_api.send_alert(payload)
+    rescue GdsApi::HTTPConflict
+      logger.info("email-alert-api returned 409 conflict for #{payload}")
+    end
   end
 end

--- a/spec/workers/email_alert_api_worker_spec.rb
+++ b/spec/workers/email_alert_api_worker_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe EmailAlertApiWorker do
 
     assert_email_alert_sent("some" => "payload")
   end
+
+  it "doesn't retry 409s" do
+    stub_any_email_alert_api_call.and_raise(GdsApi::HTTPConflict.new(409))
+
+    expect {
+      described_class.new.perform(payload: {})
+    }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Email-alert-api now checks for duplicate notification requests and returns a 409 in that event.

This PR catches 409s to halt the sidekiq retry process.