### PR TITLE
Lint as part of the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,13 @@
 require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
+
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Rubocop isn't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop spec]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,10 +4,10 @@ module ApplicationHelper
   end
 
   def locale_codes
-    I18n.t('language_names').keys
+    I18n.t("language_names").keys
   end
 
   def map_locale_names
-    locale_codes.map { |l| [t("language_names.#{l}", locale: "en"), l] }.to_h
+    locale_codes.index_by { |l| t("language_names.#{l}", locale: "en") }
   end
 end

--- a/app/models/protected_food_drink_name.rb
+++ b/app/models/protected_food_drink_name.rb
@@ -11,7 +11,7 @@ class ProtectedFoodDrinkName < Document
   validates :date_registration, presence: true, date: true
   validates :date_registration_eu, presence: true, date: true, allow_blank: true
 
-  FORMAT_SPECIFIC_FIELDS = %i(
+  FORMAT_SPECIFIC_FIELDS = %i[
     register
     status
     class_category
@@ -24,7 +24,7 @@ class ProtectedFoodDrinkName < Document
     date_registration
     date_registration_eu
     internal_notes
-  ).freeze
+  ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)
 

--- a/lib/tasks/ops.rake
+++ b/lib/tasks/ops.rake
@@ -1,11 +1,11 @@
 namespace :ops do
   desc "Discard the draft of document"
-  task :discard, [:content_id, :locale] => :environment do |_, args|
+  task :discard, %i[content_id locale] => :environment do |_, args|
     OpsTasks.discard(args.content_id, args.locale)
   end
 
   desc "Send an email for document"
-  task :email, [:content_id, :locale] => :environment do |_, args|
+  task :email, %i[content_id locale] => :environment do |_, args|
     OpsTasks.email(args.content_id, locale)
   end
 

--- a/lib/tasks/rename_country.rake
+++ b/lib/tasks/rename_country.rake
@@ -1,12 +1,12 @@
 namespace :rename_country do
   desc "Update and republish all docs that refer to a country"
-  task :all, [:old, :new] => :environment do |_t, args|
+  task :all, %i[old new] => :environment do |_t, args|
     Rake::Task["rename_country:export_health_certificates"].invoke(*args)
     Rake::Task["rename_country:international_development_funds"].invoke(*args)
   end
 
   desc "Update and republish export health certificates that refer to a country"
-  task :export_health_certificates, [:old, :new] => :environment do |_t, args|
+  task :export_health_certificates, %i[old new] => :environment do |_t, args|
     ExportHealthCertificate.find_each do |doc|
       current_value = doc.destination_country
       next unless current_value&.include? args[:old]
@@ -19,7 +19,7 @@ namespace :rename_country do
   end
 
   desc "Update and republish international development funds that refer to a country"
-  task :international_development_funds, [:old, :new] => :environment do |_t, args|
+  task :international_development_funds, %i[old new] => :environment do |_t, args|
     InternationalDevelopmentFund.find_each do |doc|
       current_value = doc.location
       next unless current_value&.include? args[:old]

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -15,7 +15,7 @@ namespace :republish do
   end
 
   desc "republish a single document (locale defaults to 'en')"
-  task :one, [:content_id, :locale] => :environment do |_, args|
+  task :one, %i[content_id locale] => :environment do |_, args|
     Republisher.republish_one(args.content_id, args.locale)
   end
 
@@ -23,7 +23,7 @@ namespace :republish do
   task :many, [:content_ids_and_locales] => :environment do |_, args|
     Republisher.republish_many(
       args.content_ids_and_locales.split(" ")
-        .map { |id_and_locale| id_and_locale.split(":") }
+        .map { |id_and_locale| id_and_locale.split(":") },
     )
   end
 end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DocumentsController, type: :controller do
 
   describe "GET show" do
     it "responds successfully" do
-      get :show, params: { document_type_slug: "cma-cases", content_id_and_locale: "#{payload["content_id"]}:#{payload["locale"]}" }
+      get :show, params: { document_type_slug: "cma-cases", content_id_and_locale: "#{payload['content_id']}:#{payload['locale']}" }
       expect(response.status).to eq(200)
     end
 
@@ -25,7 +25,7 @@ RSpec.describe DocumentsController, type: :controller do
       ).to eq(
         document_path(
           document_type_slug: "cma-cases",
-          content_id_and_locale: "#{payload["content_id"]}:#{payload["locale"]}",
+          content_id_and_locale: "#{payload['content_id']}:#{payload['locale']}",
         ),
       )
     end
@@ -37,7 +37,7 @@ RSpec.describe DocumentsController, type: :controller do
     end
 
     it "responds successfully" do
-      post :discard, params: { document_type_slug: "cma-cases", content_id_and_locale: "#{payload["content_id"]}:#{payload["locale"]}" }
+      post :discard, params: { document_type_slug: "cma-cases", content_id_and_locale: "#{payload['content_id']}:#{payload['locale']}" }
       expect(subject).to redirect_to(documents_path(document_type_slug: "cma-cases"))
     end
   end

--- a/spec/features/creating_a_protected_food_drink_name_spec.rb
+++ b/spec/features/creating_a_protected_food_drink_name_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.feature "Creating a Protected Food Drink Name", type: :feature do
   let(:fields)            { %i[base_path content_id public_updated_at title publication_state] }
-  let(:protected_food_drink_name)   { FactoryBot.create(:protected_food_drink_name) }
+  let(:protected_food_drink_name) { FactoryBot.create(:protected_food_drink_name) }
   let(:content_id)        { protected_food_drink_name["content_id"] }
   let(:public_updated_at) { protected_food_drink_name["public_updated_at"] }
 
@@ -17,7 +17,6 @@ RSpec.feature "Creating a Protected Food Drink Name", type: :feature do
 
     stub_publishing_api_has_item(protected_food_drink_name)
   end
-
 
   scenario "with valid data" do
     visit "/protected-food-drink-names/new"

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     organisation_slug { "foreign-commonwealth-development-office" }
     organisation_content_id { "f9fcf3fe-2751-4dca-97ca-becaeceb4b26" }
   end
-  
+
   factory :protected_food_drink_name_editor, parent: :editor do
     organisation_slug { "department-for-environment-food-rural-affairs" }
     organisation_content_id { "de4e9dc6-cca4-43af-a594-682023b84d6c" }
@@ -428,7 +428,7 @@ FactoryBot.define do
           "status" => "registered",
           "class_category" => ["1-1-fresh-meat-and-offal"],
           "protection_type" => "protected-geographical-indication-pgi",
-          "country" => ["united-kingdom"],
+          "country" => %w[united-kingdom],
           "date_registration" => "2020-01-01",
           "traditional_term_grapevine_product_category" => "new-wine-still-in-fermentation",
           "traditional_term_type" => "description-of-product-characteristic",


### PR DESCRIPTION
We had expected that all apps were linting with the default rake task
and removed the linting step from the Jenkins library [1]. However it
seems this app was missed.

[1]: alphagov/govuk-jenkinslib#74