### PR TITLE
Move the `.with_timeout` method in the `Services` class

### DIFF
--- a/app/lib/republisher.rb
+++ b/app/lib/republisher.rb
@@ -38,7 +38,7 @@ module_function
       raise ArgumentError, "Unknown document_type: '#{document_type}'"
     end
 
-    with_timeout(30) do
+    Services.with_timeout(30) do
       Services.publishing_api.get_content_items(
         document_type: document_type,
         fields: %i[content_id locale],
@@ -55,15 +55,5 @@ module_function
   def all_document_types
     Rails.application.eager_load!
     Document.subclasses.map(&:document_type)
-  end
-
-  def with_timeout(seconds)
-    previous_timeout = Services.publishing_api.client.options[:timeout]
-
-    Services.publishing_api.client.options[:timeout] = seconds
-    result = yield
-    Services.publishing_api.client.options[:timeout] = previous_timeout
-
-    result
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -17,4 +17,14 @@ module Services
       bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || "12345678",
     )
   end
+
+  def self.with_timeout(seconds)
+    previous_timeout = publishing_api.client.options[:timeout]
+
+    publishing_api.client.options[:timeout] = seconds
+    result = yield
+    publishing_api.client.options[:timeout] = previous_timeout
+
+    result
+  end
 end

--- a/spec/lib/services_spec.rb
+++ b/spec/lib/services_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Services do
+  describe ".with_timeout" do
+    it "executes a block of code with the defined services timeout" do
+      options = described_class.publishing_api.client.options
+
+      # Set default timeout
+      options[:timeout] = 1
+
+      expect(options).to receive(:[]=).with(:timeout, 30).once.and_call_original.ordered
+      expect(options).to receive(:[]=).with(:timeout, 1).once.and_call_original.ordered
+
+      result = described_class.with_timeout(30) { 2 + 3 }
+
+      expect(result).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
This is so we can re-use that logic outside of the Republisher class