### PR TITLE
Publishing in Bulk via Rake Task

### DIFF
--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -1,0 +1,15 @@
+# This tasks will publish documents that are in a draft publication state.
+
+require "services"
+
+namespace :publish do
+  desc "Publishes all documents of given types in a draft publication state.\n" \
+    "Usage: `rake publish:all[protected_food_drink_name,esi_fund]`"
+  task :all, [:document_types] => :environment do |_, args|
+    types = args.document_types.presence&.split(" ")&.compact
+
+    raise ArgumentError, "No type given." if types.empty?
+
+    Publisher.publish_all(types: types)
+  end
+end

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Publisher do
+  before do
+    expect_any_instance_of(described_class).to receive(:document_types).and_return(%w[raib_report some_class])
+
+    stub_publishing_api_has_content(
+      [
+        { content_id: "raib-1", locale: "en" },
+        { content_id: "raib-2", locale: "en" },
+      ],
+      document_type: "raib_report",
+      publication_state: "draft",
+      fields: %i[content_id locale],
+      per_page: 999_999,
+      order: "updated_at",
+    )
+  end
+
+  describe ".publish_all" do
+    it "find all documents in the domain still in a draft state and triggers the publishing operation on them" do
+      document_raib1 = double(:document_raib1)
+      document_raib2 = double(:document_raib2)
+
+      expect(Document).to receive(:find).with("raib-1", "en").and_return(document_raib1)
+      expect(Document).to receive(:find).with("raib-2", "en").and_return(document_raib2)
+      expect(document_raib1).to receive(:publish)
+      expect(document_raib2).to receive(:publish)
+
+      described_class.publish_all(types: %w[raib_report])
+    end
+
+    context "when the types is not known" do
+      it "fails and report an error" do
+        expect { described_class.publish_all(types: %w[some_type]) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains the code that implements a publishing in bulk feature.
The feature is accessible via Rake task. I used some code found in the `republish` task functionality. However, in the case of `publishing`, the code looks simpler as it does not have to validate states and states versions.
It will only work with documents that are currently in a Draft status.
This tasks also allow to run the publish all functionality on a subset of document types rather than all existing documents in `draft` mode.
Discussions has to happen still about the background job or in-line publiation. Looking at existing functionality, seems like a background job is the way to go.