### PR TITLE
Use GOV.UK Notify for ActionMailer messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "kaminari-mongoid"
 gem "mongoid", "< 6.3"
 # MongoDB 2.4 compatibility is required, which was removed in 2.5
 gem "mongo", "< 2.5"
+gem "notifications-ruby-client"
 gem "pundit"
 gem "sass-rails", "~> 6"
 gem "select2-rails", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
+    notifications-ruby-client (5.1.2)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
@@ -472,6 +474,7 @@ DEPENDENCIES
   kaminari-mongoid
   mongo (< 2.5)
   mongoid (< 6.3)
+  notifications-ruby-client
   plek (~> 3)
   pry-rails
   puma

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,10 @@ module SpecialistPublisher
     config.time_zone = "London"
 
     config.eager_load_paths << Rails.root.join("lib")
+
+    config.after_initialize do
+      config.action_mailer.notify_settings = { api_key: Rails.application.secrets.notify_api_key }
+    end
   end
 
   mattr_accessor :publish_pre_production_finders

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :file
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :notify
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,5 @@
+require "notify_delivery_method"
+
+ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod,
+                                       notify_api_key: Rails.application.secrets.notify_api_key,
+                                       template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,4 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -1,0 +1,35 @@
+require "notifications/client"
+require "mail"
+
+class NotifyDeliveryMethod
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    client.send_email(payload(mail))
+  end
+
+private
+
+  def client
+    @client ||= Notifications::Client.new(settings[:notify_api_key])
+  end
+
+  def payload(mail)
+    if mail.to.length > 1
+      raise "Sending emails with multiple recipients is not supported"
+    end
+
+    {
+      email_address: mail.to.first,
+      template_id: settings[:template_id],
+      personalisation: {
+        body: mail.body.raw_source,
+        subject: mail.subject,
+      },
+    }
+  end
+end

--- a/spec/lib/notify_delivery_method_spec.rb
+++ b/spec/lib/notify_delivery_method_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require "notify_delivery_method"
+
+RSpec.describe NotifyDeliveryMethod do
+  describe "#deliver!" do
+    it "calls Notify's send_email endpoint" do
+      headers = { to: "x@y.com",
+                  body: "Body content",
+                  subject: "A subject line" }
+
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
+      client = instance_double(Notifications::Client)
+
+      allow(Notifications::Client).to receive(:new)
+        .with("api-key").and_return(client)
+
+      expect(client).to receive(:send_email)
+        .with(email_address: headers[:to],
+              template_id: template_id,
+              personalisation: {
+                body: headers[:body],
+                subject: headers[:subject],
+              })
+
+      method = NotifyDeliveryMethod.new(notify_api_key: "api-key", template_id: template_id)
+      method.deliver!(message)
+    end
+
+    it "raises an exception for multiple recipients" do
+      headers = { to: ["x@y.com", "a@b.com"],
+                  body: "Body content",
+                  subject: "A subject line" }
+
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
+      client = instance_double(Notifications::Client)
+
+      allow(Notifications::Client).to receive(:new)
+        .with("api-key").and_return(client)
+
+      method = NotifyDeliveryMethod.new(notify_api_key: "api-key", template_id: template_id)
+
+      expect { method.deliver!(message) }.to raise_error(
+        RuntimeError,
+        "Sending emails with multiple recipients is not supported",
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/BYnenCah/1774-specialist-publisher-use-notify-instead-of-amazon-ses
