### PR TITLE
Improve error messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 private
 
   def user_not_authorized
-    flash[:danger] = "You aren't permitted to access #{current_format.title.pluralize}. If you feel you've reached this in error, contact your SPOC."
+    flash[:danger] = "You aren't permitted to access #{current_format.title.pluralize}. Please contact your main GDS contact if you need access."
     redirect_to root_path
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -96,7 +96,7 @@ private
     if current_format
       authorize current_format
     else
-      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
+      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, please contact your main GDS contact."
       redirect_to root_path
     end
   end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -5,7 +5,7 @@ class ExportsController < ApplicationController
     if current_format
       authorize current_format
     else
-      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, contact your SPOC."
+      flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, please contact your main GDS contact."
       redirect_to root_path
     end
   end

--- a/app/views/passthrough/error.html.erb
+++ b/app/views/passthrough/error.html.erb
@@ -1,2 +1,2 @@
-<h1>Permission Denied</h1>
-<p>You aren't permitted to access this application. If you feel you've reached this in error, contact your SPOC.</p>
+<h1>Sorry, you don't have permission to access this application</h1>
+<p>Please contact your main GDS contact if you need access.</p>

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -89,8 +89,8 @@ RSpec.feature "Access control", type: :feature do
       visit "/"
 
       expect(page.status_code).to eq(200)
-      expect(page).to have_content("Permission Denied")
-      expect(page).to have_content("You aren't permitted to access this application. If you feel you've reached this in error, contact your SPOC.")
+      expect(page).to have_content("Sorry, you don't have permission to access this application")
+      expect(page).to have_content("Please contact your main GDS contact if you need access.")
     end
   end
 end


### PR DESCRIPTION
- Makes error messages slightly friendlier and consistent with terms used elsewhere
- removes a rarely understood acronym (SPOC)
- updates relevant tests. 

[Trello](https://trello.com/c/6YJEvnfy/2025-1-improve-some-error-messages-for-publishers)