### PR TITLE
Clear si sift end dates on withdrawal

### DIFF
--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -1,10 +1,12 @@
 class StatutoryInstrument < Document
   validates :laid_date, date: true
   validates :sift_end_date, date: true
+  validates :sift_end_date, absence: { message: "must be blank when withdrawn" }, if: :withdrawn_sifting_status?
   validates :sifting_status, presence: true
   validates :subject, presence: true
   validates :primary_publishing_organisation, presence: true
   validates :withdrawn_date, presence: true, date: true, if: :withdrawn_sifting_status?
+  validates :withdrawn_date, absence: { message: "must be blank if not withdrawn" }, unless: :withdrawn_sifting_status?
 
   FORMAT_SPECIFIC_FIELDS = %i(
     laid_date

--- a/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
@@ -48,8 +48,16 @@
   %>
 <% end %>
 <% content_for :document_ready do %>
-  var $withdrawnDateEl = $(".withdrawn-date-wrapper")
+  var $withdrawnDateEl = $(".withdrawn-date-wrapper");
+  var $withdrawnDateFields = $("input[id^='statutory_instrument_withdrawn_date']");
+  var $siftEndDateFields = $("input[id^='statutory_instrument_sift_end_date']");
   $("#statutory_instrument_sifting_status").change(function(e) {
-    $withdrawnDateEl.toggle(e.target.value === "withdrawn");
+    if (e.target.value === "withdrawn") {
+      $withdrawnDateEl.show();
+      $siftEndDateFields.val("");
+    } else {
+      $withdrawnDateEl.hide();
+      $withdrawnDateFields.val("");
+    }
   });
 <% end %>

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -73,10 +73,6 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
     fill_in "Body", with: "## What is a statutory instrument?"
     select "Withdrawn", from: "Sifting status"
 
-    fill_in "statutory_instrument_sift_end_date_year", with: "2017"
-    fill_in "statutory_instrument_sift_end_date_month", with: "02"
-    fill_in "statutory_instrument_sift_end_date_day", with: "01"
-
     fill_in "statutory_instrument_laid_date_year", with: "2017"
     fill_in "statutory_instrument_laid_date_month", with: "02"
     fill_in "statutory_instrument_laid_date_day", with: "01"

--- a/spec/models/statutory_instrument_spec.rb
+++ b/spec/models/statutory_instrument_spec.rb
@@ -8,4 +8,41 @@ RSpec.describe StatutoryInstrument do
   it "is not exportable" do
     expect(described_class).not_to be_exportable
   end
+
+  describe "sift_end_date" do
+    subject(:instance) do
+      StatutoryInstrument.new(body: "", sift_end_date: "2016-01-01", sifting_status: "withdrawn")
+    end
+
+    it "is invalid on a withdrawn document" do
+      instance.validate
+      expect(instance.errors[:sift_end_date].first).to eq("must be blank when withdrawn")
+    end
+
+    it "is valid on a document in an open or closed state" do
+      %w(open closed).each do |state|
+        instance.sifting_status = state
+        instance.validate
+        expect(instance.errors[:sift_end_date]).to be_empty
+      end
+    end
+  end
+
+  describe "withdrawn_date" do
+    subject(:instance) do
+      StatutoryInstrument.new(body: "", withdrawn_date: "2016-01-01")
+    end
+
+    it "is invalid on a non-withdrawn document" do
+      instance.sifting_status = "open"
+      instance.validate
+      expect(instance.errors[:withdrawn_date].first).to eq("must be blank if not withdrawn")
+    end
+
+    it "is valid on a withdrawn document" do
+      instance.sifting_status = "withdrawn"
+      instance.validate
+      expect(instance.errors[:withdrawn_date]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/fw1aGy2j/268-clear-sift-end-date-when-making-a-statutory-instrument-withdrawn

![screenshot from 2018-06-26 15-25-32](https://user-images.githubusercontent.com/93511/41918891-2fae5d84-7955-11e8-8040-054c001ebf01.png)

* Clears sift end date | withdrawn date field values depending on sifting state
* Enforces the UI behaviour with ActiveModel validations