### PR TITLE
Add `first_published_at` as a special field for drug safety updates

### DIFF
--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -1,5 +1,6 @@
 class DrugSafetyUpdate < Document
   FORMAT_SPECIFIC_FIELDS = %i(
+    first_published_at
     therapeutic_area
   ).freeze
 


### PR DESCRIPTION
This could be better managed by changing this to a common field for specialist documents (or all documents) in Rummager, but for now this is necessary because the Rummager code looks inside the details hash for this field rather than at the top level.

See https://github.com/alphagov/specialist-publisher/blob/fix-drug-alert-dates/app/models/dfid_research_output.rb#L9 for where this is done with DFID documents.

https://trello.com/c/rM1I5XM6/404-finder-frontend-does-not-return-the-correct-results-for-drug-safety-update