### PR TITLE
Upgrade Gems Mongo & Mongoid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,8 @@ gem "jquery-rails", "~> 4"
 gem "kaminari"
 gem "kaminari-mongoid"
 gem "mail-notify"
-# MongoDB 2.4 compatibility is required, which was removed in 6.3
-gem "mongoid", "< 6.3"
-# MongoDB 2.4 compatibility is required, which was removed in 2.5
-gem "mongo", "< 2.5"
+gem "mongo", "~> 2.5.0"
+gem "mongoid", "~> 6.3.0"
 gem "pundit"
 gem "sass-rails", "~> 6"
 gem "select2-rails", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     brakeman (4.7.1)
-    bson (4.4.2)
+    bson (4.3.0)
     builder (3.2.4)
     capybara (3.29.0)
       addressable
@@ -234,11 +234,11 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    mongo (2.4.3)
-      bson (>= 4.2.1, < 5.0.0)
-    mongoid (6.2.1)
+    mongo (2.5.0)
+      bson (>= 4.3.0, < 5.0.0)
+    mongoid (6.3.0)
       activemodel (~> 5.1)
-      mongo (>= 2.4.1, < 3.0.0)
+      mongo (>= 2.5.0, < 3.0.0)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -482,8 +482,8 @@ DEPENDENCIES
   kaminari
   kaminari-mongoid
   mail-notify
-  mongo (< 2.5)
-  mongoid (< 6.3)
+  mongo (~> 2.5.0)
+  mongoid (~> 6.3.0)
   plek (~> 3)
   pry-rails
   puma


### PR DESCRIPTION
RE GOVUK are in the process of migrating Specialist Publisher from Carrenza
to AWS. As part of this process we are going to switch from using a
self hosted Mongo instance to AWS DocumentDB. DocumentDB is running
the equivalent of MongoDB 3.6.0 (a higher version than we currently have on our server).
This means that the following gems need to be updated accordingly:
mongoid to 6.3.0
mongo to  2.5.0

Mongo has now been upgraded to 2.6.12 (from 2.4.9) so this update should not cause
any errors. Please see the Ruby/Mongo driver compatibility chart for more
information:
https://docs.mongodb.com/ruby-driver/master/reference/driver-compatibility/