### PR TITLE
Tag Statutory Instruments to Brexit

### DIFF
--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -1,16 +1,22 @@
 class DocumentLinksPresenter
+  BREXIT_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+
   def initialize(document)
     @document = document
   end
 
   def to_json
-    {
+    json = {
       content_id: document.content_id,
       links: {
         organisations: document.schema_organisations,
         primary_publishing_organisation: [document.primary_publishing_organisation],
       },
     }
+    if document.is_a? StatutoryInstrument
+      json[:links][:taxons] = [BREXIT_CONTENT_ID]
+    end
+    json
   end
 
 private

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -32,7 +32,17 @@ RSpec.describe DocumentLinksPresenter do
 
       expect(presented_data[:content_id]).to eq('a-content-id')
       expect(presented_data[:links][:organisations]).to eq('an-organisation-id')
+      expect(presented_data[:links][:taxons]).to eq(nil)
       expect(presented_data[:links][:primary_publishing_organisation]).to eq([primary_publishing_organisation_id])
     end
+  end
+
+  it "expects the brexit taxon to be returned if the document type is Statutory Instrument" do
+    document = StatutoryInstrument.new
+
+    links_presenter = DocumentLinksPresenter.new(document)
+    presented_data = links_presenter.to_json
+
+    expect(presented_data[:links][:taxons]).to eq([DocumentLinksPresenter::BREXIT_CONTENT_ID])
   end
 end


### PR DESCRIPTION
Every statutory_instrument document will now be tagged to the
Topic Taxonomy's Brexit taxon.