### PR TITLE
Remove redirect URL check when unpublishing

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -77,9 +77,7 @@ class DocumentsController < ApplicationController
     else
       flash[:danger] = unknown_error_message
     end
-  rescue DocumentUnpublisher::AlternativeContentNotFound => e
-    flash[:danger] = e.message
-  ensure
+
     redirect_to document_path(current_format.slug, params[:content_id])
   end
 

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -1,21 +1,14 @@
 # Unpublish a document. Also removes attachments.
 class DocumentUnpublisher
-  AlternativeContentNotFound = Class.new(StandardError)
-
   def self.unpublish(content_id, _base_path, alternative_path = nil)
     if alternative_path.blank?
       Services.publishing_api.unpublish(content_id, type: "gone")
-
-    elsif Services.publishing_api.lookup_content_id(base_path: alternative_path)
+    else
       Services.publishing_api.unpublish(
         content_id,
         type: "redirect",
         alternative_path: alternative_path,
       )
-
-    else
-      raise AlternativeContentNotFound, "Alternative content not found at " \
-                                          "the path '#{alternative_path}'"
     end
 
     AttachmentDeleteWorker.perform_async(content_id)

--- a/spec/features/unpublishing_a_cma_case_spec.rb
+++ b/spec/features/unpublishing_a_cma_case_spec.rb
@@ -44,19 +44,6 @@ RSpec.feature "Unpublishing a CMA Case", type: :feature do
       assert_publishing_api_unpublish(content_id, type: "redirect", alternative_path: "/government/organisations/competition-and-markets-authority")
     end
 
-    scenario "specifying a redirect to an alternative GOV.UK content path that does not exist" do
-      publishing_api_has_lookups("/government/organisations/competition-and-markets-authority" => SecureRandom.uuid)
-
-      visit document_path(content_id: content_id, document_type_slug: "cma-cases")
-      expect(page).to have_content("Example CMA Case")
-
-      fill_in "alternative_path", with: "/path/to/missing"
-      click_button "Unpublish document"
-
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content("Alternative content not found at the path '/path/to/missing'")
-    end
-
     scenario "writers don't see a unpublish document button" do
       log_in_as_editor(:cma_writer)
 


### PR DESCRIPTION
This removes the check to ensure that when unpublishing a document the redirect is pointing to live content. This because the publishing api currently doesn't support lookups on base path of multi-part content. Hence publishers are currently unable to redirect to multipart content such as guides. This behaviour is also inconsistent with other publishing applications.