### PR TITLE
Add statutory instrument format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ruby:2.4.4
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
-# for capybara-webkit
-RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
-RUN gem install foreman
 
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
+
+# https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#debian--ubuntu
+RUN apt-get install -y qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME specialist-publisher
 ENV MONGODB_URI mongodb://mongo/govuk-content

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -1,0 +1,27 @@
+class StatutoryInstrument < Document
+  validates :laid_date, date: true
+  validates :sift_end_date, date: true
+  validates :sifting_status, presence: true
+  validates :subject, presence: true
+
+  FORMAT_SPECIFIC_FIELDS = %i(
+    laid_date
+    sift_end_date
+    sifting_status
+    subject
+  ).freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def self.title
+    "Statutory instrument"
+  end
+
+  def primary_publishing_organisation
+    "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+  end
+end

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -1,0 +1,19 @@
+<%= render "shared/date_fields", f: f, field: :sift_end_date, format: :statutory_instrument %>
+<%= render "shared/date_fields", f: f, field: :laid_date, format: :statutory_instrument %>
+<%= render "shared/form_group", f: f, field: :sifting_status do %>
+  <%= f.select :sifting_status, facet_options(f, :sifting_status), {}, { class: "form-control" } %>
+<% end %>
+<%= render "shared/form_group", f: f, field: :subject do %>
+  <%= f.select :subject,
+      facet_options(f, :subject),
+      {},
+      {
+        class: "select2 form-control",
+        multiple: true,
+        data:
+        {
+          placeholder: "Select subjects"
+        }
+      }
+  %>
+<% end %>

--- a/config/initializers/load_pre_production_formats.rb
+++ b/config/initializers/load_pre_production_formats.rb
@@ -3,7 +3,7 @@ def pre_production
   Dir["lib/documents/schemas/*.json"].each do |file|
     read_file = File.read(file)
     parsed_file = JSON.parse(read_file)
-    if parsed_file["pre_production"] && parsed_file["base_path"] != "/dfid-research-outputs"
+    if parsed_file["pre_production"]
       pre_production_formats << parsed_file["filter"]["document_type"]
     end
   end

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -10,6 +10,7 @@
   "organisations": [],
   "topics": [],
   "document_noun": "statutory instrument",
+  "pre_production": true,
   "facets": [
     {
       "key": "laid_date",

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -1,0 +1,107 @@
+{
+  "content_id": "f722816d-7e12-4055-8e7e-68b2d144e2b6",
+  "base_path": "/statutory-instruments",
+  "format_name": "Statutory instrument",
+  "name": "Statutory instrument",
+  "description": "Find statutory instruments",
+  "filter": {
+    "document_type": "statutory_instrument"
+  },
+  "organisations": [],
+  "topics": [],
+  "document_noun": "statutory instrument",
+  "facets": [
+    {
+      "key": "laid_date",
+      "name": "Laid on",
+      "short_name": "Laid on",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+
+    {
+      "key": "sift_end_date",
+      "name": "Sift end date",
+      "short_name": "Sift end date",
+      "type": "date",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+
+    {
+      "key": "sifting_status",
+      "name": "Sifting status",
+      "type": "text",
+      "preposition": "with status",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Open", "value": "open"},
+        {"label": "Closed", "value": "closed"},
+        {"label": "Withdrawn", "value": "withdrawn"}
+      ]
+    },
+
+    {
+      "key": "subject",
+      "name": "Subject",
+      "type": "text",
+      "preposition": "relating to",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Animal welfare", "value": "animal-welfare"},
+        {"label": "Benefits", "value": "benefits"},
+        {"label": "Business and enterprise", "value": "business-and-enterprise"},
+        {"label": "Business tax", "value": "business-tax"},
+        {"label": "Climate change and energy", "value": "climate-change-and-energy"},
+        {"label": "Coal", "value": "coal"},
+        {"label": "Commercial fishing and fisheries", "value": "commercial-fishing-and-fisheries"},
+        {"label": "Community organisations", "value": "community-organisations"},
+        {"label": "Company registration and filing", "value": "company-registration-and-filing"},
+        {"label": "Competition", "value": "competition"},
+        {"label": "Crime and policing", "value": "crime-and-policing"},
+        {"label": "Dealing with HMRC", "value": "dealing-with-hmrc"},
+        {"label": "Death and wills", "value": "death-and-wills"},
+        {"label": "Defence and armed forces", "value": "defence-and-armed-forces"},
+        {"label": "Driving and motorcycle instructors", "value": "driving-and-motorcycle-instructors"},
+        {"label": "Driving tests and learning to drive", "value": "driving-tests-and-learning-to-drive"},
+        {"label": "Environmental management", "value": "environmental-management"},
+        {"label": "Farming and food grants and payments", "value": "farming-and-food-grants-and-payments"},
+        {"label": "Further education and skills", "value": "further-education-and-skills"},
+        {"label": "Government", "value": "government"},
+        {"label": "Guidance for government digital publishing and services", "value": "guidance-for-government-digital-publishing-and-services"},
+        {"label": "Health protection", "value": "health-protection"},
+        {"label": "Help for British nationals overseas", "value": "help-for-british-nationals-overseas"},
+        {"label": "High Speed 2", "value": "high-speed-2"},
+        {"label": "Higher education", "value": "higher-education"},
+        {"label": "Housing", "value": "housing"},
+        {"label": "Intellectual property", "value": "intellectual-property"},
+        {"label": "Keeping farmed animals", "value": "keeping-farmed-animals"},
+        {"label": "Land registration", "value": "land-registration"},
+        {"label": "Law and the justice system", "value": "law-and-the-justice-system"},
+        {"label": "Legal aid", "value": "legal-aid"},
+        {"label": "Local communities", "value": "local-communities"},
+        {"label": "Local government", "value": "local-government"},
+        {"label": "MOT and vehicle tests", "value": "mot-and-vehicle-tests"},
+        {"label": "Medicines, medical devices and blood regulation and safety", "value": "medicines-medical-devices-and-blood-regulation-and-safety"},
+        {"label": "Oil and gas", "value": "oil-and-gas"},
+        {"label": "Outdoor access and recreation", "value": "outdoor-access-and-recreation"},
+        {"label": "Personal tax", "value": "personal-tax"},
+        {"label": "Planning and development", "value": "planning-and-development"},
+        {"label": "Population screening programmes", "value": "population-screening-programmes"},
+        {"label": "Prisons and probation", "value": "prisons-and-probation"},
+        {"label": "Producing and distributing food", "value": "producing-and-distributing-food"},
+        {"label": "Public safety and emergencies", "value": "public-safety-and-emergencies"},
+        {"label": "Schools, colleges and children's services", "value": "schools-colleges-and-childrens-services"},
+        {"label": "Setting up and running a charity", "value": "setting-up-and-running-a-charity"},
+        {"label": "Ships and cargoes", "value": "ships-and-cargoes"},
+        {"label": "Transport", "value": "transport"},
+        {"label": "Visas and immigration operational guidance", "value": "visas-and-immigration-operational-guidance"},
+        {"label": "Work and careers", "value": "work-and-careers"},
+        {"label": "Working at sea", "value": "working-at-sea"}
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -418,6 +418,22 @@ FactoryBot.define do
     end
   end
 
+  factory :statutory_instrument, parent: :document do
+    base_path "/statutory-instruments/example-document"
+    document_type "statutory_instrument"
+
+    transient do
+      default_metadata {
+        {
+          "laid_date" => "2018-01-01",
+          "sift_end_date" => "2018-01-05",
+          "sifting_status" => "open",
+          "subject" => ["oil-and-gas"],
+        }
+      }
+    end
+  end
+
   factory :tax_tribunal_decision, parent: :document do
     base_path "/tax-and-chancery-tribunal-decisions/example-document"
     document_type "tax_tribunal_decision"

--- a/spec/models/statutory_instrument_spec.rb
+++ b/spec/models/statutory_instrument_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe StatutoryInstrument do
+  let(:payload) { FactoryBot.create(:statutory_instrument) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+end


### PR DESCRIPTION
<img width="1050" alt="screen shot 2018-06-13 at 14 04 46" src="https://user-images.githubusercontent.com/109225/41353412-165256ba-6f14-11e8-991e-c56ef2a54866.png">

https://trello.com/c/mmvxwKWa/206-spike-create-new-type-in-specialist-publisher-to-handle-statutory-instruments
https://trello.com/c/6wjzkfut/207-spike-create-finder-for-new-statutory-instrument-specialist-document-type
https://trello.com/c/mxh2qAcv/220-drop-down-for-subjects-in-eu-exit-statutory-instrument-specialist-publisher-document-type
https://trello.com/c/XuhoYZak/221-date-field-for-laid-date-in-eu-exit-statutory-instrument-specialist-publisher-document-type

Tested on @barrucadu's machine (with thanks), we got as far as loading the finder which we can't do since it's going to take a long time to rebuild his rummager indexes.

The finder was published, however, as we can see in the screenshot, as the metadata block doesn't work without it.