### PR TITLE
Move International Development Funds to FCDO

### DIFF
--- a/app/models/international_development_fund.rb
+++ b/app/models/international_development_fund.rb
@@ -22,6 +22,6 @@ class InternationalDevelopmentFund < Document
   end
 
   def primary_publishing_organisation
-    "db994552-7644-404d-a770-a2fe659c661f"
+    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
   end
 end

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -4,13 +4,14 @@
   "format_name": "International development funding",
   "name": "International development funding",
   "description": "Find and apply for funds to run international development projects",
+  "summary": "<p>Grants published before XX September 2020 were published by the Department for International Development (DFID).</p>",
   "filter": {
     "format": "international_development_fund"
   },
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "show_summaries": true,
-  "organisations": ["db994552-7644-404d-a770-a2fe659c661f"],
+  "organisations": ["f9fcf3fe-2751-4dca-97ca-becaeceb4b26"],
   "subscription_list_title_prefix": "International development funds",
   "document_noun": "fund",
   "facets": [

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -4,7 +4,7 @@
   "format_name": "International development funding",
   "name": "International development funding",
   "description": "Find and apply for funds to run international development projects",
-  "summary": "<p>Grants published before XX September 2020 were published by the Department for International Development (DFID).</p>",
+  "summary": "<p>Grants published before 2 September 2020 were published by the Department for International Development (DFID).</p>",
   "filter": {
     "format": "international_development_fund"
   },

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DocumentLinksPresenter do
     BusinessFinanceSupportScheme => "2bde479a-97f2-42b5-986a-287a623c2a1c",
     AsylumSupportDecision => "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     ServiceStandardReport => "af07d5a5-df63-4ddc-9383-6a666845ebe9",
-    InternationalDevelopmentFund => "db994552-7644-404d-a770-a2fe659c661f",
+    InternationalDevelopmentFund => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
   }
 
   document_types.each do |klass, primary_publishing_organisation_id|


### PR DESCRIPTION
The International Development Funds finder is moving to FCDO as the primary publishing organisation.

This PR updates the organisation ID and adds a summary to alert users to the change in ownership.