### PR TITLE
Make it possible to transform payload when republishing

### DIFF
--- a/app/services/republish_service.rb
+++ b/app/services/republish_service.rb
@@ -1,0 +1,62 @@
+require "services"
+
+class RepublishService
+  def call(content_id)
+    document = Document.find(content_id)
+
+    if document.publication_state == "published"
+      document.update_type = "republish"
+
+      publishing_api_put_content(document)
+      publishing_api_patch_links(document)
+      publishing_api_publish(document)
+    elsif document.publication_state == "draft"
+      published_edition_version_number = document.state_history.key("published")
+
+      publishing_api_patch_links(document)
+
+      if published_edition_version_number.present?
+        published_document = Document.find(
+          content_id,
+          version: published_edition_version_number,
+        )
+        published_document.update_type = "republish"
+
+        publishing_api_put_content(published_document)
+        publishing_api_publish(published_document)
+      end
+
+      publishing_api_put_content(document)
+    else
+      print_limitations_of_republishing(document)
+    end
+  end
+
+private
+
+  def print_limitations_of_republishing(document)
+    content_id = document.content_id
+    state = document.publication_state
+
+    message = "Skipped republishing document with content_id #{content_id}"
+    message += " because it has a state of '#{state}'. Currently, there is"
+    message += " no way to safely republish the document that is supported by"
+    message += " the platform."
+
+    logger.warn message
+  end
+
+  def publishing_api_put_content(document)
+    payload = DocumentPresenter.new(document).to_json
+    Services.publishing_api.put_content(document.content_id, payload)
+  end
+
+  def publishing_api_patch_links(document)
+    payload = DocumentLinksPresenter.new(document).to_json
+    Services.publishing_api.patch_links(document.content_id, payload)
+  end
+
+  def publishing_api_publish(document)
+    Services.publishing_api.publish(document.content_id, "republish")
+  end
+end

--- a/app/workers/republish_worker.rb
+++ b/app/workers/republish_worker.rb
@@ -1,64 +1,7 @@
-require "services"
-
 class RepublishWorker
   include Sidekiq::Worker
 
   def perform(content_id)
-    document = Document.find(content_id)
-
-    if document.publication_state == "published"
-      document.update_type = "republish"
-
-      publishing_api_put_content(document)
-      publishing_api_patch_links(document)
-      publishing_api_publish(document)
-    elsif document.publication_state == "draft"
-      published_edition_version_number = document.state_history.key("published")
-
-      publishing_api_patch_links(document)
-
-      if published_edition_version_number.present?
-        published_document = Document.find(
-          content_id,
-          version: published_edition_version_number,
-        )
-        published_document.update_type = "republish"
-
-        publishing_api_put_content(published_document)
-        publishing_api_publish(published_document)
-      end
-
-      publishing_api_put_content(document)
-    else
-      print_limitations_of_republishing(document)
-    end
-  end
-
-private
-
-  def print_limitations_of_republishing(document)
-    content_id = document.content_id
-    state = document.publication_state
-
-    message = "Skipped republishing document with content_id #{content_id}"
-    message += " because it has a state of '#{state}'. Currently, there is"
-    message += " no way to safely republish the document that is supported by"
-    message += " the platform."
-
-    logger.warn message
-  end
-
-  def publishing_api_put_content(document)
-    payload = DocumentPresenter.new(document).to_json
-    Services.publishing_api.put_content(document.content_id, payload)
-  end
-
-  def publishing_api_patch_links(document)
-    payload = DocumentLinksPresenter.new(document).to_json
-    Services.publishing_api.patch_links(document.content_id, payload)
-  end
-
-  def publishing_api_publish(document)
-    Services.publishing_api.publish(document.content_id, "republish")
+    RepublishService.new.call(content_id)
   end
 end

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe RepublishService do
+  let(:document) { FactoryBot.create(:cma_case) }
+  let(:content_id) { document["content_id"] }
+
+  let(:uses_republish_update_type) do
+    request_json_includes("update_type" => "republish")
+  end
+
+  let(:does_not_use_republish_update_type) do
+    request_json_includes("update_type" => "major")
+  end
+
+  before do
+    stub_any_publishing_api_call
+
+    stub_publishing_api_has_item(document)
+  end
+
+  %i[draft redrafted].each do |publication_state|
+    context "when the publication_state is '#{publication_state}'" do
+      let(:document) do
+        FactoryBot.create(:cma_case, publication_state)
+      end
+
+      it "sends the document to the publishing api" do
+        subject.call(content_id)
+
+        assert_publishing_api_put_content(content_id, does_not_use_republish_update_type)
+        assert_publishing_api_patch_links(content_id)
+      end
+
+      it "does not speak to email alert api" do
+        subject.call(content_id)
+
+        expect(WebMock).not_to have_requested(:post, /notifications/)
+      end
+    end
+  end
+
+  context "when the document is published" do
+    let(:document) do
+      FactoryBot.create(:cma_case, :published)
+    end
+
+    it "sends the document to the publishing api" do
+      subject.call(content_id)
+
+      assert_publishing_api_put_content(content_id, uses_republish_update_type)
+      assert_publishing_api_patch_links(content_id)
+    end
+
+    it "publishes the document" do
+      subject.call(content_id)
+
+      assert_publishing_api_publish(content_id, uses_republish_update_type)
+    end
+
+    it "does not speak to email alert api" do
+      subject.call(content_id)
+
+      expect(WebMock).not_to have_requested(:post, /notifications/)
+    end
+  end
+
+  context "when the document is unpublished" do
+    let(:document) do
+      FactoryBot.create(:cma_case, :unpublished)
+    end
+
+    it "skips republishing of the document" do
+      expect(WebMock).not_to have_requested(:put, /publishing-api/)
+      expect(WebMock).not_to have_requested(:post, /publishing-api/)
+      expect(WebMock).not_to have_requested(:post, /notifications/)
+    end
+  end
+
+  context "when the document is in any other state" do
+    let(:document) do
+      FactoryBot.create(:cma_case, publication_state: "unrecognised")
+    end
+
+    it "skips republishing of the document" do
+      expect(WebMock).not_to have_requested(:put, /publishing-api/)
+      expect(WebMock).not_to have_requested(:post, /publishing-api/)
+      expect(WebMock).not_to have_requested(:post, /notifications/)
+    end
+  end
+end

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe RepublishService do
     stub_publishing_api_has_item(document)
   end
 
+  shared_examples "transform put content" do |times|
+    it "allows transforming the put content payload" do
+      subject.call(content_id) do |payload|
+        payload[:title] = "Transformed title"
+      end
+
+      assert_publishing_api_put_content(
+        content_id, request_json_includes("title" => "Transformed title"), times
+      )
+    end
+  end
+
   %i[draft redrafted].each do |publication_state|
     context "when the publication_state is '#{publication_state}'" do
       let(:document) do
@@ -36,6 +48,8 @@ RSpec.describe RepublishService do
 
         expect(WebMock).not_to have_requested(:post, /notifications/)
       end
+
+      include_examples "transform put content", publication_state == :redrafted ? 2 : 1
     end
   end
 
@@ -62,6 +76,8 @@ RSpec.describe RepublishService do
 
       expect(WebMock).not_to have_requested(:post, /notifications/)
     end
+
+    include_examples "transform put content", 1
   end
 
   context "when the document is unpublished" do

--- a/spec/workers/republish_worker_spec.rb
+++ b/spec/workers/republish_worker_spec.rb
@@ -1,90 +1,12 @@
 require "rails_helper"
 
 RSpec.describe RepublishWorker do
-  let(:document) { FactoryBot.create(:cma_case) }
-  let(:content_id) { document["content_id"] }
+  let(:content_id) { SecureRandom.uuid }
 
-  let(:uses_republish_update_type) do
-    request_json_includes("update_type" => "republish")
-  end
+  it "calls the RepublishService" do
+    expect_any_instance_of(RepublishService)
+      .to receive(:call).with(content_id)
 
-  let(:does_not_use_republish_update_type) do
-    request_json_includes("update_type" => "major")
-  end
-
-  before do
-    stub_any_publishing_api_call
-
-    stub_publishing_api_has_item(document)
-  end
-
-  %i[draft redrafted].each do |publication_state|
-    context "when the publication_state is '#{publication_state}'" do
-      let(:document) do
-        FactoryBot.create(:cma_case, publication_state)
-      end
-
-      it "sends the document to the publishing api" do
-        subject.perform(content_id)
-
-        assert_publishing_api_put_content(content_id, does_not_use_republish_update_type)
-        assert_publishing_api_patch_links(content_id)
-      end
-
-      it "does not speak to email alert api" do
-        subject.perform(content_id)
-
-        expect(WebMock).not_to have_requested(:post, /notifications/)
-      end
-    end
-  end
-
-  context "when the document is published" do
-    let(:document) do
-      FactoryBot.create(:cma_case, :published)
-    end
-
-    it "sends the document to the publishing api" do
-      subject.perform(content_id)
-
-      assert_publishing_api_put_content(content_id, uses_republish_update_type)
-      assert_publishing_api_patch_links(content_id)
-    end
-
-    it "publishes the document" do
-      subject.perform(content_id)
-
-      assert_publishing_api_publish(content_id, uses_republish_update_type)
-    end
-
-    it "does not speak to email alert api" do
-      subject.perform(content_id)
-
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
-  end
-
-  context "when the document is unpublished" do
-    let(:document) do
-      FactoryBot.create(:cma_case, :unpublished)
-    end
-
-    it "skips republishing of the document" do
-      expect(WebMock).not_to have_requested(:put, /publishing-api/)
-      expect(WebMock).not_to have_requested(:post, /publishing-api/)
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
-  end
-
-  context "when the document is in any other state" do
-    let(:document) do
-      FactoryBot.create(:cma_case, publication_state: "unrecognised")
-    end
-
-    it "skips republishing of the document" do
-      expect(WebMock).not_to have_requested(:put, /publishing-api/)
-      expect(WebMock).not_to have_requested(:post, /publishing-api/)
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
+    described_class.perform_async(content_id)
   end
 end


### PR DESCRIPTION
We're needing to migrate the document type, base path and metadata of a number of documents. To make sure we keep the history we want to do this via Specialist Publisher.

Currently it's not possible to change these when republishing, but this PR makes it possible to pass a block to the `RepublishService` and transform the content before it's given to the Publishing API.