### PR TITLE
Make summary optional for ProtectedFoodDrinkName

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,7 +39,7 @@ class Document
   alias_method :temporary_update_type?, :temporary_update_type
 
   validates :title, presence: true
-  validates :summary, presence: true
+  validates :summary, presence: true, unless: :protected_food_drink_name?
   validates :body, presence: true, safe_html: true, inline_attachments: true
   validates :update_type, presence: true, unless: :first_draft?
   validates :change_note, presence: true, if: :change_note_required?
@@ -359,5 +359,9 @@ private
 
   def publishable?
     !content_item_blocking_publish?
+  end
+
+  def protected_food_drink_name?
+    document_type == "protected_food_drink_name"
   end
 end

--- a/spec/features/creating_a_protected_food_drink_name_spec.rb
+++ b/spec/features/creating_a_protected_food_drink_name_spec.rb
@@ -55,7 +55,6 @@ RSpec.feature "Creating a Protected Food Drink Name", type: :feature do
     expect(page.status_code).to eq(422)
 
     expect(page).to have_content("Title can't be blank")
-    expect(page).to have_content("Summary can't be blank")
     expect(page).to have_content("Body can't be blank")
     expect(page).to have_content("Register can't be blank")
     expect(page).to have_content("Status can't be blank")

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe Document do
       expect(subject.save).to be true
       assert_publishing_api_put_content(subject.content_id, request_json_includes(update_type: "major"))
     end
+
+    describe "#summary" do
+      before { subject.summary = nil }
+
+      context "when document_type is not 'protected_food_drink_name'" do
+        it "requires a summary" do
+          expect(subject).to_not be_valid
+          expect(subject.errors.messages).to eq(summary: ["can't be blank"])
+        end
+      end
+
+      context "when document_type is 'protected_food_drink_name'" do
+        before { expect(subject).to receive(:document_type).and_return("protected_food_drink_name") }
+
+        it "does not require a summary" do
+          expect(subject).to be_valid
+          expect(subject.errors.messages).to be_blank
+        end
+      end
+    end
   end
 
   before(:all) do


### PR DESCRIPTION
This is a departmental request. See related [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4197468).

Trello card: https://trello.com/c/XYFBR2Bt/2187-3-update-protected-food-names-frontend-template-make-summary-optional-for-this-finder