### PR TITLE
Replace primary organisation for CMA cases

### DIFF
--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -29,6 +29,6 @@ class CmaCase < Document
   end
 
   def primary_publishing_organisation
-    "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -33,4 +33,16 @@ namespace :publishing_api do
       end
     end
   end
+
+  desc "Send links for all cma cases to Publishing API."
+  task patch_cma_case_links: :environment do
+    AllDocumentsFinder.find_each(CmaCase) do |cma_case|
+      content_id = cma_case.content_id
+      payload = {
+          primary_publishing_organisation: [cma_case.primary_publishing_organisation]
+      }
+
+      Services.publishing_api.patch_links(content_id, links: payload, bulk_publishing: true)
+    end
+  end
 end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DocumentLinksPresenter do
     DfidResearchOutput => 'db994552-7644-404d-a770-a2fe659c661f',
     EmploymentTribunalDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
     AaibReport => "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
-    CmaCase => "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+    CmaCase => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
     EmploymentAppealTribunalDecision => '6f757605-ab8f-4b62-84e4-99f79cf085c2',
     MaibReport => "9c66b9a3-1e6a-48e8-974d-2a5635f84679",
     EsiFund => "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",


### PR DESCRIPTION
The primary publishing organisation for CMA cases was set to the finder rather than the organisation. This change replaces the finder to the organisation.

**Before**
![Screen Shot 2019-06-13 at 11 12 23](https://user-images.githubusercontent.com/6651749/59424579-25e32a00-8dcc-11e9-9c72-46dffe12a8c9.png)

**After**
![Screen Shot 2019-06-13 at 11 12 39](https://user-images.githubusercontent.com/6651749/59424590-2b407480-8dcc-11e9-9dd7-8fe207db7bd1.png)

Trello: https://trello.com/c/fb6PqK2a