### PR TITLE
Update to base_path rake task

### DIFF
--- a/lib/tasks/base_path.rake
+++ b/lib/tasks/base_path.rake
@@ -6,7 +6,7 @@ namespace :base_path do
 
     document.base_path = args[:new_base_path]
     document.update_type = 'minor'
-    document.save!
+    document.save
 
     puts "#{old_base_path} -> #{document.base_path}"
   end


### PR DESCRIPTION
The `save!` method doesn't exist and fails when testing the rake task in `Integration`.

Trello card: [Document how to change a URL in Specialist Publisher](https://trello.com/c/kTKWF48j/530-document-how-to-change-a-url-in-specialist-publisher)