### PR TITLE
Add 'South West' to business finance support finder

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -109,6 +109,7 @@
         {"label": "Northern Ireland", "value": "northern-ireland"},
         {"label": "Scotland", "value": "scotland"},
         {"label": "South East", "value": "south-east"},
+        {"label": "South West", "value": "south-west"},
         {"label": "Wales", "value": "wales"},
         {"label": "West Midlands", "value": "west-midlands"},
         {"label": "Yorkshire and the Humber", "value": "yorkshire-and-the-humber"}


### PR DESCRIPTION
Adding a missing region.

Trello card: https://trello.com/c/d8vArNoY/354-add-south-west-region-to-finance-and-support-for-your-business-finder