### PR TITLE
[DO NOT MERGE] Add state aid type and outcomes to CMA cases

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -94,7 +94,8 @@
           {"label": "Mergers", "value": "mergers"},
           {"label": "Consumer enforcement", "value": "consumer-enforcement"},
           {"label": "Regulatory references and appeals", "value": "regulatory-references-and-appeals"},
-          {"label": "Reviews of orders and undertakings", "value": "review-of-orders-and-undertakings"}
+          {"label": "Reviews of orders and undertakings", "value": "review-of-orders-and-undertakings"},
+          {"label": "State aid", "value": "state-aid"}
         ]
     },
 
@@ -187,7 +188,15 @@
         {"label": "Consumer enforcement - court order", "value": "consumer-enforcement-court-order"},
         {"label": "Consumer enforcement - undertakings", "value": "consumer-enforcement-undertakings"},
         {"label": "Consumer enforcement - changes to business practices agreed", "value": "consumer-enforcement-changes-to-business-practices-agreed"},
-        {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"}
+        {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"},
+        {"label": "State aid - no aid", "value": "state-aid-no-aid"},
+        {"label": "State aid - aid approved", "value": "state-aid-aid-approved"},
+        {"label": "State aid - conditional decision", "value": "state-aid-conditional-decision"},
+        {"label": "State aid - aid not approved", "value": "state-aid-aid-not-approved"},
+        {"label": "State aid - investigation", "value": "state-aid-investigation"},
+        {"label": "State aid - recommendation accepted", "value": "state-aid-recommendation-accepted"},
+        {"label": "State aid - recommendation implemented", "value": "state-aid-recommendation-implemented"},
+        {"label": "State aid - aid not misused", "value": "state-aid-aid-not-misused"}
       ]
     },
 


### PR DESCRIPTION
This shouldn't be merged until the corresponding changes have been made to the content schemas and the search schemas and search-api has been reindexed.

---

[Trello card](https://trello.com/c/3vWYXrjO/801-cma-case-finder-tool-update)