### PR TITLE
Update the marine_notice model spec

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -189,8 +189,8 @@ FactoryBot.define do
       default_metadata do
         {
           "marine_notice_type" => "marine-guidance-note",
-          "marine_notice_vessel_type" => "pleasure-vessels",
-          "marine_notice_topic" => "crew-and-training",
+          "marine_notice_vessel_type" => %w[pleasure-vessels high-speed-craft],
+          "marine_notice_topic" => %w[crew-and-training navigation],
           "issued_date" => "2015-10-10",
         }
       end


### PR DESCRIPTION
I changed the content schema to allow multiple options in https://github.com/alphagov/govuk-content-schemas/pull/984

I now want to remove the `string` option in the schema as per https://github.com/alphagov/govuk-content-schemas/pull/985 but I need to update this spec first.