### PR TITLE
We should have prepositions on facets

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -17,6 +17,7 @@
       "name": "Destination country",
       "short_name": "Destination",
       "type": "text",
+      "preposition": "to",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [
@@ -249,6 +250,7 @@
       "name": "Commodity type",
       "short_name": "Commodity",
       "type": "text",
+      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [


### PR DESCRIPTION
The new facet tag presenter needs prepositions to make sense. We're specifying a default in finder frontend, but it's better if we can be specific.