### PR TITLE
Add Pregnancy and Breasfeeding Therapeutic Areas

### DIFF
--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -29,6 +29,7 @@
       "filterable": true,
       "allowed_values": [
         {"label": "Anaesthesia and intensive care", "value": "anaesthesia-intensive-care"},
+        {"label": "Breastfeeding", "value": "breastfeeding"},
         {"label": "Cancer", "value": "cancer"},
         {"label": "Cardiovascular disease and lipidology", "value": "cardiovascular-disease-lipidology"},
         {"label": "Dentistry", "value": "dentistry"},
@@ -46,6 +47,7 @@
         {"label": "Ophthalmology", "value": "ophthalmology"},
         {"label": "Paediatrics and neonatology", "value": "paediatrics-neonatology"},
         {"label": "Pain management and palliation", "value": "pain-management-palliation"},
+        {"label": "Pregnancy", "value": "pregnancy"},
         {"label": "Psychiatry", "value": "psychiatry"},
         {"label": "Radiology and imaging", "value": "radiology-imaging"},
         {"label": "Respiratory disease and allergy", "value": "respiratory-disease-allergy"},


### PR DESCRIPTION
This refers to https://www.gov.uk/drug-safety-update which is edited by
MHRA (Medicines and Healthcare products Regulatory Agency) in
https://specialist-publisher.publishing.service.gov.uk/drug-safety-updates

This is needed because they are launching a major new, lengthy project
on medicines and pregnant women, so will have a lot more content in this
area going forward, and wish to allow users to group existing content on
these topics closely together.

The request to add these two Therapeutic Areas came through Zendesk:
https://govuk.zendesk.com/agent/tickets/4099517

Related PRs:
- https://github.com/alphagov/search-api/pull/2113
- https://github.com/alphagov/govuk-content-schemas/pull/993