### PR TITLE
Update subscriber list title test

### DIFF
--- a/docs/phase-2-migration/update-types.md
+++ b/docs/phase-2-migration/update-types.md
@@ -12,7 +12,7 @@ If the update type is 'major', we send a request to the Email Alert API when the
 content is published. The only exception to this is the 'Drug Safety Update'
 format which has this [explicitly
 disabled](https://github.com/alphagov/specialist-publisher-rebuild/blob/39745ac21b8717130cb3d210469b06cfb2ea72ca/app/models/drug_safety_update.rb#L16-L18). Instead, the MHRA manually send out a monthly digest of
-updates through the govdelivery interface.
+updates through their own GovDelivery account.
 
 If the content item is a 'first draft', we also artificially add a
 'First published.' change note to the content item. We do this immediately

--- a/spec/finders/email_alert_configuration_spec.rb
+++ b/spec/finders/email_alert_configuration_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "Email alert configuration" do
         end
       end
 
-      # GovDelivery limits the name of a subscription list to 255 characters
+      # email-alert-api limits the name of a subscription list to 1000 characters
       # We test here to make sure we don't try to create lists with names
       # longer than this for live finders
-      it "doesn't have a name longer than 255 characters" do
+      it "doesn't have a name longer than 1000 characters" do
         next unless finder["subscription_list_title_prefix"] && !finder["pre_production"]
 
         if finder["subscription_list_title_prefix"]["plural"]
@@ -44,7 +44,7 @@ RSpec.describe "Email alert configuration" do
           name = finder["subscription_list_title_prefix"]
         end
 
-        expect(name.length).to be <= 255
+        expect(name.length).to be <= 1000
       end
     end
   end


### PR DESCRIPTION
We now allow up to 1000 characters for subscriber list titles. Also amend the docs about MHRA drug safety updates.

Trello: https://trello.com/c/VK18GrmW/736-clean-up-all-remaining-govdelivery-references-across-all-repos