### PR TITLE
Add email_filter_name for medical safety alerts

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -17,6 +17,7 @@
     "medicines-medical-devices-blood/medical-devices-regulation-safety",
     "medicines-medical-devices-blood/vigilance-safety-alerts"
   ],
+  "email_filter_name": "Alert Type",
   "email_filter_by": "alert_type",
   "email_signup_choice": [
     {


### PR DESCRIPTION
This is needed to render the email signup page and is missing from this file.

https://sentry.io/govuk/app-finder-frontend/issues/771880592/?query=is:unresolved%20environment:staging