### PR TITLE
Migrate finders to use email_filter_facets

### DIFF
--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -72,9 +72,8 @@ private
     {
       "beta" => schema.fetch("signup_beta", false),
       "email_filter_facets" => schema.fetch("email_filter_facets", []),
-      # TODO: Do we need email_filter_by and email_filter_name?
+      # TODO: Remove email_filter_by once finder-frontend doesn't use it.
       "email_filter_by" => schema.fetch("email_filter_by", nil),
-      "email_filter_name" => schema.fetch("email_filter_name", nil),
       "filter" => schema.fetch("filter", nil),
       "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", {}),
     }

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -71,8 +71,8 @@ private
   def details
     {
       "beta" => schema.fetch("signup_beta", false),
-      "email_signup_choice" => schema.fetch("email_signup_choice", []),
       "email_filter_facets" => schema.fetch("email_filter_facets", []),
+      # TODO: Do we need email_filter_by and email_filter_name?
       "email_filter_by" => schema.fetch("email_filter_by", nil),
       "email_filter_name" => schema.fetch("email_filter_name", nil),
       "filter" => schema.fetch("filter", nil),

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -27,54 +27,60 @@
     "singular": "case type",
     "plural": "case types"
   },
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "ca98-and-civil-cartels",
-      "radio_button_name": "CA98 and civil cartels",
-      "topic_name": "CA98 and civil cartels",
-      "prechecked": false
-    },
-    {
-      "key": "competition-disqualification",
-      "radio_button_name": "Competition disqualification",
-      "topic_name": "competition disqualification",
-      "prechecked": false
-    },
-    {
-      "key": "criminal-cartels",
-      "radio_button_name": "Criminal cartels",
-      "topic_name": "criminal cartels",
-      "prechecked": false
-    },
-    {
-      "key": "markets",
-      "radio_button_name": "Markets",
-      "topic_name": "markets",
-      "prechecked": false
-    },
-    {
-      "key": "mergers",
-      "radio_button_name": "Mergers",
-      "topic_name": "mergers",
-      "prechecked": false
-    },
-    {
-      "key": "consumer-enforcement",
-      "radio_button_name": "Consumer enforcement",
-      "topic_name": "consumer enforcement",
-      "prechecked": false
-    },
-    {
-      "key": "regulatory-references-and-appeals",
-      "radio_button_name": "Regulatory references and appeals",
-      "topic_name": "regulatory references and appeals",
-      "prechecked": false
-    },
-    {
-      "key": "review-of-orders-and-undertakings",
-      "radio_button_name": "Reviews of orders and undertakings",
-      "topic_name": "reviews of orders and undertakings",
-      "prechecked": false
+      "facet_id": "case_type",
+      "facet_name": "Case type",
+      "facet_choices": [
+        {
+          "key": "ca98-and-civil-cartels",
+          "radio_button_name": "CA98 and civil cartels",
+          "topic_name": "CA98 and civil cartels",
+          "prechecked": false
+        },
+        {
+          "key": "competition-disqualification",
+          "radio_button_name": "Competition disqualification",
+          "topic_name": "competition disqualification",
+          "prechecked": false
+        },
+        {
+          "key": "criminal-cartels",
+          "radio_button_name": "Criminal cartels",
+          "topic_name": "criminal cartels",
+          "prechecked": false
+        },
+        {
+          "key": "markets",
+          "radio_button_name": "Markets",
+          "topic_name": "markets",
+          "prechecked": false
+        },
+        {
+          "key": "mergers",
+          "radio_button_name": "Mergers",
+          "topic_name": "mergers",
+          "prechecked": false
+        },
+        {
+          "key": "consumer-enforcement",
+          "radio_button_name": "Consumer enforcement",
+          "topic_name": "consumer enforcement",
+          "prechecked": false
+        },
+        {
+          "key": "regulatory-references-and-appeals",
+          "radio_button_name": "Regulatory references and appeals",
+          "topic_name": "regulatory references and appeals",
+          "prechecked": false
+        },
+        {
+          "key": "review-of-orders-and-undertakings",
+          "radio_button_name": "Reviews of orders and undertakings",
+          "topic_name": "reviews of orders and undertakings",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "document_noun": "case",

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -23,10 +23,6 @@
     "many": "Competition and Markets Authority (CMA) cases: "
   },
   "email_filter_by": "case_type",
-  "email_filter_name": {
-    "singular": "case type",
-    "plural": "case types"
-  },
   "email_filter_facets": [
     {
       "facet_id": "case_type",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -28,60 +28,66 @@
     "singular": "location",
     "plural": "locations"
   },
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "north-east",
-      "radio_button_name": "North East",
-      "topic_name": "north east",
-      "prechecked": false
-    },
-    {
-      "key": "north-west",
-      "radio_button_name": "North West",
-      "topic_name": "north west",
-      "prechecked": false
-    },
-    {
-      "key": "yorkshire-and-humber",
-      "radio_button_name": "Yorkshire and Humber",
-      "topic_name": "yorkshire and humber",
-      "prechecked": false
-    },
-    {
-      "key": "east-midlands",
-      "radio_button_name": "East Midlands",
-      "topic_name": "east midlands",
-      "prechecked": false
-    },
-    {
-      "key": "west-midlands",
-      "radio_button_name": "West Midlands",
-      "topic_name": "west midlands",
-      "prechecked": false
-    },
-    {
-      "key": "east-of-england",
-      "radio_button_name": "East of England",
-      "topic_name": "east of england",
-      "prechecked": false
-    },
-    {
-      "key": "south-east",
-      "radio_button_name": "South East",
-      "topic_name": "south east",
-      "prechecked": false
-    },
-    {
-      "key": "south-west",
-      "radio_button_name": "South West",
-      "topic_name": "south west",
-      "prechecked": false
-    },
-    {
-      "key": "london",
-      "radio_button_name": "London",
-      "topic_name": "london",
-      "prechecked": false
+      "facet_id": "location",
+      "facet_name": "Locations",
+      "facet_choices": [
+        {
+          "key": "north-east",
+          "radio_button_name": "North East",
+          "topic_name": "north east",
+          "prechecked": false
+        },
+        {
+          "key": "north-west",
+          "radio_button_name": "North West",
+          "topic_name": "north west",
+          "prechecked": false
+        },
+        {
+          "key": "yorkshire-and-humber",
+          "radio_button_name": "Yorkshire and Humber",
+          "topic_name": "yorkshire and humber",
+          "prechecked": false
+        },
+        {
+          "key": "east-midlands",
+          "radio_button_name": "East Midlands",
+          "topic_name": "east midlands",
+          "prechecked": false
+        },
+        {
+          "key": "west-midlands",
+          "radio_button_name": "West Midlands",
+          "topic_name": "west midlands",
+          "prechecked": false
+        },
+        {
+          "key": "east-of-england",
+          "radio_button_name": "East of England",
+          "topic_name": "east of england",
+          "prechecked": false
+        },
+        {
+          "key": "south-east",
+          "radio_button_name": "South East",
+          "topic_name": "south east",
+          "prechecked": false
+        },
+        {
+          "key": "south-west",
+          "radio_button_name": "South West",
+          "topic_name": "south west",
+          "prechecked": false
+        },
+        {
+          "key": "london",
+          "radio_button_name": "London",
+          "topic_name": "london",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "document_noun": "call",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -24,10 +24,6 @@
     "many": "European Structural and Investment Funds: "
   },
   "email_filter_by": "location",
-  "email_filter_name": {
-    "singular": "location",
-    "plural": "locations"
-  },
   "email_filter_facets": [
     {
       "facet_id": "location",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -13,10 +13,6 @@
   "signup_copy": "You'll get an email each time an export health certificate is updated or a new export health certificate is published.",
   "subscription_list_title_prefix": "Export health certificates",
   "email_filter_by": "all_selected_facets",
-  "email_filter_name": {
-    "singular": "export health certificate",
-    "plural": "export health certificates"
-  },
   "email_filter_facets": [
     {
       "facet_id": "destination_country",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -21,36 +21,42 @@
     "singular": "vessel type",
     "plural": "vessel types"
   },
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "merchant-vessel-100-gross-tons-or-over",
-      "radio_button_name": "Merchant vessel 100 gross tons or over",
-      "topic_name": "merchant vessel 100 gross tons or over",
-      "prechecked": false
-    },
-    {
-      "key": "merchant-vessel-under-100-gross-tons",
-      "radio_button_name": "Merchant vessel under 100 gross tons",
-      "topic_name": "merchant vessel under 100 gross tons",
-      "prechecked": false
-    },
-    {
-      "key": "fishing-vessel",
-      "radio_button_name": "Fishing vessel",
-      "topic_name": "fishing vessel",
-      "prechecked": false
-    },
-    {
-      "key": "recreational-craft-sail",
-      "radio_button_name": "Recreational craft - sail",
-      "topic_name": "recreational craft - sail",
-      "prechecked": false
-    },
-    {
-      "key": "recreational-craft-power",
-      "radio_button_name": "Recreational craft - power",
-      "topic_name": "recreational craft - power",
-      "prechecked": false
+      "facet_id": "vessel_type",
+      "facet_name": "Vessel types",
+      "facet_choices": [
+        {
+          "key": "merchant-vessel-100-gross-tons-or-over",
+          "radio_button_name": "Merchant vessel 100 gross tons or over",
+          "topic_name": "merchant vessel 100 gross tons or over",
+          "prechecked": false
+        },
+        {
+          "key": "merchant-vessel-under-100-gross-tons",
+          "radio_button_name": "Merchant vessel under 100 gross tons",
+          "topic_name": "merchant vessel under 100 gross tons",
+          "prechecked": false
+        },
+        {
+          "key": "fishing-vessel",
+          "radio_button_name": "Fishing vessel",
+          "topic_name": "fishing vessel",
+          "prechecked": false
+        },
+        {
+          "key": "recreational-craft-sail",
+          "radio_button_name": "Recreational craft - sail",
+          "topic_name": "recreational craft - sail",
+          "prechecked": false
+        },
+        {
+          "key": "recreational-craft-power",
+          "radio_button_name": "Recreational craft - power",
+          "topic_name": "recreational craft - power",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "document_noun": "report",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -17,10 +17,6 @@
     "many": "Marine Accident Investigation Branch (MAIB) reports: "
   },
   "email_filter_by": "vessel_type",
-  "email_filter_name": {
-    "singular": "vessel type",
-    "plural": "vessel types"
-  },
   "email_filter_facets": [
     {
       "facet_id": "vessel_type",

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -19,34 +19,40 @@
   ],
   "email_filter_name": "Alert Type",
   "email_filter_by": "alert_type",
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "devices",
-      "radio_button_name": "Medical device alerts",
-      "topic_name": "medical device alerts",
-      "body": "information published by the MHRA about defective medical devices.",
-      "prechecked": true
-    },
-    {
-      "key": "drugs",
-      "radio_button_name": "Drug alerts",
-      "topic_name": "drug alerts",
-      "body": "information published by the MHRA about defective medicines.",
-      "prechecked": true
-    },
-    {
-      "key": "field-safety-notices",
-      "radio_button_name": "Field safety notice",
-      "topic_name": "field safety notice",
-      "body": "information from medical device manufacturers.",
-      "prechecked": true
-    },
-    {
-      "key": "company-led-drugs",
-      "radio_button_name": "Drug alert: company-led",
-      "topic_name": "drug alert: company-led",
-      "body": "recalls of medicines issued by manufacturers.",
-      "prechecked": true
+      "facet_id": "alert_type",
+      "facet_name": "Alert Type",
+      "facet_choices": [
+        {
+          "key": "devices",
+          "radio_button_name": "Medical device alerts",
+          "topic_name": "medical device alerts",
+          "body": "information published by the MHRA about defective medical devices.",
+          "prechecked": true
+        },
+        {
+          "key": "drugs",
+          "radio_button_name": "Drug alerts",
+          "topic_name": "drug alerts",
+          "body": "information published by the MHRA about defective medicines.",
+          "prechecked": true
+        },
+        {
+          "key": "field-safety-notices",
+          "radio_button_name": "Field safety notice",
+          "topic_name": "field safety notice",
+          "body": "information from medical device manufacturers.",
+          "prechecked": true
+        },
+        {
+          "key": "company-led-drugs",
+          "radio_button_name": "Drug alert: company-led",
+          "topic_name": "drug alert: company-led",
+          "body": "recalls of medicines issued by manufacturers.",
+          "prechecked": true
+        }
+      ]
     }
   ],
   "document_noun": "alert",

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -17,7 +17,6 @@
     "medicines-medical-devices-blood/medical-devices-regulation-safety",
     "medicines-medical-devices-blood/vigilance-safety-alerts"
   ],
-  "email_filter_name": "Alert Type",
   "email_filter_by": "alert_type",
   "email_filter_facets": [
     {

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -16,10 +16,6 @@
     "many": "Rail Accident Investigation Branch (RAIB) reports: "
   },
   "email_filter_by": "railway_type",
-  "email_filter_name": {
-    "singular": "railway type",
-    "plural": "railway types"
-  },
   "email_filter_facets": [
     {
       "facet_id": "railway_type",

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -20,30 +20,36 @@
     "singular": "railway type",
     "plural": "railway types"
   },
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "heavy-rail",
-      "radio_button_name": "Heavy rail",
-      "topic_name": "heavy rail",
-      "prechecked": false
-    },
-    {
-      "key": "light-rail",
-      "radio_button_name": "Light rail",
-      "topic_name": "light rail",
-      "prechecked": false
-    },
-    {
-      "key": "metros",
-      "radio_button_name": "Metros",
-      "topic_name": "metros",
-      "prechecked": false
-    },
-    {
-      "key": "heritage-railways",
-      "radio_button_name": "Heritage railways",
-      "topic_name": "heritage railways",
-      "prechecked": false
+      "facet_id": "railway_type",
+      "facet_name": "Railway types",
+      "facet_choices": [
+        {
+          "key": "heavy-rail",
+          "radio_button_name": "Heavy rail",
+          "topic_name": "heavy rail",
+          "prechecked": false
+        },
+        {
+          "key": "light-rail",
+          "radio_button_name": "Light rail",
+          "topic_name": "light rail",
+          "prechecked": false
+        },
+        {
+          "key": "metros",
+          "radio_button_name": "Metros",
+          "topic_name": "metros",
+          "prechecked": false
+        },
+        {
+          "key": "heritage-railways",
+          "radio_button_name": "Heritage railways",
+          "topic_name": "heritage railways",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "document_noun": "report",

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -20,7 +20,6 @@
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Residential property tribunal decisions",
   "email_filter_by": "all_selected_facets",
-  "email_filter_name": null,
   "email_filter_facets": [
     {
       "facet_id": "tribunal_decision_category",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -25,10 +25,6 @@
     "many": "Upper Tribunal (Tax and Chancery Chamber) decisions: "
   },
   "email_filter_by": "tribunal_decision_category",
-  "email_filter_name": {
-    "singular": "category",
-    "plural": "categories"
-  },
   "email_filter_facets": [
     {
       "facet_id": "tribunal_decision_category",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -29,42 +29,48 @@
     "singular": "category",
     "plural": "categories"
   },
-  "email_signup_choice": [
+  "email_filter_facets": [
     {
-      "key": "banking",
-      "radio_button_name": "Banking",
-      "topic_name": "banking",
-      "prechecked": false
-    },
-    {
-      "key": "charity",
-      "radio_button_name": "Charity",
-      "topic_name": "charity",
-      "prechecked": false
-    },
-    {
-      "key": "financial-services",
-      "radio_button_name": "Financial Services",
-      "topic_name": "financial services",
-      "prechecked": false
-    },
-    {
-      "key": "land-registration",
-      "radio_button_name": "Land Registration",
-      "topic_name": "land registration",
-      "prechecked": false
-    },
-    {
-      "key": "pensions",
-      "radio_button_name": "Pensions",
-      "topic_name": "pensions",
-      "prechecked": false
-    },
-    {
-      "key": "tax",
-      "radio_button_name": "Tax",
-      "topic_name": "tax",
-      "prechecked": false
+      "facet_id": "tribunal_decision_category",
+      "facet_name": "Categories",
+      "facet_choices": [
+        {
+          "key": "banking",
+          "radio_button_name": "Banking",
+          "topic_name": "banking",
+          "prechecked": false
+        },
+        {
+          "key": "charity",
+          "radio_button_name": "Charity",
+          "topic_name": "charity",
+          "prechecked": false
+        },
+        {
+          "key": "financial-services",
+          "radio_button_name": "Financial Services",
+          "topic_name": "financial services",
+          "prechecked": false
+        },
+        {
+          "key": "land-registration",
+          "radio_button_name": "Land Registration",
+          "topic_name": "land registration",
+          "prechecked": false
+        },
+        {
+          "key": "pensions",
+          "radio_button_name": "Pensions",
+          "topic_name": "pensions",
+          "prechecked": false
+        },
+        {
+          "key": "tax",
+          "radio_button_name": "Tax",
+          "topic_name": "tax",
+          "prechecked": false
+        }
+      ]
     }
   ],
   "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",

--- a/spec/finders/email_alert_configuration_spec.rb
+++ b/spec/finders/email_alert_configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Email alert configuration" do
           allowed_value["value"]
         end
 
-        finder["email_signup_choice"].each do |choice|
+        finder.dig("email_filter_facets", 0, "facet_choices").each do |choice|
           expect(choice["key"]).to be_in(actually_possible_keys_for_which_emails_will_be_sent)
         end
       end
@@ -38,7 +38,7 @@ RSpec.describe "Email alert configuration" do
           # form with every possible topic name appended to make the longest
           # possible name
           name = (finder["subscription_list_title_prefix"]["plural"] +
-            finder["email_signup_choice"].collect { |topic| topic["topic_name"] }.to_sentence)
+            finder.dig("email_filter_facets", 0, "facet_choices").collect { |topic| topic["topic_name"] }.to_sentence)
             .humanize
         else
           # If the list name only has one form, then topic names are not


### PR DESCRIPTION
All other finders use email_filter_facets, not email_signup_choice.

This removes email_signup_choice, but shouldn't change anything for end users. It will make working on finder email signup pages easier as they'll be more consistent.

Essentially, in finder email signup content items, the array `email_signup_choice` has been moved to `email_filter_facets[0].facet_choices`.

https://trello.com/c/otcTG22f/1246-email-alert-signup-tech-debt