### PR TITLE
Revert "Add state aid type and outcomes to CMA cases"

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -94,8 +94,7 @@
           {"label": "Mergers", "value": "mergers"},
           {"label": "Consumer enforcement", "value": "consumer-enforcement"},
           {"label": "Regulatory references and appeals", "value": "regulatory-references-and-appeals"},
-          {"label": "Reviews of orders and undertakings", "value": "review-of-orders-and-undertakings"},
-          {"label": "State aid", "value": "state-aid"}
+          {"label": "Reviews of orders and undertakings", "value": "review-of-orders-and-undertakings"}
         ]
     },
 
@@ -188,15 +187,7 @@
         {"label": "Consumer enforcement - court order", "value": "consumer-enforcement-court-order"},
         {"label": "Consumer enforcement - undertakings", "value": "consumer-enforcement-undertakings"},
         {"label": "Consumer enforcement - changes to business practices agreed", "value": "consumer-enforcement-changes-to-business-practices-agreed"},
-        {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"},
-        {"label": "State aid - no aid", "value": "state-aid-no-aid"},
-        {"label": "State aid - aid approved", "value": "state-aid-aid-approved"},
-        {"label": "State aid - conditional decision", "value": "state-aid-conditional-decision"},
-        {"label": "State aid - aid not approved", "value": "state-aid-aid-not-approved"},
-        {"label": "State aid - investigation", "value": "state-aid-investigation"},
-        {"label": "State aid - recommendation accepted", "value": "state-aid-recommendation-accepted"},
-        {"label": "State aid - recommendation implemented", "value": "state-aid-recommendation-implemented"},
-        {"label": "State aid - aid not misused", "value": "state-aid-aid-not-misused"}
+        {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"}
       ]
     },
 


### PR DESCRIPTION
Reverts alphagov/specialist-publisher#1450

We need to delay this until after brexit.

https://trello.com/c/wborKvnf/831-roll-back-cma-state-aid-thing