### PR TITLE
Remove 'Select all' link from dropdowns

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -13,7 +13,9 @@ jQuery(function($) {
   // Add "select all"/"clear all" buttons to each select2 dropdown menu
   // but exclude those that aren't for multiple selection
   var dropdownSelectAll = new GOVUKAdmin.Modules.DropdownSelectAll();
-  dropdownSelectAll.start($("select.select2[multiple]"));
+  dropdownSelectAll.init($("select.select2[multiple]").not(".select-all-disabled"));
+  var dropdownClearAll = new GOVUKAdmin.Modules.DropdownClearAll();
+  dropdownClearAll.init($("select.select2[multiple]").not(".clear-all-disabled"));
 
   ////
   // Make a select2 that will create new values on return as you type them

--- a/app/assets/javascript/dropdown_select_all.js
+++ b/app/assets/javascript/dropdown_select_all.js
@@ -1,13 +1,12 @@
 (function(Modules) {
   "use strict";
   Modules.DropdownSelectAll = function() {
-    var that = this;
-    that.start = function(elements) {
+    var self = this;
+    self.init = function(elements) {
       elements.each(function() {
         var selectId = $(this).attr("id");
         $(this).parent()
           .append('<a href="#" class="dropdown-select-all" data-select-id="#' + selectId  + '">Select all</a>')
-          .append('<a href="#" class="dropdown-clear-all" data-select-id="#' + selectId + '">Clear all</a>');
       });
 
       $(".dropdown-select-all").click(function() {
@@ -17,6 +16,17 @@
           .parent()
           .trigger("change");
         return false;
+      });
+    };
+  };
+
+  Modules.DropdownClearAll = function() {
+    var self = this;
+    self.init = function(elements) {
+      elements.each(function() {
+        var selectId = $(this).attr("id");
+        $(this).parent()
+          .append('<a href="#" class="dropdown-clear-all" data-select-id="#' + selectId + '">Clear all</a>');
       });
 
       $(".dropdown-clear-all").click(function() {

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -8,7 +8,7 @@
       facet_options(f, :subject),
       {},
       {
-        class: "select2 form-control",
+        class: "select2 form-control select-all-disabled",
         multiple: true,
         data:
         {
@@ -35,7 +35,7 @@
       organisations_options,
       {},
       {
-        class: "select2 form-control",
+        class: "select2 form-control select-all-disabled",
         multiple: true,
         data: {
           placeholder: "Select organisations"


### PR DESCRIPTION
https://trello.com/c/XpT7Xcfe/243-remove-select-all-from-eu-exit-statutory-instrument-publisher

We shouldn't display the 'Select all' link below certain multiple select2 elements. Given the select/clear all links have been applied everywhere in Specialist Publisher it's simpler to exclude specific fields.

![screenshot from 2018-06-19 10-01-05](https://user-images.githubusercontent.com/93511/41587694-b5ba3d34-73a7-11e8-997b-2c193424306d.png)
