### PR TITLE
GDPR rules

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -19,7 +19,7 @@
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment tribunal decisions",
-  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-tribunal-hearing-centre-eagle-building'>Glasgow Tribunal Hearing Centre</a> for cases in Scotland.</p>",
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-tribunal-hearing-centre-eagle-building'>Glasgow Tribunal Hearing Centre</a> for cases in Scotland.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK</p>",
   "document_noun": "decision",
   "facets": [
     {


### PR DESCRIPTION
Added: </p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK</p>

Because: department has shown evidence that people are asking for decisions to be removed because of GDPR. These rules do not affect tribunal decisions.