### PR TITLE
Add a conditional withdrawn date to statutory instruments

### DIFF
--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -4,12 +4,14 @@ class StatutoryInstrument < Document
   validates :sifting_status, presence: true
   validates :subject, presence: true
   validates :primary_publishing_organisation, presence: true
+  validates :withdrawn_date, presence: true, date: true, if: :withdrawn_sifting_status?
 
   FORMAT_SPECIFIC_FIELDS = %i(
     laid_date
     sift_end_date
     sifting_status
     subject
+    withdrawn_date
   ).freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
@@ -34,5 +36,9 @@ class StatutoryInstrument < Document
 
   def has_organisations?
     true
+  end
+
+  def withdrawn_sifting_status?
+    sifting_status == "withdrawn"
   end
 end

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -3,6 +3,10 @@
 <%= render "shared/form_group", f: f, field: :sifting_status do %>
   <%= f.select :sifting_status, facet_options(f, :sifting_status), {}, { class: "form-control" } %>
 <% end %>
+<% withdrawn_date_display = f.object.withdrawn_sifting_status? ? "block" : "none" %>
+<div class="withdrawn-date-wrapper" style="display:<%= withdrawn_date_display %>">
+  <%= render "shared/date_fields", f: f, field: :withdrawn_date, format: :statutory_instrument %>
+</div>
 <%= render "shared/form_group", f: f, field: :subject do %>
   <%= f.select :subject,
       facet_options(f, :subject),
@@ -42,4 +46,10 @@
         }
       }
   %>
+<% end %>
+<% content_for :document_ready do %>
+  var $withdrawnDateEl = $(".withdrawn-date-wrapper")
+  $("#statutory_instrument_sifting_status").change(function(e) {
+    $withdrawnDateEl.toggle(e.target.value === "withdrawn");
+  });
 <% end %>

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -64,4 +64,36 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
 
     expect(page.body).to have_content("Created Statutory instrument")
   end
+
+  scenario "saving a withdrawn document" do
+    visit "/statutory-instruments/new"
+
+    fill_in "Title", with: "Statutory instrument"
+    fill_in "Summary", with: "This is a statutory instrument"
+    fill_in "Body", with: "## What is a statutory instrument?"
+    select "Withdrawn", from: "Sifting status"
+
+    fill_in "statutory_instrument_sift_end_date_year", with: "2017"
+    fill_in "statutory_instrument_sift_end_date_month", with: "02"
+    fill_in "statutory_instrument_sift_end_date_day", with: "01"
+
+    fill_in "statutory_instrument_laid_date_year", with: "2017"
+    fill_in "statutory_instrument_laid_date_month", with: "02"
+    fill_in "statutory_instrument_laid_date_day", with: "01"
+
+    select "Oil and gas", from: "Subject"
+    select "Org 1", from: "Publishing organisation"
+
+    click_on "Save"
+
+    expect(page.body).to have_content("Withdrawn date can't be blank")
+
+    fill_in "statutory_instrument_withdrawn_date_year", with: "2017"
+    fill_in "statutory_instrument_withdrawn_date_month", with: "02"
+    fill_in "statutory_instrument_withdrawn_date_day", with: "01"
+
+    click_on "Save"
+
+    expect(page.body).to have_content("Created Statutory instrument")
+  end
 end


### PR DESCRIPTION
https://trello.com/c/y7mL2Dgk/241-add-a-withdrawn-date-to-eu-exit-statutory-instrument-publisher

If the sifting status of a statutory instrument is 'withdrawn'
show an additional required date field to record the withdrawn
date.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/785