### PR TITLE
Add email alert signups for export health certificate specialist finder

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -24,11 +24,51 @@
     },
     {
       "facet_id": "commodity_type",
-      "facet_name": "commodity type"
-    },
-    {
-      "facet_id": "certificate_status",
-      "facet_name": "certificate status"
+      "facet_name": "commodity type",
+      "facet_choices": [
+        {
+          "key": "animal-products-including-food",
+          "radio_button_name": "Animal products including food",
+          "topic_name": "Animal products including food",
+          "prechecked": false
+        },
+        {
+          "key": "equine",
+          "radio_button_name": "Equine",
+          "topic_name": "Equine",
+          "prechecked": false
+        },
+        {
+          "key": "fish",
+          "radio_button_name": "Fish",
+          "topic_name": "Fish",
+          "prechecked": false
+        },
+        {
+          "key": "germplasm",
+          "radio_button_name": "Germplasm",
+          "topic_name": "Germplasm",
+          "prechecked": false
+        },
+        {
+          "key": "live-animals",
+          "radio_button_name": "Live animals",
+          "topic_name": "Live animals",
+          "prechecked": false
+        },
+        {
+          "key": "livestock",
+          "radio_button_name": "Livestock",
+          "topic_name": "Livestock",
+          "prechecked": false
+        },
+        {
+          "key": "pets",
+          "radio_button_name": "Pets",
+          "topic_name": "Pets",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "topics": ["keeping-farmed-animals/animal-welfare"],

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -9,6 +9,28 @@
     "document_type": "export_health_certificate"
   },
   "organisations": ["4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"],
+  "signup_content_id": "9a5260d2-07e7-45dc-a24a-791b02e4a9da",
+  "signup_copy": "You'll get an email each time an export health certificate is updated or a new export health certificate is published.",
+  "subscription_list_title_prefix": "Export health certificates",
+  "email_filter_by": null,
+  "email_filter_name": {
+    "singular": "export health certificate",
+    "plural": "export health certificates"
+  },
+  "email_filter_facets": [
+    {
+      "facet_id": "destination_country",
+      "facet_name": "destination country"
+    },
+    {
+      "facet_id": "commodity_type",
+      "facet_name": "commodity type"
+    },
+    {
+      "facet_id": "certificate_status",
+      "facet_name": "certificate status"
+    }
+  ],
   "topics": ["keeping-farmed-animals/animal-welfare"],
   "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
   "document_noun": "export health certificate",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -20,56 +20,1396 @@
   "email_filter_facets": [
     {
       "facet_id": "destination_country",
-      "facet_name": "destination country"
-    },
-    {
-      "facet_id": "commodity_type",
-      "facet_name": "commodity type",
+      "facet_name": "destination country",
       "facet_choices": [
-        {
-          "key": "animal-products-including-food",
-          "radio_button_name": "Animal products including food",
-          "topic_name": "Animal products including food",
-          "prechecked": false
+            {
+              "key": "afghanistan",
+              "radio_button_name": "Afghanistan",
+              "topic_name": "Afghanistan",
+              "prechecked": false
+            },
+            {
+              "key": "albania",
+              "radio_button_name": "Albania",
+              "topic_name": "Albania",
+              "prechecked": false
+            },
+            {
+              "key": "algeria",
+              "radio_button_name": "Algeria",
+              "topic_name": "Algeria",
+              "prechecked": false
+            },
+            {
+              "key": "andean-community-of-peru-bolivia-colombia-ecuador",
+              "radio_button_name": "Andean Community of Peru, Bolivia, Colombia, Ecuador",
+              "topic_name": "Andean Community of Peru, Bolivia, Colombia, Ecuador",
+              "prechecked": false
+            },
+            {
+              "key": "angola",
+              "radio_button_name": "Angola",
+              "topic_name": "Angola",
+              "prechecked": false
+            },
+            {
+              "key": "anguilla",
+              "radio_button_name": "Anguilla",
+              "topic_name": "Anguilla",
+              "prechecked": false
+            },
+            {
+              "key": "antigua",
+              "radio_button_name": "Antigua",
+              "topic_name": "Antigua",
+              "prechecked": false
+            },
+            {
+              "key": "argentina",
+              "radio_button_name": "Argentina",
+              "topic_name": "Argentina",
+              "prechecked": false
+            },
+            {
+              "key": "armenia",
+              "radio_button_name": "Armenia",
+              "topic_name": "Armenia",
+              "prechecked": false
+            },
+            {
+              "key": "ascension-island",
+              "radio_button_name": "Ascension Island",
+              "topic_name": "Ascension Island",
+              "prechecked": false
+            },
+            {
+              "key": "australia",
+              "radio_button_name": "Australia",
+              "topic_name": "Australia",
+              "prechecked": false
+            },
+            {
+              "key": "austria",
+              "radio_button_name": "Austria",
+              "topic_name": "Austria",
+              "prechecked": false
+            },
+            {
+              "key": "azerbaijan",
+              "radio_button_name": "Azerbaijan",
+              "topic_name": "Azerbaijan",
+              "prechecked": false
+            },
+            {
+              "key": "bahamas",
+              "radio_button_name": "Bahamas",
+              "topic_name": "Bahamas",
+              "prechecked": false
+            },
+            {
+              "key": "bahrain",
+              "radio_button_name": "Bahrain",
+              "topic_name": "Bahrain",
+              "prechecked": false
+            },
+            {
+              "key": "bangladesh",
+              "radio_button_name": "Bangladesh",
+              "topic_name": "Bangladesh",
+              "prechecked": false
+            },
+            {
+              "key": "barbados",
+              "radio_button_name": "Barbados",
+              "topic_name": "Barbados",
+              "prechecked": false
+            },
+            {
+              "key": "belarus",
+              "radio_button_name": "Belarus",
+              "topic_name": "Belarus",
+              "prechecked": false
+            },
+            {
+              "key": "belgium",
+              "radio_button_name": "Belgium",
+              "topic_name": "Belgium",
+              "prechecked": false
+            },
+            {
+              "key": "belize",
+              "radio_button_name": "Belize",
+              "topic_name": "Belize",
+              "prechecked": false
+            },
+            {
+              "key": "benin",
+              "radio_button_name": "Benin",
+              "topic_name": "Benin",
+              "prechecked": false
+            },
+            {
+              "key": "bermuda",
+              "radio_button_name": "Bermuda",
+              "topic_name": "Bermuda",
+              "prechecked": false
+            },
+            {
+              "key": "bhutan",
+              "radio_button_name": "Bhutan",
+              "topic_name": "Bhutan",
+              "prechecked": false
+            },
+            {
+              "key": "bolivia",
+              "radio_button_name": "Bolivia",
+              "topic_name": "Bolivia",
+              "prechecked": false
+            },
+            {
+              "key": "bosnia-and-herzegovina",
+              "radio_button_name": "Bosnia and Herzegovina",
+              "topic_name": "Bosnia and Herzegovina",
+              "prechecked": false
+            },
+            {
+              "key": "botswana",
+              "radio_button_name": "Botswana",
+              "topic_name": "Botswana",
+              "prechecked": false
+            },
+            {
+              "key": "brazil",
+              "radio_button_name": "Brazil",
+              "topic_name": "Brazil",
+              "prechecked": false
+            },
+            {
+              "key": "british-virgin-islands",
+              "radio_button_name": "British Virgin Islands",
+              "topic_name": "British Virgin Islands",
+              "prechecked": false
+            },
+            {
+              "key": "brunei",
+              "radio_button_name": "Brunei",
+              "topic_name": "Brunei",
+              "prechecked": false
+            },
+            {
+              "key": "bulgaria",
+              "radio_button_name": "Bulgaria",
+              "topic_name": "Bulgaria",
+              "prechecked": false
+            },
+            {
+              "key": "burkina-faso",
+              "radio_button_name": "Burkina Faso",
+              "topic_name": "Burkina Faso",
+              "prechecked": false
+            },
+            {
+              "key": "burundi",
+              "radio_button_name": "Burundi",
+              "topic_name": "Burundi",
+              "prechecked": false
+            },
+            {
+              "key": "cambodia",
+              "radio_button_name": "Cambodia",
+              "topic_name": "Cambodia",
+              "prechecked": false
+            },
+            {
+              "key": "cameroon",
+              "radio_button_name": "Cameroon",
+              "topic_name": "Cameroon",
+              "prechecked": false
+            },
+            {
+              "key": "canada",
+              "radio_button_name": "Canada",
+              "topic_name": "Canada",
+              "prechecked": false
+            },
+            {
+              "key": "cape-verde",
+              "radio_button_name": "Cape Verde",
+              "topic_name": "Cape Verde",
+              "prechecked": false
+            },
+            {
+              "key": "cayman-islands",
+              "radio_button_name": "Cayman Islands",
+              "topic_name": "Cayman Islands",
+              "prechecked": false
+            },
+            {
+              "key": "central-african-republic",
+              "radio_button_name": "Central African Republic",
+              "topic_name": "Central African Republic",
+              "prechecked": false
+            },
+            {
+              "key": "chad",
+              "radio_button_name": "Chad",
+              "topic_name": "Chad",
+              "prechecked": false
+            },
+            {
+              "key": "chile",
+              "radio_button_name": "Chile",
+              "topic_name": "Chile",
+              "prechecked": false
+            },
+            {
+              "key": "china",
+              "radio_button_name": "China",
+              "topic_name": "China",
+              "prechecked": false
+            },
+            {
+              "key": "colombia",
+              "radio_button_name": "Colombia",
+              "topic_name": "Colombia",
+              "prechecked": false
+            },
+            {
+              "key": "comoros",
+              "radio_button_name": "Comoros",
+              "topic_name": "Comoros",
+              "prechecked": false
+            },
+            {
+              "key": "congo-democratic-republic-of",
+              "radio_button_name": "Congo, Democratic Republic of",
+              "topic_name": "Congo, Democratic Republic of",
+              "prechecked": false
+            },
+            {
+              "key": "congo-republic-of",
+              "radio_button_name": "Congo, Republic of",
+              "topic_name": "Congo, Republic of",
+              "prechecked": false
+            },
+            {
+              "key": "costa-rica",
+              "radio_button_name": "Costa Rica",
+              "topic_name": "Costa Rica",
+              "prechecked": false
+            },
+            {
+              "key": "cote-d-ivoire",
+              "radio_button_name": "Cote d'Ivoire",
+              "topic_name": "Cote d'Ivoire",
+              "prechecked": false
+            },
+            {
+              "key": "croatia",
+              "radio_button_name": "Croatia",
+              "topic_name": "Croatia",
+              "prechecked": false
+            },
+            {
+              "key": "cuba",
+              "radio_button_name": "Cuba",
+              "topic_name": "Cuba",
+              "prechecked": false
+            },
+            {
+              "key": "cyprus",
+              "radio_button_name": "Cyprus",
+              "topic_name": "Cyprus",
+              "prechecked": false
+            },
+            {
+              "key": "czech-republic",
+              "radio_button_name": "Czech Republic",
+              "topic_name": "Czech Republic",
+              "prechecked": false
+            },
+            {
+              "key": "denmark",
+              "radio_button_name": "Denmark",
+              "topic_name": "Denmark",
+              "prechecked": false
+            },
+            {
+              "key": "djibouti",
+              "radio_button_name": "Djibouti",
+              "topic_name": "Djibouti",
+              "prechecked": false
+            },
+            {
+              "key": "dominica",
+              "radio_button_name": "Dominica",
+              "topic_name": "Dominica",
+              "prechecked": false
+            },
+            {
+              "key": "dominican-republic",
+              "radio_button_name": "Dominican Republic",
+              "topic_name": "Dominican Republic",
+              "prechecked": false
+            },
+            {
+              "key": "east-timor",
+              "radio_button_name": "East Timor",
+              "topic_name": "East Timor",
+              "prechecked": false
+            },
+            {
+              "key": "ecuador",
+              "radio_button_name": "Ecuador",
+              "topic_name": "Ecuador",
+              "prechecked": false
+            },
+            {
+              "key": "egypt",
+              "radio_button_name": "Egypt",
+              "topic_name": "Egypt",
+              "prechecked": false
+            },
+            {
+              "key": "el-salvador",
+              "radio_button_name": "El Salvador",
+              "topic_name": "El Salvador",
+              "prechecked": false
+            },
+            {
+              "key": "equatorial-guinea",
+              "radio_button_name": "Equatorial Guinea",
+              "topic_name": "Equatorial Guinea",
+              "prechecked": false
+            },
+            {
+              "key": "eritrea",
+              "radio_button_name": "Eritrea",
+              "topic_name": "Eritrea",
+              "prechecked": false
+            },
+            {
+              "key": "estonia",
+              "radio_button_name": "Estonia",
+              "topic_name": "Estonia",
+              "prechecked": false
+            },
+            {
+              "key": "eswatini-previously-swaziland",
+              "radio_button_name": "Eswatini (previously Swaziland)",
+              "topic_name": "Eswatini (previously Swaziland)",
+              "prechecked": false
+            },
+            {
+              "key": "ethiopia",
+              "radio_button_name": "Ethiopia",
+              "topic_name": "Ethiopia",
+              "prechecked": false
+            },
+            {
+              "key": "eu",
+              "radio_button_name": "EU",
+              "topic_name": "EU",
+              "prechecked": false
+            },
+            {
+              "key": "eurasian-customs-union",
+              "radio_button_name": "Eurasian Customs Union",
+              "topic_name": "Eurasian Customs Union",
+              "prechecked": false
+            },
+            {
+              "key": "falkland-islands",
+              "radio_button_name": "Falkland Islands",
+              "topic_name": "Falkland Islands",
+              "prechecked": false
+            },
+            {
+              "key": "faroe-islands",
+              "radio_button_name": "Faroe Islands",
+              "topic_name": "Faroe Islands",
+              "prechecked": false
+            },
+            {
+              "key": "fiji",
+              "radio_button_name": "Fiji",
+              "topic_name": "Fiji",
+              "prechecked": false
+            },
+            {
+              "key": "finland",
+              "radio_button_name": "Finland",
+              "topic_name": "Finland",
+              "prechecked": false
+            },
+            {
+              "key": "france",
+              "radio_button_name": "France",
+              "topic_name": "France",
+              "prechecked": false
+            },
+            {
+              "key": "french-polynesia",
+              "radio_button_name": "French Polynesia",
+              "topic_name": "French Polynesia",
+              "prechecked": false
+            },
+            {
+              "key": "gabon",
+              "radio_button_name": "Gabon",
+              "topic_name": "Gabon",
+              "prechecked": false
+            },
+            {
+              "key": "gambia",
+              "radio_button_name": "Gambia",
+              "topic_name": "Gambia",
+              "prechecked": false
+            },
+            {
+              "key": "georgia",
+              "radio_button_name": "Georgia",
+              "topic_name": "Georgia",
+              "prechecked": false
+            },
+            {
+              "key": "germany",
+              "radio_button_name": "Germany",
+              "topic_name": "Germany",
+              "prechecked": false
+            },
+            {
+              "key": "ghana",
+              "radio_button_name": "Ghana",
+              "topic_name": "Ghana",
+              "prechecked": false
+            },
+            {
+              "key": "gibraltar",
+              "radio_button_name": "Gibraltar",
+              "topic_name": "Gibraltar",
+              "prechecked": false
+            },
+            {
+              "key": "great-britain",
+              "radio_button_name": "Great Britain",
+              "topic_name": "Great Britain",
+              "prechecked": false
+            },
+            {
+              "key": "greece",
+              "radio_button_name": "Greece",
+              "topic_name": "Greece",
+              "prechecked": false
+            },
+            {
+              "key": "grenada",
+              "radio_button_name": "Grenada",
+              "topic_name": "Grenada",
+              "prechecked": false
+            },
+            {
+              "key": "guam",
+              "radio_button_name": "Guam",
+              "topic_name": "Guam",
+              "prechecked": false
+            },
+            {
+              "key": "guatemala",
+              "radio_button_name": "Guatemala",
+              "topic_name": "Guatemala",
+              "prechecked": false
+            },
+            {
+              "key": "guernsey",
+              "radio_button_name": "Guernsey",
+              "topic_name": "Guernsey",
+              "prechecked": false
+            },
+            {
+              "key": "guinea",
+              "radio_button_name": "Guinea",
+              "topic_name": "Guinea",
+              "prechecked": false
+            },
+            {
+              "key": "guinea-bissau",
+              "radio_button_name": "Guinea-Bissau",
+              "topic_name": "Guinea-Bissau",
+              "prechecked": false
+            },
+            {
+              "key": "guyana",
+              "radio_button_name": "Guyana",
+              "topic_name": "Guyana",
+              "prechecked": false
+            },
+            {
+              "key": "haiti",
+              "radio_button_name": "Haiti",
+              "topic_name": "Haiti",
+              "prechecked": false
+            },
+            {
+              "key": "hawaii",
+              "radio_button_name": "Hawaii",
+              "topic_name": "Hawaii",
+              "prechecked": false
+            },
+            {
+              "key": "honduras",
+              "radio_button_name": "Honduras",
+              "topic_name": "Honduras",
+              "prechecked": false
+            },
+            {
+              "key": "hong-kong",
+              "radio_button_name": "Hong Kong",
+              "topic_name": "Hong Kong",
+              "prechecked": false
+            },
+            {
+              "key": "hungary",
+              "radio_button_name": "Hungary",
+              "topic_name": "Hungary",
+              "prechecked": false
+            },
+            {
+              "key": "iceland",
+              "radio_button_name": "Iceland",
+              "topic_name": "Iceland",
+              "prechecked": false
+            },
+            {
+              "key": "india",
+              "radio_button_name": "India",
+              "topic_name": "India",
+              "prechecked": false
+            },
+            {
+              "key": "indonesia",
+              "radio_button_name": "Indonesia",
+              "topic_name": "Indonesia",
+              "prechecked": false
+            },
+            {
+              "key": "iran",
+              "radio_button_name": "Iran",
+              "topic_name": "Iran",
+              "prechecked": false
+            },
+            {
+              "key": "iraq",
+              "radio_button_name": "Iraq",
+              "topic_name": "Iraq",
+              "prechecked": false
+            },
+            {
+              "key": "isle-of-man",
+              "radio_button_name": "Isle Of Man",
+              "topic_name": "Isle Of Man",
+              "prechecked": false
+            },
+            {
+              "key": "israel",
+              "radio_button_name": "Israel",
+              "topic_name": "Israel",
+              "prechecked": false
+            },
+            {
+              "key": "italy",
+              "radio_button_name": "Italy",
+              "topic_name": "Italy",
+              "prechecked": false
+            },
+            {
+              "key": "jamaica",
+              "radio_button_name": "Jamaica",
+              "topic_name": "Jamaica",
+              "prechecked": false
+            },
+            {
+              "key": "japan",
+              "radio_button_name": "Japan",
+              "topic_name": "Japan",
+              "prechecked": false
+            },
+            {
+              "key": "jersey",
+              "radio_button_name": "Jersey",
+              "topic_name": "Jersey",
+              "prechecked": false
+            },
+            {
+              "key": "jordan",
+              "radio_button_name": "Jordan",
+              "topic_name": "Jordan",
+              "prechecked": false
+            },
+            {
+              "key": "kazakhstan",
+              "radio_button_name": "Kazakhstan",
+              "topic_name": "Kazakhstan",
+              "prechecked": false
+            },
+            {
+              "key": "kenya",
+              "radio_button_name": "Kenya",
+              "topic_name": "Kenya",
+              "prechecked": false
+            },
+            {
+              "key": "kiribati",
+              "radio_button_name": "Kiribati",
+              "topic_name": "Kiribati",
+              "prechecked": false
+            },
+            {
+              "key": "kosovo",
+              "radio_button_name": "Kosovo",
+              "topic_name": "Kosovo",
+              "prechecked": false
+            },
+            {
+              "key": "kuwait",
+              "radio_button_name": "Kuwait",
+              "topic_name": "Kuwait",
+              "prechecked": false
+            },
+            {
+              "key": "kyrgyzstan",
+              "radio_button_name": "Kyrgyzstan",
+              "topic_name": "Kyrgyzstan",
+              "prechecked": false
+            },
+            {
+              "key": "laos",
+              "radio_button_name": "Laos",
+              "topic_name": "Laos",
+              "prechecked": false
+            },
+            {
+              "key": "latvia",
+              "radio_button_name": "Latvia",
+              "topic_name": "Latvia",
+              "prechecked": false
+            },
+            {
+              "key": "lebanon",
+              "radio_button_name": "Lebanon",
+              "topic_name": "Lebanon",
+              "prechecked": false
+            },
+            {
+              "key": "lesotho",
+              "radio_button_name": "Lesotho",
+              "topic_name": "Lesotho",
+              "prechecked": false
+            },
+            {
+              "key": "liberia",
+              "radio_button_name": "Liberia",
+              "topic_name": "Liberia",
+              "prechecked": false
+            },
+            {
+              "key": "libya",
+              "radio_button_name": "Libya",
+              "topic_name": "Libya",
+              "prechecked": false
+            },
+            {
+              "key": "liechtenstein",
+              "radio_button_name": "Liechtenstein",
+              "topic_name": "Liechtenstein",
+              "prechecked": false
+            },
+            {
+              "key": "lithuania",
+              "radio_button_name": "Lithuania",
+              "topic_name": "Lithuania",
+              "prechecked": false
+            },
+            {
+              "key": "luxembourg",
+              "radio_button_name": "Luxembourg",
+              "topic_name": "Luxembourg",
+              "prechecked": false
+            },
+            {
+              "key": "macao",
+              "radio_button_name": "Macao",
+              "topic_name": "Macao",
+              "prechecked": false
+            },
+            {
+              "key": "macedonia",
+              "radio_button_name": "Macedonia",
+              "topic_name": "Macedonia",
+              "prechecked": false
+            },
+            {
+              "key": "madagascar",
+              "radio_button_name": "Madagascar",
+              "topic_name": "Madagascar",
+              "prechecked": false
+            },
+            {
+              "key": "malawi",
+              "radio_button_name": "Malawi",
+              "topic_name": "Malawi",
+              "prechecked": false
+            },
+            {
+              "key": "malaysia",
+              "radio_button_name": "Malaysia",
+              "topic_name": "Malaysia",
+              "prechecked": false
+            },
+            {
+              "key": "maldives",
+              "radio_button_name": "Maldives",
+              "topic_name": "Maldives",
+              "prechecked": false
+            },
+            {
+              "key": "mali",
+              "radio_button_name": "Mali",
+              "topic_name": "Mali",
+              "prechecked": false
+            },
+            {
+              "key": "malta",
+              "radio_button_name": "Malta",
+              "topic_name": "Malta",
+              "prechecked": false
+            },
+            {
+              "key": "marshall-islands",
+              "radio_button_name": "Marshall Islands",
+              "topic_name": "Marshall Islands",
+              "prechecked": false
+            },
+            {
+              "key": "mauritania",
+              "radio_button_name": "Mauritania",
+              "topic_name": "Mauritania",
+              "prechecked": false
+            },
+            {
+              "key": "mauritius",
+              "radio_button_name": "Mauritius",
+              "topic_name": "Mauritius",
+              "prechecked": false
+            },
+            {
+              "key": "mexico",
+              "radio_button_name": "Mexico",
+              "topic_name": "Mexico",
+              "prechecked": false
+            },
+            {
+              "key": "micronesia",
+              "radio_button_name": "Micronesia",
+              "topic_name": "Micronesia",
+              "prechecked": false
+            },
+            {
+              "key": "moldova",
+              "radio_button_name": "Moldova",
+              "topic_name": "Moldova",
+              "prechecked": false
+            },
+            {
+              "key": "mongolia",
+              "radio_button_name": "Mongolia",
+              "topic_name": "Mongolia",
+              "prechecked": false
+            },
+            {
+              "key": "montenegro",
+              "radio_button_name": "Montenegro",
+              "topic_name": "Montenegro",
+              "prechecked": false
+            },
+            {
+              "key": "montserrat",
+              "radio_button_name": "Montserrat",
+              "topic_name": "Montserrat",
+              "prechecked": false
+            },
+            {
+              "key": "morocco",
+              "radio_button_name": "Morocco",
+              "topic_name": "Morocco",
+              "prechecked": false
+            },
+            {
+              "key": "mozambique",
+              "radio_button_name": "Mozambique",
+              "topic_name": "Mozambique",
+              "prechecked": false
+            },
+            {
+              "key": "myanmar",
+              "radio_button_name": "Myanmar",
+              "topic_name": "Myanmar",
+              "prechecked": false
+            },
+            {
+              "key": "namibia",
+              "radio_button_name": "Namibia",
+              "topic_name": "Namibia",
+              "prechecked": false
+            },
+            {
+              "key": "nauru",
+              "radio_button_name": "Nauru",
+              "topic_name": "Nauru",
+              "prechecked": false
+            },
+            {
+              "key": "nepal",
+              "radio_button_name": "Nepal",
+              "topic_name": "Nepal",
+              "prechecked": false
+            },
+            {
+              "key": "netherlands",
+              "radio_button_name": "Netherlands",
+              "topic_name": "Netherlands",
+              "prechecked": false
+            },
+            {
+              "key": "new-caledonia",
+              "radio_button_name": "New Caledonia",
+              "topic_name": "New Caledonia",
+              "prechecked": false
+            },
+            {
+              "key": "new-zealand",
+              "radio_button_name": "New Zealand",
+              "topic_name": "New Zealand",
+              "prechecked": false
+            },
+            {
+              "key": "nicaragua",
+              "radio_button_name": "Nicaragua",
+              "topic_name": "Nicaragua",
+              "prechecked": false
+            },
+            {
+              "key": "niger",
+              "radio_button_name": "Niger",
+              "topic_name": "Niger",
+              "prechecked": false
+            },
+            {
+              "key": "nigeria",
+              "radio_button_name": "Nigeria",
+              "topic_name": "Nigeria",
+              "prechecked": false
+            },
+            {
+              "key": "north-korea",
+              "radio_button_name": "North Korea",
+              "topic_name": "North Korea",
+              "prechecked": false
+            },
+            {
+              "key": "north-sudan",
+              "radio_button_name": "North Sudan",
+              "topic_name": "North Sudan",
+              "prechecked": false
+            },
+            {
+              "key": "northern-cyprus",
+              "radio_button_name": "Northern Cyprus",
+              "topic_name": "Northern Cyprus",
+              "prechecked": false
+            },
+            {
+              "key": "northern-ireland",
+              "radio_button_name": "Northern Ireland",
+              "topic_name": "Northern Ireland",
+              "prechecked": false
+            },
+            {
+              "key": "norway",
+              "radio_button_name": "Norway",
+              "topic_name": "Norway",
+              "prechecked": false
+            },
+            {
+              "key": "oman",
+              "radio_button_name": "Oman",
+              "topic_name": "Oman",
+              "prechecked": false
+            },
+            {
+              "key": "pakistan",
+              "radio_button_name": "Pakistan",
+              "topic_name": "Pakistan",
+              "prechecked": false
+            },
+            {
+              "key": "palau",
+              "radio_button_name": "Palau",
+              "topic_name": "Palau",
+              "prechecked": false
+            },
+            {
+              "key": "palestine",
+              "radio_button_name": "Palestine",
+              "topic_name": "Palestine",
+              "prechecked": false
+            },
+            {
+              "key": "panama",
+              "radio_button_name": "Panama",
+              "topic_name": "Panama",
+              "prechecked": false
+            },
+            {
+              "key": "papua-new-guinea",
+              "radio_button_name": "Papua New Guinea",
+              "topic_name": "Papua New Guinea",
+              "prechecked": false
+            },
+            {
+              "key": "paraguay",
+              "radio_button_name": "Paraguay",
+              "topic_name": "Paraguay",
+              "prechecked": false
+            },
+            {
+              "key": "peru",
+              "radio_button_name": "Peru",
+              "topic_name": "Peru",
+              "prechecked": false
+            },
+            {
+              "key": "philippines",
+              "radio_button_name": "Philippines",
+              "topic_name": "Philippines",
+              "prechecked": false
+            },
+            {
+              "key": "poland",
+              "radio_button_name": "Poland",
+              "topic_name": "Poland",
+              "prechecked": false
+            },
+            {
+              "key": "portugal",
+              "radio_button_name": "Portugal",
+              "topic_name": "Portugal",
+              "prechecked": false
+            },
+            {
+              "key": "qatar",
+              "radio_button_name": "Qatar",
+              "topic_name": "Qatar",
+              "prechecked": false
+            },
+            {
+              "key": "republic-of-ireland",
+              "radio_button_name": "Republic of Ireland",
+              "topic_name": "Republic of Ireland",
+              "prechecked": false
+            },
+            {
+              "key": "romania",
+              "radio_button_name": "Romania",
+              "topic_name": "Romania",
+              "prechecked": false
+            },
+            {
+              "key": "russia",
+              "radio_button_name": "Russia",
+              "topic_name": "Russia",
+              "prechecked": false
+            },
+            {
+              "key": "rwanda",
+              "radio_button_name": "Rwanda",
+              "topic_name": "Rwanda",
+              "prechecked": false
+            },
+            {
+              "key": "samoa",
+              "radio_button_name": "Samoa",
+              "topic_name": "Samoa",
+              "prechecked": false
+            },
+            {
+              "key": "san-marino",
+              "radio_button_name": "San Marino",
+              "topic_name": "San Marino",
+              "prechecked": false
+            },
+            {
+              "key": "sao-tome-and-principe",
+              "radio_button_name": "São Tomé and Principe",
+              "topic_name": "São Tomé and Principe",
+              "prechecked": false
+            },
+            {
+              "key": "saudi-arabia",
+              "radio_button_name": "Saudi Arabia",
+              "topic_name": "Saudi Arabia",
+              "prechecked": false
+            },
+            {
+              "key": "senegal",
+              "radio_button_name": "Senegal",
+              "topic_name": "Senegal",
+              "prechecked": false
+            },
+            {
+              "key": "serbia",
+              "radio_button_name": "Serbia",
+              "topic_name": "Serbia",
+              "prechecked": false
+            },
+            {
+              "key": "seychelles",
+              "radio_button_name": "Seychelles",
+              "topic_name": "Seychelles",
+              "prechecked": false
+            },
+            {
+              "key": "sierra-leone",
+              "radio_button_name": "Sierra Leone",
+              "topic_name": "Sierra Leone",
+              "prechecked": false
+            },
+            {
+              "key": "singapore",
+              "radio_button_name": "Singapore",
+              "topic_name": "Singapore",
+              "prechecked": false
+            },
+            {
+              "key": "slovakia",
+              "radio_button_name": "Slovakia",
+              "topic_name": "Slovakia",
+              "prechecked": false
+            },
+            {
+              "key": "slovenia",
+              "radio_button_name": "Slovenia",
+              "topic_name": "Slovenia",
+              "prechecked": false
+            },
+            {
+              "key": "solomon-islands",
+              "radio_button_name": "Solomon Islands",
+              "topic_name": "Solomon Islands",
+              "prechecked": false
+            },
+            {
+              "key": "somalia",
+              "radio_button_name": "Somalia",
+              "topic_name": "Somalia",
+              "prechecked": false
+            },
+            {
+              "key": "south-africa",
+              "radio_button_name": "South Africa",
+              "topic_name": "South Africa",
+              "prechecked": false
+            },
+            {
+              "key": "south-korea",
+              "radio_button_name": "South Korea",
+              "topic_name": "South Korea",
+              "prechecked": false
+            },
+            {
+              "key": "south-sudan",
+              "radio_button_name": "South Sudan",
+              "topic_name": "South Sudan",
+              "prechecked": false
+            },
+            {
+              "key": "spain",
+              "radio_button_name": "Spain",
+              "topic_name": "Spain",
+              "prechecked": false
+            },
+            {
+              "key": "sri-lanka",
+              "radio_button_name": "Sri Lanka",
+              "topic_name": "Sri Lanka",
+              "prechecked": false
+            },
+            {
+              "key": "st-helena",
+              "radio_button_name": "St Helena",
+              "topic_name": "St Helena",
+              "prechecked": false
+            },
+            {
+              "key": "st-kitts-and-nevis",
+              "radio_button_name": "St Kitts and Nevis",
+              "topic_name": "St Kitts and Nevis",
+              "prechecked": false
+            },
+            {
+              "key": "st-lucia",
+              "radio_button_name": "St Lucia",
+              "topic_name": "St Lucia",
+              "prechecked": false
+            },
+            {
+              "key": "st-vincent-and-the-grenadines",
+              "radio_button_name": "St Vincent and The Grenadines",
+              "topic_name": "St Vincent and The Grenadines",
+              "prechecked": false
+            },
+            {
+              "key": "sudan",
+              "radio_button_name": "Sudan",
+              "topic_name": "Sudan",
+              "prechecked": false
+            },
+            {
+              "key": "suriname",
+              "radio_button_name": "Suriname",
+              "topic_name": "Suriname",
+              "prechecked": false
+            },
+            {
+              "key": "swaziland-now-eswatini",
+              "radio_button_name": "Swaziland (now Eswatini)",
+              "topic_name": "Swaziland (now Eswatini)",
+              "prechecked": false
+            },
+            {
+              "key": "sweden",
+              "radio_button_name": "Sweden",
+              "topic_name": "Sweden",
+              "prechecked": false
+            },
+            {
+              "key": "switzerland",
+              "radio_button_name": "Switzerland",
+              "topic_name": "Switzerland",
+              "prechecked": false
+            },
+            {
+              "key": "syria",
+              "radio_button_name": "Syria",
+              "topic_name": "Syria",
+              "prechecked": false
+            },
+            {
+              "key": "taiwan",
+              "radio_button_name": "Taiwan",
+              "topic_name": "Taiwan",
+              "prechecked": false
+            },
+            {
+              "key": "tajikistan",
+              "radio_button_name": "Tajikistan",
+              "topic_name": "Tajikistan",
+              "prechecked": false
+            },
+            {
+              "key": "tanzania",
+              "radio_button_name": "Tanzania",
+              "topic_name": "Tanzania",
+              "prechecked": false
+            },
+            {
+              "key": "thailand",
+              "radio_button_name": "Thailand",
+              "topic_name": "Thailand",
+              "prechecked": false
+            },
+            {
+              "key": "togo",
+              "radio_button_name": "Togo",
+              "topic_name": "Togo",
+              "prechecked": false
+            },
+            {
+              "key": "tonga",
+              "radio_button_name": "Tonga",
+              "topic_name": "Tonga",
+              "prechecked": false
+            },
+            {
+              "key": "trinidad-and-tobago",
+              "radio_button_name": "Trinidad and Tobago",
+              "topic_name": "Trinidad and Tobago",
+              "prechecked": false
+            },
+            {
+              "key": "tristan-da-cunha",
+              "radio_button_name": "Tristan Da Cunha",
+              "topic_name": "Tristan Da Cunha",
+              "prechecked": false
+            },
+            {
+              "key": "tunisia",
+              "radio_button_name": "Tunisia",
+              "topic_name": "Tunisia",
+              "prechecked": false
+            },
+            {
+              "key": "turkey",
+              "radio_button_name": "Turkey",
+              "topic_name": "Turkey",
+              "prechecked": false
+            },
+            {
+              "key": "turkmenistan",
+              "radio_button_name": "Turkmenistan",
+              "topic_name": "Turkmenistan",
+              "prechecked": false
+            },
+            {
+              "key": "turks-and-caicos-islands",
+              "radio_button_name": "Turks and Caicos Islands",
+              "topic_name": "Turks and Caicos Islands",
+              "prechecked": false
+            },
+            {
+              "key": "tuvalu",
+              "radio_button_name": "Tuvalu",
+              "topic_name": "Tuvalu",
+              "prechecked": false
+            },
+            {
+              "key": "uganda",
+              "radio_button_name": "Uganda",
+              "topic_name": "Uganda",
+              "prechecked": false
+            },
+            {
+              "key": "ukraine",
+              "radio_button_name": "Ukraine",
+              "topic_name": "Ukraine",
+              "prechecked": false
+            },
+            {
+              "key": "united-arab-emirates",
+              "radio_button_name": "United Arab Emirates",
+              "topic_name": "United Arab Emirates",
+              "prechecked": false
+            },
+            {
+              "key": "uruguay",
+              "radio_button_name": "Uruguay",
+              "topic_name": "Uruguay",
+              "prechecked": false
+            },
+            {
+              "key": "usa",
+              "radio_button_name": "USA",
+              "topic_name": "USA",
+              "prechecked": false
+            },
+            {
+              "key": "uzbekistan",
+              "radio_button_name": "Uzbekistan",
+              "topic_name": "Uzbekistan",
+              "prechecked": false
+            },
+            {
+              "key": "vanuatu",
+              "radio_button_name": "Vanuatu",
+              "topic_name": "Vanuatu",
+              "prechecked": false
+            },
+            {
+              "key": "venezuela",
+              "radio_button_name": "Venezuela",
+              "topic_name": "Venezuela",
+              "prechecked": false
+            },
+            {
+              "key": "vietnam",
+              "radio_button_name": "Vietnam",
+              "topic_name": "Vietnam",
+              "prechecked": false
+            },
+            {
+              "key": "wallis-and-futuna-islands",
+              "radio_button_name": "Wallis and Futuna Islands",
+              "topic_name": "Wallis and Futuna Islands",
+              "prechecked": false
+            },
+            {
+              "key": "yemen",
+              "radio_button_name": "Yemen",
+              "topic_name": "Yemen",
+              "prechecked": false
+            },
+            {
+              "key": "zambia",
+              "radio_button_name": "Zambia",
+              "topic_name": "Zambia",
+              "prechecked": false
+            },
+            {
+              "key": "zimbabwe",
+              "radio_button_name": "Zimbabwe",
+              "topic_name": "Zimbabwe",
+              "prechecked": false
+            }
+          ]
         },
         {
-          "key": "equine",
-          "radio_button_name": "Equine",
-          "topic_name": "Equine",
-          "prechecked": false
-        },
-        {
-          "key": "fish",
-          "radio_button_name": "Fish",
-          "topic_name": "Fish",
-          "prechecked": false
-        },
-        {
-          "key": "germplasm",
-          "radio_button_name": "Germplasm",
-          "topic_name": "Germplasm",
-          "prechecked": false
-        },
-        {
-          "key": "live-animals",
-          "radio_button_name": "Live animals",
-          "topic_name": "Live animals",
-          "prechecked": false
-        },
-        {
-          "key": "livestock",
-          "radio_button_name": "Livestock",
-          "topic_name": "Livestock",
-          "prechecked": false
-        },
-        {
-          "key": "pets",
-          "radio_button_name": "Pets",
-          "topic_name": "Pets",
-          "prechecked": false
+          "facet_id": "commodity_type",
+          "facet_name": "commodity type",
+          "facet_choices": [
+            {
+              "key": "animal-products-including-food",
+              "radio_button_name": "Animal products including food",
+              "topic_name": "Animal products including food",
+              "prechecked": false
+            },
+            {
+              "key": "equine",
+              "radio_button_name": "Equine",
+              "topic_name": "Equine",
+              "prechecked": false
+            },
+            {
+              "key": "fish",
+              "radio_button_name": "Fish",
+              "topic_name": "Fish",
+              "prechecked": false
+            },
+            {
+              "key": "germplasm",
+              "radio_button_name": "Germplasm",
+              "topic_name": "Germplasm",
+              "prechecked": false
+            },
+            {
+              "key": "live-animals",
+              "radio_button_name": "Live animals",
+              "topic_name": "Live animals",
+              "prechecked": false
+            },
+            {
+              "key": "livestock",
+              "radio_button_name": "Livestock",
+              "topic_name": "Livestock",
+              "prechecked": false
+            },
+            {
+              "key": "pets",
+              "radio_button_name": "Pets",
+              "topic_name": "Pets",
+              "prechecked": false
+            }
+          ]
         }
-      ]
-    }
   ],
   "topics": ["keeping-farmed-animals/animal-welfare"],
   "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -12,7 +12,7 @@
   "signup_content_id": "9a5260d2-07e7-45dc-a24a-791b02e4a9da",
   "signup_copy": "You'll get an email each time an export health certificate is updated or a new export health certificate is published.",
   "subscription_list_title_prefix": "Export health certificates",
-  "email_filter_by": null,
+  "email_filter_by": "all_selected_facets",
   "email_filter_name": {
     "singular": "export health certificate",
     "plural": "export health certificates"


### PR DESCRIPTION
Allows the user to subscribe to email alerts filtered by the facets they selected on the finder page.

Once deployed, the finder needs to be republished to publishing-api so that finder-frontend can process selected facets and pass them onto email alert API.

https://trello.com/c/jZ2yuKkp/757-add-email-alerts-to-export-health-certificates-%F0%9F%8D%90