### PR TITLE
Re-point drug safety updates to MHRA account

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -42,6 +42,7 @@ private
       format_name: file.fetch("format_name", nil),
       logo_path: file.fetch("logo_path", nil),
       show_summaries: file.fetch("show_summaries", false),
+      signup_link: file.fetch("signup_link", nil),
       summary: file.fetch("summary", nil),
       facets: file.fetch("facets", nil),
       default_order: file.fetch("default_order", nil),

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -8,8 +8,7 @@
     "document_type": "drug_safety_update"
   },
   "show_summaries": true,
-  "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
-  "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
+  "signup_link": "https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": [
     "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",


### PR DESCRIPTION
This commit changes the drug safety update finder to point to the MHRA GovDelivery account for signing up to email alerts. It also allows this field to make its way to the content item, where it will be picked up by finder-frontend, and removes the signup page text and content ID since this page will no longer exist.

Trello: https://trello.com/c/QeBmdZCN/670-re-point-drug-safety-updates-to-mhra-account