### PR TITLE
Allow multiple vessel types/topics

### DIFF
--- a/app/views/metadata_fields/_marine_notices.html.erb
+++ b/app/views/metadata_fields/_marine_notices.html.erb
@@ -10,7 +10,13 @@
   <%= f.select :marine_notice_vessel_type,
       f.object.facet_options(:marine_notice_vessel_type),
       { label: "Vessel type", include_blank: 'Select vessel type' },
-      { class: 'form-control' }
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select a vessel type'
+        }
+      }
   %>
 <% end %>
 
@@ -18,7 +24,13 @@
   <%= f.select :marine_notice_topic,
       f.object.facet_options(:marine_notice_topic),
       { label: "Topic", include_blank: 'Select topic' },
-      { class: 'form-control' }
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select a topic'
+        }
+      }
   %>
 <% end %>
 


### PR DESCRIPTION
This allows multiple vessel types and topics to be selected for a marine notice.

This UI pattern is used for other specialist doc types, such as [AAIB reports](https://github.com/alphagov/specialist-publisher/blob/856a928bfbfb098b170376c9f85751e4e9e7b571/app/views/metadata_fields/_aaib_reports.html.erb#L17-L22)

There's no live content for this specialist document type yet.  

Half of https://github.com/alphagov/govuk-content-schemas/pull/984