### PR TITLE
Add a Rake task for migrate DFID research outputs

### DIFF
--- a/app/lib/republisher.rb
+++ b/app/lib/republisher.rb
@@ -39,6 +39,7 @@ module_function
         document_type: document_type,
         fields: [:content_id],
         per_page: 999_999,
+        order: "updated_at",
       )["results"].map { |r| r["content_id"] }
     end
   end

--- a/lib/tasks/dfid.rake
+++ b/lib/tasks/dfid.rake
@@ -1,0 +1,26 @@
+namespace :dfid do
+  desc "Migrate research outputs"
+  task migrate_research_outputs: :environment do
+    content_ids = Republisher.content_ids_for_document_type("dfid_research_output")
+    content_ids.each do |content_id|
+      RepublishService.new.call(content_id) do |payload|
+        puts "#{payload[:base_path]} - #{payload[:title]}"
+
+        payload[:document_type] = "research_for_development_output"
+
+        base_path = payload[:base_path].gsub("dfid-research-outputs", "research-for-development-outputs")
+        payload[:base_path] = base_path
+        payload[:routes][0][:path] = base_path
+
+        payload[:details][:metadata] = payload[:details][:metadata].tap do |metadata|
+          metadata[:research_document_type] = metadata.delete(:dfid_document_type) || []
+          metadata[:authors] = metadata.delete(:dfid_authors) || []
+          metadata[:theme] = metadata.delete(:dfid_theme) || []
+          if (review_status = metadata.delete(:dfid_review_status))
+            metadata[:review_status] = review_status
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/republisher_spec.rb
+++ b/spec/lib/republisher_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Republisher do
       document_type: document_type,
       fields: [:content_id],
       per_page: 999_999,
+      order: "updated_at",
     )
   end
 


### PR DESCRIPTION
We're moving these to a new finder with a new document type, base path and metadata fields. This Rake task should migrate the documents one by one over to the new finder by republishing new editions of the document with the payload transformed to the new format.

[Trello Card](https://trello.com/c/wye58SZu/2109-update-x2-dfid-specialist-finders-to-fcdo)