### PR TITLE
Add language names

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,70 +3,11 @@ module ApplicationHelper
     form.object.facet_options(facet)
   end
 
-  def locale_options
-    # Copied from the specialist document schema
-    %w[
-      ar
-      az
-      be
-      bg
-      bn
-      cs
-      cy
-      da
-      de
-      dr
-      el
-      en
-      es
-      es-419
-      et
-      fa
-      fi
-      fr
-      gd
-      he
-      hi
-      hr
-      hu
-      hy
-      id
-      is
-      it
-      ja
-      ka
-      kk
-      ko
-      lt
-      lv
-      ms
-      mt
-      nl
-      no
-      pl
-      ps
-      pt
-      ro
-      ru
-      si
-      sk
-      sl
-      so
-      sq
-      sr
-      sv
-      sw
-      ta
-      th
-      tk
-      tr
-      uk
-      ur
-      uz
-      vi
-      zh
-      zh-hk
-      zh-tw
-    ]
+  def locale_codes
+    I18n.t('language_names').keys
+  end
+
+  def map_locale_names
+    locale_codes.index_by { |l| [t("language_names.#{l}", locale: "en")] }
   end
 end

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -13,10 +13,10 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :locale } do %>
   <%= f.select(
     :locale,
-    locale_options,
-    {
-      selected: @document.locale || "en",
-    },
+    options_for_select(
+      map_locale_names,
+      @document.locale || "en"
+    ),
     {
       class: 'select2',
       multiple: false,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,67 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  i18n:
+    direction: ltr
+  language_names:
+    ar: Arabic
+    de: German
+    dr: Dari
+    en: English
+    cy: Welsh
+    es: Spanish
+    es-419: Latin American Spanish
+    et: Estonian
+    fa: Persian
+    fr: French
+    it: Italian
+    ja: Japanese
+    pt: Portuguese
+    ru: Russian
+    tr: Turkish
+    ur: Urdu
+    zh: Chinese
+    zh-hk: Cantonese
+    zh-tw: Traditional Chinese
+    bg: Bulgarian
+    cs: Czech
+    he: Hebrew
+    ko: Korean
+    pl: Polish
+    ro: Romanian
+    sr: Serbian
+    th: Thai
+    uk: Ukrainian
+    vi: Vietnamese
+    sq: Albanian
+    hy: Armenian
+    az: Azeri
+    bn: Bangla
+    be: Belarusian
+    ka: Georgian
+    el: Greek
+    hu: Hungarian
+    hi: Hindi
+    lv: Latvian
+    lt: Lithuanian
+    ms: Malay
+    ps: Pashto
+    si: Sinhala
+    sk: Slovak
+    so: Somali
+    sw: Swahili
+    ta: Tamil
+    tk: Turkmen
+    uz: Uzbeki
+    id: Indonesian
+    nl: Dutch
+    "no": Norwegian
+    hr: Croatian
+    mt: Maltese
+    da: Danish
+    fi: Finish
+    is: Icelandic
+    gd: Irish
+    sl: Slovenian
+    sv: Swedish
+    kk: Kazakh


### PR DESCRIPTION
Publishers will be able to choose from a list of language names instead of language codes

https://trello.com/c/wVIOzUd9/2134-investigate-how-to-make-bulk-changes-to-the-language-tagging-of-content