### PR TITLE
Remove second sentence from statutory instruments finder summary

### DIFF
--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -4,7 +4,7 @@
   "format_name": "EU Withdrawal Act 2018 statutory instrument",
   "name": "EU Withdrawal Act 2018 statutory instruments",
   "description": "Find EU Withdrawal Act statutory instruments",
-  "summary": "<p>Find proposed negative statutory instruments created under the EU (Withdrawal) Act 2018.</p>",
+  "summary": "<p>Find proposed negative statutory instruments under the EU (Withdrawal) Act 2018.</p>",
   "filter": {
     "document_type": "statutory_instrument"
   },

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -4,7 +4,7 @@
   "format_name": "EU Withdrawal Act 2018 statutory instrument",
   "name": "EU Withdrawal Act 2018 statutory instruments",
   "description": "Find EU Withdrawal Act statutory instruments",
-  "summary": "<p>Find proposed negative statutory instruments created under the EU (Withdrawal) Act 2018.</p><p>‘Proposed negative’ means the government is proposing that the statutory instruments don’t need to be debated in parliament.</p>",
+  "summary": "<p>Find proposed negative statutory instruments created under the EU (Withdrawal) Act 2018.</p>",
   "filter": {
     "document_type": "statutory_instrument"
   },


### PR DESCRIPTION
This is a temporary change while we hash out content with DExEU. At the moment they're afraid that this sentence makes it sound like Parliament doesn't have any scrutiny.