### PR TITLE
Remove leftover delivery_method parameter

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,6 +85,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
-
-  config.action_mailer.delivery_method = :ses
 end


### PR DESCRIPTION
This parameter was left over when configuring Notify in https://github.com/alphagov/specialist-publisher/pull/1593