### PR TITLE
Move the js_compressor on production only

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,9 +28,6 @@ module SpecialistPublisher
     # config.time_zone = 'Central Time (US & Canada)'
     config.time_zone = "London"
 
-    # Compress JS using a preprocessor.
-    config.assets.js_compressor = :uglifier
-
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Compress JS using a preprocessor.
+  config.assets.js_compressor = :uglifier
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
This is a fixup from #1693 