### PR TITLE
Don't set public=>true when uploading a file

### DIFF
--- a/lib/s3_file_uploader.rb
+++ b/lib/s3_file_uploader.rb
@@ -12,7 +12,6 @@ class S3FileUploader
     directory.files.create(
       key: filename,
       body: csv,
-      public: true,
     )
   end
 end


### PR DESCRIPTION
It's unnecessary and seems to lead to permissions errors
