### PR TITLE
Use params for constructing the edit form URL

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -14,7 +14,7 @@
 <div class="row">
   <div class="col-md-8">
     <%= form_for @document, url: document_path(document_type_slug: params[:document_type_slug],
-                                               content_id_and_locale: @document.content_id_and_locale),
+                                               content_id_and_locale: "#{@content_id_param}:#{@locale_param}"),
                                                method: :put,
                                                html: { class: "edit_document" } do |f| %>
         <%= render partial: "shared/form_fields", locals: {f: f} %>


### PR DESCRIPTION
When the locale was introduced in to the URL, as the locale can be
changed, this means that if you fill in the form, including changing
the locale, but there are validation errors, the form will be
re-rendered using the values you entered including the changed locale
in the URL, but this change hasn't been sent to the Publishing API
yet. The result is that Specialist Publisher can't find the document
when you submit the form.

To avoid this, use the URL parameters to construct the URL, as these
shouldn't change half way through handling the request.