### PR TITLE
Change cookie serialisation method to :json

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
       expect(page).to have_content("Example CMA Case")
       click_button "Unpublish document"
       expect(page.status_code).to eq(200)
-      expect(page).to have_content("Something has gone wrong. Please try again and see if it works. Let us know if the problem happens again and a developer will look into it.")
+      expect(page).to have_content("Something has gone wrong. Please try again and see if it works.")
     end
   end
 end


### PR DESCRIPTION
The :marshal option is potentially unsafe, and has been added to
brakeman as a security warning.

Deploying this will invalidate everyone's cookies, but
specialist-publisher should just re-auth them against signon.