### PR TITLE
Pass links to the Email Alert API

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -12,6 +12,7 @@ class EmailAlertPresenter
       change_note: change_note,
       subject: subject,
       tags: tags,
+      links: links,
       urgent: urgent,
       document_type: document.document_type,
       email_document_supertype: "other",
@@ -36,6 +37,10 @@ private
       # This format should be the same as https://github.com/alphagov/finder-frontend/blob/2c1d5f25e7e4212795b485b6e4c290c6764c813c/app/controllers/email_alert_subscriptions_controller.rb#L41
       format: document.format
     }.deep_merge(document.format_specific_metadata.reject { |_k, v| v.blank? })
+  end
+
+  def links
+    DocumentLinksPresenter.new(document).to_json[:links]
   end
 
   def org_title

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe EmailAlertPresenter do
         expect(presented_data.keys).to match_array(%i(
           title description change_note subject tags document_type
           email_document_supertype government_document_supertype content_id
-          public_updated_at publishing_app base_path urgent priority
+          public_updated_at publishing_app base_path urgent priority links
         ))
       end
     end


### PR DESCRIPTION
Including the links in the Email Alert API payload, as this means that
this content will be picked up by relevant subscriptions, for example
linking content to an organisation.