### PR TITLE
Add multi-filter email alert signups for residential property tribunal decisions

### DIFF
--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -72,6 +72,7 @@ private
     {
       "beta" => schema.fetch("signup_beta", false),
       "email_signup_choice" => schema.fetch("email_signup_choice", []),
+      "email_filter_facets" => schema.fetch("email_filter_facets", []),
       "email_filter_by" => schema.fetch("email_filter_by", nil),
       "email_filter_name" => schema.fetch("email_filter_name", nil),
       "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", {}),

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -19,6 +19,14 @@
   "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Residential property tribunal decisions",
+  "email_filter_by": null,
+  "email_filter_name": null,
+  "email_filter_facets": [
+    {
+      "facet_id": "tribunal_decision_category",
+      "facet_name": "tribunal decision categories"
+    }
+  ],
   "summary": "<p>Find decisions on Residential Property Tribunal cases in England from December 2018 onwards.</p><p>If the decision was about leasehold and was made before December 2018, visit <a href=\"https://decisions.lease-advice.org/\" rel=\"external\">Lease Advice</a>. Other decisions made before December 2018 can be found on <a href=\"https://www.bailii.org/recent-decisions.html\" rel=\"external\">BAILII</a></p>",
   "document_noun": "decision",
   "facets": [

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -24,7 +24,51 @@
   "email_filter_facets": [
     {
       "facet_id": "tribunal_decision_category",
-      "facet_name": "tribunal decision categories"
+      "facet_name": "tribunal decision categories",
+      "facet_choices": [
+        {
+          "key": "housing-act-2004-and-housing-and-planning-act-2016",
+          "radio_button_name": "Housing Act 2004 and Housing and Planning Act 2016",
+          "topic_name": "Housing Act 2004 and Housing and Planning Act 2016",
+          "prechecked": false
+        },
+        {
+          "key": "leasehold-disputes-management",
+          "radio_button_name": "Leasehold disputes (management)",
+          "topic_name": "Leasehold disputes (management)",
+          "prechecked": false
+        },
+        {
+          "key": "leasehold-enfranchisement-and-extension",
+          "radio_button_name": "Leasehold enfranchisement and extension",
+          "topic_name": "Leasehold enfranchisement and extension",
+          "prechecked": false
+        },
+        {
+          "key": "park-homes",
+          "radio_button_name": "Park homes",
+          "topic_name": "Park homes",
+          "prechecked": false
+        },
+        {
+          "key": "rents",
+          "radio_button_name": "Rents",
+          "topic_name": "Rents",
+          "prechecked": false
+        },
+        {
+          "key": "right-to-buy",
+          "radio_button_name": "Right to Buy",
+          "topic_name": "Right to Buy",
+          "prechecked": false
+        },
+        {
+          "key": "tenant-associations",
+          "radio_button_name": "Tenant associations",
+          "topic_name": "Tenant associations",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "summary": "<p>Find decisions on Residential Property Tribunal cases in England from December 2018 onwards.</p><p>If the decision was about leasehold and was made before December 2018, visit <a href=\"https://decisions.lease-advice.org/\" rel=\"external\">Lease Advice</a>. Other decisions made before December 2018 can be found on <a href=\"https://www.bailii.org/recent-decisions.html\" rel=\"external\">BAILII</a></p>",


### PR DESCRIPTION
Allows the user to subscribe to email alerts filtered by the facets they selected on the finder page.

Once deployed, the finder needs to be republished to publishing-api so that finder-frontend can process selected facets and pass them onto email alert API.

https://trello.com/c/rTCRCbiM/930-fix-the-email-subscriptions-for-residential-property-tribunal-decisions-et-al-%F0%9F%8D%90