### PR TITLE
Fix casing of country names for UK MCABs

### DIFF
--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -455,7 +455,7 @@
           "label": "Ivory Coast"
         },
         {
-          "value": "Jamaica",
+          "value": "jamaica",
           "label": "Jamaica"
         },
         {
@@ -507,7 +507,7 @@
           "label": "Latvia"
         },
         {
-          "value": "Lebanon",
+          "value": "lebanon",
           "label": "Lebanon"
         },
         {


### PR DESCRIPTION
Attempting to create a document which applies to all countries fails
with errors about Jamaica, Lebanon, and the Ivory Coast.  Jamaica and
Lebanon are failing because they should be lowercase (like all the
other countries), Ivory Coast is failing because it's missing from the
schema (which will be fixed in govuk-content-schemas).

---

[Trello card](https://trello.com/c/3CyH4j89/892-specialist-publisher-schema-validation-errors)