### PR TITLE
Add categories to Employment appeal tribunal decisions finder

### DIFF
--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -63,6 +63,10 @@
           "value": "employment-agencies-act-1973"
         },
         {
+          "label": "Employee, Worker or Self Employed",
+          "value": "employee-worker-or-self-employed"
+        },
+        {
           "label": "Equal Pay Act",
           "value": "equal-pay-act"
         },
@@ -79,6 +83,10 @@
           "value": "flexible-working"
         },
         {
+          "label": "Gender Reassignment/Transgender Discrimination",
+          "value": "gender-reassignment-transgender-discrimination"
+        },
+        {
           "label": "Harassment",
           "value": "harassment"
         },
@@ -93,6 +101,10 @@
         {
           "label": "Jurisdictional Points",
           "value": "jurisdictional-points"
+        },
+        {
+          "label": "Marriage and Civil Partnership",
+          "value": "marriage-and-civil-partnership"
         },
         {
           "label": "Maternity Rights and Parental Leave",
@@ -189,6 +201,10 @@
         {
           "label": "Victimisation Discrimination",
           "value": "victimisation-discrimination"
+        },
+        {
+          "label": "Whistleblowing, Protected Disclosures",
+          "value": "whistleblowing-protected-disclosures"
         },
         {
           "label": "Working Time Regulations",


### PR DESCRIPTION
This adds 4 new categories

<img width="781" alt="categories" src="https://user-images.githubusercontent.com/38078064/71177949-050cfd00-2265-11ea-8946-efe624907f5c.png">

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3874840