### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
-
 # for capybara-webkit
 RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
+RUN gem install foreman
+
 
 ENV GOVUK_APP_NAME specialist-publisher
 ENV MONGODB_URI mongodb://mongo/govuk-content
@@ -23,4 +24,4 @@ RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:pr
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '5.0.2'
 
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'foreman'
 gem 'govuk_sidekiq', '~> 2.0'
 gem 'hashdiff'
 gem 'jquery-rails', '~> 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,8 +91,6 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -407,7 +405,6 @@ DEPENDENCIES
   capybara-webkit
   database_cleaner
   factory_bot
-  foreman
   gds-api-adapters (~> 51.2.0)
   gds-sso (= 13.6.0)
   govspeak (~> 5.4.0)
@@ -437,4 +434,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec foreman run web
+bundle exec rails s -p 3064


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via `gem install` in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.