### PR TITLE
Present finder topic links to publishing-api

### DIFF
--- a/app/presenters/finder_links_presenter.rb
+++ b/app/presenters/finder_links_presenter.rb
@@ -7,6 +7,7 @@ FinderLinksPresenter = Struct.new(:file) do
         related: related,
         email_alert_signup: email_alert_signup,
         parent: parent,
+        topics: topics,
       },
     }
   end
@@ -19,6 +20,10 @@ private
 
   def related
     file.fetch("related", [])
+  end
+
+  def topics
+    file.fetch("topics", [])
   end
 
   def email_alert_signup

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -11,11 +11,11 @@
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
   "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
   "topics": [
-    "competition/competition-act-cartels",
-    "competition/consumer-protection",
-    "competition/markets",
-    "competition/mergers",
-    "competition/regulatory-appeals-references"
+    "4a6f14ad-baa1-4b15-8026-8282913ef693",
+    "65a89136-2117-41aa-ba96-35feb9d821f5",
+    "1433d403-333f-4d81-b83a-c5358412fd1b",
+    "7aa3ec0c-683e-44ba-aa3f-cc9655651b9b",
+    "fd11e3b0-76bc-4197-b652-a030b57915be"
   ],
   "subscription_list_title_prefix": {
     "singular": "CMA cases with the following case type: ",

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -15,7 +15,7 @@
     "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
   ],
   "topics": [
-    "medicines-medical-devices-blood/vigilance-safety-alerts"
+    "3455b248-9237-40ac-ae9b-480a6a8ebd88"
   ],
   "subscription_list_title_prefix": "Drug Safety Update",
   "document_noun": "update",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -9,7 +9,7 @@
     "document_type": "export_health_certificate"
   },
   "organisations": ["4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"],
-  "topics": ["keeping-farmed-animals/animal-welfare"],
+  "topics": ["03f78404-e87c-4c2a-954b-f6ee9403efb8"],
   "document_noun": "export health certificate",
   "facets": [
     {

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -10,6 +10,7 @@
   },
   "organisations": ["4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"],
   "topics": ["03f78404-e87c-4c2a-954b-f6ee9403efb8"],
+  "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
   "document_noun": "export health certificate",
   "facets": [
     {

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -14,8 +14,8 @@
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
   "topics": [
-    "medicines-medical-devices-blood/medical-devices-regulation-safety",
-    "medicines-medical-devices-blood/vigilance-safety-alerts"
+    "dd762ed5-abc8-4502-b4b4-3b51f9b7b0ca",
+    "3455b248-9237-40ac-ae9b-480a6a8ebd88"
   ],
   "email_filter_name": "Alert Type",
   "email_filter_by": "alert_type",


### PR DESCRIPTION
These are defined in a few of the json files but not actually used
anywhere.  Apparently, the topic tagging was once managed by
panopticon (94d6879), but panopticon hasn't been around for quite a
while now...

---

https://govuk.zendesk.com/agent/tickets/3778731