### PR TITLE
Add MHRA footnote to medical safety alert emails

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -273,6 +273,10 @@ class Document
     nil
   end
 
+  def email_footnote
+    nil
+  end
+
   def content_item_blocking_publish?
     warnings && warnings.has_key?("content_item_blocking_publish")
   end

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -21,4 +21,8 @@ class MedicalSafetyAlert < Document
   def urgent
     true
   end
+
+  def email_footnote
+    "Do not reply to this email. To contact MHRA, email email.support@mhra.gov.uk"
+  end
 end

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -125,6 +125,10 @@ private
     urgent ? "high" : "normal"
   end
 
+  def footnote
+    document.email_footnote
+  end
+
   def public_updated_at
     document.public_updated_at
   end
@@ -145,6 +149,7 @@ private
     {
       header: header,
       footer: footer,
+      footnote: footnote,
     }.reject { |_k, v| v.nil? }
   end
 

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe EmailAlertPresenter do
         expect(presented_data[:body]).to include(mhra_email_address)
         expect(presented_data[:document_type]).to eq("medical_safety_alert")
         expect(presented_data[:priority]).to eq("high")
+        expect(presented_data[:footnote]).to eq("Do not reply to this email. To contact MHRA, email email.support@mhra.gov.uk")
       end
     end
   end


### PR DESCRIPTION
This makes sure that the emails include the sentence "Do not reply to this email. To contact MHRA, email email.support@mhra.gov.uk" at the bottom of each email.

[Trello Card](https://trello.com/c/f9gAAlay/627-add-an-extra-blurb-for-medical-device-alert-emails)