### PR TITLE
Set primary publishing organisation for each document type

### DIFF
--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -21,4 +21,8 @@ class AaibReport < Document
   def self.title
     "AAIB Report"
   end
+
+  def primary_publishing_organisation
+    "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
+  end
 end

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -27,4 +27,8 @@ class AsylumSupportDecision < Document
   def self.title
     "Asylum Support Decisions"
   end
+
+  def primary_publishing_organisation
+    '6f757605-ab8f-4b62-84e4-99f79cf085c2'
+  end
 end

--- a/app/models/business_finance_support_scheme.rb
+++ b/app/models/business_finance_support_scheme.rb
@@ -27,4 +27,8 @@ class BusinessFinanceSupportScheme < Document
   def self.title
     "Business Finance Support Scheme"
   end
+
+  def primary_publishing_organisation
+    "2bde479a-97f2-42b5-986a-287a623c2a1c"
+  end
 end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -23,4 +23,8 @@ class CmaCase < Document
   def self.title
     "CMA Case"
   end
+
+  def primary_publishing_organisation
+    "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+  end
 end

--- a/app/models/countryside_stewardship_grant.rb
+++ b/app/models/countryside_stewardship_grant.rb
@@ -15,4 +15,8 @@ class CountrysideStewardshipGrant < Document
   def self.title
     "Countryside Stewardship Grant"
   end
+
+  def primary_publishing_organisation
+    "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
+  end
 end

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -47,4 +47,8 @@ class DfidResearchOutput < Document
   def dfid_author_tags=(tags)
     self.dfid_authors = (tags || "").split("::")
   end
+
+  def primary_publishing_organisation
+    'db994552-7644-404d-a770-a2fe659c661f'
+  end
 end

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -16,4 +16,8 @@ class DrugSafetyUpdate < Document
   def send_email_on_publish?
     false
   end
+
+  def primary_publishing_organisation
+    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
+  end
 end

--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -24,4 +24,8 @@ class EmploymentAppealTribunalDecision < Document
   def self.slug
     "employment-appeal-tribunal-decisions"
   end
+
+  def primary_publishing_organisation
+    '6f757605-ab8f-4b62-84e4-99f79cf085c2'
+  end
 end

--- a/app/models/employment_tribunal_decision.rb
+++ b/app/models/employment_tribunal_decision.rb
@@ -23,4 +23,8 @@ class EmploymentTribunalDecision < Document
   def self.slug
     "employment-tribunal-decisions"
   end
+
+  def primary_publishing_organisation
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2"
+  end
 end

--- a/app/models/esi_fund.rb
+++ b/app/models/esi_fund.rb
@@ -18,4 +18,8 @@ class EsiFund < Document
   def self.title
     "ESI Fund"
   end
+
+  def primary_publishing_organisation
+    "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28"
+  end
 end

--- a/app/models/international_development_fund.rb
+++ b/app/models/international_development_fund.rb
@@ -16,4 +16,8 @@ class InternationalDevelopmentFund < Document
   def self.title
     "International Development Fund"
   end
+
+  def primary_publishing_organisation
+    'db994552-7644-404d-a770-a2fe659c661f'
+  end
 end

--- a/app/models/maib_report.rb
+++ b/app/models/maib_report.rb
@@ -16,4 +16,8 @@ class MaibReport < Document
   def self.title
     "MAIB Report"
   end
+
+  def primary_publishing_organisation
+    "9c66b9a3-1e6a-48e8-974d-2a5635f84679"
+  end
 end

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -25,4 +25,8 @@ class MedicalSafetyAlert < Document
   def email_footnote
     "If you have any questions about the medical content in this email, contact MHRA on info@mhra.gov.uk"
   end
+
+  def primary_publishing_organisation
+    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
+  end
 end

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -16,4 +16,8 @@ class RaibReport < Document
   def self.title
     "RAIB Report"
   end
+
+  def primary_publishing_organisation
+    "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
+  end
 end

--- a/app/models/residential_property_tribunal_decision.rb
+++ b/app/models/residential_property_tribunal_decision.rb
@@ -19,4 +19,8 @@ class ResidentialPropertyTribunalDecision < Document
   def self.title
     "Residential Property Tribunal Decision"
   end
+
+  def primary_publishing_organisation
+    '6f757605-ab8f-4b62-84e4-99f79cf085c2'
+  end
 end

--- a/app/models/service_standard_report.rb
+++ b/app/models/service_standard_report.rb
@@ -10,4 +10,8 @@ class ServiceStandardReport < Document
   def self.title
     "Service Standard Report"
   end
+
+  def primary_publishing_organisation
+    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  end
 end

--- a/app/models/tax_tribunal_decision.rb
+++ b/app/models/tax_tribunal_decision.rb
@@ -17,4 +17,8 @@ class TaxTribunalDecision < Document
   def self.title
     "Tax Tribunal Decision"
   end
+
+  def primary_publishing_organisation
+    '6f757605-ab8f-4b62-84e4-99f79cf085c2'
+  end
 end

--- a/app/models/utaac_decision.rb
+++ b/app/models/utaac_decision.rb
@@ -22,4 +22,8 @@ class UtaacDecision < Document
   def self.title
     "UTAAC Decision"
   end
+
+  def primary_publishing_organisation
+    '6f757605-ab8f-4b62-84e4-99f79cf085c2'
+  end
 end

--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -7,7 +7,8 @@ class DocumentLinksPresenter
     {
       content_id: document.content_id,
       links: {
-        organisations: document.organisations
+        organisations: document.organisations,
+        primary_publishing_organisation: [document.primary_publishing_organisation],
       },
     }
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Document do
       "My Document Type"
     end
 
+    def primary_publishing_organisation
+      'a-primary-org-id'
+    end
+
     attr_accessor :field1, :field2, :field3
 
     def initialize(params = {})

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe DocumentLinksPresenter do
+  document_types = {
+    DfidResearchOutput => 'db994552-7644-404d-a770-a2fe659c661f',
+    EmploymentTribunalDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
+    AaibReport => "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
+    CmaCase => "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+    EmploymentAppealTribunalDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
+    MaibReport => "9c66b9a3-1e6a-48e8-974d-2a5635f84679",
+    EsiFund => "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+    TaxTribunalDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
+    UtaacDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
+    DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
+    MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
+    RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
+    CountrysideStewardshipGrant => "d3ce4ba7-bc75-46b4-89d9-38cb3240376d",
+    BusinessFinanceSupportScheme => "2bde479a-97f2-42b5-986a-287a623c2a1c",
+    AsylumSupportDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
+    ServiceStandardReport => "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+    InternationalDevelopmentFund => 'db994552-7644-404d-a770-a2fe659c661f',
+  }
+
+  document_types.each do |klass, primary_publishing_organisation_id|
+    it "set primary publishing organisations for #{klass}" do
+      document = klass.new
+      document.content_id = 'a-content-id'
+      allow(document).to receive(:organisations).and_return('an-organisation-id')
+
+      presenter = DocumentLinksPresenter.new(document)
+      presented_data = presenter.to_json
+
+      expect(presented_data[:content_id]).to eq('a-content-id')
+      expect(presented_data[:links][:organisations]).to eq('an-organisation-id')
+      expect(presented_data[:links][:primary_publishing_organisation]).to eq([primary_publishing_organisation_id])
+    end
+  end
+end


### PR DESCRIPTION
In order to query data by primary_organisation each document type needs to be
assigned a primary publishing organisation. This PR assigns primary publishing organisation for each based on the best estimates from Mark McLeod and Ben Hazell as part of the Data Informed Content team's datawarehouse work. See [this trello card.]https://trello.com/c/UFSgQxK9/331-3-set-primary-org-in-specialist-publisher)