### PR TITLE
Bugfix for minor Drug Safety Updates being published as major updates

### DIFF
--- a/app/models/dfid_research_output.rb
+++ b/app/models/dfid_research_output.rb
@@ -36,14 +36,6 @@ class DfidResearchOutput < Document
     'DFID Research Output'
   end
 
-  def first_draft?
-    draft? && state_history_one_or_shorter?
-  end
-
-  def state_history_one_or_shorter?
-    state_history.nil? ? true : state_history.size < 2
-  end
-
   def dfid_author_tags
     (dfid_authors || []).join("::")
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -135,7 +135,11 @@ class Document
   end
 
   def first_draft?
-    draft? && first_published_at.blank?
+    draft? && state_history_one_or_shorter?
+  end
+
+  def state_history_one_or_shorter?
+    state_history.nil? || state_history.size < 2
   end
 
   def change_note_required?

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -133,6 +133,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
           :cma_case,
           update_type: "major",
           first_published_at: "2016-01-01",
+          state_history: { "3" => "draft", "2" => "published", "1" => "superseded" },
         )
       end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Document do
       let(:published_document) {
         MyDocumentType.from_publishing_api(
           FactoryBot.create(:document,
-            :published,
+            :redrafted,
             payload_attributes.merge(
               publication_state: publication_state,
               content_id: document.content_id
@@ -694,15 +694,25 @@ RSpec.describe Document do
 
   context '#first_draft?' do
     subject { MyDocumentType.new }
-
-    it "is true if there is no first_published_at" do
-      subject.first_published_at = nil
+    it "is true if the state_history is less than 2" do
+      subject.state_history = nil
       expect(subject.first_draft?).to eq(true)
     end
 
-    it "is false if there is a first_published_at" do
-      subject.first_published_at = "2015-11-15T00:00:00+00:00"
+    it "is true if the state_history indicates it has not been published" do
+      subject.state_history = { "1" => "draft" }
+      expect(subject.first_draft?).to eq(true)
+    end
+
+    it "is false if the state_history indicates it has been published" do
+      subject.state_history = { "3" => "draft", "2" => "published", "1" => "superseded" }
       expect(subject.first_draft?).to eq(false)
+    end
+
+    it "is true if there is a first_published_at and a state history indicating it has not been published" do
+      subject.state_history = { "1" => "draft" }
+      subject.first_published_at = "2019-02-21T00:00:00+00:00"
+      expect(subject.first_draft?).to eq(true)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/bzOxc6iS/463-bug-specialist-publisher-minor-updates-considered-major

This fixes a bug where a document would be sent to publishing_api
as a major update even if the publisher user had set the
update_type to minor.

The bug would occur because first_published_at could be sent as
nil when the user clicks publish (probably due to PR #1362).

Because first_published_at was nil, we would consider the document
to be a first draft, and set the update_type to major before
sending the document to the publishing_api.

This was reported as a bug via 2nd line at:
https://govuk.zendesk.com/agent/tickets/3603919

The fix copies the DfidResearchOutput approach,
which overrides first_draft? to use the state
history rather than the first_published_at date.

DfidResearchOutput and DrugSafetyUpdate are the only
classes that extend Document and also provide
a way to set a custom first_published_at,
therefore there isnt a need for further changes.