### PR TITLE
[WIP] Add OPT to IDF, and rename Burma to Myanmar

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -143,10 +143,6 @@
           "label": "Burkina Faso"
         },
         {
-          "value": "burma",
-          "label": "Burma"
-        },
-        {
           "value": "burundi",
           "label": "Burundi"
         },
@@ -519,6 +515,10 @@
           "label": "Mozambique"
         },
         {
+          "value": "myanmar",
+          "label": "Myanmar"
+        },
+        {
           "value": "namibia",
           "label": "Namibia"
         },
@@ -557,6 +557,10 @@
         {
           "value": "norway",
           "label": "Norway"
+        },
+        {
+          "value": "the-occupied-palestinian-territories",
+          "label": "Occupied Palestinian Territories, The"
         },
         {
           "value": "oman",


### PR DESCRIPTION
Adds the Occupied Palestinian Territories to the International Development Funds, following this [Zendesk](https://govuk.zendesk.com/agent/tickets/3771248)

The OPT already exists as a world location
https://www.gov.uk/api/world-locations/the-occupied-palestinian-territories

Also renames Burma to Myanmar