### PR TITLE
Fix statutory instrument editor authentication

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -8,15 +8,6 @@ class DocumentsController < ApplicationController
   before_action :fetch_document, except: [:index, :new, :create]
   before_action :check_authorisation, if: :document_type_slug
 
-  def check_authorisation
-    if current_format
-      authorize current_format
-    else
-      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
-      redirect_to root_path
-    end
-  end
-
   def index
     page = filtered_page_param(params[:page])
     per_page = filtered_per_page_param(params[:per_page])
@@ -100,6 +91,15 @@ class DocumentsController < ApplicationController
   end
 
 private
+
+  def check_authorisation
+    if current_format
+      authorize current_format
+    else
+      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
+      redirect_to root_path
+    end
+  end
 
   def unknown_error_message
     support_url = Plek.new.external_url_for('support') + "/technical_fault_report/new"

--- a/app/controllers/passthrough_controller.rb
+++ b/app/controllers/passthrough_controller.rb
@@ -2,17 +2,21 @@ class PassthroughController < ApplicationController
   after_action :skip_authorization
 
   def index
-    current_organisation = document_models.find { |model| model.schema_organisations.include? current_user.organisation_content_id }
-
-    if current_user.gds_editor?
-      redirect_to "/aaib-reports"
-    elsif current_organisation
-      redirect_to "/" + current_organisation.slug
+    if first_permitted_format
+      redirect_to documents_path(document_type_slug: first_permitted_format.slug)
     else
       redirect_to error_path
     end
   end
 
   def error
+  end
+
+private
+
+  def first_permitted_format
+    @first_permitted_format ||= document_models.sort_by(&:name).find do |document_class|
+      DocumentPolicy.new(current_user, document_class).index?
+    end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -22,6 +22,6 @@ class ApplicationPolicy
   end
 
   def document_type_editor?
-    user.permissions.include?(document_class.class.name.underscore + "_editor")
+    user.permissions.include?(document_class.name.underscore + "_editor")
   end
 end

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -1,4 +1,4 @@
-<% presenter = ActionsPresenter.new(@document, policy(@document)) %>
+<% presenter = ActionsPresenter.new(@document, policy(@document.class)) %>
 
 <div class="row">
   <div class="col-md-8">

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -65,6 +65,19 @@ RSpec.feature "Access control", type: :feature do
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Statutory instruments")
     end
+
+    scenario "visiting another format" do
+      visit "/cma-cases"
+
+      expect(page.current_path).to eq("/statutory-instruments")
+      expect(page).to have_content("You aren't permitted to access CMA Cases")
+    end
+
+    scenario "visiting the home page" do
+      visit "/"
+
+      expect(page.current_path).to eq("/statutory-instruments")
+    end
   end
 
   context "as an editor with incorrect organisation_content_id" do

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Access control", type: :feature do
   before do
     publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
     publishing_api_has_content([], hash_including(document_type: AaibReport.document_type))
+    publishing_api_has_content([], hash_including(document_type: StatutoryInstrument.document_type))
   end
 
   context "as a CMA Editor" do
@@ -50,6 +51,19 @@ RSpec.feature "Access control", type: :feature do
 
       expect(page.current_path).to eq("/aaib-reports")
       expect(page).to have_content("You aren't permitted to access CMA Cases")
+    end
+  end
+
+  context "as a statutory instrument editor" do
+    before do
+      log_in_as_editor(:statutory_instrument_editor)
+    end
+
+    scenario "visiting the statutory instruments format" do
+      visit "/statutory-instruments"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Statutory instruments")
     end
   end
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     permissions %w(signin gds_editor)
   end
 
+  factory :statutory_instrument_editor, parent: :user do
+    permissions %w(signin statutory_instrument_editor)
+  end
+
   factory :cma_editor, parent: :editor do
     organisation_slug "competition-and-markets-authority"
     organisation_content_id "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"

--- a/spec/policies/document_policy_spec.rb
+++ b/spec/policies/document_policy_spec.rb
@@ -1,17 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe DocumentPolicy do
+  class TestDocument < Document
+    cattr_accessor :schema_organisations
+  end
+
   let(:allowed_organisation_id) { 'department-of-serious-business' }
   let(:not_allowed_organisation_id) { 'ministry-of-funk' }
   let(:gds_editor) { User.new(permissions: %w(signin gds_editor)) }
   let(:departmental_editor) { User.new(permissions: %w(signin editor), organisation_content_id: allowed_organisation_id) }
   let(:departmental_writer) { User.new(permissions: ['signin'], organisation_content_id: allowed_organisation_id) }
-  let(:document_type_editor) { User.new(permissions: ['class_editor']) }
+  let(:document_type_editor) { User.new(permissions: ['test_document_editor']) }
 
   let(:document_type) {
-    Class.new(Document) do
-      cattr_accessor :schema_organisations
-    end
+    TestDocument
   }
 
   let(:allowed_document_type) {


### PR DESCRIPTION
- Fix format-specific access permissions
- Always redirect homepage to first permitted format

https://trello.com/c/LggqHPEI/244-user-cant-access-the-statutory-instrument-specialist-publisher