### PR TITLE
Remove `publishing_api:patch_cma_case_links`

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -34,18 +34,6 @@ namespace :publishing_api do
     end
   end
 
-  desc "Send links for all cma cases to Publishing API."
-  task patch_cma_case_links: :environment do
-    AllDocumentsFinder.find_each(CmaCase) do |cma_case|
-      content_id = cma_case.content_id
-      payload = {
-        primary_publishing_organisation: [cma_case.primary_publishing_organisation],
-      }
-
-      Services.publishing_api.patch_links(content_id, links: payload, bulk_publishing: true)
-    end
-  end
-
   desc "Patch links for all instances of specified document type in Publishing API."
   task :patch_document_type_links, [:document_type] => :environment do |_, args|
     klass = args.document_type.camelize.constantize


### PR DESCRIPTION
With the introduction of the more general `publishing_api:patch_document_type_links[document_type]` rake task in https://github.com/alphagov/specialist-publisher/pull/1688, this rake task is now redundant. Instead of using `publishing_api:patch_cma_case_links`, we can now use `publishing_api:patch_document_type_links[cma_case]`.