### PR TITLE
Remove Burma from locations schema

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -143,10 +143,6 @@
           "label": "Burkina Faso"
         },
         {
-          "value": "burma",
-          "label": "Burma"
-        },
-        {
           "value": "burundi",
           "label": "Burundi"
         },


### PR DESCRIPTION
Last part of the work for this ticket https://trello.com/c/C818g8vk/1218-3-switch-burma-to-myanmar-in-specialist-publisher

I didn't remove Burma initially so I could safely retag the documents without causing any issues, this is now done so any references to Burma can be safely removed. 

### Related PR's

- https://github.com/alphagov/search-api/pull/1726
- https://github.com/alphagov/specialist-publisher/pull/1513
- https://github.com/alphagov/specialist-publisher/commit/5e8963af29ef5640b31d36ddf5720e4d2252f449
- https://github.com/alphagov/search-api/commit/e8b38c7a82e5e03f8184a811228b9f18960b06df
- https://github.com/alphagov/govuk-content-schemas/commit/24aafbc3ba5c16b334595c9f15015119a4b98980