### PR TITLE
Remove final draft clarification sentence as it's no longer applicable.

### DIFF
--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -4,7 +4,7 @@
   "format_name": "EU Withdrawal Act 2018 statutory instrument",
   "name": "EU Withdrawal Act 2018 statutory instruments",
   "description": "Find EU Withdrawal Act statutory instruments",
-  "summary": "<p>Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.</p><p>Before the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the '<a href=\"https://www.parliament.uk/about/how/laws/secondary-legislation/\">negative procedure</a>'.</p><p>Until committees in both Houses are ready, these SIs are final drafts and have not been laid for sifting by the committees.</p>",
+  "summary": "<p>Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.</p><p>Before the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the '<a href=\"https://www.parliament.uk/about/how/laws/secondary-legislation/\">negative procedure</a>'.</p>",
   "filter": {
     "document_type": "statutory_instrument"
   },


### PR DESCRIPTION
https://trello.com/c/c5nMjRND/344-remove-final-sentence-from-si-finder

Removes sentence about final draft status as this is no longer applicable.