### PR TITLE
Fix Schema validation test failure

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -433,7 +433,7 @@ FactoryBot.define do
           "laid_date" => "2018-01-01",
           "sift_end_date" => "2018-01-05",
           "sifting_status" => "open",
-          "subject" => ["oil-and-gas"],
+          "subject" => ["business"],
         }
       }
 


### PR DESCRIPTION
This test is throwing a Validation error, due to a `statutory_instrument`
document being created with a `subject` of 'oil-and-gas' which isn't a
permitted field in the govuk_content_schemas. Changing the `subject` to
`business` passes the validation as this is a permitted value.

Error;

```
The property '#/details/metadata/subject/0' value "oil-and-gas" did not
match one of the following values: business, crime-justice-and-law,
defence, education-training-and-skills, entering-and-staying-in-the-uk,
environment, going-and-being-abroad, government, health-and-social-care,
housing-local-and-community, international, life-circumstances, money,
parenting-childcare-and-childrens-services,
regional-and-local-government, society-and-culture, transport, welfare,
work
```