### PR TITLE
Automatically tag specialist content to the topic taxonomy.

### DIFF
--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -18,6 +18,10 @@ class AaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [AIR_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID]
+  end
+
   def self.title
     "AAIB Report"
   end

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -24,6 +24,10 @@ class AsylumSupportDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [ASYLUM_DECISIONS_AND_APPEALS_TAXON_ID]
+  end
+
   def self.title
     "Asylum Support Decisions"
   end

--- a/app/models/business_finance_support_scheme.rb
+++ b/app/models/business_finance_support_scheme.rb
@@ -20,6 +20,10 @@ class BusinessFinanceSupportScheme < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [BUSINESS_FINANCE_AND_SUPPORT_TAXON_ID]
+  end
+
   def self.exportable?
     true
   end

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -20,6 +20,10 @@ class CmaCase < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COMPETITION_TAXON_ID]
+  end
+
   def self.title
     "CMA Case"
   end

--- a/app/models/countryside_stewardship_grant.rb
+++ b/app/models/countryside_stewardship_grant.rb
@@ -12,6 +12,10 @@ class CountrysideStewardshipGrant < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COUNTRYSIDE_TAXON_ID]
+  end
+
   def self.title
     "Countryside Stewardship Grant"
   end

--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -19,6 +19,10 @@ class DfidResearchOutput < Document
     self.dfid_author_tags = params[:dfid_author_tags]
   end
 
+  def taxons
+    [INTERNATIONAL_AID_AND_DEVELOPMENT_TAXON_ID]
+  end
+
   ##
   # DFID research outputs are always bulk published, because our 'publication'
   # is just a proxy for a research output PDF. Its date is not important to a

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -53,8 +53,26 @@ class Document
     :warnings
   ].freeze
 
+  AIR_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID = '951ece54-c6df-4fbc-aa18-1bc629815fe2'.freeze
+  ALERTS_AND_RECALLS_TAXON_ID = '51bbdf23-292a-4b74-8a66-f7db6b93b163'.freeze
+  ASYLUM_DECISIONS_AND_APPEALS_TAXON_ID = 'e1d2032c-6a59-4a1a-919c-dc149847dffb'.freeze
+  BREXIT_TAXON_ID = 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'.freeze
+  BUSINESS_FINANCE_AND_SUPPORT_TAXON_ID = 'ccfc50f5-e193-4dac-9d78-50b3a8bb24c5'.freeze
+  COMPETITION_TAXON_ID = '8db04387-9076-4287-ab46-6a6695b593d7'.freeze
+  COUNTRYSIDE_TAXON_ID = '9129d716-365b-44ba-9856-383423fe1e41'.freeze
+  COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID = '357110bb-cbc5-4708-9711-1b26e6c63e86'.freeze
+  DIGITAL_SERVICE_STANDARD_TAXON_ID = '84630bce-4c1c-4406-a38a-e8c41967b8f7'.freeze
+  EUROPEAN_FUNDS_TAXON_ID = '2894668d-0c21-491a-9069-a271e67f6025'.freeze
+  INTERNATIONAL_AID_AND_DEVELOPMENT_TAXON_ID = '9fb30a53-70fb-4f1c-878b-0064b202d1ba'.freeze
+  MARITIME_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID = '7a5e878e-2b0f-4c3f-9079-586590a1a194'.freeze
+  RAIL_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID = 'c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7'.freeze
+
   def self.policy_class
     DocumentPolicy
+  end
+
+  def taxons
+    []
   end
 
   def initialize(params = {}, format_specific_fields = [])

--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -9,6 +9,10 @@ class DrugSafetyUpdate < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [ALERTS_AND_RECALLS_TAXON_ID]
+  end
+
   def self.title
     "Drug Safety Update"
   end

--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -17,6 +17,10 @@ class EmploymentAppealTribunalDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID]
+  end
+
   def self.title
     "EAT Decision"
   end

--- a/app/models/employment_tribunal_decision.rb
+++ b/app/models/employment_tribunal_decision.rb
@@ -16,6 +16,10 @@ class EmploymentTribunalDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID]
+  end
+
   def self.title
     "ET Decision"
   end

--- a/app/models/esi_fund.rb
+++ b/app/models/esi_fund.rb
@@ -15,6 +15,10 @@ class EsiFund < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [EUROPEAN_FUNDS_TAXON_ID]
+  end
+
   def self.title
     "ESI Fund"
   end

--- a/app/models/international_development_fund.rb
+++ b/app/models/international_development_fund.rb
@@ -13,6 +13,10 @@ class InternationalDevelopmentFund < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [INTERNATIONAL_AID_AND_DEVELOPMENT_TAXON_ID]
+  end
+
   def self.title
     "International Development Fund"
   end

--- a/app/models/maib_report.rb
+++ b/app/models/maib_report.rb
@@ -13,6 +13,10 @@ class MaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [MARITIME_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID]
+  end
+
   def self.title
     "MAIB Report"
   end

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -14,6 +14,10 @@ class MedicalSafetyAlert < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [ALERTS_AND_RECALLS_TAXON_ID]
+  end
+
   def self.title
     "Medical Safety Alert"
   end

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -13,6 +13,10 @@ class RaibReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [RAIL_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID]
+  end
+
   def self.title
     "RAIB Report"
   end

--- a/app/models/residential_property_tribunal_decision.rb
+++ b/app/models/residential_property_tribunal_decision.rb
@@ -16,6 +16,10 @@ class ResidentialPropertyTribunalDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID]
+  end
+
   def self.title
     "Residential Property Tribunal Decision"
   end

--- a/app/models/service_standard_report.rb
+++ b/app/models/service_standard_report.rb
@@ -7,6 +7,10 @@ class ServiceStandardReport < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [DIGITAL_SERVICE_STANDARD_TAXON_ID]
+  end
+
   def self.title
     "Service Standard Report"
   end

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -25,6 +25,10 @@ class StatutoryInstrument < Document
     @organisations = params[:organisations]
   end
 
+  def taxons
+    [BREXIT_TAXON_ID]
+  end
+
   def self.title
     "EU Withdrawal Act 2018 statutory instrument"
   end

--- a/app/models/tax_tribunal_decision.rb
+++ b/app/models/tax_tribunal_decision.rb
@@ -14,6 +14,10 @@ class TaxTribunalDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID]
+  end
+
   def self.title
     "Tax Tribunal Decision"
   end

--- a/app/models/utaac_decision.rb
+++ b/app/models/utaac_decision.rb
@@ -19,6 +19,10 @@ class UtaacDecision < Document
     super(params, FORMAT_SPECIFIC_FIELDS)
   end
 
+  def taxons
+    [COURTS_SENTENCING_AND_TRIBUNALS_TAXON_ID]
+  end
+
   def self.title
     "UTAAC Decision"
   end

--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -1,22 +1,18 @@
 class DocumentLinksPresenter
-  BREXIT_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
   def initialize(document)
     @document = document
   end
 
   def to_json
-    json = {
+    {
       content_id: document.content_id,
       links: {
         organisations: document.schema_organisations,
         primary_publishing_organisation: [document.primary_publishing_organisation],
+        taxons: document.taxons
       },
     }
-    if document.is_a? StatutoryInstrument
-      json[:links][:taxons] = [BREXIT_CONTENT_ID]
-    end
-    json
   end
 
 private

--- a/lib/documents_tagger.rb
+++ b/lib/documents_tagger.rb
@@ -1,0 +1,42 @@
+class DocumentsTagger
+  def self.tag_all(do_tag = true)
+    new(do_tag).tag_all
+  end
+
+  def initialize(do_tag = true)
+    @do_tag = do_tag
+  end
+
+  def tag_all
+    all_documents.map do |document|
+      mapped_taxon_ids = mapped_taxons(document['document_type'])
+      taxons_tagged = mapped_taxon_ids.empty? ? [] : tag_to_taxons(document['content_id'], mapped_taxon_ids)
+      { base_path: document['base_path'], content_id: document['content_id'], taxons: taxons_tagged }
+    end
+  end
+
+private
+
+  def tag_to_taxons(content_id, taxon_ids)
+    tagged = Tagger.add_tags(content_id, @do_tag) do |existing_taxon_ids|
+      existing_taxon_ids + taxon_ids
+    end
+    tagged ? taxon_ids : []
+  end
+
+  def all_document_types
+    FinderSchema.schema_names.map(&:singularize)
+  end
+
+  def mapped_taxons(document_type)
+    document_type.camelize.constantize.new.taxons
+  end
+
+  def all_documents
+    Services.publishing_api.get_content_items_enum(
+      publishing_app: 'specialist-publisher',
+      document_type: all_document_types,
+      fields: %i[content_id document_type base_path]
+    ).lazy
+  end
+end

--- a/lib/tagger.rb
+++ b/lib/tagger.rb
@@ -1,0 +1,39 @@
+class Tagger
+  def self.add_tags(content_id, do_tag = true)
+    self.new.add_tags(content_id, do_tag, &Proc.new)
+  end
+
+  def add_tags(content_id, do_tag = true)
+    existing_taxon_ids, version = fetch_existing_taxons(content_id)
+    new_taxon_ids = (yield existing_taxon_ids).uniq
+    return false if no_change_in_taxons?(existing_taxon_ids, new_taxon_ids)
+    tag(content_id, new_taxon_ids, version) if do_tag
+    true
+  rescue GdsApi::HTTPConflict, GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException
+    retries ||= 0
+    retry if (retries += 1) < 3
+    raise
+  rescue GdsApi::HTTPNotFound
+    Rails.logger.warn("Cannot find content item '#{content_id}' in the publishing api")
+  end
+
+private
+
+  def no_change_in_taxons?(existing_taxon_ids, new_taxon_ids)
+    existing_taxon_ids.sort == new_taxon_ids.sort
+  end
+
+  def tag(content_id, taxon_ids, version)
+    Services.publishing_api.patch_links(content_id,
+                                        links: { taxons: taxon_ids },
+                                        previous_version: version,
+                                        bulk_publishing: true)
+  end
+
+  def fetch_existing_taxons(content_id)
+    link_content = Services.publishing_api.get_links(content_id)
+    version = link_content['version']
+    taxons = link_content.dig('links', 'taxons') || []
+    [taxons, version]
+  end
+end

--- a/lib/tasks/auto_tagging.rake
+++ b/lib/tasks/auto_tagging.rake
@@ -1,0 +1,6 @@
+desc "Apply tagging rules to all content"
+task :auto_tagging, [:do_tag] => :environment do |_, args|
+  DocumentsTagger.tag_all(args.do_tag == 'tag').each do |result|
+    puts "#{result[:base_path]} (#{result[:content_id]}) - #{result[:taxons].join(', ')}" unless result[:taxons].empty?
+  end
+end

--- a/spec/lib/document_tagger_spec.rb
+++ b/spec/lib/document_tagger_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe DocumentsTagger do
+  before :each do
+    @content_id = SecureRandom.uuid
+
+    stub_const('DocumentTypeOne', Class.new do
+                                    def taxons
+                                      ['mapped_taxon_id']
+                                    end
+                                  end)
+
+    stub_const('DocumentTypeTwo', Class.new do
+                                    def taxons
+                                      []
+                                    end
+                                  end)
+
+    allow(FinderSchema).to receive(:schema_names).and_return(%w[document_type_one document_type_two])
+  end
+
+  it 'automatically tags a document' do
+    get_content_items_enum_returns(['base_path' => '/base_path', 'content_id' => @content_id, 'document_type' => 'document_type_one'])
+    expect(Tagger).to receive(:add_tags).with(@content_id, true).and_yield(['mapped_taxon_id']).and_return(true)
+    expect(DocumentsTagger.tag_all(true).to_a).to eq([{ base_path: '/base_path', content_id: @content_id, taxons: ['mapped_taxon_id'] }])
+  end
+
+  it 'does not tag the documents because the do_tag option is set to false - it does return potentially tagged taxons' do
+    get_content_items_enum_returns(['base_path' => '/base_path', 'content_id' => @content_id, 'document_type' => 'document_type_one'])
+    expect(Tagger).to receive(:add_tags).with(@content_id, false).and_yield(['mapped_taxon_id']).and_return(true)
+    expect(DocumentsTagger.tag_all(false).to_a).to eq([{ base_path: '/base_path', content_id: @content_id, taxons: ['mapped_taxon_id'] }])
+  end
+
+  it 'does not tag a document because it has already been tagged' do
+    get_content_items_enum_returns(['base_path' => '/base_path', 'content_id' => @content_id, 'document_type' => 'document_type_one'])
+    expect(Tagger).to receive(:add_tags).with(@content_id, true).and_yield(['mapped_taxon_id']).and_return(false)
+    expect(DocumentsTagger.tag_all(true).to_a).to eq([{ base_path: '/base_path', content_id: @content_id, taxons: [] }])
+  end
+
+  it 'Does not tag documents - or invoke tagging logic - because the mapping does not specify a taxon to tag' do
+    get_content_items_enum_returns(['base_path' => '/base_path', 'content_id' => @content_id, 'document_type' => 'document_type_two'])
+    expect(Tagger).to receive(:add_tags).never
+    expect(DocumentsTagger.tag_all.to_a).to eq([{ base_path: '/base_path', content_id: @content_id, taxons: [] }])
+  end
+
+  def get_content_items_enum_returns(return_value)
+    allow(Services.publishing_api).to receive(:get_content_items_enum).with(
+      hash_including(document_type: %w[document_type_one document_type_two])
+    ).and_return(return_value)
+  end
+end

--- a/spec/lib/tagger_spec.rb
+++ b/spec/lib/tagger_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Tagger do
+  subject { described_class }
+
+  before :each do
+    @content_id = '64aadc14-9bca-40d9-abb4-4f21f9792a05'
+    publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
+    stub_any_publishing_api_patch_links
+  end
+
+  describe '#tag' do
+    it 'tags content to a taxon' do
+      expect(subject.add_tags(@content_id) { %w[ccc ddd] }).to be true
+      assert_publishing_api_patch_links(@content_id, links: { taxons: %w[ccc ddd] }, previous_version: 5, bulk_publishing: true)
+    end
+
+    it 'does not tag content to a set of taxons because the content is already tagged' do
+      expect(subject.add_tags(@content_id) { |ts| ts }).to be false
+      assert_publishing_api_patch_links(@content_id, (->(_) { true }), 0)
+    end
+
+    it 'yields existing taxons' do
+      expected_existing_taxons = nil
+      subject.add_tags(@content_id) do |ts|
+        expected_existing_taxons = ts
+      end
+      expect(expected_existing_taxons).to match_array(%w[aaa bbb])
+    end
+
+    it 'retries 3 times' do
+      stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: '{}')
+      expect { subject.add_tags(@content_id) { ['ccc'] } }.to_not raise_error
+
+      stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(3).then.to_return(body: '{}')
+      expect { subject.add_tags(@content_id) { ['ccc'] } }.to raise_error(GdsApi::HTTPConflict)
+    end
+  end
+end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe DocumentLinksPresenter do
 
       expect(presented_data[:content_id]).to eq('a-content-id')
       expect(presented_data[:links][:organisations]).to eq('an-organisation-id')
-      expect(presented_data[:links][:taxons]).to eq(nil)
       expect(presented_data[:links][:primary_publishing_organisation]).to eq([primary_publishing_organisation_id])
     end
   end
@@ -43,6 +42,6 @@ RSpec.describe DocumentLinksPresenter do
     links_presenter = DocumentLinksPresenter.new(document)
     presented_data = links_presenter.to_json
 
-    expect(presented_data[:links][:taxons]).to eq([DocumentLinksPresenter::BREXIT_CONTENT_ID])
+    expect(presented_data[:links][:taxons]).to eq([Document::BREXIT_TAXON_ID])
   end
 end


### PR DESCRIPTION
- When specialist content is saved, it is automatically tagged to the topic taxonomy.
- Added a rake task to automatically tag all specialist content to the topic taxonomy.

`rake auto_tagging[tag]
` 
Tags all content if the argument 'tag' is supplied.

Trello: https://trello.com/c/iOt4YLW5/176-setup-specialist-publisher-to-automatically-tag-more-content-to-the-topic-taxonomy