### PR TITLE
Stop sending hidden_indexable_content to Email Alert API

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -31,10 +31,12 @@ private
 
   # The tags are sent to email-alert-api and matched against subscriberlists.
   def tags
-    {
-      # This format should be the same as https://github.com/alphagov/finder-frontend/blob/2c1d5f25e7e4212795b485b6e4c290c6764c813c/app/controllers/email_alert_subscriptions_controller.rb#L41
-      format: document.format,
-    }.deep_merge(document.format_specific_metadata.reject { |_k, v| v.blank? })
+    metadata_tags = document.format_specific_metadata.reject do |k, v|
+      # remove the lengthy indexable text content present in many document types
+      k == :hidden_indexable_content || v.blank?
+    end
+
+    { format: document.format }.merge(metadata_tags)
   end
 
   def links

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe EmailAlertPresenter do
       end
     end
 
+    it "removes hidden indexable content from tags" do
+      asylum_support_decision_payload = FactoryBot.create(:asylum_support_decision)
+      stub_publishing_api_has_item(asylum_support_decision_payload)
+      asylum_support_decision = AsylumSupportDecision.find(asylum_support_decision_payload["content_id"])
+      expect(asylum_support_decision.format_specific_metadata.keys)
+        .to include(:hidden_indexable_content)
+
+      presented_data = EmailAlertPresenter.new(asylum_support_decision).to_json
+      expect(presented_data[:tags])
+        .not_to include(:hidden_indexable_content)
+    end
+
     context "Medical Safety Alerts documents" do
       let(:mhra_email_address) { "email.support@mhra.gov.uk" }
 


### PR DESCRIPTION
This change is prompted by seeing rather lengthy prose appearing in the
Email Alert API database that seems rather out of place. It transpires
the Specialist Publisher declares all of the fields flagged as metadata
for a format as tags, even those that are lengthy prose.

I've taken the rather lazy approach here of solving this with an
exceptional condition in the EmailAlertPresenter.

Pondering what the right way to solve this is somewhat riddled with
rabbit holes. It seems somewhat dubious that this presenter class holds
the logic as to what is a tag and what isn't, this feels more something
that is in the scope of the model. However, once pondering that the
question arises about why is Specialist Publisher not telling the
Publishing API what the tags are which indicates the path forward is
probably to be re-structuring the Publishing API details to have a tags
field and to consider whether the metadata hash is needed or not.