### PR TITLE
Add ResearchForDevelopmentOutputs Finder

### DIFF
--- a/app/helpers/research_for_development_outputs_helper.rb
+++ b/app/helpers/research_for_development_outputs_helper.rb
@@ -1,0 +1,21 @@
+module ResearchForDevelopmentOutputsHelper
+  ##
+  # Only exists here - rather than in the finder schema - because
+  # specialist-frontend won't allow us to suppress any metadata that's
+  # present (unlike finder-frontend, which allows us to suppress with
+  # +display_as_result_metadata+).
+  #
+  # FCDO still need to be able to record the value without it showing up
+  # publicly (for now), and until we can add the ability to specialist-frontend
+  # to selectively hide data (we only want "Peer reviewed" to show up when present
+  # as 'unreviewed' means nothing), this is where the backend gets its values.
+  #
+  def review_status_options
+    # rubocop:disable Style/WordArray
+    [
+      ["Unreviewed",    "unreviewed"],
+      ["Peer reviewed", "peer_reviewed"],
+    ]
+    # rubocop:enable Style/WordArray
+  end
+end

--- a/app/models/research_for_development_output.rb
+++ b/app/models/research_for_development_output.rb
@@ -1,0 +1,50 @@
+class ResearchForDevelopmentOutput < Document
+  validates :first_published_at, presence: true, date: true
+  validates :theme, presence: true
+  validates :research_document_type, presence: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    research_document_type
+    country
+    first_published_at
+    authors
+    theme
+    review_status
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+    self.author_tags = params[:author_tags]
+  end
+
+  def taxons
+    [INTERNATIONAL_AID_AND_DEVELOPMENT_TAXON_ID]
+  end
+
+  ##
+  # Research for Development outputs are always bulk published, because our 'publication'
+  # is just a proxy for a research output PDF. Its date is not important to a
+  # user. Setting this +true+ means that specialist-frontend will never render
+  # the publishing-api +published+ date.
+  def bulk_published
+    true
+  end
+
+  def self.title
+    "Research for Development Output"
+  end
+
+  def author_tags
+    (authors || []).join("::")
+  end
+
+  def author_tags=(tags)
+    self.authors = (tags || "").split("::")
+  end
+
+  def primary_publishing_organisation
+    "db994552-7644-404d-a770-a2fe659c661f"
+  end
+end

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -1,0 +1,34 @@
+<%= render layout: 'shared/form_group', locals: { f: f, field: :research_document_type, label: 'Document type' } do %>
+  <%=
+    f.select :research_document_type, facet_options(f, :research_document_type),
+      { include_blank: true },
+      { class: 'select2', multiple: false, data: { placeholder: 'Select document type' } }
+  %>
+<% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :authors, label: 'Authors' } do %>
+  <%= f.text_field :author_tags, class: 'form-control free-form-list', data: { placeholder: 'Add authors' } %>
+<% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: 'Countries' } do %>
+  <%=
+    f.select :country, facet_options(f, :country),
+      { include_blank: true },
+      { class: 'select2', multiple: true, data: { placeholder: 'Select countries' } }
+  %>
+<% end %>
+
+<%= render layout: 'shared/form_group', locals: { f: f, field: :theme, label: 'Themes' } do %>
+  <%=
+    f.select :theme, facet_options(f, :theme),
+             { include_blank: false },
+             { class: 'select2', multiple: true, data: { placeholder: 'Select themes' } }
+  %>
+<% end %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :first_published_at, format: :research_for_development_output } do %>
+<% end %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :review_status, label: 'Review status' } do %>
+  <%= f.select :review_status, review_status_options,
+    {},
+    { class: 'form-control' } %>
+<% end %>

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -1,0 +1,987 @@
+{
+  "content_id": "853596e7-8ae3-42bd-838b-25ca3076e35f",
+  "base_path": "/research-for-development-outputs",
+  "format_name": "Research for Development Output",
+  "name": "Research for Development Outputs",
+  "description": "Find outputs from Research for Development projects",
+  "filter": {
+    "format": "research_for_development_output"
+  },
+  "signup_content_id": "fdcbada2-1ad4-4194-98dc-5f04a448316e",
+  "signup_copy": "You'll get an email each time an output is updated or a new output is published.",
+  "organisations": [
+    "db994552-7644-404d-a770-a2fe659c661f"
+  ],
+  "subscription_list_title_prefix": "Research for Development output",
+  "document_noun": "output",
+  "facets": [
+    {
+      "key": "country",
+      "name": "Country",
+      "type": "text",
+      "preposition": "covering",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "AF",
+          "label": "Afghanistan"
+        },
+        {
+          "value": "AL",
+          "label": "Albania"
+        },
+        {
+          "value": "DZ",
+          "label": "Algeria"
+        },
+        {
+          "value": "AD",
+          "label": "Andorra"
+        },
+        {
+          "value": "AO",
+          "label": "Angola"
+        },
+        {
+          "value": "AG",
+          "label": "Antigua and Barbuda"
+        },
+        {
+          "value": "AR",
+          "label": "Argentina"
+        },
+        {
+          "value": "AM",
+          "label": "Armenia"
+        },
+        {
+          "value": "AU",
+          "label": "Australia"
+        },
+        {
+          "value": "AT",
+          "label": "Austria"
+        },
+        {
+          "value": "AZ",
+          "label": "Azerbaijan"
+        },
+        {
+          "value": "BS",
+          "label": "Bahamas, The"
+        },
+        {
+          "value": "BH",
+          "label": "Bahrain"
+        },
+        {
+          "value": "BD",
+          "label": "Bangladesh"
+        },
+        {
+          "value": "BB",
+          "label": "Barbados"
+        },
+        {
+          "value": "BY",
+          "label": "Belarus"
+        },
+        {
+          "value": "BE",
+          "label": "Belgium"
+        },
+        {
+          "value": "BZ",
+          "label": "Belize"
+        },
+        {
+          "value": "BJ",
+          "label": "Benin"
+        },
+        {
+          "value": "BT",
+          "label": "Bhutan"
+        },
+        {
+          "value": "BO",
+          "label": "Bolivia"
+        },
+        {
+          "value": "BA",
+          "label": "Bosnia and Herzegovina"
+        },
+        {
+          "value": "BW",
+          "label": "Botswana"
+        },
+        {
+          "value": "BR",
+          "label": "Brazil"
+        },
+        {
+          "value": "BN",
+          "label": "Brunei"
+        },
+        {
+          "value": "BG",
+          "label": "Bulgaria"
+        },
+        {
+          "value": "BF",
+          "label": "Burkina Faso"
+        },
+        {
+          "value": "MM",
+          "label": "Burma"
+        },
+        {
+          "value": "BI",
+          "label": "Burundi"
+        },
+        {
+          "value": "KH",
+          "label": "Cambodia"
+        },
+        {
+          "value": "CM",
+          "label": "Cameroon"
+        },
+        {
+          "value": "CA",
+          "label": "Canada"
+        },
+        {
+          "value": "CV",
+          "label": "Cape Verde"
+        },
+        {
+          "value": "CF",
+          "label": "Central African Republic"
+        },
+        {
+          "value": "TD",
+          "label": "Chad"
+        },
+        {
+          "value": "CL",
+          "label": "Chile"
+        },
+        {
+          "value": "CN",
+          "label": "China"
+        },
+        {
+          "value": "CO",
+          "label": "Colombia"
+        },
+        {
+          "value": "KM",
+          "label": "Comoros"
+        },
+        {
+          "value": "CG",
+          "label": "Congo"
+        },
+        {
+          "value": "CD",
+          "label": "Congo (Democratic Republic)"
+        },
+        {
+          "value": "CK",
+          "label": "Cook Islands"
+        },
+        {
+          "value": "CR",
+          "label": "Costa Rica"
+        },
+        {
+          "value": "HR",
+          "label": "Croatia"
+        },
+        {
+          "value": "CU",
+          "label": "Cuba"
+        },
+        {
+          "value": "CY",
+          "label": "Cyprus"
+        },
+        {
+          "value": "CZ",
+          "label": "Czech Republic"
+        },
+        {
+          "value": "DK",
+          "label": "Denmark"
+        },
+        {
+          "value": "DJ",
+          "label": "Djibouti"
+        },
+        {
+          "value": "DM",
+          "label": "Dominica"
+        },
+        {
+          "value": "DO",
+          "label": "Dominican Republic"
+        },
+        {
+          "value": "TL",
+          "label": "East Timor"
+        },
+        {
+          "value": "EC",
+          "label": "Ecuador"
+        },
+        {
+          "value": "EG",
+          "label": "Egypt"
+        },
+        {
+          "value": "SV",
+          "label": "El Salvador"
+        },
+        {
+          "value": "GQ",
+          "label": "Equatorial Guinea"
+        },
+        {
+          "value": "ER",
+          "label": "Eritrea"
+        },
+        {
+          "value": "EE",
+          "label": "Estonia"
+        },
+        {
+          "value": "ET",
+          "label": "Ethiopia"
+        },
+        {
+          "value": "FJ",
+          "label": "Fiji"
+        },
+        {
+          "value": "FI",
+          "label": "Finland"
+        },
+        {
+          "value": "FR",
+          "label": "France"
+        },
+        {
+          "value": "GA",
+          "label": "Gabon"
+        },
+        {
+          "value": "GM",
+          "label": "Gambia, The"
+        },
+        {
+          "value": "GE",
+          "label": "Georgia"
+        },
+        {
+          "value": "DE",
+          "label": "Germany"
+        },
+        {
+          "value": "GH",
+          "label": "Ghana"
+        },
+        {
+          "value": "GR",
+          "label": "Greece"
+        },
+        {
+          "value": "GD",
+          "label": "Grenada"
+        },
+        {
+          "value": "GT",
+          "label": "Guatemala"
+        },
+        {
+          "value": "GN",
+          "label": "Guinea"
+        },
+        {
+          "value": "GW",
+          "label": "Guinea-Bissau"
+        },
+        {
+          "value": "GY",
+          "label": "Guyana"
+        },
+        {
+          "value": "HT",
+          "label": "Haiti"
+        },
+        {
+          "value": "HN",
+          "label": "Honduras"
+        },
+        {
+          "value": "HU",
+          "label": "Hungary"
+        },
+        {
+          "value": "IS",
+          "label": "Iceland"
+        },
+        {
+          "value": "IN",
+          "label": "India"
+        },
+        {
+          "value": "ID",
+          "label": "Indonesia"
+        },
+        {
+          "value": "IR",
+          "label": "Iran"
+        },
+        {
+          "value": "IQ",
+          "label": "Iraq"
+        },
+        {
+          "value": "IE",
+          "label": "Ireland"
+        },
+        {
+          "value": "IL",
+          "label": "Israel"
+        },
+        {
+          "value": "IT",
+          "label": "Italy"
+        },
+        {
+          "value": "CI",
+          "label": "Ivory Coast"
+        },
+        {
+          "value": "JM",
+          "label": "Jamaica"
+        },
+        {
+          "value": "JP",
+          "label": "Japan"
+        },
+        {
+          "value": "JO",
+          "label": "Jordan"
+        },
+        {
+          "value": "KZ",
+          "label": "Kazakhstan"
+        },
+        {
+          "value": "KE",
+          "label": "Kenya"
+        },
+        {
+          "value": "KI",
+          "label": "Kiribati"
+        },
+        {
+          "value": "XK",
+          "label": "Kosovo"
+        },
+        {
+          "value": "KW",
+          "label": "Kuwait"
+        },
+        {
+          "value": "KG",
+          "label": "Kyrgyzstan"
+        },
+        {
+          "value": "LA",
+          "label": "Laos"
+        },
+        {
+          "value": "LV",
+          "label": "Latvia"
+        },
+        {
+          "value": "LB",
+          "label": "Lebanon"
+        },
+        {
+          "value": "LS",
+          "label": "Lesotho"
+        },
+        {
+          "value": "LR",
+          "label": "Liberia"
+        },
+        {
+          "value": "LY",
+          "label": "Libya"
+        },
+        {
+          "value": "LI",
+          "label": "Liechtenstein"
+        },
+        {
+          "value": "LT",
+          "label": "Lithuania"
+        },
+        {
+          "value": "LU",
+          "label": "Luxembourg"
+        },
+        {
+          "value": "MK",
+          "label": "Macedonia"
+        },
+        {
+          "value": "MG",
+          "label": "Madagascar"
+        },
+        {
+          "value": "MW",
+          "label": "Malawi"
+        },
+        {
+          "value": "MY",
+          "label": "Malaysia"
+        },
+        {
+          "value": "MV",
+          "label": "Maldives"
+        },
+        {
+          "value": "ML",
+          "label": "Mali"
+        },
+        {
+          "value": "MT",
+          "label": "Malta"
+        },
+        {
+          "value": "MH",
+          "label": "Marshall Islands"
+        },
+        {
+          "value": "MR",
+          "label": "Mauritania"
+        },
+        {
+          "value": "MU",
+          "label": "Mauritius"
+        },
+        {
+          "value": "MX",
+          "label": "Mexico"
+        },
+        {
+          "value": "FM",
+          "label": "Micronesia"
+        },
+        {
+          "value": "MD",
+          "label": "Moldova"
+        },
+        {
+          "value": "MC",
+          "label": "Monaco"
+        },
+        {
+          "value": "MN",
+          "label": "Mongolia"
+        },
+        {
+          "value": "ME",
+          "label": "Montenegro"
+        },
+        {
+          "value": "MA",
+          "label": "Morocco"
+        },
+        {
+          "value": "MZ",
+          "label": "Mozambique"
+        },
+        {
+          "value": "NA",
+          "label": "Namibia"
+        },
+        {
+          "value": "NR",
+          "label": "Nauru"
+        },
+        {
+          "value": "NP",
+          "label": "Nepal"
+        },
+        {
+          "value": "NL",
+          "label": "Netherlands"
+        },
+        {
+          "value": "NZ",
+          "label": "New Zealand"
+        },
+        {
+          "value": "NI",
+          "label": "Nicaragua"
+        },
+        {
+          "value": "NE",
+          "label": "Niger"
+        },
+        {
+          "value": "NG",
+          "label": "Nigeria"
+        },
+        {
+          "value": "KP",
+          "label": "North Korea"
+        },
+        {
+          "value": "NO",
+          "label": "Norway"
+        },
+        {
+          "value": "OM",
+          "label": "Oman"
+        },
+        {
+          "value": "PK",
+          "label": "Pakistan"
+        },
+        {
+          "value": "PW",
+          "label": "Palau"
+        },
+        {
+          "value": "PA",
+          "label": "Panama"
+        },
+        {
+          "value": "PG",
+          "label": "Papua New Guinea"
+        },
+        {
+          "value": "PY",
+          "label": "Paraguay"
+        },
+        {
+          "value": "PE",
+          "label": "Peru"
+        },
+        {
+          "value": "PH",
+          "label": "Philippines"
+        },
+        {
+          "value": "PL",
+          "label": "Poland"
+        },
+        {
+          "value": "PT",
+          "label": "Portugal"
+        },
+        {
+          "value": "QA",
+          "label": "Qatar"
+        },
+        {
+          "value": "RO",
+          "label": "Romania"
+        },
+        {
+          "value": "RU",
+          "label": "Russia"
+        },
+        {
+          "value": "RW",
+          "label": "Rwanda"
+        },
+        {
+          "value": "WS",
+          "label": "Samoa"
+        },
+        {
+          "value": "SM",
+          "label": "San Marino"
+        },
+        {
+          "value": "ST",
+          "label": "Sao Tome and Principe"
+        },
+        {
+          "value": "SA",
+          "label": "Saudi Arabia"
+        },
+        {
+          "value": "SN",
+          "label": "Senegal"
+        },
+        {
+          "value": "RS",
+          "label": "Serbia"
+        },
+        {
+          "value": "SC",
+          "label": "Seychelles"
+        },
+        {
+          "value": "SL",
+          "label": "Sierra Leone"
+        },
+        {
+          "value": "SG",
+          "label": "Singapore"
+        },
+        {
+          "value": "SK",
+          "label": "Slovakia"
+        },
+        {
+          "value": "SI",
+          "label": "Slovenia"
+        },
+        {
+          "value": "SB",
+          "label": "Solomon Islands"
+        },
+        {
+          "value": "SO",
+          "label": "Somalia"
+        },
+        {
+          "value": "ZA",
+          "label": "South Africa"
+        },
+        {
+          "value": "KR",
+          "label": "South Korea"
+        },
+        {
+          "value": "SS",
+          "label": "South Sudan"
+        },
+        {
+          "value": "ES",
+          "label": "Spain"
+        },
+        {
+          "value": "LK",
+          "label": "Sri Lanka"
+        },
+        {
+          "value": "KN",
+          "label": "St Kitts and Nevis"
+        },
+        {
+          "value": "LC",
+          "label": "St Lucia"
+        },
+        {
+          "value": "VC",
+          "label": "St Vincent"
+        },
+        {
+          "value": "SD",
+          "label": "Sudan"
+        },
+        {
+          "value": "SR",
+          "label": "Suriname"
+        },
+        {
+          "value": "SZ",
+          "label": "Swaziland"
+        },
+        {
+          "value": "SE",
+          "label": "Sweden"
+        },
+        {
+          "value": "CH",
+          "label": "Switzerland"
+        },
+        {
+          "value": "SY",
+          "label": "Syria"
+        },
+        {
+          "value": "TJ",
+          "label": "Tajikistan"
+        },
+        {
+          "value": "TZ",
+          "label": "Tanzania"
+        },
+        {
+          "value": "TH",
+          "label": "Thailand"
+        },
+        {
+          "value": "TG",
+          "label": "Togo"
+        },
+        {
+          "value": "TO",
+          "label": "Tonga"
+        },
+        {
+          "value": "TT",
+          "label": "Trinidad and Tobago"
+        },
+        {
+          "value": "TN",
+          "label": "Tunisia"
+        },
+        {
+          "value": "TR",
+          "label": "Turkey"
+        },
+        {
+          "value": "TM",
+          "label": "Turkmenistan"
+        },
+        {
+          "value": "TV",
+          "label": "Tuvalu"
+        },
+        {
+          "value": "UG",
+          "label": "Uganda"
+        },
+        {
+          "value": "UA",
+          "label": "Ukraine"
+        },
+        {
+          "value": "AE",
+          "label": "United Arab Emirates"
+        },
+        {
+          "value": "GB",
+          "label": "United Kingdom"
+        },
+        {
+          "value": "US",
+          "label": "United States"
+        },
+        {
+          "value": "UY",
+          "label": "Uruguay"
+        },
+        {
+          "value": "UZ",
+          "label": "Uzbekistan"
+        },
+        {
+          "value": "VU",
+          "label": "Vanuatu"
+        },
+        {
+          "value": "VA",
+          "label": "Vatican City"
+        },
+        {
+          "value": "VE",
+          "label": "Venezuela"
+        },
+        {
+          "value": "VN",
+          "label": "Vietnam"
+        },
+        {
+          "value": "YE",
+          "label": "Yemen"
+        },
+        {
+          "value": "ZM",
+          "label": "Zambia"
+        },
+        {
+          "value": "ZW",
+          "label": "Zimbabwe"
+        }
+      ]
+    },
+    {
+      "key": "research_document_type",
+      "name": "Document Type",
+      "short_name": "Document Type",
+      "type": "text",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "book",
+          "label": "Book"
+        },
+        {
+          "value": "book_chapter",
+          "label": "Book Chapter"
+        },
+        {
+          "value": "briefing",
+          "label": "Briefing"
+        },
+        {
+          "value": "case_study",
+          "label": "Case Study"
+        },
+        {
+          "value": "conference_paper",
+          "label": "Conference Paper"
+        },
+        {
+          "value": "country_report",
+          "label": "Country Report"
+        },
+        {
+          "value": "dataset",
+          "label": "Dataset"
+        },
+        {
+          "value": "discussion_paper",
+          "label": "Discussion Paper"
+        },
+        {
+          "value": "evaluation_report",
+          "label": "Evaluation Report"
+        },
+        {
+          "value": "journal_article",
+          "label": "Journal Article"
+        },
+        {
+          "value": "journal_issue",
+          "label": "Journal Issue"
+        },
+        {
+          "value": "lessons_learned",
+          "label": "Lessons Learned"
+        },
+        {
+          "value": "literature_review",
+          "label": "Literature Review"
+        },
+        {
+          "value": "manual",
+          "label": "Manual"
+        },
+        {
+          "value": "protocol",
+          "label": "Protocol"
+        },
+        {
+          "value": "research_paper",
+          "label": "Research Paper"
+        },
+        {
+          "value": "systematic_review",
+          "label": "Systematic Review"
+        },
+        {
+          "value": "technical_report",
+          "label": "Technical Report"
+        },
+        {
+          "value": "thematic_summary",
+          "label": "Thematic Summary"
+        },
+        {
+          "value": "tool_kit",
+          "label": "Tool kit"
+        },
+        {
+          "value": "training_materials",
+          "label": "Training Materials"
+        },
+        {
+          "value": "working_paper",
+          "label": "Working Paper"
+        }
+      ]
+    },
+    {
+      "key": "theme",
+      "name": "Theme",
+      "short_name": "Theme",
+      "type": "text",
+      "preposition": "about",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "value": "agriculture",
+          "label": "Agriculture"
+        },
+        {
+          "value": "climate_and_environment",
+          "label": "Climate and Environment"
+        },
+        {
+          "value": "economic_growth",
+          "label": "Economic Growth"
+        },
+        {
+          "value": "education",
+          "label": "Education"
+        },
+        {
+          "value": "food_and_nutrition",
+          "label": "Food and Nutrition"
+        },
+        {
+          "value": "governance_and_conflict",
+          "label": "Governance and Conflict"
+        },
+        {
+          "value": "health",
+          "label": "Health"
+        },
+        {
+          "value": "humanitarian_disasters_and_emergencies",
+          "label": "Humanitarian Disasters and Emergencies"
+        },
+        {
+          "value": "infrastructure",
+          "label": "Infrastructure"
+        },
+        {
+          "value": "research_communication_and_uptake",
+          "label": "Research Communication and Uptake"
+        },
+        {
+          "value": "social_change",
+          "label": "Social Change"
+        },
+        {
+          "value": "water_and_sanitation",
+          "label": "Water and Sanitation"
+        }
+      ]
+    },
+    {
+      "key": "first_published_at",
+      "name": "First published",
+      "short_name": "First published",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "authors",
+      "name": "Authors",
+      "short_name": "Authors",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    }
+  ]
+}

--- a/spec/features/creating_a_research_for_development_output_spec.rb
+++ b/spec/features/creating_a_research_for_development_output_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.feature "Creating a Research for Development Output", type: :feature do
+  let(:fields)            { %i[base_path content_id public_updated_at title publication_state] }
+  let(:research_output)   { FactoryBot.create(:research_for_development_output) }
+  let(:content_id)        { research_output["content_id"] }
+  let(:public_updated_at) { research_output["public_updated_at"] }
+
+  before do
+    log_in_as_editor(:research_for_development_output_editor)
+
+    Timecop.freeze(Time.zone.parse(public_updated_at))
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    stub_publishing_api_has_item(research_output)
+  end
+
+  scenario "with valid data" do
+    visit "/research-for-development-outputs/new"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+    title = "Example Research for Development Output"
+    summary = "This is the summary of an example research for development output"
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: summary
+    fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example Research for Development output" * 10))
+    fill_in "[research_for_development_output]first_published_at(1i)", with: "2013"
+    fill_in "[research_for_development_output]first_published_at(2i)", with: "01"
+    fill_in "[research_for_development_output]first_published_at(3i)", with: "01"
+    select "Book Chapter", from: "Document type"
+    select "Infrastructure", from: "Themes"
+    select "Peer reviewed", from: "Review status"
+
+    click_button "Save as draft"
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example Research for Development Output")
+  end
+
+  scenario "with no data" do
+    visit "/research-for-development-outputs/new"
+
+    expect(page.status_code).to eq(200)
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+    expect(page).not_to have_content("Country can't be blank")
+  end
+
+  scenario "with invalid data" do
+    visit "/research-for-development-outputs/new"
+
+    expect(page.status_code).to eq(200)
+    fill_in "Title", with: "Example Research for Development output"
+    fill_in "Summary", with: "This is the summary of an example Research for Development output"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+  end
+end

--- a/spec/features/editing_a_research_for_development_output_spec.rb
+++ b/spec/features/editing_a_research_for_development_output_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.feature "Editing a Research for Development Output", type: :feature do
+  let(:research_output)   { FactoryBot.create(:research_for_development_output) }
+  let(:content_id)        { research_output["content_id"] }
+  let(:public_updated_at) { research_output["public_updated_at"] }
+
+  before do
+    allow_any_instance_of(DocumentPolicy).to receive(:departmental_editor?).and_return(true)
+
+    log_in_as_editor(:research_for_development_output_editor)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+
+    stub_publishing_api_has_item(research_output)
+  end
+
+  scenario "with valid data" do
+    visit  "/research-for-development-outputs/#{content_id}/edit"
+    expect(page).to have_css("div.govspeak-help")
+
+    title = "Example Research For Development output"
+    summary = "This is the summary of an example research fro development output"
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: summary
+    fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example research for development output" * 10))
+    fill_in "[research_for_development_output]first_published_at(1i)", with: "2013"
+    fill_in "[research_for_development_output]first_published_at(2i)", with: "01"
+    fill_in "[research_for_development_output]first_published_at(3i)", with: "01"
+    select "United Kingdom", from: "Countries"
+    select "Book Chapter", from: "Document type"
+
+    click_button "Save as draft"
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Example Research For Development output")
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -52,6 +52,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
       expect(page).to have_text("MAIB Reports")
       expect(page).to have_text("Medical Safety Alerts")
       expect(page).to have_text("RAIB Reports")
+      expect(page).to have_text("Research for Development Outputs")
       expect(page).to have_text("Residential Property Tribunal Decisions")
       expect(page).to have_text("Service Standard Reports")
       expect(page).to have_text("Tax Tribunal Decisions")

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -48,6 +48,11 @@ FactoryBot.define do
     organisation_content_id { "db994552-7644-404d-a770-a2fe659c661f" }
   end
 
+  factory :research_for_development_output_editor, parent: :editor do
+    organisation_slug { "department-for-international-development" }
+    organisation_content_id { "db994552-7644-404d-a770-a2fe659c661f" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }
@@ -295,6 +300,24 @@ FactoryBot.define do
           "country" => %w[GB],
           "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
           "dfid_theme" => %w[infrastructure],
+          "first_published_at" => "2016-04-28",
+          "bulk_published" => true,
+        }
+      end
+    end
+  end
+
+  factory :research_for_development_output, parent: :document do
+    base_path { "/research-for-development-outputs/example-document" }
+    document_type { "research_for_development_output" }
+
+    transient do
+      default_metadata do
+        {
+          "research_document_type" => "book_chapter",
+          "country" => %w[GB],
+          "authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
+          "theme" => %w[infrastructure],
           "first_published_at" => "2016-04-28",
           "bulk_published" => true,
         }

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe FinderSchema do
     end
   end
 
-  let(:schema) { FinderSchema.new("dfid_research_outputs") }
+  let(:schema) { FinderSchema.new("research_for_development_outputs") }
 
   describe "#humanized_facet_name" do
     it "returns the name defined in the schema for the supplied facet key" do
-      expect(schema.humanized_facet_name("dfid_document_type")).to eq("Document Type")
+      expect(schema.humanized_facet_name("research_document_type")).to eq("Document Type")
     end
 
     it "returns the humanized version of the supplied facet key is not defined in the schema" do
-      expect(schema.humanized_facet_name("dfid_review_status")).to eq("Dfid review status")
+      expect(schema.humanized_facet_name("review_status")).to eq("Review status")
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe FinderSchema do
         it "returns the value itself" do
           authors_value = ["Mr. Potato Head", "Mrs. Potato Head"]
           expect(
-            schema.humanized_facet_value("dfid_authors", authors_value),
+            schema.humanized_facet_value("authors", authors_value),
           ).to eql(authors_value)
         end
       end

--- a/spec/models/research_for_development_output_spec.rb
+++ b/spec/models/research_for_development_output_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe ResearchForDevelopmentOutput do
+  let(:payload) { FactoryBot.create(:research_for_development_output) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+
+  it "is always bulk published to hide the publishing-api published date" do
+    expect(subject.bulk_published).to be true
+  end
+
+  it "has a author_tags virtual attribute" do
+    subject.author_tags = "a, b::c"
+    expect(subject.authors).to eq ["a, b", "c"]
+
+    subject.authors = ["foo, bar", "baz"]
+    expect(subject.author_tags).to eq "foo, bar::baz"
+
+    subject = described_class.new(author_tags: "foo, bar::baz")
+    expect(subject.authors).to eq ["foo, bar", "baz"]
+  end
+end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe DocumentLinksPresenter do
     DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
+    ResearchForDevelopmentOutput => "db994552-7644-404d-a770-a2fe659c661f",
     CountrysideStewardshipGrant => "e8fae147-6232-4163-a3f1-1c15b755a8a4",
     BusinessFinanceSupportScheme => "2bde479a-97f2-42b5-986a-287a623c2a1c",
     AsylumSupportDecision => "6f757605-ab8f-4b62-84e4-99f79cf085c2",


### PR DESCRIPTION
DFID is being merged into the new FCDO. This PR adds a new `ResearchForDevelopmentOutputs` Finder based on   `DFIDResearchOutputs`. 

[govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/1001)
[search-api](https://github.com/alphagov/search-api/pull/2171)

[Trello](https://trello.com/c/wye58SZu/2109-update-x2-dfid-specialist-finders-to-fcdo)