### PR TITLE
UKMCAB specialist finder improvements

### DIFF
--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -19,6 +19,7 @@
     {
       "key": "uk_market_conformity_assessment_body_name",
       "name": "Body Name",
+      "short_name": "Body Name",
       "type": "text",
       "display_as_result_metadata": false,
       "filterable": false
@@ -26,6 +27,7 @@
     {
       "key": "uk_market_conformity_assessment_body_number",
       "name": "Body number",
+      "short_name": "Body number",
       "type": "text",
       "display_as_result_metadata": false,
       "filterable": false
@@ -33,6 +35,7 @@
     {
       "key": "updated_at",
       "name": "Last updated",
+      "short_name": "Last updated",
       "type": "date",
       "display_as_result_metadata": false,
       "filterable": false
@@ -40,6 +43,7 @@
     {
       "key": "uk_market_conformity_assessment_body_type",
       "name": "Body type",
+      "short_name": "Body type",
       "type": "text",
       "preposition": "registered as",
       "display_as_result_metadata": true,
@@ -70,6 +74,7 @@
     {
       "key": "uk_market_conformity_assessment_body_registered_office_location",
       "name": "Registered office location",
+      "short_name": "Registered office location",
       "type": "text",
       "preposition": "based in",
       "display_as_result_metadata": true,
@@ -112,6 +117,7 @@
     {
       "key": "uk_market_conformity_assessment_body_testing_locations",
       "name": "Testing locations",
+      "short_name": "Testing locations",
       "type": "text",
       "preposition": "testing in",
       "display_as_result_metadata": true,
@@ -902,6 +908,7 @@
     {
       "key": "uk_market_conformity_assessment_body_website",
       "name": "Website",
+      "short_name": "Website",
       "type": "text",
       "filterable": false,
       "display_as_result_metadata": false
@@ -909,6 +916,7 @@
     {
       "key": "uk_market_conformity_assessment_body_email",
       "name": "Email",
+      "short_name": "Email",
       "type": "text",
       "filterable": false,
       "display_as_result_metadata": false
@@ -916,6 +924,7 @@
     {
       "key": "uk_market_conformity_assessment_body_phone",
       "name": "Phone",
+      "short_name": "Phone",
       "type": "text",
       "filterable": false,
       "display_as_result_metadata": false
@@ -923,6 +932,7 @@
     {
       "key": "uk_market_conformity_assessment_body_legislative_area",
       "name": "Legislative area",
+      "short_name": "Legislative area",
       "type": "text",
       "preposition": "concerned with",
       "display_as_result_metadata": true,

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -6,7 +6,7 @@
   "description": "",
   "phase": "alpha",
   "filter": {
-    "document_type": "uk_market_conformity_assessment_bodies"
+    "document_type": "uk_market_conformity_assessment_body"
   },
   "show_summaries": true,
   "organisations": ["2bde479a-97f2-42b5-986a-287a623c2a1c"],

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -20,21 +20,21 @@
       "key": "uk_market_conformity_assessment_body_name",
       "name": "Body Name",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false
     },
     {
       "key": "uk_market_conformity_assessment_body_number",
       "name": "Body number",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false
     },
     {
       "key": "updated_at",
       "name": "Last updated",
       "type": "date",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false
     },
     {


### PR DESCRIPTION
This PR fixes a number of problems with the UKMCAB finder. Specifically:
1. It now filters on the correct document type
2. Metadata displayed for each search result mirrors the things you can filter by, labelled in the same way.

## Before:
<img width="981" alt="Screen Shot 2019-10-07 at 19 15 30" src="https://user-images.githubusercontent.com/17908089/66337337-dc988680-e936-11e9-94ce-f530db8039c3.png">


## After
<img width="981" alt="Screen Shot 2019-10-07 at 19 14 46" src="https://user-images.githubusercontent.com/17908089/66337290-cab6e380-e936-11e9-8053-237457068fbd.png">

Trello:
https://trello.com/c/rdsypkBb/1059-ukmcab-specialist-finder
