### PR TITLE
Enable Brakeman

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ library("govuk")
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-specialist-publisher")
-  govuk.buildProject(sassLint: false, publishingE2ETests: true)
+  govuk.buildProject(sassLint: false, publishingE2ETests: true, brakeman: true)
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,5 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  # protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
   include Pundit

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -20,6 +20,25 @@
       "note": "The document_type_slug is checked by the check_authorisation method which checks that the current_format is set. If it doesn't exist, then the template won't be rendered."
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "4febd038b878af391d4ed2ba73417e43de948a9cda2ab88f5534e49e652a02e7",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in link_to href",
+      "file": "app/views/shared/_attachments_form.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Attachment.new.filename, Attachment.new.url)",
+      "render_path": [{"type":"controller","class":"AttachmentsController","method":"new","line":11,"file":"app/controllers/attachments_controller.rb"},{"type":"template","name":"attachments/new","line":5,"file":"app/views/attachments/new.html.erb"}],
+      "location": {
+        "type": "template",
+        "template": "shared/_attachments_form"
+      },
+      "user_input": "Attachment.new.url",
+      "confidence": "Weak",
+      "note": "It's not unsafe as it's from a new Attachment. There is no user input involved."
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "d34a7635364873f3063b096bc40cdb17b804fef975b7fe9b84a8d1b1973477c5",
@@ -39,6 +58,6 @@
       "note": "The document_type_slug is checked by the check_authorisation method which checks that the current_format is set. If it doesn't exist, then the template won't be rendered."
     }
   ],
-  "updated": "2018-08-02 15:05:11 +0100",
+  "updated": "2018-08-02 15:08:05 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,44 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "1710d332aa168aed33f01c22c64698cfec18b7dfa3be0c5ac696530205a5ce57",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/documents/edit.html.erb",
+      "line": 24,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => \"metadata_fields/#{params[:document_type_slug].underscore}\", { :locals => ({ :f => FormBuilder.new }) })",
+      "render_path": [{"type":"controller","class":"DocumentsController","method":"edit","line":45,"file":"app/controllers/documents_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "documents/edit"
+      },
+      "user_input": "params[:document_type_slug].underscore",
+      "confidence": "Medium",
+      "note": "The document_type_slug is checked by the check_authorisation method which checks that the current_format is set. If it doesn't exist, then the template won't be rendered."
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "d34a7635364873f3063b096bc40cdb17b804fef975b7fe9b84a8d1b1973477c5",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/documents/new.html.erb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => \"metadata_fields/#{params[:document_type_slug].underscore}\", { :locals => ({ :f => FormBuilder.new }) })",
+      "render_path": [{"type":"controller","class":"DocumentsController","method":"create","line":31,"file":"app/controllers/documents_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "documents/new"
+      },
+      "user_input": "params[:document_type_slug].underscore",
+      "confidence": "Medium",
+      "note": "The document_type_slug is checked by the check_authorisation method which checks that the current_format is set. If it doesn't exist, then the template won't be rendered."
+    }
+  ],
+  "updated": "2018-08-02 15:05:11 +0100",
+  "brakeman_version": "4.3.1"
+}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -39,6 +39,26 @@
       "note": "It's not unsafe as it's from a new Attachment. There is no user input involved."
     },
     {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "79a8953064431979892bbf285e301dc8c06c8d9080beea44507c660d7a4841f5",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/controllers/documents_controller.rb",
+      "line": 147,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params[current_format.document_type].permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DocumentsController",
+        "method": "permitted_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "Although we pass everything into the model, only allowed fields are set. We use set_attribute and pass in the valid fields fro that particular document type."
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "d34a7635364873f3063b096bc40cdb17b804fef975b7fe9b84a8d1b1973477c5",
@@ -58,6 +78,6 @@
       "note": "The document_type_slug is checked by the check_authorisation method which checks that the current_format is set. If it doesn't exist, then the template won't be rendered."
     }
   ],
-  "updated": "2018-08-02 15:08:05 +0100",
+  "updated": "2018-08-02 15:17:14 +0100",
   "brakeman_version": "4.3.1"
 }


### PR DESCRIPTION
This allows us to find security vulnerabilities.

I've also had to fix an issue and ignore some false positives, more details of which are available in each commit.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)