### PR TITLE
Upload csv to s3 and link in email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "~> 5"
 
 gem "bootstrap-kaminari-views", "~> 0.0.5"
+gem "fog-aws", "~> 3.5"
 gem "govuk_sidekiq", "~> 3"
 gem "hashdiff"
 gem "jquery-rails", "~> 4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,12 +86,30 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
+    excon (0.72.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    fog-aws (3.5.2)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     gds-api-adapters (63.4.0)
       addressable
       link_header
@@ -166,6 +184,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -437,6 +456,7 @@ DEPENDENCIES
   capybara-select-2
   database_cleaner
   factory_bot
+  fog-aws (~> 3.5)
   gds-api-adapters (~> 63)
   gds-sso (~> 14)
   govspeak (~> 6)

--- a/app/controllers/document_list_export_request_controller.rb
+++ b/app/controllers/document_list_export_request_controller.rb
@@ -1,0 +1,46 @@
+class DocumentListExportRequestController < ApplicationController
+  before_action :check_authorisation
+  def show
+    begin
+      response = DocumentListExportRequest.find(params[:id])
+    rescue Mongoid::Errors::DocumentNotFound
+      head :not_found
+      return
+    end
+
+    if response.ready?
+      file = get_csv_file_from_s3(response.filename)
+      send_data(file, filename: response.filename)
+    else
+      head :not_found
+    end
+  end
+
+  def check_authorisation
+    begin
+      document_type_slug = DocumentListExportRequest.find(params[:id]).document_class
+    rescue Mongoid::Errors::DocumentNotFound
+      head :not_found
+      return
+    end
+
+    document_slugs = FinderSchema.schema_names.map { |schema_name| schema_name.singularize.camelize.constantize }
+    current_format = document_slugs.detect { |model| model.slug == document_type_slug }
+    authorize current_format
+  end
+
+  def get_csv_file_from_s3(filename)
+    connection = Fog::Storage.new(
+      provider: "AWS",
+      region: ENV["AWS_REGION"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    )
+
+    directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+
+    file = directory.files.get(filename)
+
+    file.body
+  end
+end

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -1,7 +1,6 @@
 class NotificationsMailer < ApplicationMailer
-  def document_list(csv, user, document_klass, query)
-    attachments["document_list.csv"] = csv
-
+  def document_list(url, user, document_klass, query)
+    @url = url
     @user = user
     @document_klass = document_klass
     @query = query

--- a/app/models/document_list_export_request.rb
+++ b/app/models/document_list_export_request.rb
@@ -1,0 +1,16 @@
+class DocumentListExportRequest
+  include Mongoid::Document
+  field :filename, type: String
+  field :document_class, type: String
+  field :query, type: String
+  field :notification_email, type: String
+  field :generated_at, type: Time
+
+  def ready?
+    generated_at.present?
+  end
+
+  def public_url
+    Plek.find("specialist-publisher", external: true) + "/export/#{id}"
+  end
+end

--- a/app/views/notifications_mailer/document_list.text.erb
+++ b/app/views/notifications_mailer/document_list.text.erb
@@ -1,3 +1,7 @@
 Hi <%= @user.name %>,
 
-Please find attached the CSV of <%= @document_klass.title.pluralize %><% if @query.present? %> matching the query "<%= @query %>"<% end %> you requested from GOV.UK specialist publisher.
+You requested a CSV of <%= @document_klass.title.pluralize %><% if @query.present? %> matching the query "<%= @query %>"<% end %> from GOV.UK specialist publisher.
+
+You can download this from the following address:
+
+<%= @url %>

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -1,4 +1,5 @@
 require "csv"
+require "date"
 
 class DocumentListExportWorker
   include Sidekiq::Worker
@@ -8,7 +9,9 @@ class DocumentListExportWorker
     format = fetch_format(document_type_slug)
     authorize user, format
     csv = generate_csv(format, query)
-    send_mail(csv, user, format, query)
+    filename = "document_list_#{user_id}_#{DateTime.now.xmlschema}.csv"
+    url = upload_csv(filename, csv)
+    send_mail(url, user, format, query)
   end
 
 private
@@ -28,8 +31,8 @@ private
     end
   end
 
-  def send_mail(csv, user, format, query)
-    NotificationsMailer.document_list(csv, user, format, query).deliver_now
+  def send_mail(url, user, format, query)
+    NotificationsMailer.document_list(url, user, format, query).deliver_now
   end
 
   def fetch_exporter(format)
@@ -45,5 +48,10 @@ private
         csv << presenter.row
       end
     end
+  end
+
+  def upload_csv(filename, csv)
+    s3_file = S3FileUploader.save_file_to_s3(filename, csv)
+    s3_file.public_url
   end
 end

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -10,8 +10,14 @@ class DocumentListExportWorker
     authorize user, format
     csv = generate_csv(format, query)
     filename = "document_list_#{user_id}_#{DateTime.now.xmlschema}.csv"
-    url = upload_csv(filename, csv)
-    send_mail(url, user, format, query)
+
+    request = DocumentListExportRequest.new(filename: filename, document_class: format, query: query)
+    upload_csv(filename, csv)
+    request.save!
+
+    request.touch(:generated_at)
+
+    send_mail(request.public_url, user, format, query)
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 
-  resources :passthrough, only: [:index]
+  resources :document_list_export_request, path: "/export", only: [:show]
 
   resources :documents, path: "/:document_type_slug", param: :content_id, except: :destroy do
     collection do

--- a/lib/s3_file_uploader.rb
+++ b/lib/s3_file_uploader.rb
@@ -1,0 +1,18 @@
+class S3FileUploader
+  def self.save_file_to_s3(filename, csv)
+    connection = Fog::Storage.new(
+      provider: "AWS",
+      region: ENV["AWS_REGION"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    )
+
+    directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+
+    directory.files.create(
+      key: filename,
+      body: csv,
+      public: true,
+    )
+  end
+end

--- a/spec/controllers/document_list_export_request_controller_spec.rb
+++ b/spec/controllers/document_list_export_request_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe DocumentListExportRequestController, type: :controller do
+  before do
+    log_in_as_gds_editor
+
+    Fog.mock!
+    ENV["AWS_REGION"] = "eu-west-1"
+    ENV["AWS_ACCESS_KEY_ID"] = "test"
+    ENV["AWS_SECRET_ACCESS_KEY"] = "test"
+    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+
+    # Create an S3 bucket so the code being tested can find it
+    connection = Fog::Storage.new(
+      provider: "AWS",
+      region: ENV["AWS_REGION"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    )
+    @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+  end
+
+  describe "GET show" do
+    it "responds successfully if there is a valid file" do
+      filename = "test.txt"
+      @directory.files.create(key: filename, body: "hello world")
+      export_request = DocumentListExportRequest.new(filename: filename, document_class: "asylum-support-decisions")
+      export_request.save!
+      export_request.touch(:generated_at)
+
+      get :show, params: { id: export_request.id }
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("hello world")
+    end
+
+    it "returns an error if there is no request" do
+      get :show, params: { id: "no-such-id" }
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/lib/s3_file_uploader_spec.rb
+++ b/spec/lib/s3_file_uploader_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe S3FileUploader do
+  before do
+    Fog.mock!
+    ENV["AWS_REGION"] = "eu-west-1"
+    ENV["AWS_ACCESS_KEY_ID"] = "test"
+    ENV["AWS_SECRET_ACCESS_KEY"] = "test"
+    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+
+    # Create an S3 bucket so the code being tested can find it
+    connection = Fog::Storage.new(
+      provider: "AWS",
+      region: ENV["AWS_REGION"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    )
+    @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+  end
+
+  it "has the expected filename and content" do
+    s3_file = described_class.save_file_to_s3("test_file_name.txt", "hello, world\n")
+    expect(s3_file.key).to eq "test_file_name.txt"
+    file = @directory.files.get("test_file_name.txt")
+    expect(file).not_to be nil
+    expect(file.body).to eq "hello, world\n"
+  end
+end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.describe NotificationsMailer, type: :mailer do
   let(:user) { FactoryBot.create(:user) }
   let(:csv) { "Header one,Header two\r\nrow a value one,row a value two\r\nrow b value one,row b value two\r\n" }
+  let(:url) { "http://www.example.com/foo.csv" }
   describe "document_list without a query" do
-    let(:mail) { described_class.document_list(csv, user, BusinessFinanceSupportScheme, nil) }
+    let(:mail) { described_class.document_list(url, user, BusinessFinanceSupportScheme, nil) }
 
     it "renders the headers" do
       expect(mail.subject).to eq("Your exported list of Business Finance Support Schemes from GOV.UK")
@@ -17,14 +18,17 @@ RSpec.describe NotificationsMailer, type: :mailer do
       expect(mail.body.encoded).to match("CSV of Business Finance Support Schemes you requested from GOV.UK specialist publisher")
     end
 
-    it "attaches the CSV" do
-      expect(mail.attachments.first.filename).to eq "document_list.csv"
-      expect(mail.attachments.first.body.to_s).to eq csv
+    it "does not attach a CSV" do
+      expect(mail.attachments).to be_empty
+    end
+
+    it "contains a url" do
+      expect(mail.body).to include "http://www.example.com/foo.csv"
     end
   end
 
   describe "document_list with a query" do
-    let(:mail) { described_class.document_list(csv, user, BusinessFinanceSupportScheme, "startups") }
+    let(:mail) { described_class.document_list(url, user, BusinessFinanceSupportScheme, "startups") }
 
     it "renders the headers" do
       expect(mail.subject).to eq("Your exported list of Business Finance Support Schemes from GOV.UK")
@@ -37,9 +41,12 @@ RSpec.describe NotificationsMailer, type: :mailer do
       expect(mail.body.encoded).to match('CSV of Business Finance Support Schemes matching the query "startups" you requested from GOV.UK specialist publisher')
     end
 
-    it "attaches the CSV" do
-      expect(mail.attachments.first.filename).to eq "document_list.csv"
-      expect(mail.attachments.first.body.to_s).to eq csv
+    it "does not attach a CSV" do
+      expect(mail.attachments).to be_empty
+    end
+
+    it "contains a url" do
+      expect(mail.body).to include "http://www.example.com/foo.csv"
     end
   end
 end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NotificationsMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Hi #{user.name}")
-      expect(mail.body.encoded).to match("CSV of Business Finance Support Schemes you requested from GOV.UK specialist publisher")
+      expect(mail.body.encoded).to match("You requested a CSV of Business Finance Support Schemes from GOV.UK specialist publisher")
     end
 
     it "does not attach a CSV" do
@@ -38,7 +38,7 @@ RSpec.describe NotificationsMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Hi #{user.name}")
-      expect(mail.body.encoded).to match('CSV of Business Finance Support Schemes matching the query "startups" you requested from GOV.UK specialist publisher')
+      expect(mail.body.encoded).to match('You requested a CSV of Business Finance Support Schemes matching the query "startups" from GOV.UK specialist publisher')
     end
 
     it "does not attach a CSV" do

--- a/spec/workers/document_list_export_worker_spec.rb
+++ b/spec/workers/document_list_export_worker_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe DocumentListExportWorker do
       csv_data = "my,csv\nfile,is\ngreat,really\n"
       allow(subject).to receive(:generate_csv).and_return csv_data
 
-      s3_url = /https:\/\/#{ENV['AWS_S3_BUCKET_NAME']}.s3-#{ENV['AWS_REGION']}.amazonaws.com\/document_list_.*\.csv/
+      request_url = %r{^http://specialist-publisher.dev.gov.uk/export/[0-9a-f]+$}
 
-      expect(NotificationsMailer).to receive(:document_list).with(s3_url, user, BusinessFinanceSupportScheme, nil).and_return(double(ActionMailer::MessageDelivery, deliver_now: true))
+      expect(NotificationsMailer).to receive(:document_list).with(request_url, user, BusinessFinanceSupportScheme, nil).and_return(double(ActionMailer::MessageDelivery, deliver_now: true))
 
       subject.perform(BusinessFinanceSupportScheme.slug, user.id, nil)
     end

--- a/spec/workers/document_list_export_worker_spec.rb
+++ b/spec/workers/document_list_export_worker_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe DocumentListExportWorker do
       ]
     end
 
+    before do
+      Fog.mock!
+      ENV["AWS_REGION"] = "eu-west-1"
+      ENV["AWS_ACCESS_KEY_ID"] = "test"
+      ENV["AWS_SECRET_ACCESS_KEY"] = "test"
+      ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+
+      # Create an S3 bucket so the code being tested can find it
+      connection = Fog::Storage.new(
+        provider: "AWS",
+        region: ENV["AWS_REGION"],
+        aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      )
+      @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+    end
+
     it "raises an error if the user does not have permission to see the document type" do
       user.update(permissions: %w[signin])
       expect {
@@ -41,7 +58,9 @@ RSpec.describe DocumentListExportWorker do
       csv_data = "my,csv\nfile,is\ngreat,really\n"
       allow(subject).to receive(:generate_csv).and_return csv_data
 
-      expect(NotificationsMailer).to receive(:document_list).with(csv_data, user, BusinessFinanceSupportScheme, nil).and_return(double(ActionMailer::MessageDelivery, deliver_now: true))
+      s3_url = /https:\/\/#{ENV['AWS_S3_BUCKET_NAME']}.s3-#{ENV['AWS_REGION']}.amazonaws.com\/document_list_.*\.csv/
+
+      expect(NotificationsMailer).to receive(:document_list).with(s3_url, user, BusinessFinanceSupportScheme, nil).and_return(double(ActionMailer::MessageDelivery, deliver_now: true))
 
       subject.perform(BusinessFinanceSupportScheme.slug, user.id, nil)
     end


### PR DESCRIPTION
Use S3 to transfer files, to be consistent with other emails and also compatible (in future) with Notify.

https://trello.com/c/yrMNgb9T/1714-3-specialist-publisher-make-documentlistexport-use-s3-instead-of-email-attachments