### PR TITLE
Add organisations fields

### DIFF
--- a/app/controllers/passthrough_controller.rb
+++ b/app/controllers/passthrough_controller.rb
@@ -2,7 +2,7 @@ class PassthroughController < ApplicationController
   after_action :skip_authorization
 
   def index
-    current_organisation = document_models.find { |model| model.organisations.include? current_user.organisation_content_id }
+    current_organisation = document_models.find { |model| model.schema_organisations.include? current_user.organisation_content_id }
 
     if current_user.gds_editor?
       redirect_to "/aaib-reports"

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,0 +1,5 @@
+module OrganisationsHelper
+  def organisations_options
+    Organisation.all.map { |o| [o.title, o.content_id] }
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -295,6 +295,10 @@ class Document
     false
   end
 
+  def has_organisations?
+    false
+  end
+
 private
 
   def finder_schema

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -148,12 +148,12 @@ class Document
     finder_schema.options_for(facet)
   end
 
-  def organisations
+  def schema_organisations
     finder_schema.organisations
   end
 
-  def self.organisations
-    new.organisations
+  def self.schema_organisations
+    new.schema_organisations
   end
 
   def format_specific_metadata

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,6 @@
 class Organisation
   def self.all
-    @organisations ||= fetch_all_organisations(organisation_params)
+    @organisations = fetch_all_organisations(organisation_params)
   end
 
   attr_reader :content_id, :title

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,42 @@
+class Organisation
+  def self.all
+    @organisations ||= fetch_all_organisations(organisation_params)
+  end
+
+  attr_reader :content_id, :title
+
+  def initialize(attrs)
+    @content_id = attrs["content_id"]
+    @title = attrs["title"]
+  end
+
+  class << self
+    def document_type
+      "organisation"
+    end
+
+    def fetch_all_organisations(params)
+      orgs = []
+      current_page = 1
+      loop do
+        response = Services.publishing_api.get_content_items(params.merge(page: current_page))
+        orgs << response["results"].map { |attrs| Organisation.new(attrs) }
+        if response["pages"] > current_page
+          current_page += 1
+        else
+          break
+        end
+      end
+      orgs.flatten
+    end
+
+    def organisation_params
+      {
+        document_type: document_type,
+        fields: %i[content_id title],
+        order: "base_path",
+        per_page: "600", # Around ~1070 orgs.
+      }
+    end
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,7 +18,7 @@ class Organisation
     def fetch_all_organisations(params)
       orgs = []
       current_page = 1
-      loop do
+      10.times do
         response = Services.publishing_api.get_content_items(params.merge(page: current_page))
         orgs << response["results"].map { |attrs| Organisation.new(attrs) }
         if response["pages"] > current_page

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -3,6 +3,7 @@ class StatutoryInstrument < Document
   validates :sift_end_date, date: true
   validates :sifting_status, presence: true
   validates :subject, presence: true
+  validates :primary_publishing_organisation, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
     laid_date
@@ -12,10 +13,11 @@ class StatutoryInstrument < Document
   ).freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
-  attr_accessor :organisations
+  attr_accessor :organisations, :primary_publishing_organisation
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    @primary_publishing_organisation = params[:primary_publishing_organisation]
     @organisations = params[:organisations]
   end
 
@@ -23,11 +25,14 @@ class StatutoryInstrument < Document
     "Statutory instrument"
   end
 
-  def primary_publishing_organisation
-    "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+  def links
+    super.merge(
+      organisations: organisations,
+      primary_publishing_organisation: [primary_publishing_organisation]
+    )
   end
 
-  def links
-    super.merge("organisations": organisations)
+  def has_organisations?
+    true
   end
 end

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -12,9 +12,11 @@ class StatutoryInstrument < Document
   ).freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+  attr_accessor :organisations
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    @organisations = params[:organisations]
   end
 
   def self.title
@@ -23,5 +25,9 @@ class StatutoryInstrument < Document
 
   def primary_publishing_organisation
     "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+  end
+
+  def links
+    super.merge("organisations": organisations)
   end
 end

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -27,7 +27,7 @@ class StatutoryInstrument < Document
 
   def links
     super.merge(
-      organisations: organisations,
+      organisations: organisations | [primary_publishing_organisation],
       primary_publishing_organisation: [primary_publishing_organisation]
     )
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -6,7 +6,7 @@ class ApplicationPolicy
   end
 
   def user_organisation_owns_document_type?
-    document_class.organisations.include?(user.organisation_content_id)
+    document_class.schema_organisations.include?(user.organisation_content_id)
   end
 
   def departmental_editor?
@@ -19,5 +19,9 @@ class ApplicationPolicy
 
   def gds_editor?
     user.gds_editor?
+  end
+
+  def document_type_editor?
+    user.permissions.include?(document_class.class.name.underscore + "_editor")
   end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -1,6 +1,6 @@
 class DocumentPolicy < ApplicationPolicy
   def index?
-    gds_editor? || departmental_editor? || writer?
+    document_type_editor? || gds_editor? || departmental_editor? || writer?
   end
 
   alias_method :new?, :index?
@@ -12,7 +12,7 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :destroy?, :index?
 
   def publish?
-    gds_editor? || departmental_editor?
+    document_type_editor? || gds_editor? || departmental_editor?
   end
 
   alias_method :unpublish?, :publish?

--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -7,7 +7,7 @@ class DocumentLinksPresenter
     {
       content_id: document.content_id,
       links: {
-        organisations: document.organisations,
+        organisations: document.schema_organisations,
         primary_publishing_organisation: [document.primary_publishing_organisation],
       },
     }

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -19,7 +19,8 @@ class DocumentBuilder
 
     set_update_type(document, payload)
 
-    if document.respond_to?(:organisations=)
+    if document.has_organisations?
+      document.primary_publishing_organisation = payload['links']['primary_publishing_organisation'].first
       document.organisations = payload['links']['organisations']
     end
 

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -14,10 +14,14 @@ class DocumentBuilder
       bulk_published: payload['details']['metadata']['bulk_published'],
       previous_version: payload['previous_version'],
       temporary_update_type: payload['details']['temporary_update_type'],
-      warnings: payload['warnings'] || {}
+      warnings: payload['warnings'] || {},
     )
 
     set_update_type(document, payload)
+
+    if document.respond_to?(:organisations=)
+      document.organisations = payload['links']['organisations']
+    end
 
     document.attachments = Attachment.all_from_publishing_api(payload)
 

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -20,8 +20,9 @@ class DocumentBuilder
     set_update_type(document, payload)
 
     if document.has_organisations?
-      document.primary_publishing_organisation = payload['links']['primary_publishing_organisation'].first
-      document.organisations = payload['links']['organisations']
+      primary_organisation_ary = payload['links']['primary_publishing_organisation']
+      document.primary_publishing_organisation = primary_organisation_ary.first
+      document.organisations = payload['links']['organisations'] - primary_organisation_ary
     end
 
     document.attachments = Attachment.all_from_publishing_api(payload)

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -17,7 +17,7 @@
       }
   %>
 <% end %>
-<%= render "shared/form_group", f: f, field: :primary_publishing_organisation do %>
+<%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
       {},
@@ -30,7 +30,7 @@
       }
   %>
 <% end %>
-<%= render "shared/form_group", f: f, field: :organisations do %>
+<%= render "shared/form_group", f: f, field: :organisations, label: "Other associated organisations" do %>
   <%= f.select :organisations,
       organisations_options,
       {},

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -17,3 +17,16 @@
       }
   %>
 <% end %>
+<%= render "shared/form_group", f: f, field: :organisations do %>
+  <%= f.select :organisations,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control",
+        multiple: true,
+        data: {
+          placeholder: "Select organisations"
+        }
+      }
+  %>
+<% end %>

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -17,6 +17,19 @@
       }
   %>
 <% end %>
+<%= render "shared/form_group", f: f, field: :primary_publishing_organisation do %>
+  <%= f.select :primary_publishing_organisation,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control",
+        multiple: false,
+        data: {
+          placeholder: "Select a primary publishing organisation"
+        }
+      }
+  %>
+<% end %>
 <%= render "shared/form_group", f: f, field: :organisations do %>
   <%= f.select :organisations,
       organisations_options,

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -57,8 +57,8 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
     fill_in "statutory_instrument_laid_date_day", with: "01"
 
     select "Oil and gas", from: "Subject"
-    select "Org 1", from: "Primary publishing organisation"
-    select "Org 2", from: "Organisations"
+    select "Org 1", from: "Publishing organisation"
+    select "Org 2", from: "Other associated organisations"
 
     click_on "Save"
 

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -1,0 +1,49 @@
+RSpec.feature "Creating a Statutory Instrument", type: :feature do
+  def statutory_instrument_content_item_links
+    {
+      "content_id" => "4a656f42-35ad-4034-8c7a-08870db7fffe",
+      "links" => {
+        "organisations" => ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+      }
+    }
+  end
+
+  let(:statutory_instrument) { FactoryBot.create(:statutory_instrument) }
+  let(:organisations) { [
+    { "content_id" => "12345", "title" => "Org 1" },
+    { "content_id" => "67890", "title" => "Org 2" }
+  ] }
+  let(:content_id) { statutory_instrument['content_id'] }
+  let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
+
+  before do
+    log_in_as_editor(:gds_editor)
+
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    publishing_api_has_content([statutory_instrument], hash_including(document_type: StatutoryInstrument.document_type))
+    publishing_api_has_item(statutory_instrument)
+    publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+  end
+
+  scenario "getting to the new document page" do
+    visit "/statutory-instruments"
+    click_link "Add another Statutory instrument"
+
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/statutory-instruments/new")
+  end
+
+  scenario "saving valid form values" do
+    visit "/statutory-instruments/new"
+
+    fill_in "Title", with: "Foo"
+    fill_in "Summary", with: "Bar"
+    fill_in "Body", with: "## This is great"
+
+  end
+end

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -9,10 +9,12 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
   end
 
   let(:statutory_instrument) { FactoryBot.create(:statutory_instrument) }
-  let(:organisations) { [
-    { "content_id" => "12345", "title" => "Org 1" },
-    { "content_id" => "67890", "title" => "Org 2" }
-  ] }
+  let(:organisations) {
+    [
+      { "content_id" => "12345", "title" => "Org 1" },
+      { "content_id" => "67890", "title" => "Org 2" }
+    ]
+  }
   let(:content_id) { statutory_instrument['content_id'] }
   let(:save_button_disable_with_message) { page.find_button('Save as draft')["data-disable-with"] }
 
@@ -32,6 +34,7 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
 
   scenario "getting to the new document page" do
     visit "/statutory-instruments"
+
     click_link "Add another Statutory instrument"
 
     expect(page.status_code).to eq(200)
@@ -41,9 +44,24 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
   scenario "saving valid form values" do
     visit "/statutory-instruments/new"
 
-    fill_in "Title", with: "Foo"
-    fill_in "Summary", with: "Bar"
-    fill_in "Body", with: "## This is great"
+    fill_in "Title", with: "Statutory instrument"
+    fill_in "Summary", with: "This is a statutory instrument"
+    fill_in "Body", with: "## What is a statutory instrument?"
 
+    fill_in "statutory_instrument_sift_end_date_year", with: "2017"
+    fill_in "statutory_instrument_sift_end_date_month", with: "02"
+    fill_in "statutory_instrument_sift_end_date_day", with: "01"
+
+    fill_in "statutory_instrument_laid_date_year", with: "2017"
+    fill_in "statutory_instrument_laid_date_month", with: "02"
+    fill_in "statutory_instrument_laid_date_day", with: "01"
+
+    select "Oil and gas", from: "Subject"
+    select "Org 1", from: "Primary publishing organisation"
+    select "Org 2", from: "Organisations"
+
+    click_on "Save"
+
+    expect(page.body).to have_content("Created Statutory instrument")
   end
 end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -80,7 +80,7 @@ FactoryBot.define do
     state_history {
       { "1": "draft" }
     }
-    links {}
+    links { {} }
 
     routes {
       [
@@ -431,7 +431,20 @@ FactoryBot.define do
           "subject" => ["oil-and-gas"],
         }
       }
+
+      organisation_content_id "6de6b795-9d30-4bd8-a257-ab9a6879e1ea"
     end
+
+    initialize_with {
+
+      attributes.merge(
+        links: {
+          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          organisations: [organisation_content_id],
+        }
+      )
+
+    }
   end
 
   factory :tax_tribunal_decision, parent: :document do

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -113,12 +113,13 @@ FactoryBot.define do
     initialize_with {
       merged_details = default_details.deep_stringify_keys.deep_merge(details.deep_stringify_keys)
       result = attributes.merge(details: merged_details)
-
-      result = result.merge(
-        links: {
-          finder: [FinderSchema.new(document_type.pluralize).content_id]
-        },
-      ) if document_type
+      if document_type
+        result = result.merge(
+          links: {
+            finder: [FinderSchema.new(document_type.pluralize).content_id]
+          },
+        )
+      end
 
       result
     }
@@ -433,17 +434,17 @@ FactoryBot.define do
       }
 
       organisation_content_id "6de6b795-9d30-4bd8-a257-ab9a6879e1ea"
+      primary_publishing_org_content_id "a03b5b02-e864-4660-94d9-39fa0cf86248"
     end
 
     initialize_with {
-
       attributes.merge(
         links: {
           finder: [FinderSchema.new(document_type.pluralize).content_id],
           organisations: [organisation_content_id],
+          primary_publishing_organisation: [primary_publishing_org_content_id]
         }
       )
-
     }
   end
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -434,14 +434,14 @@ FactoryBot.define do
       }
 
       organisation_content_id "6de6b795-9d30-4bd8-a257-ab9a6879e1ea"
-      primary_publishing_org_content_id "a03b5b02-e864-4660-94d9-39fa0cf86248"
+      primary_publishing_org_content_id "d31d9806-2644-4023-be70-5376cae84a06"
     end
 
     initialize_with {
       attributes.merge(
         links: {
           finder: [FinderSchema.new(document_type.pluralize).content_id],
-          organisations: [organisation_content_id],
+          organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id]
         }
       )

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+RSpec.describe Organisation do
+  describe "initialize" do
+    subject(:instance) do
+      Organisation.new("content_id" => "12345", "title" => "Org")
+    end
+
+    it "populates content_id" do
+      expect(instance.content_id).to eq("12345")
+    end
+
+    it "populates title" do
+      expect(instance.title).to eq("Org")
+    end
+  end
+
+  describe ".all" do
+    let(:p1) do
+      [
+        { "content_id" => "12345", "title" => "First org" },
+        { "content_id" => "67890", "title" => "Second org" },
+      ]
+    end
+
+    let(:p2) do
+      [
+        { "content_id" => "09876", "title" => "Third org" },
+        { "content_id" => "54321", "title" => "Fourth org" },
+      ]
+    end
+
+    before do
+      # organisations are memoized on the Organisation class
+      Object.send(:remove_const, :Organisation)
+      load "organisation.rb"
+
+      allow(Services.publishing_api).to receive(:get_content_items)
+        .with(a_hash_including(page: 1))
+        .and_return("results" => p1, "pages" => 2)
+      allow(Services.publishing_api).to receive(:get_content_items)
+        .with(a_hash_including(page: 2))
+        .and_return("results" => p2, "pages" => 2)
+    end
+
+    it "returns results as Organisations" do
+      expect(Organisation.all.size).to eq(4)
+      expect(Organisation.all.first.title).to eq("First org")
+      expect(Organisation.all.last.title).to eq("Fourth org")
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Organisation do
     end
 
     before do
-      # organisations are memoized on the Organisation class
-      Object.send(:remove_const, :Organisation)
-      load "organisation.rb"
-
       allow(Services.publishing_api).to receive(:get_content_items)
         .with(a_hash_including(page: 1))
         .and_return("results" => p1, "pages" => 2)

--- a/spec/policies/document_policy_spec.rb
+++ b/spec/policies/document_policy_spec.rb
@@ -6,22 +6,23 @@ RSpec.describe DocumentPolicy do
   let(:gds_editor) { User.new(permissions: %w(signin gds_editor)) }
   let(:departmental_editor) { User.new(permissions: %w(signin editor), organisation_content_id: allowed_organisation_id) }
   let(:departmental_writer) { User.new(permissions: ['signin'], organisation_content_id: allowed_organisation_id) }
+  let(:document_type_editor) { User.new(permissions: ['class_editor']) }
 
   let(:document_type) {
     Class.new(Document) do
-      cattr_accessor :organisations
+      cattr_accessor :schema_organisations
     end
   }
 
   let(:allowed_document_type) {
     document_type.tap do |dt|
-      dt.organisations = [allowed_organisation_id]
+      dt.schema_organisations = [allowed_organisation_id]
     end
   }
 
   let(:not_allowed_document_type) {
     document_type.tap do |dt|
-      dt.organisations = [not_allowed_organisation_id]
+      dt.schema_organisations = [not_allowed_organisation_id]
     end
   }
 
@@ -36,6 +37,10 @@ RSpec.describe DocumentPolicy do
 
     it 'grants access to users with GDS Editor permissions' do
       expect(described_class).to permit(gds_editor, allowed_document_type)
+    end
+
+    it 'grants access to users with document type permissions' do
+      expect(described_class).to permit(document_type_editor, allowed_document_type)
     end
   end
 
@@ -54,6 +59,10 @@ RSpec.describe DocumentPolicy do
 
     it 'grants access to users with GDS Editor permissions' do
       expect(described_class).to permit(gds_editor, allowed_document_type)
+    end
+
+    it 'grants access to users with document type permissions' do
+      expect(described_class).to permit(document_type_editor, allowed_document_type)
     end
   end
 end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DocumentLinksPresenter do
     it "set primary publishing organisations for #{klass}" do
       document = klass.new
       document.content_id = 'a-content-id'
-      allow(document).to receive(:organisations).and_return('an-organisation-id')
+      allow(document).to receive(:schema_organisations).and_return('an-organisation-id')
 
       presenter = DocumentLinksPresenter.new(document)
       presented_data = presenter.to_json


### PR DESCRIPTION
https://trello.com/c/Hf90xZZq/219-drop-down-for-organisations-in-eu-exit-statutory-instrument-specialist-publisher-document-type

Adds the abilities to select Primary publishing organisation and organisations for Statutory Instruments.

![screenshot from 2018-06-15 11-53-04](https://user-images.githubusercontent.com/93511/41464546-afb4720a-7092-11e8-96bb-fbad8e837708.png)
