### PR TITLE
Changed link and link text for Glasgow

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -19,7 +19,7 @@
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment tribunal decisions",
-  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-tribunal-hearing-centre-eagle-building'>Glasgow Tribunal Hearing Centre</a> for cases in Scotland.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-employment-and-immigration-tribunals-eagle-building'>Glasgow Employment and Immigration Tribunals</a> for cases in Scotland.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
   "document_noun": "decision",
   "facets": [
     {


### PR DESCRIPTION
We received a Zendesk [ticket](https://govuk.zendesk.com/agent/tickets/3929541) from a user complaining that the link to the Glasgow Tribunal Hearing Centre on this [page](https://www.gov.uk/employment-tribunal-decisions) shows a broken link. It is indeed broken, so here is a fix to correct that. 
