### PR TITLE
Specify email alert signup content item default filters

### DIFF
--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -75,6 +75,7 @@ private
       "email_filter_facets" => schema.fetch("email_filter_facets", []),
       "email_filter_by" => schema.fetch("email_filter_by", nil),
       "email_filter_name" => schema.fetch("email_filter_name", nil),
+      "filter" => schema.fetch("filter", nil),
       "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", {}),
     }
   end


### PR DESCRIPTION
We need to specify default filters in the email signup content item schema so that a user can sign up for alerts without having selected any facets on the search page.

https://github.com/alphagov/govuk-content-schemas/pull/940 will need to be merged and deployed first so that this PR can pass validation against the updated schema.

https://trello.com/c/OPAcIhIF/1193-cannot-sign-up-to-email-alerts-when-no-facets-are-selected