### PR TITLE
Add Sweden and remove Northern Ireland exception copy from the Exports Form Finder

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -4,7 +4,7 @@
   "format_name": "Export health certificate",
   "name": "Export health certificates",
   "description": "Find export health certificates (EHCs) used for exporting live animals and products of animal origin",
-  "summary": "Use this tool to find the EHC and supporting documents you need to export a live animal or animal product like food and germplasm. You can download the forms and fill them in. You will always find the latest version of certificates on here.<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">Do not use this tool if you are exporting from Northern Ireland.</div>",
+  "summary": "Use this tool to find the EHC and supporting documents you need to export a live animal or animal product like food and germplasm. You can download the forms and fill them in. You will always find the latest version of certificates on here.",
   "filter": {
     "document_type": "export_health_certificate"
   },

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -214,6 +214,7 @@
         {"label": "Sudan", "value": "sudan"},
         {"label": "Suriname", "value": "suriname"},
         {"label": "Swaziland (now Eswatini)", "value": "swaziland-now-eswatini"},
+        {"label": "Sweden", "value": "sweden"},
         {"label": "Switzerland", "value": "switzerland"},
         {"label": "Syria", "value": "syria"},
         {"label": "Taiwan", "value": "taiwan"},


### PR DESCRIPTION
Adds ‘Sweden’ as a destination country, which was missing and removes the “Do not use this tool if you are exporting from Northern Ireland” callout text, since NI now follows the same process.

<img width="968" alt="Screen Shot 2019-03-12 at 10 30 12" src="https://user-images.githubusercontent.com/38078064/54194590-848ac600-44b4-11e9-9a4a-2540c44485f1.png">

in Specialist publisher
<img width="291" alt="Screen Shot 2019-05-10 at 13 27 14" src="https://user-images.githubusercontent.com/38078064/57527382-6a8c2900-7327-11e9-9098-965917b138b6.png">

[Trello card](https://trello.com/c/dZIPRphR/826-add-sweden-and-remove-northern-ireland-exception-copy-from-the-exports-form-finder)