### PR TITLE
Set our republish tasks free!

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -22,6 +22,7 @@ class Document
     :summary,
     :body,
     :format_specific_fields,
+    :last_edited_at,
     :public_updated_at,
     :state,
     :publication_state,
@@ -51,6 +52,7 @@ class Document
     body
     publication_state
     state_history
+    last_edited_at
     public_updated_at
     first_published_at
     update_type

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -11,6 +11,7 @@ class DocumentBuilder
       publication_state: payload["publication_state"],
       state_history: payload["state_history"],
       public_updated_at: payload["public_updated_at"],
+      last_edited_at: payload["last_edited_at"],
       first_published_at: payload["first_published_at"],
       bulk_published: payload["details"]["metadata"]["bulk_published"],
       previous_version: payload["previous_version"],

--- a/app/services/republish_service.rb
+++ b/app/services/republish_service.rb
@@ -51,6 +51,7 @@ private
     payload = DocumentPresenter.new(document).to_json
     payload = payload.tap { |x| block.call(x) } if block
     payload.merge!(bulk_publishing: true)
+    payload.merge!(last_edited_at: document.last_edited_at)
     Services.publishing_api.put_content(document.content_id, payload)
   end
 

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -14,13 +14,16 @@ namespace :republish do
     Republisher.republish_document_type(args.document_type)
   end
 
-  desc "republish a single document"
-  task :one, [:content_id] => :environment do |_, args|
-    Republisher.republish_one(args.content_id)
+  desc "republish a single document (locale defaults to 'en')"
+  task :one, [:content_id, :locale] => :environment do |_, args|
+    Republisher.republish_one(args.content_id, args.locale)
   end
 
-  desc "republish many documents (space separated list of content IDs)"
-  task :many, [:content_ids] => :environment do |_, args|
-    Republisher.republish_many(args.content_ids.split(" "))
+  desc "republish many documents (space separated list of content_id:locale strings)"
+  task :many, [:content_ids_and_locales] => :environment do |_, args|
+    Republisher.republish_many(
+      args.content_ids_and_locales.split(" ")
+        .map { |id_and_locale| id_and_locale.split(":") }
+    )
   end
 end

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -4,19 +4,6 @@ require "csv"
 require "services"
 
 namespace :republish do
-  ##########
-  #
-  # WARNING: do not run these tasks in production, unless absolutely necessary,
-  # as they will effectively shuffle the documents in the
-  # specialist-publisher UI.  This is because the updated_at
-  # timestamps in publishing-api will change, and specialist-publisher
-  # uses publishing-api as its backing store.
-  #
-  # If data is incorrect in Publishing API it should be fixed in
-  # Publishing API
-  #
-  ##########
-
   desc "republish all documents"
   task all: :environment do
     Republisher.republish_all

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe RepublishService do
     stub_publishing_api_has_item(document)
   end
 
+  shared_examples "preserve timestamp" do |times: 1|
+    it "preserves the last edit timestamp" do
+      subject.call(content_id, locale)
+
+      assert_publishing_api_put_content(
+        content_id, request_json_includes("last_edited_at" => document["last_edited_at"]), times
+      )
+    end
+  end
+
   shared_examples "no emails" do
     it "does not speak to email alert api" do
       subject.call(content_id, locale)
@@ -49,6 +59,7 @@ RSpec.describe RepublishService do
       assert_publishing_api_patch_links(content_id)
     end
 
+    include_examples "preserve timestamp"
     include_examples "no emails"
     include_examples "transform put content"
   end
@@ -71,6 +82,7 @@ RSpec.describe RepublishService do
       assert_publishing_api_publish(content_id, uses_republish_update_type)
     end
 
+    include_examples "preserve timestamp", times: 2
     include_examples "no emails"
     include_examples "transform put content", times: 2
   end
@@ -92,6 +104,7 @@ RSpec.describe RepublishService do
       assert_publishing_api_publish(content_id, uses_republish_update_type)
     end
 
+    include_examples "preserve timestamp"
     include_examples "no emails"
     include_examples "transform put content", 1
   end

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -15,8 +15,14 @@ RSpec.describe RepublishService do
 
   before do
     stub_any_publishing_api_call
-
     stub_publishing_api_has_item(document)
+  end
+
+  shared_examples "no emails" do
+    it "does not speak to email alert api" do
+      subject.call(content_id, locale)
+      expect(WebMock).not_to have_requested(:post, /notifications/)
+    end
   end
 
   shared_examples "transform put content" do |times: 1|
@@ -43,12 +49,7 @@ RSpec.describe RepublishService do
       assert_publishing_api_patch_links(content_id)
     end
 
-    it "does not speak to email alert api" do
-      subject.call(content_id, locale)
-
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
-
+    include_examples "no emails"
     include_examples "transform put content"
   end
 
@@ -67,15 +68,10 @@ RSpec.describe RepublishService do
 
     it "publishes the document" do
       subject.call(content_id, locale)
-
       assert_publishing_api_publish(content_id, uses_republish_update_type)
     end
 
-    it "does not speak to email alert api" do
-      subject.call(content_id, locale)
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
-
+    include_examples "no emails"
     include_examples "transform put content", times: 2
   end
 
@@ -93,16 +89,10 @@ RSpec.describe RepublishService do
 
     it "publishes the document" do
       subject.call(content_id, locale)
-
       assert_publishing_api_publish(content_id, uses_republish_update_type)
     end
 
-    it "does not speak to email alert api" do
-      subject.call(content_id, locale)
-
-      expect(WebMock).not_to have_requested(:post, /notifications/)
-    end
-
+    include_examples "no emails"
     include_examples "transform put content", 1
   end
 

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RepublishService do
     stub_publishing_api_has_item(document)
   end
 
-  shared_examples "transform put content" do |times|
+  shared_examples "transform put content" do |times: 1|
     it "allows transforming the put content payload" do
       subject.call(content_id, locale) do |payload|
         payload[:title] = "Transformed title"
@@ -49,7 +49,7 @@ RSpec.describe RepublishService do
       expect(WebMock).not_to have_requested(:post, /notifications/)
     end
 
-    include_examples "transform put content", 1
+    include_examples "transform put content"
   end
 
   context "when the document is redrafted" do
@@ -76,7 +76,7 @@ RSpec.describe RepublishService do
       expect(WebMock).not_to have_requested(:post, /notifications/)
     end
 
-    include_examples "transform put content", 2
+    include_examples "transform put content", times: 2
   end
 
   context "when the document is published" do


### PR DESCRIPTION
https://trello.com/c/J6DOuBBp/990-country-updates

Previously we were unable to run these tasks due to the
reordering effect they had on the lists of documents in
this app. There's no point having code we're scared to
execute; this fixes that. Please see commits for details.