### PR TITLE
Use a select box for the locale

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,71 @@ module ApplicationHelper
   def facet_options(form, facet)
     form.object.facet_options(facet)
   end
+
+  def locale_options
+    # Copied from the specialist document schema
+    %w[
+      ar
+      az
+      be
+      bg
+      bn
+      cs
+      cy
+      da
+      de
+      dr
+      el
+      en
+      es
+      es-419
+      et
+      fa
+      fi
+      fr
+      gd
+      he
+      hi
+      hr
+      hu
+      hy
+      id
+      is
+      it
+      ja
+      ka
+      kk
+      ko
+      lt
+      lv
+      ms
+      mt
+      nl
+      no
+      pl
+      ps
+      pt
+      ro
+      ru
+      si
+      sk
+      sl
+      so
+      sq
+      sr
+      sv
+      sw
+      ta
+      th
+      tk
+      tr
+      uk
+      ur
+      uz
+      vi
+      zh
+      zh-hk
+      zh-tw
+    ]
+  end
 end

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -7,7 +7,18 @@
 <% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :locale } do %>
-  <%= f.text_field :locale, class: 'form-control', value: @document.locale || "en" %>
+  <%= f.select(
+    :locale,
+    locale_options,
+    {
+      selected: @document.locale || "en",
+    },
+    {
+      class: 'select2',
+      multiple: false,
+      data: { placeholder: 'Select locale' }
+    },
+  ) %>
 <% end %>
 
 <%= render layout: 'shared/form_group', locals: { f: f, field: :authors, label: 'Authors' } do %>


### PR DESCRIPTION
This is better, as it's clearer to the user what the options are. It
would be better to have more understandable names to go along with the
locale codes, but I'm not sure where to get those from. Also, maybe
the list of locales should be fetched from the schema rather than be
copied in to the code.

![image](https://user-images.githubusercontent.com/1130010/94033931-59777700-fdb9-11ea-8ce5-6a2e7c6b5e34.png)
