### PR TITLE
Add additional stages to Service Standards Report

### DIFF
--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -42,8 +42,12 @@
       "filterable": true,
       "allowed_values": [
         {"label": "Alpha", "value": "alpha"},
+        {"label": "Alpha reassessment", "value": "alpha-reassessment"},
         {"label": "Beta", "value": "beta"},
-        {"label": "Live", "value": "live"}
+        {"label": "Beta reassessment", "value": "alpha-reassessment"},
+        {"label": "Live", "value": "live"},
+        {"label": "Live reassessment", "value": "live-reassessment"},
+        {"label": "Live review", "value": "live-review"}
       ]
     }
   ]


### PR DESCRIPTION
The `Stage` facet for the Service Standards Report requires four additional
options.

[Trello](https://trello.com/c/FjYzSTIh/1008-add-new-facet-options-to-service-standard-reports-finder)