### PR TITLE
Replace deprecated authentication method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include Pundit
 
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
   before_action :set_authenticated_user_header
   after_action :verify_authorized
 


### PR DESCRIPTION
Replace `require_signin_permission!` with `authenticate_user!` to fix deprecation warning in gds-sso: https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md#1330