### PR TITLE
Allow specialist finders to have parents

### DIFF
--- a/app/presenters/finder_links_presenter.rb
+++ b/app/presenters/finder_links_presenter.rb
@@ -6,6 +6,7 @@ FinderLinksPresenter = Struct.new(:file) do
         organisations: organisations,
         related: related,
         email_alert_signup: email_alert_signup,
+        parent: parent,
       },
     }
   end
@@ -22,5 +23,9 @@ private
 
   def email_alert_signup
     [file.fetch("signup_content_id", nil)].compact
+  end
+
+  def parent
+    [file.fetch("parent", nil)].compact
   end
 end


### PR DESCRIPTION
We want [this page](https://www.gov.uk/export-health-certificates) to have the same breadcrumbs as [this page](https://www.gov.uk/guidance/get-an-export-health-certificate).

I think we can do that by giving the finder a `parent` link.  Specialist publisher doesn't publish such links at the moment, so first we need to make it do that.