### PR TITLE
Adds the OPT to the IDF list

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -558,6 +558,10 @@
           "value": "norway",
           "label": "Norway"
         },
+	{
+          "value": "the-occupied-palestinian-territories",
+          "label": "Occupied Palestinian Territories, The"
+        },
         {
           "value": "oman",
           "label": "Oman"


### PR DESCRIPTION
Adds the Occupied Palentinian Territories to the International Development Funds.

This is to replace this PR https://github.com/alphagov/specialist-publisher/pull/1479
as it made better sense to seperate the two streams of work.