### PR TITLE
Change MHRA email footnote

### DIFF
--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -23,6 +23,6 @@ class MedicalSafetyAlert < Document
   end
 
   def email_footnote
-    "Do not reply to this email. To contact MHRA, email email.support@mhra.gov.uk"
+    "If you have any questions about the medical content in this email, contact MHRA on info@mhra.gov.uk"
   end
 end

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe EmailAlertPresenter do
         expect(presented_data[:body]).to include(mhra_email_address)
         expect(presented_data[:document_type]).to eq("medical_safety_alert")
         expect(presented_data[:priority]).to eq("high")
-        expect(presented_data[:footnote]).to eq("Do not reply to this email. To contact MHRA, email email.support@mhra.gov.uk")
+        expect(presented_data[:footnote]).to eq("If you have any questions about the medical content in this email, contact MHRA on info@mhra.gov.uk")
       end
     end
   end


### PR DESCRIPTION
This commit changes the footnote on MHRA emails to clarify that they should only be contacted for medical-related queries.

Trello: https://trello.com/c/MancG0LB/739-amend-mhra-footer-text-in-emails