### PR TITLE
Release statutory instruments

### DIFF
--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -11,7 +11,6 @@
   "organisations": [],
   "topics": [],
   "document_noun": "statutory instrument",
-  "pre_production": true,
   "facets": [
     {
       "key": "laid_date",


### PR DESCRIPTION
Makes the statutory instruments format publishable.

Do not forget to republish the finder (`rake publishing_api:publish_finder[statutory_instruments]`) when deployed.

https://trello.com/c/h0qClAyM/270-remove-pre-production-flag-from-statutory-instrument-document-type