### PR TITLE
Add Myanmar to IDF list

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -519,6 +519,10 @@
           "label": "Mozambique"
         },
         {
+          "value": "myanmar",
+          "label": "Myanmar"
+        },
+        {
           "value": "namibia",
           "label": "Namibia"
         },


### PR DESCRIPTION
Adds Myanmar to the International Development Fund list.

Originally part of this pr https://github.com/alphagov/specialist-publisher/pull/1479

Was split as the two streams of work seemed distinct.