### PR TITLE
Move Research For Development Outputs to FCDO

### DIFF
--- a/app/models/research_for_development_output.rb
+++ b/app/models/research_for_development_output.rb
@@ -45,6 +45,6 @@ class ResearchForDevelopmentOutput < Document
   end
 
   def primary_publishing_organisation
-    "db994552-7644-404d-a770-a2fe659c661f"
+    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
   end
 end

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -4,13 +4,14 @@
   "format_name": "Research for Development Output",
   "name": "Research for Development Outputs",
   "description": "Find outputs from Research for Development projects",
+  "summary": "<p>Research outputs published before XX September 2020 were published by the Department for International Development (DFID)</p>",
   "filter": {
     "format": "research_for_development_output"
   },
   "signup_content_id": "fdcbada2-1ad4-4194-98dc-5f04a448316e",
   "signup_copy": "You'll get an email each time an output is updated or a new output is published.",
   "organisations": [
-    "db994552-7644-404d-a770-a2fe659c661f"
+    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
   ],
   "subscription_list_title_prefix": "Research for Development output",
   "document_noun": "output",

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -4,7 +4,7 @@
   "format_name": "Research for Development Output",
   "name": "Research for Development Outputs",
   "description": "Find outputs from Research for Development projects",
-  "summary": "<p>Research outputs published before XX September 2020 were published by the Department for International Development (DFID)</p>",
+  "summary": "<p>Research outputs published before 2 September 2020 were published by the Department for International Development (DFID)</p>",
   "filter": {
     "format": "research_for_development_output"
   },

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -49,8 +49,8 @@ FactoryBot.define do
   end
 
   factory :research_for_development_output_editor, parent: :editor do
-    organisation_slug { "department-for-international-development" }
-    organisation_content_id { "db994552-7644-404d-a770-a2fe659c661f" }
+    organisation_slug { "foreign-commonwealth-development-office" }
+    organisation_content_id { "f9fcf3fe-2751-4dca-97ca-becaeceb4b26" }
   end
 
   # Writer factories:

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DocumentLinksPresenter do
     DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
-    ResearchForDevelopmentOutput => "db994552-7644-404d-a770-a2fe659c661f",
+    ResearchForDevelopmentOutput => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
     CountrysideStewardshipGrant => "e8fae147-6232-4163-a3f1-1c15b755a8a4",
     BusinessFinanceSupportScheme => "2bde479a-97f2-42b5-986a-287a623c2a1c",
     AsylumSupportDecision => "6f757605-ab8f-4b62-84e4-99f79cf085c2",


### PR DESCRIPTION
The Research for Development Output finder is moving to FCDO as the primary publishing organisation.

This PR updates the organisation ID and adds a summary to alert users to the change in ownership.