### PR TITLE
Add rake task to combine publish + patch links

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -49,4 +49,10 @@ namespace :publishing_api do
     end
     puts "Links patched for #{counter} #{args.document_type} documents."
   end
+
+  desc "Publish a Finder to the Publishing API and patch links for all its documents."
+  task :publish_finder_and_patch_documents_links, [:schema] => :environment do |_, args|
+    Rake::Task["publishing_api:publish_finder"].invoke(args.schema)
+    Rake::Task["publishing_api:patch_document_type_links"].invoke(args.schema.singularize)
+  end
 end


### PR DESCRIPTION
In https://github.com/alphagov/specialist-publisher/pull/1688, we introduced `publishing_api:patch_document_type_links[document_type]`.

As an improvement, and to avoid extra steps, this introduces a new rake task (`publishing_api:publish_finder_and_patch_documents_links[schema]`) that combines `publishing_api:publish_finder[schema]` and `publishing_api:patch_document_type_links[document_type]`. This means that this rake task will publish the specified finder and patch links for all its documents.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department. It will make it possible to tag documents to organisations without republishing them.

This means that the steps to change (add/remove/substitute) the tagged organisation(s) in a specialist finder and to cascade the change to all its documents have now been reduced to:

- edit the `organisations` array in the finder's schema (e.g. https://github.com/alphagov/specialist-publisher/blob/d50ad6504c47702dd2a1e208f3988d1b25d64ea6/lib/documents/schemas/international_development_funds.json#L13)
- deploy the change
- run `publishing_api:publish_finder_and_patch_documents_links[schema]`

Trello card: https://trello.com/c/b0qCc1jJ/2058-investigate-organisation-tagging-of-specialist-finders-and-their-content