### PR TITLE
Add flood_and_coastal_erosion_risk_management_research_report

### DIFF
--- a/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
+++ b/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
@@ -1,0 +1,42 @@
+class FloodAndCoastalErosionRiskManagementResearchReport < Document
+  validates :category, presence: true
+  validates :date_of_completion, date: true
+  validates :date_of_start, date: true
+  validates :project_code, presence: true
+  validates :project_status, presence: true
+  validates :topics, presence: true
+  validates :primary_publishing_organisation, presence: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    category
+    date_of_completion
+    date_of_start
+    project_code
+    project_status
+    topics
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+  attr_accessor :organisations, :primary_publishing_organisation
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+    @primary_publishing_organisation = params[:primary_publishing_organisation]
+    @organisations = params[:organisations]
+  end
+
+  def self.title
+    "Flood and Coastal Erosion Risk Management Research Report"
+  end
+
+  def links
+    super.merge(
+      organisations: organisations | [primary_publishing_organisation],
+      primary_publishing_organisation: [primary_publishing_organisation],
+    )
+  end
+
+  def has_organisations?
+    true
+  end
+end

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -1,0 +1,67 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :category } do %>
+  <%= f.select :category,
+      f.object.facet_options(:category),
+      {},
+      { class: "form-control" }
+  %>
+<% end %>
+
+<%= render layout: "shared/date_fields", locals: { f: f, field: :date_of_start, format: :flood_and_coastal_erosion_risk_management_research_report } do %>
+<% end %>
+
+<%= render layout: "shared/date_fields", locals: { f: f, field: :date_of_completion, format: :flood_and_coastal_erosion_risk_management_research_report } do %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :project_code } do %>
+  <%= f.text_field :project_code, class: "form-control" %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :project_status } do %>
+  <%= f.select :project_status,
+      f.object.facet_options(:project_status),
+      {},
+      { class: "form-control" }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :topics } do %>
+  <%= f.select :topics,
+      f.object.facet_options(:topics),
+      {},
+      {
+        class: "select2 form-control",
+        multiple: true,
+        data: {
+          placeholder: "Select topics"
+        }
+      }
+  %>
+<% end %>
+
+<%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
+  <%= f.select :primary_publishing_organisation,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control",
+        multiple: false,
+        data: {
+          placeholder: "Select a primary publishing organisation"
+        }
+      }
+  %>
+<% end %>
+
+<%= render "shared/form_group", f: f, field: :organisations, label: "Other associated organisations" do %>
+  <%= f.select :organisations,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control select-all-disabled",
+        multiple: true,
+        data: {
+          placeholder: "Select organisations"
+        }
+      }
+  %>
+<% end %>

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -1,0 +1,135 @@
+{
+  "content_id": "a37f6a22-af8a-465a-89df-de5a5b40b6d0",
+  "base_path": "/flood-and-coastal-erosion-risk-management-research-reports",
+  "format_name": "Flood and Coastal Erosion Risk Management Research Report",
+  "name": "Flood and Coastal Erosion Risk Management Research Reports",
+  "description": "Find Flood and Coastal Erosion Risk Management Research Reports",
+  "filter": {
+    "format": "flood_and_coastal_erosion_risk_management_research_report"
+  },
+  "organisations": [],
+  "document_noun": "research report",
+  "facets": [
+    {
+      "key": "category",
+      "name": "Category",
+      "type": "text",
+      "preposition": "with category",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Environmental management and sustainability", "value": "environmental-management-and-sustainability"},
+        {"label": "Increasing resilience to flooding", "value": "increasing-resilience-to-flooding"},
+        {"label": "Managing flood incidents", "value": "managing-flood-incidents"},
+        {"label": "Policy, governance and funding", "value": "policy-governance-and-funding"},
+        {"label": "Understanding risks from all sources of flooding", "value": "understanding-risks-from-all-sources-of-flooding"},
+        {"label": "Whole life asset management", "value": "whole-life-asset-management"}
+      ]
+    },
+
+    {
+      "key": "date_of_start",
+      "name": "Start date",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+
+    {
+      "key": "date_of_completion",
+      "name": "Completion date",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+
+    {
+      "key": "project_code",
+      "name": "Project code",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+
+    {
+      "key": "project_status",
+      "name": "Project status",
+      "type": "text",
+      "preposition": "with project status",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Completed", "value": "completed"},
+        {"label": "Ongoing", "value": "ongoing"}
+      ]
+    },
+
+    {
+      "key": "topics",
+      "name": "Topics",
+      "type": "text",
+      "preposition": "with topics",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Adaptation", "value": "adaptation"},
+        {"label": "Alternative construction materials", "value": "alternative-construction-materials"},
+        {"label": "Appraisal guidance", "value": "appraisal-guidance"},
+        {"label": "Appraisal strategy", "value": "appraisal-strategy"},
+        {"label": "Artificial intelligence", "value": "artificial-intelligence"},
+        {"label": "Asset maintenance", "value": "asset-maintenance"},
+        {"label": "Asset monitoring", "value": "asset-monitoring"},
+        {"label": "Asset performance", "value": "asset-performance"},
+        {"label": "Asset system optimisation", "value": "asset-system-optimisation"},
+        {"label": "Behavioural change", "value": "behavioural-change"},
+        {"label": "Big data", "value": "big-data"},
+        {"label": "Carbon", "value": "carbon"},
+        {"label": "Channel management", "value": "channel-management"},
+        {"label": "Citizen science", "value": "citizen-science"},
+        {"label": "Climate change", "value": "climate-change"},
+        {"label": "Coast", "value": "coast"},
+        {"label": "Coastal erosion", "value": "coastal-erosion"},
+        {"label": "Communicating risk", "value": "communicating-risk"},
+        {"label": "Community participation", "value": "community-participation"},
+        {"label": "Community response and resilience", "value": "community-response-and-resilience"},
+        {"label": "Decision making with uncertainty", "value": "decision-making-with-uncertainty"},
+        {"label": "Design and build", "value": "design-and-build"},
+        {"label": "Deterioration", "value": "deterioration"},
+        {"label": "Ecosystem service benefits", "value": "ecosystem-service-benefits"},
+        {"label": "Emergency planning", "value": "emergency-planning"},
+        {"label": "Flood costs", "value": "flood-costs"},
+        {"label": "Flood forecasting", "value": "flood-forecasting"},
+        {"label": "Flood risk assessment", "value": "flood-risk-assessment"},
+        {"label": "flood risk governance", "value": "flood-risk-governance"},
+        {"label": "Flood warning", "value": "flood-warning"},
+        {"label": "Groundwater", "value": "groundwater"},
+        {"label": "Health safety and wellbeing", "value": "health-safety-and-wellbeing"},
+        {"label": "Hydrology", "value": "hydrology"},
+        {"label": "Incident management", "value": "incident-management"},
+        {"label": "insurance", "value": "insurance"},
+        {"label": "Investment", "value": "investment"},
+        {"label": "Machine learning", "value": "machine-learning"},
+        {"label": "Meteorology", "value": "meteorology"},
+        {"label": "Modelling", "value": "modelling"},
+        {"label": "Monitoring and detection", "value": "monitoring-and-detection"},
+        {"label": "Natural capital", "value": "natural-capital"},
+        {"label": "Natural flood management", "value": "natural-flood-management"},
+        {"label": "Non-stationarity", "value": "non-stationarity"},
+        {"label": "Offsite methods and remote techniques", "value": "offsite-methods-and-remote-techniques"},
+        {"label": "Partnership working", "value": "partnership-working"},
+        {"label": "Recovery", "value": "recovery"},
+        {"label": "Reservoirs", "value": "reservoirs"},
+        {"label": "Resilience planning", "value": "resilience-planning"},
+        {"label": "Resilient infrastructure", "value": "resilient-infrastructure"},
+        {"label": "Sea level rise", "value": "sea-level-rise"},
+        {"label": "Spatial planning", "value": "spatial-planning"},
+        {"label": "Strategy and planning", "value": "strategy-and-planning"},
+        {"label": "Surface water", "value": "surface-water"},
+        {"label": "Sustainability", "value": "sustainability"},
+        {"label": "Sustainable drainage systems", "value": "sustainable-drainage-systems"},
+        {"label": "Understanding physical processes", "value": "understanding-physical-processes"},
+        {"label": "Whole life costs", "value": "whole-life-costs"}
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -387,6 +387,35 @@ FactoryBot.define do
     end
   end
 
+  factory :flood_and_coastal_erosion_risk_management_research_report, parent: :document do
+    base_path { "/flood-and-coastal-erosion-risk-management-research-reports/example-document" }
+    document_type { "flood_and_coastal_erosion_risk_management_research_report" }
+
+    transient do
+      default_metadata do
+        {
+          "category" => "managing-flood-incidents",
+          "project_code" => "code",
+          "project_status" => "ongoing",
+          "topics" => %w[big-data carbon],
+        }
+      end
+
+      organisation_content_id { "6de6b795-9d30-4bd8-a257-ab9a6879e1ea" }
+      primary_publishing_org_content_id { "d31d9806-2644-4023-be70-5376cae84a06" }
+    end
+
+    initialize_with do
+      attributes.merge(
+        links: {
+          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          organisations: [organisation_content_id, primary_publishing_org_content_id],
+          primary_publishing_organisation: [primary_publishing_org_content_id],
+        },
+      )
+    end
+  end
+
   factory :maib_report, parent: :document do
     base_path { "/maib-reports/example-document" }
     document_type { "maib_report" }

--- a/spec/models/flood_and_coastal_erosion_risk_management_research_report_spec.rb
+++ b/spec/models/flood_and_coastal_erosion_risk_management_research_report_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe FloodAndCoastalErosionRiskManagementResearchReport do
+  let(:payload) { FactoryBot.create(:flood_and_coastal_erosion_risk_management_research_report) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+end


### PR DESCRIPTION
This is a new type of specialist document and finder that will be published by Defra and other organisations.

Related to https://github.com/alphagov/govuk-content-schemas/pull/1024 and https://github.com/alphagov/search-api/pull/2212.

[Trello Card](https://trello.com/c/atDp5GQO/2199-3-add-flood-and-coastal-erosion-specialist-document)