### PR TITLE
Unhide regional location facet

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -96,7 +96,7 @@
     {
       "key": "regions",
       "name": "Region",
-      "type": "hidden",
+      "type": "text",
       "preposition": "for businesses in",
       "display_as_result_metadata": false,
       "filterable": true,


### PR DESCRIPTION
Unhide regional location facet on 'Finance and Support for your business' finder.

The reason this was hidden is that the content wasn't tagged yet, so this facet wasn't useful. Now that the content is tagged, we can show this facet.

Trello card: https://trello.com/c/MgCGp4tW/659-unhide-regional-location-facet-on-finance-and-support-for-your-business-finder