### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.3
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
+    - config/rails.yml
 
 AllCops:
   TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -33,11 +33,11 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot"
   gem "govuk-content-schema-test-helpers"
-  gem "govuk-lint"
   gem "govuk_test"
   gem "pry-rails"
   gem "puma"
   gem "rspec-rails"
+  gem "rubocop-govuk"
   gem "simplecov", require: false
   gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,11 +122,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -248,7 +243,7 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     plek (3.0.0)
@@ -340,10 +335,14 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.0)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
@@ -367,8 +366,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.142.6)
@@ -447,7 +444,6 @@ DEPENDENCIES
   gds-sso (~> 14)
   govspeak (~> 6)
   govuk-content-schema-test-helpers
-  govuk-lint
   govuk_admin_template (~> 6)
   govuk_app_config (~> 2)
   govuk_frontend_toolkit (~> 9)
@@ -466,6 +462,7 @@ DEPENDENCIES
   rails (~> 5)
   rails-controller-testing
   rspec-rails
+  rubocop-govuk
   sass-rails (~> 6)
   select2-rails (~> 3)
   simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -31,7 +31,7 @@ class AttachmentsController < ApplicationController
   def update
     document = fetch_document
     attachment = document.attachments.find(attachment_content_id)
-    attachment.update_attributes(attachment_params)
+    attachment.update_properties(attachment_params)
 
     if attachment.file.nil?
       save_updated_title(document, attachment)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -112,7 +112,7 @@ private
   def document_error_messages
     heading = content_tag(:h4, "Please fix the following errors")
     errors = content_tag(:ul, class: "list-unstyled remove-bottom-margin") do
-      safe_join(@document.errors.full_messages.map { |message| content_tag(:li, message.html_safe) })
+      safe_join(@document.errors.full_messages.map { |message| content_tag(:li, message.html_safe) }) # rubocop:disable Rails/OutputSafety
     end
 
     heading + errors

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,7 +28,7 @@ class DocumentsController < ApplicationController
       redirect_to document_path(current_format.slug, @document.content_id)
     elsif @document.errors.any?
       flash.now[:errors] = document_error_messages
-      render :new, status: 422
+      render :new, status: :unprocessable_entity
     else
       flash.now[:danger] = unknown_error_message
       render :new
@@ -56,7 +56,7 @@ class DocumentsController < ApplicationController
       end
     else
       flash.now[:errors] = document_error_messages
-      render :edit, status: 422
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,8 +2,10 @@ require "gds_api/publishing_api_v2"
 
 class DocumentsController < ApplicationController
   include ActionView::Context
+  include ActionView::Helpers::OutputSafetyHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::UrlHelper
 
   before_action :fetch_document, except: %i[index new create]
   before_action :check_authorisation, if: :document_type_slug
@@ -104,23 +106,13 @@ private
   def unknown_error_message
     support_url = Plek.new.external_url_for("support") + "/technical_fault_report/new"
 
-    "Something has gone wrong. Please try again and see if it works. <a href='#{support_url}'>Let us know</a>
-    if the problem happens again and a developer will look into it.".html_safe
+    safe_join(["Something has gone wrong. Please try again and see if it works. ", link_to("Let us know", support_url), " if the problem happens again and a developer will look into it."])
   end
 
   def document_error_messages
-    @document.errors.messages
-    heading = content_tag(
-      :h4,
-      %{
-        Please fix the following errors
-      },
-    )
-    errors = content_tag :ul, class: "list-unstyled remove-bottom-margin" do
-      list_items = @document.errors.full_messages.map do |message|
-        content_tag(:li, message.html_safe)
-      end
-      list_items.join.html_safe
+    heading = content_tag(:h4, "Please fix the following errors")
+    errors = content_tag(:ul, class: "list-unstyled remove-bottom-margin") do
+      safe_join(@document.errors.full_messages.map { |message| content_tag(:li, message.html_safe) })
     end
 
     heading + errors

--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -12,6 +12,6 @@ class GovspeakController < ApplicationController
                             attachments: attachments }, [:attachments])
     govspeak_presenter = GovspeakPresenter.new(document)
     govspeak_preview = govspeak_presenter.html_body
-    render html: govspeak_preview.html_safe
+    render html: govspeak_preview.html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,16 +2,4 @@ module ApplicationHelper
   def facet_options(form, facet)
     form.object.facet_options(facet)
   end
-
-  def state(document)
-    state = document.publication_state
-
-    if document.publication_state == "draft"
-      classes = "label label-primary"
-    else
-      classes = "label label-default"
-    end
-
-    content_tag(:span, state, class: classes)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,6 @@ module ApplicationHelper
       classes = "label label-default"
     end
 
-    content_tag(:span, state, class: classes).html_safe
+    content_tag(:span, state, class: classes)
   end
 end

--- a/app/helpers/publishing_helper.rb
+++ b/app/helpers/publishing_helper.rb
@@ -1,30 +1,28 @@
 module PublishingHelper
-  def handle_remote_error
+  def handle_remote_error(document)
     begin
       yield
       true
     rescue GdsApi::HTTPErrorResponse => e
-      error_response_message(:base, e.message) if @publishable
+      error_response_message(document, :base, e.message)
       GovukError.notify(e)
       false
     end
   end
 
-  def set_errors_on(obj)
-    unless obj.class.include?(ActiveModel::Validations)
+  def set_errors_on(document)
+    unless document.class.include?(ActiveModel::Validations)
       raise ArgumentError.new(
         "Can only set errors on an object which includes ActiveModel::Validations",
       )
     end
-
-    @publishable = obj
   end
 
-  def error_response_message(key, message)
+  def error_response_message(document, key, message)
     if message.include? "conflicts with content_id"
-      @publishable.errors.add(key, "Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title.")
+      document.errors.add(key, "Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title.")
     else
-      @publishable.errors.add(:base, message)
+      document.errors.add(:base, message)
     end
   end
 end

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -1,14 +1,12 @@
 module StateHelper
+  def classes_for_frontend(document)
+    return "label label-primary" if state_for_frontend(document) =~ /draft/
+
+    "label label-default"
+  end
+
   def state_for_frontend(document)
-    state = compose_state(document.state_history.to_h)
-
-    if state =~ /draft/
-      classes = "label label-primary"
-    else
-      classes = "label label-default"
-    end
-
-    content_tag(:span, state, class: classes)
+    compose_state(document.state_history.to_h)
   end
 
   def compose_state(state_history)

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -8,7 +8,7 @@ module StateHelper
       classes = "label label-default"
     end
 
-    content_tag(:span, state, class: classes).html_safe
+    content_tag(:span, state, class: classes)
   end
 
   def compose_state(state_history)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -27,7 +27,7 @@ class Attachment < Document
     EXTENSION_WHITE_LIST.include? extension
   end
 
-  def update_attributes(new_params)
+  def update_properties(new_params)
     new_params.each do |k, v|
       self.public_send(:"#{k}=", v)
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -220,7 +220,7 @@ class Document
   def save(validate: true)
     return false if validate && !self.valid?
 
-    handle_remote_error do
+    handle_remote_error(self) do
       DocumentSaver.save(self)
     end
   end
@@ -228,19 +228,19 @@ class Document
   def publish
     return false unless publishable?
 
-    handle_remote_error do
+    handle_remote_error(self) do
       DocumentPublisher.publish(self)
     end
   end
 
   def unpublish(alternative_path = nil)
-    handle_remote_error do
+    handle_remote_error(self) do
       DocumentUnpublisher.unpublish(content_id, base_path, alternative_path)
     end
   end
 
   def discard
-    handle_remote_error do
+    handle_remote_error(self) do
       Services.publishing_api.discard_draft(content_id, previous_version: previous_version)
     end
   end

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -19,26 +19,24 @@ class ActionsPresenter
 
   def publish_text
     if state == "published"
-      text = "There are no changes to publish."
+      "There are no changes to publish."
     elsif state == "unpublished"
-      text = "The document is unpublished. You need to create a new draft before it can be published."
+      "The document is unpublished. You need to create a new draft before it can be published."
     elsif !policy.publish?
-      text = "You don't have permission to publish this document."
+      "You don't have permission to publish this document."
     elsif update_type == "minor"
-      text = safe_join([
+      safe_join([
         content_tag(:span, "You are about to publish a "),
         content_tag(:strong, "minor edit."),
       ])
     elsif update_type == "major" && !document.first_draft?
-      text = safe_join([
+      safe_join([
         content_tag(:strong, "You are about to publish a major edit with a public change note. "),
         content_tag(:span, "Publishing will email subscribers to #{klass_name}."),
       ])
     else
-      text = "Publishing will email subscribers to #{klass_name}."
+      "Publishing will email subscribers to #{klass_name}."
     end
-
-    text
   end
 
   def publish_alert

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -1,5 +1,6 @@
 class ActionsPresenter
   include Rails.application.routes.url_helpers
+  include ActionView::Helpers::TagHelper
 
   attr_accessor :document, :policy
 
@@ -18,21 +19,26 @@ class ActionsPresenter
 
   def publish_text
     if state == "published"
-      text = "<p>There are no changes to publish.</p>"
+      text = "There are no changes to publish."
     elsif state == "unpublished"
-      text = "<p>The document is unpublished. You need to create a new draft before it can be published.</p>"
+      text = "The document is unpublished. You need to create a new draft before it can be published."
     elsif !policy.publish?
-      text = "<p>You don't have permission to publish this document.</p>"
+      text = "You don't have permission to publish this document."
     elsif update_type == "minor"
-      text = "<p>You are about to publish a <strong>minor edit</strong>.</p>"
+      text = safe_join([
+        content_tag(:span, "You are about to publish a "),
+        content_tag(:strong, "minor edit."),
+      ])
     elsif update_type == "major" && !document.first_draft?
-      text = "<p><strong>You are about to publish a major edit with a public change note.</strong></p>"
-      text += "<p>Publishing will email subscribers to #{klass_name}.</p>"
+      text = safe_join([
+        content_tag(:strong, "You are about to publish a major edit with a public change note. "),
+        content_tag(:span, "Publishing will email subscribers to #{klass_name}."),
+      ])
     else
-      text = "<p>Publishing will email subscribers to #{klass_name}.</p>"
+      text = "Publishing will email subscribers to #{klass_name}."
     end
 
-    text.html_safe
+    text
   end
 
   def publish_alert
@@ -53,20 +59,20 @@ class ActionsPresenter
 
   def unpublish_text
     if document.first_draft?
-      text = "<p>The document has never been published.</p>"
+      text = "The document has never been published."
     elsif state == "draft"
-      text = "<p>The document cannot be unpublished because it has a draft. You need to publish the draft first.</p>"
+      text = "The document cannot be unpublished because it has a draft. You need to publish the draft first."
     elsif state == "unpublished"
-      text = "<p>The document is already unpublished.</p>"
+      text = "The document is already unpublished."
     elsif !policy.unpublish?
-      text = "<p>You don't have permission to unpublish this document.</p>"
+      text = "You don't have permission to unpublish this document."
     elsif state == "published"
-      text = "<p>The document will be removed from the site. It will still be possible to edit and publish a new version.</p>"
+      text = "The document will be removed from the site. It will still be possible to edit and publish a new version."
     else
       raise ArgumentError, "Unrecognised state: '#{state}'"
     end
 
-    text.html_safe
+    text
   end
 
   def unpublish_alert
@@ -83,14 +89,14 @@ class ActionsPresenter
 
   def discard_text
     if state != "draft"
-      text = "<p>There is no draft to discard.</p>"
+      text = "There is no draft to discard."
     elsif !policy.discard?
-      text = "<p>You don't have permission to discard this draft.</p>"
+      text = "You don't have permission to discard this draft."
     else
-      text = "<p>This draft will be discarded.</p>"
+      text = "This draft will be discarded."
     end
 
-    text.html_safe
+    text
   end
 
   def discard_alert

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -11,7 +11,7 @@
     <%= form_tag(presenter.publish_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Publish document</h3></div>
       <div class="panel-body">
-        <%= presenter.publish_text %>
+        <%= content_tag(:p, presenter.publish_text) %>
 
         <% if presenter.publish_button_visible? %>
           <button name="submit" class="btn btn-danger"
@@ -25,7 +25,7 @@
     <%= form_tag(presenter.unpublish_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Unpublish document</h3></div>
       <div class="panel-body">
-        <%= presenter.unpublish_text %>
+        <%= content_tag(:p, presenter.unpublish_text) %>
 
         <% if presenter.unpublish_button_visible? %>
           <div class="form-group">
@@ -46,7 +46,7 @@
     <%= form_tag(presenter.discard_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Discard draft</h3></div>
       <div class="panel-body">
-        <%= presenter.discard_text %>
+        <%= content_tag(:p, presenter.discard_text) %>
 
         <% if presenter.discard_button_visible? %>
           <button name="submit" class="btn btn-warning"

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -5,7 +5,7 @@
       <li class="text-muted last-edited-at">Updated <%= time_ago_in_words(document.last_edited_at) %> ago</li>
     <% end %>
     <li>
-      <%= state_for_frontend(document) %>
+      <%= content_tag(:span, state_for_frontend(document), class: classes_for_frontend(document)) %>
     </li>
   </ul>
 </li>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -28,7 +28,9 @@
       <dt>Bulk published</dt>
       <dd><%= @document.bulk_published %></dd>
       <dt>Publication state</dt>
-      <dd><%= state_for_frontend(@document) %></dd>
+      <dd>
+        <%= content_tag(:span, state_for_frontend(@document), class: classes_for_frontend(@document)) %>
+      </dd>
     </dl>
   </div>
 </div>

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils # rubocop:disable Style/MixinUsage
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,9 +14,9 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
@@ -24,11 +24,11 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils # rubocop:disable Style/MixinUsage
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,16 +14,16 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,4 +1,4 @@
-revision_file = File.join(Rails.root, "REVISION")
+revision_file = Rails.root.join("REVISION")
 if File.exist?(revision_file)
   revision = File.read(revision_file).strip
   CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --format clang app config Gemfile lib spec"
+  sh "bundle exec rubocop"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
-task "lint" do
+task lint: :environment do
   sh "bundle exec rubocop"
 end

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
     log_in_as_editor(:cma_editor)
 
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
-    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+    Timecop.freeze(Time.zone.parse("2015-12-03 16:59:13 UTC"))
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links

--- a/spec/features/creating_a_dfid_research_output_spec.rb
+++ b/spec/features/creating_a_dfid_research_output_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Creating a DFID Research Output", type: :feature do
   before do
     log_in_as_editor(:dfid_editor)
 
-    Timecop.freeze(Time.parse(public_updated_at))
+    Timecop.freeze(Time.zone.parse(public_updated_at))
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
 
     stub_any_publishing_api_put_content

--- a/spec/features/creating_a_residential_property_tribunal_decision_spec.rb
+++ b/spec/features/creating_a_residential_property_tribunal_decision_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Creating a residential property tribunal decision", type: :featur
   before do
     log_in_as_editor(:moj_editor)
 
-    Timecop.freeze(Time.parse(public_updated_at))
+    Timecop.freeze(Time.zone.parse(public_updated_at))
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
 
     stub_any_publishing_api_put_content

--- a/spec/features/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/creating_a_statutory_instrument_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
     log_in_as_editor(:gds_editor)
 
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
-    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+    Timecop.freeze(Time.zone.parse("2015-12-03 16:59:13 UTC"))
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links

--- a/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
+++ b/spec/features/creating_an_employment_appeal_tribunal_decision_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Creating a Employment appeal tribunal decision", type: :feature d
       allow(Rails.env).to receive(:development?).and_return(true)
       log_in_as_editor(:gds_editor)
 
-      Timecop.freeze(Time.parse(public_updated_at))
+      Timecop.freeze(Time.zone.parse(public_updated_at))
       allow(SecureRandom).to receive(:uuid).and_return(content_id)
 
       stub_any_publishing_api_put_content

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
   let(:save_button_disable_with_message) { page.find_button("Save as draft")["data-disable-with"] }
 
   before do
-    Timecop.freeze(Time.parse("2015-12-03T16:59:13+00:00"))
+    Timecop.freeze(Time.zone.parse("2015-12-03T16:59:13+00:00"))
     log_in_as_editor(:cma_editor)
 
     stub_any_publishing_api_put_content

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
   let(:publish_disable_with_message) { page.find_button("Publish")["data-disable-with"] }
 
   before do
-    Timecop.freeze(Time.parse("2015-12-03T16:59:13+00:00"))
+    Timecop.freeze(Time.zone.parse("2015-12-03T16:59:13+00:00"))
     log_in_as_editor(:cma_editor)
 
     publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))

--- a/spec/helpers/publishing_helper_spec.rb
+++ b/spec/helpers/publishing_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PublishingHelper, type: :helper do
     it "calls the given block" do
       expect(document).to receive(:publish!).once
 
-      handled = handle_remote_error do
+      handled = handle_remote_error(document) do
         document.publish!
       end
 
@@ -20,7 +20,7 @@ RSpec.describe PublishingHelper, type: :helper do
       allow(document).to receive(:explode!).and_raise(http_error)
       expect(GovukError).to receive(:notify).with(http_error)
 
-      handled = handle_remote_error do
+      handled = handle_remote_error(document) do
         document.explode!
       end
 
@@ -34,7 +34,7 @@ RSpec.describe PublishingHelper, type: :helper do
       allow(document).to receive(:explode!).and_raise(http_error)
       expect(GovukError).to receive(:notify).with(http_error)
 
-      handled = handle_remote_error do
+      handled = handle_remote_error(document)do
         set_errors_on(document)
         document.explode!
       end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Attachment do
     end
   end
 
-  describe "#update_attributes" do
+  describe "#update_properties" do
     let(:content_id) { SecureRandom.uuid }
 
     let(:attachment) {
@@ -172,7 +172,7 @@ RSpec.describe Attachment do
     }
 
     it "should update the title, file and has_changed attributes" do
-      attachment.update_attributes(file: http_file_upload, title: "updated attachment title")
+      attachment.update_properties(file: http_file_upload, title: "updated attachment title")
 
       expect(attachment.file).to eq(http_file_upload)
       expect(attachment.title).to eq("updated attachment title")

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Document do
       }
 
       it 'saves a "First published." change note before asking the api to publish' do
-        Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC")) do
+        Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC")) do
           unpublished_document.publish
 
           changed_json = {
@@ -443,7 +443,7 @@ RSpec.describe Document do
   describe "#save" do
     before do
       publishing_api_has_item(payload)
-      Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
+      Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC"))
     end
 
     it "saves document" do

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples "it saves payloads that are valid against the 'specialist_
   describe "#save" do
     it "saves a valid document" do
       publishing_api_has_item(payload)
-      Timecop.freeze(Time.parse("2015-12-18 10:12:26 UTC"))
+      Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC"))
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
 

--- a/spec/presenters/attachment_presenter_spec.rb
+++ b/spec/presenters/attachment_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AttachmentPresenter do
   }
 
   before do
-    Timecop.freeze(Time.parse("2015-12-03 16:59:13 UTC"))
+    Timecop.freeze(Time.zone.parse("2015-12-03 16:59:13 UTC"))
   end
 
   after do

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocumentPresenter do
   let(:presented_data) { document_presenter.to_json }
 
   before do
-    Timecop.freeze(Time.parse("2015-12-03T16:59:13+00:00"))
+    Timecop.freeze(Time.zone.parse("2015-12-03T16:59:13+00:00"))
   end
 
   after do

--- a/spec/workers/document_list_export_worker_spec.rb
+++ b/spec/workers/document_list_export_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DocumentListExportWorker do
     end
 
     it "raises an error if the user does not have permission to see the document type" do
-      user.update_attributes(permissions: %w[signin])
+      user.update(permissions: %w[signin])
       expect {
         subject.perform(BusinessFinanceSupportScheme.slug, user.id, nil)
       }.to raise_error Pundit::NotAuthorizedError


### PR DESCRIPTION
Replace deprecated govuk-lint with rubocop-govuk https://github.com/alphagov/rubocop-govuk, and fixes the shiny new linting errors.