### PR TITLE
Add rake task to edit a document's base_bath

### DIFF
--- a/lib/tasks/base_path.rake
+++ b/lib/tasks/base_path.rake
@@ -1,0 +1,24 @@
+namespace :base_path do
+  desc "Edits the base_path of a document, given its content_id and the new base_path"
+  task :edit, [:content_id, :base_path] => [:environment] do |_t, args|
+    content_id = args[:content_id]
+    base_path = args[:base_path]
+
+    begin
+      document = Document.find(content_id)
+    rescue DocumentFinder::RecordNotFound => e
+      puts "Error finding the document: #{e.inspect}"
+    end
+
+    if document
+      document.base_path = base_path
+      document.update_type = 'minor'
+      if document.save
+        puts "The #{document.class} with title \"#{document.title}\" has been successfully edited"
+        puts "Its new base_path is now \"#{document.base_path}\""
+      else
+        puts "Couldn't edit the #{document.class} with title \"#{document.title}\""
+      end
+    end
+  end
+end

--- a/lib/tasks/base_path.rake
+++ b/lib/tasks/base_path.rake
@@ -1,24 +1,13 @@
 namespace :base_path do
   desc "Edits the base_path of a document, given its content_id and the new base_path"
-  task :edit, [:content_id, :base_path] => [:environment] do |_t, args|
-    content_id = args[:content_id]
-    base_path = args[:base_path]
+  task :edit, %i[content_id new_base_path] => %i[environment] do |_t, args|
+    document = Document.find(args[:content_id])
+    old_base_path = document.base_path
 
-    begin
-      document = Document.find(content_id)
-    rescue DocumentFinder::RecordNotFound => e
-      puts "Error finding the document: #{e.inspect}"
-    end
+    document.base_path = args[:new_base_path]
+    document.update_type = 'minor'
+    document.save!
 
-    if document
-      document.base_path = base_path
-      document.update_type = 'minor'
-      if document.save
-        puts "The #{document.class} with title \"#{document.title}\" has been successfully edited"
-        puts "Its new base_path is now \"#{document.base_path}\""
-      else
-        puts "Couldn't edit the #{document.class} with title \"#{document.title}\""
-      end
-    end
+    puts "#{old_base_path} -> #{document.base_path}"
   end
 end


### PR DESCRIPTION
Add rake task to edit a document's base_bath

Trello card:
https://trello.com/c/kTKWF48j/530-document-how-to-change-a-url-in-specialist-publisher

How to change a URL in Specialist Publisher wasn't a documented process.
Making it into a rake task seems a nicer solution than simply
documenting how to do it and then having to do it manually.

Now, in order to edit a document's base_path, it's possible to just use
the rake task passing the document's `content_id` and the new
`base_path` as arguments.
