### PR TITLE
Add required field to some facets

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -27,6 +27,7 @@
     {
       "facet_id": "case_type",
       "facet_name": "Case type",
+      "required": true,
       "facet_choices": [
         {
           "key": "ca98-and-civil-cartels",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -28,6 +28,7 @@
     {
       "facet_id": "location",
       "facet_name": "Locations",
+      "required": true,
       "facet_choices": [
         {
           "key": "north-east",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -21,6 +21,7 @@
     {
       "facet_id": "vessel_type",
       "facet_name": "Vessel types",
+      "required": true,
       "facet_choices": [
         {
           "key": "merchant-vessel-100-gross-tons-or-over",

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -22,6 +22,7 @@
     {
       "facet_id": "alert_type",
       "facet_name": "Alert Type",
+      "required": true,
       "facet_choices": [
         {
           "key": "devices",

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -20,6 +20,7 @@
     {
       "facet_id": "railway_type",
       "facet_name": "Railway types",
+      "required": true,
       "facet_choices": [
         {
           "key": "heavy-rail",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -29,6 +29,7 @@
     {
       "facet_id": "tribunal_decision_category",
       "facet_name": "Categories",
+      "required": true,
       "facet_choices": [
         {
           "key": "banking",


### PR DESCRIPTION
Some email signup filters are required to have a value. Making this change will make it possible for finder-frontend to validate that all required filters have values before creating a subscription.

For example, we want users to select a case type when subscribing to CMA cases, so this field will enable us to enforce this.

Related: https://github.com/alphagov/govuk-content-schemas/pull/952

https://trello.com/c/BOUerRPp/1252