### PR TITLE
Add National Patient Safety Alert

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -68,7 +68,8 @@
         {"label": "Drug alert", "value": "drugs"},
         {"label": "Medical device alert", "value": "devices"},
         {"label": "Field safety notice", "value": "field-safety-notices"},
-        {"label": "Drug alert: company-led", "value": "company-led-drugs"}
+        {"label": "Drug alert: company-led", "value": "company-led-drugs"},
+        {"label": "National Patient Safety alert", "value": "national-patient-safety"}
       ]
     },
     {


### PR DESCRIPTION
This is a new category of medical safety alert that MHRA would like to start using.

[Trello Card](https://trello.com/c/gnHVgWtw/2131-add-national-patient-safety-alerts) &middot; [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4210399)