### PR TITLE
Add device-safety-information

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -58,6 +58,13 @@
           "topic_name": "National Patient Safety alert",
           "body": "information published by the MHRA related to patient safety.",
           "prechecked": true
+        },
+        {
+          "key": "device-safety-information",
+          "radio_button_name": "Device safety information",
+          "topic_name": "device safety information",
+          "body": "information published by the MHRA related to device safety.",
+          "prechecked": true
         }
       ]
     }
@@ -76,7 +83,8 @@
         {"label": "Medical device alert", "value": "devices"},
         {"label": "Field safety notice", "value": "field-safety-notices"},
         {"label": "Drug alert: company-led", "value": "company-led-drugs"},
-        {"label": "National Patient Safety alert", "value": "national-patient-safety"}
+        {"label": "National Patient Safety alert", "value": "national-patient-safety"},
+        {"label": "Device safety information", "value": "device-safety-information"}
       ]
     },
     {

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -54,8 +54,8 @@
         },
         {
           "key": "national-patient-safety",
-          "radio_button_name": "National Patient Safety alert",
-          "topic_name": "National Patient Safety alert",
+          "radio_button_name": "National patient safety alert",
+          "topic_name": "national patient safety alert",
           "body": "information published by the MHRA related to patient safety.",
           "prechecked": true
         },
@@ -83,7 +83,7 @@
         {"label": "Medical device alert", "value": "devices"},
         {"label": "Field safety notice", "value": "field-safety-notices"},
         {"label": "Drug alert: company-led", "value": "company-led-drugs"},
-        {"label": "National Patient Safety alert", "value": "national-patient-safety"},
+        {"label": "National patient safety alert", "value": "national-patient-safety"},
         {"label": "Device safety information", "value": "device-safety-information"}
       ]
     },


### PR DESCRIPTION
This is an alert type for medical safety alerts which MHRA would like to start using with 447bebe to replace "Medical Device Alert".

Depends on https://github.com/alphagov/govuk-content-schemas/pull/1007 and https://github.com/alphagov/search-api/pull/2179

[Trello Card](https://trello.com/c/gnHVgWtw/2131-add-national-patient-safety-alerts) &middot; [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4210399)