### PR TITLE
Fix some broken bits of the NANDOs finder

### DIFF
--- a/app/models/uk_market_conformity_assessment_body.rb
+++ b/app/models/uk_market_conformity_assessment_body.rb
@@ -10,7 +10,6 @@ class UkMarketConformityAssessmentBody < Document
   validates :uk_market_conformity_assessment_body_legislative_area, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
-    uk_market_conformity_assessment_body_name
     updated_at
     uk_market_conformity_assessment_body_number
     uk_market_conformity_assessment_body_type

--- a/app/models/uk_market_conformity_assessment_body.rb
+++ b/app/models/uk_market_conformity_assessment_body.rb
@@ -36,10 +36,6 @@ class UkMarketConformityAssessmentBody < Document
     "UK Market Conformity Assessment Body"
   end
 
-  def self.slug
-    "uk-market-conformity-assessment-body"
-  end
-
   def primary_publishing_organisation
     '2bde479a-97f2-42b5-986a-287a623c2a1c'
   end

--- a/app/models/uk_market_conformity_assessment_body.rb
+++ b/app/models/uk_market_conformity_assessment_body.rb
@@ -1,13 +1,13 @@
 class UkMarketConformityAssessmentBody < Document
-  validates :uk_market_conformity_assessment_body_name, presence: true
-  validates :updated_at, presence: true, date: true
-  validates :uk_market_conformity_assessment_body_number, presence: true
-  validates :uk_market_conformity_assessment_body_type, presence: true
-  validates :uk_market_conformity_assessment_body_registered_office_location, presence: true
-  validates :uk_market_conformity_assessment_body_testing_locations, presence: true
-  validates :uk_market_conformity_assessment_body_email, presence: true
-  validates :uk_market_conformity_assessment_body_phone, presence: true
-  validates :uk_market_conformity_assessment_body_legislative_area, presence: true
+  # validates :updated_at, presence: true, date: true
+  # validates :uk_market_conformity_assessment_body_number, presence: true
+  # validates :uk_market_conformity_assessment_body_type, presence: true
+  # validates :uk_market_conformity_assessment_body_registered_office_location, presence: true
+  # validates :uk_market_conformity_assessment_body_testing_locations, presence: true
+  # validates :uk_market_conformity_assessment_body_website, presence: true
+  # validates :uk_market_conformity_assessment_body_email, presence: true
+  # validates :uk_market_conformity_assessment_body_phone, presence: true
+  # validates :uk_market_conformity_assessment_body_legislative_area, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i(
     updated_at

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -1,16 +1,14 @@
 <%= render layout: "shared/date_fields", locals: { f: f, field: :updated_at, format: :uk_market_conformity_assessment_body } do %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_number } do %>
-  <%= f.select :uk_market_conformity_assessment_body_number,
-      f.object.facet_options(:uk_market_conformity_assessment_body_number),
-      { label: "Body Number" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_number, label: "Body Number" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_number,
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_type } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_type, label: "Body Type" } do %>
   <%= f.select :uk_market_conformity_assessment_body_type,
       f.object.facet_options(:uk_market_conformity_assessment_body_type),
-      { label: "Body Type" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -21,10 +19,10 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_registered_office_location } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_registered_office_location, label: "Registered Office Location" } do %>
   <%= f.select :uk_market_conformity_assessment_body_registered_office_location,
       f.object.facet_options(:uk_market_conformity_assessment_body_registered_office_location),
-      { label: "Registered Office Location" },
+      {},
       {
         class: 'select2 form-control',
         multiple: false,
@@ -35,10 +33,10 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_testing_locations } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_testing_locations, label: "Testing Locations" } do %>
   <%= f.select :uk_market_conformity_assessment_body_testing_locations,
       f.object.facet_options(:uk_market_conformity_assessment_body_testing_locations),
-      { label: "Testing Locations" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -49,31 +47,25 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_website } do %>
-  <%= f.select :uk_market_conformity_assessment_body_website,
-      f.object.facet_options(:uk_market_conformity_assessment_body_website),
-      { label: "Website" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_website, label: "Website" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_website,
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_email } do %>
-  <%= f.select :uk_market_conformity_assessment_body_email,
-      f.object.facet_options(:uk_market_conformity_assessment_body_email),
-      { label: "Email" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_email, label: "Email address" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_email,
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_phone } do %>
-  <%= f.select :uk_market_conformity_assessment_body_phone,
-      f.object.facet_options(:uk_market_conformity_assessment_body_phone),
-      { label: "Phone" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_phone, label: "Phone" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_phone,
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_legislative_area } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_legislative_area, label: "Legislation" } do %>
   <%= f.select :uk_market_conformity_assessment_body_legislative_area,
       f.object.facet_options(:uk_market_conformity_assessment_body_legislative_area),
-      { label: "Legislation" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -1,10 +1,3 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_name } do %>
-  <%= f.select :uk_market_conformity_assessment_body_name,
-      f.object.facet_options(:uk_market_conformity_assessment_body_name),
-      { label: "Body Name" },
-      { class: 'form-control' }
-  %>
-<% end %>
 <%= render layout: "shared/date_fields", locals: { f: f, field: :updated_at, format: :uk_market_conformity_assessment_body } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_number } do %>

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -5,7 +5,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/date_fields", locals: { f: f, field: :updated_at } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :updated_at, format: :uk_market_conformity_assessment_body } do %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_number } do %>
   <%= f.select :uk_market_conformity_assessment_body_number,

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -76,6 +76,10 @@
       "filterable": true,
       "allowed_values": [
         {
+          "label": "United Kingdom",
+          "value": "united-kingdom"
+        },
+        {
           "label": "Australia",
           "value": "australia"
         },
@@ -98,10 +102,6 @@
         {
           "label": "Switzerland",
           "value": "switzerland"
-        },
-        {
-          "label": "United Kingdom",
-          "value": "united-kingdom"
         },
         {
           "label": "United States of America",

--- a/spec/features/editing_a_uk_market_conformity_assessment_body_spec.rb
+++ b/spec/features/editing_a_uk_market_conformity_assessment_body_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.feature "Editing a UK market conformity assessment body", type: :feature do
+  let(:body_document) { FactoryBot.create(:uk_market_conformity_assessment_body) }
+  let(:content_id) { body_document['content_id'] }
+  let(:public_updated_at) { body_document['public_updated_at'] }
+
+  before do
+    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor?).and_return(true)
+
+    log_in_as_editor(:gds_editor)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    publishing_api_has_item(body_document)
+  end
+
+  scenario "with valid data" do
+    visit  "/uk-market-conformity-assessment-bodies/#{content_id}/edit"
+    expect(page).to have_css('div.govspeak-help')
+
+    title = "Example Company Ltd"
+    summary = "This is the summary of a body"
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: summary
+    fill_in "Body", with: "## Header\n\nThis is some text"
+    fill_in "Body Number", with: "AB - 1234"
+    select "United Kingdom", from: "Registered Office Location"
+
+    click_button "Save as draft"
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Updated Example Company Ltd")
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -31,12 +31,32 @@ RSpec.feature 'The root specialist-publisher page', type: :feature do
       expect(page).to have_text('Add another CMA Case')
     end
 
-    it 'has a finder for DFID research outputs' do
+    it 'has expected finders' do
       visit '/'
 
       click_link('AAIB Reports', match: :first)
 
+      expect(page).to have_text('AAIB Reports')
+      expect(page).to have_text('Asylum Support Decisions')
+      expect(page).to have_text('Business Finance Support Schemes')
+      expect(page).to have_text('CMA Cases')
+      expect(page).to have_text('Countryside Stewardship Grants')
       expect(page).to have_text('DFID Research Outputs')
+      expect(page).to have_text('Drug Safety Updates')
+      expect(page).to have_text('EAT Decisions')
+      expect(page).to have_text('ESI Funds')
+      expect(page).to have_text('ET Decisions')
+      expect(page).to have_text('EU Withdrawal Act 2018 statutory instruments')
+      expect(page).to have_text('Export health certificates')
+      expect(page).to have_text('International Development Funds')
+      expect(page).to have_text('MAIB Reports')
+      expect(page).to have_text('Medical Safety Alerts')
+      expect(page).to have_text('RAIB Reports')
+      expect(page).to have_text('Residential Property Tribunal Decisions')
+      expect(page).to have_text('Service Standard Reports')
+      expect(page).to have_text('Tax Tribunal Decisions')
+      expect(page).to have_text('UK Market Conformity Assessment Bodies')
+      expect(page).to have_text('UTAAC Decisions')
     end
   end
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -468,6 +468,27 @@ FactoryBot.define do
     end
   end
 
+  factory :uk_market_conformity_assessment_body, parent: :document do
+    base_path { "/uk_market_conformity_assessment_body/example-document" }
+    document_type { "uk_market_conformity_assessment_body" }
+
+    transient do
+      default_metadata do
+        {
+          "updated_at" => '2019-04-10',
+          "uk_market_conformity_assessment_body_number" => 'AB 0000',
+          "uk_market_conformity_assessment_body_type" => 'approved-body',
+          "uk_market_conformity_assessment_body_registered_office_location" => 'united-kingdom',
+          "uk_market_conformity_assessment_body_testing_locations" => ['united-kingdom'],
+          "uk_market_conformity_assessment_body_website" => 'www.example.com',
+          "uk_market_conformity_assessment_body_email" => 'info@example.com',
+          "uk_market_conformity_assessment_body_phone" => '0800 000 000',
+          "uk_market_conformity_assessment_body_legislative_area" => 'explosives',
+        }
+      end
+    end
+  end
+
   factory :utaac_decision, parent: :document do
     base_path { "/administrative-appeals-tribunal-decisions/example-document" }
     document_type { "utaac_decision" }


### PR DESCRIPTION
There were some bits of the new specialist document set up for the UK market conformity bodies that didn't quite work, or were changed after seeing what they actually look like in the wild.

They are:
- We'd overridden the slug which meant that the logic to derive which metadata partial to use broke
- The labels on the form fields weren't quite in the right place which meant we fell back to using the default
- We had a `body name` field defined, but we can use the existing `title` field instead
- A small tweak to put UK at the top of the select drop down
- Added some tests which just make sure that basic stuff works OK


I've disabled some validation (temporarily) as we're about to create and partially import a bunch of things.  We'll re-enable this once the initial tranche is complete.

https://trello.com/c/ayXlI8nK/594-automatically-generate-the-public-bodies-for-ops-to-tag-to-the-nandos-finder