### PR TITLE
Add editing organisation functionality

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -170,8 +170,16 @@ class Document
     finder_schema.organisations
   end
 
+  def schema_editing_organisations
+    finder_schema.editing_organisations
+  end
+
   def self.schema_organisations
     new.schema_organisations
+  end
+
+  def self.schema_editing_organisations
+    new.schema_editing_organisations
   end
 
   def format_specific_metadata

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -6,7 +6,8 @@ class ApplicationPolicy
   end
 
   def user_organisation_owns_document_type?
-    document_class.schema_organisations.include?(user.organisation_content_id)
+    document_class.schema_organisations.include?(user.organisation_content_id) ||
+      document_class.schema_editing_organisations.include?(user.organisation_content_id)
   end
 
   def departmental_editor?

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -9,8 +9,10 @@
     "document_type": "asylum_support_decision"
   },
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "7141e343-e7bb-483b-920a-c6a5cf8f758c"
   ],

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -9,8 +9,10 @@
     "document_type": "employment_appeal_tribunal_decision"
   },
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "caeb418c-d11c-4352-92e9-47b21289f696"
   ],

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -9,8 +9,10 @@
     "document_type": "employment_tribunal_decision"
   },
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "8bb37087-a5a7-4493-8afe-900b36ebc927"
   ],

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -9,8 +9,10 @@
     "document_type": "residential_property_tribunal_decision"
   },
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "bb2b028f-efaa-44fd-b3f8-971b25cb51a2"
   ],

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -10,8 +10,10 @@
   },
   "default_order": "-tribunal_decision_decision_date",
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "1a68b2cc-eb52-4528-8989-429f710da00f"
   ],

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -10,8 +10,10 @@
   "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "show_summaries": true,
+  "editing_organisations": [
+    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+  ],
   "organisations": [
-    "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
   ],

--- a/lib/finder_schema.rb
+++ b/lib/finder_schema.rb
@@ -6,12 +6,13 @@ class FinderSchema
     end
   end
 
-  attr_reader :base_path, :organisations, :format, :content_id
+  attr_reader :base_path, :organisations, :format, :content_id, :editing_organisations
 
   def initialize(schema_type)
     @schema ||= load_schema_for(schema_type)
     @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
+    @editing_organisations = schema.fetch("editing_organisations", [])
     @format = schema.fetch("filter", {}).fetch("document_type")
     @content_id = schema.fetch("content_id")
   end

--- a/spec/policies/document_policy_spec.rb
+++ b/spec/policies/document_policy_spec.rb
@@ -3,13 +3,17 @@ require 'spec_helper'
 RSpec.describe DocumentPolicy do
   class TestDocument < Document
     cattr_accessor :schema_organisations
+    cattr_accessor :schema_editing_organisations
   end
 
   let(:allowed_organisation_id) { 'department-of-serious-business' }
+  let(:allowed_editing_organisation_id) { 'hm-serious-business-countersigners' }
   let(:not_allowed_organisation_id) { 'ministry-of-funk' }
   let(:gds_editor) { User.new(permissions: %w(signin gds_editor)) }
   let(:departmental_editor) { User.new(permissions: %w(signin editor), organisation_content_id: allowed_organisation_id) }
+  let(:other_departmental_editor) { User.new(permissions: %w(signin editor), organisation_content_id: allowed_editing_organisation_id) }
   let(:departmental_writer) { User.new(permissions: ['signin'], organisation_content_id: allowed_organisation_id) }
+  let(:other_departmental_writer) { User.new(permissions: ['signin'], organisation_content_id: allowed_editing_organisation_id) }
   let(:document_type_editor) { User.new(permissions: ['test_document_editor']) }
 
   let(:document_type) {
@@ -19,6 +23,7 @@ RSpec.describe DocumentPolicy do
   let(:allowed_document_type) {
     document_type.tap do |dt|
       dt.schema_organisations = [allowed_organisation_id]
+      dt.schema_editing_organisations = [allowed_editing_organisation_id]
     end
   }
 
@@ -37,6 +42,10 @@ RSpec.describe DocumentPolicy do
       expect(described_class).to permit(departmental_writer, allowed_document_type)
     end
 
+    it 'grants access to users from an editing organisation' do
+      expect(described_class).to permit(other_departmental_writer, allowed_document_type)
+    end
+
     it 'grants access to users with GDS Editor permissions' do
       expect(described_class).to permit(gds_editor, allowed_document_type)
     end
@@ -51,12 +60,20 @@ RSpec.describe DocumentPolicy do
       expect(described_class).not_to permit(departmental_writer, allowed_document_type)
     end
 
+    it 'denies access to other users without editors permissions' do
+      expect(described_class).not_to permit(other_departmental_writer, allowed_document_type)
+    end
+
     it 'denies access to editors from another organisation' do
       expect(described_class).not_to permit(departmental_editor, not_allowed_document_type)
     end
 
     it 'grants access to editors from the organisation to which the document belongs' do
       expect(described_class).to permit(departmental_editor, allowed_document_type)
+    end
+
+    it 'grants access to editors from the organisation which can edit the document' do
+      expect(described_class).to permit(other_departmental_editor, allowed_document_type)
     end
 
     it 'grants access to users with GDS Editor permissions' do


### PR DESCRIPTION
MoJ need to be able to retain the ability to edit tribunal decisions, but don't want the ministry-of-justice org to be linked to them when they're published.

IDs in the `organisations` array are used to both determine who is allowed to edit and publish documents, and which orgs are linked to the document when it is published.  I've added the `editing_organisations` array to allow for extra editors who don't want to be linked to by the published content. 

`dcc907d6-433c-42df-9ffb-d9c68be5dc4d` is MOJ - can be verified at https://www.gov.uk/api/content/government/organisations/ministry-of-justice

This has come up partly because of the amendment to org pages which now show more documents including tribunal decisions.  Tribunal decisions will now only be tagged to the tribunal itself and HMCTS.  Before this point, I think they were mostly oblivious that this content was being linked to them.

It's related to this: https://govuk.zendesk.com/agent/tickets/2891477