### PR TITLE
Add a parent link to the EHC finder

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -10,6 +10,7 @@
   },
   "organisations": ["4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"],
   "topics": ["keeping-farmed-animals/animal-welfare"],
+  "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
   "document_noun": "export health certificate",
   "facets": [
     {


### PR DESCRIPTION
This is so that we can make the breadcrumbs consistent with
https://www.gov.uk/guidance/get-an-export-health-certificate