### PR TITLE
Send attachment_type and id for attachments to pub-api

### DIFF
--- a/app/presenters/attachment_presenter.rb
+++ b/app/presenters/attachment_presenter.rb
@@ -5,12 +5,14 @@ class AttachmentPresenter
 
   def to_json(*_args)
     {
+      attachment_type: "file",
       url: @attachment.url,
       title: @attachment.title,
       content_type: @attachment.content_type,
       updated_at: updated_at,
       created_at: created_at,
       content_id: @attachment.content_id,
+      id: @attachment.content_id,
     }
   end
 

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -202,6 +202,8 @@ RSpec.feature "Editing a CMA case", type: :feature do
     let(:existing_attachments) {
       [
         {
+          "attachment_type" => "file",
+          "id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
           "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
           "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
           "content_type" => "application/jpg",
@@ -210,6 +212,8 @@ RSpec.feature "Editing a CMA case", type: :feature do
           "updated_at" => "2015-12-03T16:59:13+00:00",
         },
         {
+          "attachment_type" => "file",
+          "id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
           "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
           "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
           "content_type" => "application/pdf",

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe DocumentPresenter do
                         details: {
                           attachments: [
                             {
+                              "attachment_type" => "file",
+                              "id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
                               "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
                               "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
                               "content_type" => "application/jpeg",
@@ -47,6 +49,8 @@ RSpec.describe DocumentPresenter do
                               "updated_at" => "2015-12-03T16:59:13+00:00",
                             },
                             {
+                              "attachment_type" => "file",
+                              "id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
                               "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
                               "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
                               "content_type" => "application/pdf",


### PR DESCRIPTION
These fields are going to become mandatory.

---

[Trello card](https://trello.com/c/jq7Srpk4/1353-introduce-new-mandatory-attachment-metadata)