### PR TITLE
Add rake task to patch links for a `document_type`

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -45,4 +45,20 @@ namespace :publishing_api do
       Services.publishing_api.patch_links(content_id, links: payload, bulk_publishing: true)
     end
   end
+
+  desc "Patch links for all instances of specified document type in Publishing API."
+  task :patch_document_type_links, [:document_type] => :environment do |_, args|
+    klass = args.document_type.camelize.constantize
+    counter = 0
+
+    AllDocumentsFinder.find_each(klass) do |document|
+      document_links_presenter = DocumentLinksPresenter.new(document).to_json
+      payload = document_links_presenter.merge(bulk_publishing: true)
+
+      Services.publishing_api.patch_links(document.content_id, payload)
+      puts "Links patched for \"#{document.title}\"."
+      counter += 1
+    end
+    puts "Links patched for #{counter} #{args.document_type} documents."
+  end
 end


### PR DESCRIPTION
This adds the `publishing_api:patch_document_type_links[document_type]` rake task to patch links for all instances of the specified `document_type`.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department. It will make it possible to tag documents to organisations without republishing them.

To change (add/remove/substitute) the tagged organisation(s) in a specialist finder we need to:
- edit the `organisations` array in the finder's schema (e.g. https://github.com/alphagov/specialist-publisher/blob/d50ad6504c47702dd2a1e208f3988d1b25d64ea6/lib/documents/schemas/international_development_funds.json#L13)
- deploy the change
- run the `publishing_api:publish_finder[name]` rake task

Since the change is not automatically cascaded to the finder's documents and republishing all documents (which would work to reflect the change) is [discouraged](https://github.com/alphagov/specialist-publisher/blob/d50ad6504c47702dd2a1e208f3988d1b25d64ea6/lib/tasks/republish.rake#L7-L18), this newly introduced rake task can be run instead.

Example output of the rake task: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/169117/console

Trello card: https://trello.com/c/b0qCc1jJ/2058-investigate-organisation-tagging-of-specialist-finders-and-their-content