### PR TITLE
Enable non-modifiable email facet choices for Residential Property Tribunal Decisions finder

### DIFF
--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -19,7 +19,7 @@
   "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Residential property tribunal decisions",
-  "email_filter_by": null,
+  "email_filter_by": "all_selected_facets",
   "email_filter_name": null,
   "email_filter_facets": [
     {

--- a/spec/finders/email_alert_configuration_spec.rb
+++ b/spec/finders/email_alert_configuration_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Email alert configuration" do
   end
 
   all_finders.each do |finder|
+    next if finder["email_filter_by"] == "all_selected_facets"
+
     describe "Finder configuration for #{finder['name']}" do
       next unless finder["email_filter_by"]
 


### PR DESCRIPTION
This PR makes sure the Residential Property Tribunal Decisions specialist finder email signups behave in the following way: selected search filters are directly used as email filters, without showing checkboxes.

--

Related to https://github.com/alphagov/finder-frontend/pull/1757.

Trello card: https://trello.com/c/rTCRCbiM/930-fix-the-email-subscriptions-for-residential-property-tribunal-decisions-et-al-%F0%9F%8D%90