### PR TITLE
Specialist food changes

### DIFF
--- a/app/models/protected_food_drink_name.rb
+++ b/app/models/protected_food_drink_name.rb
@@ -7,6 +7,7 @@ class ProtectedFoodDrinkName < Document
   validates :traditional_term_grapevine_product_category, presence: true, allow_blank: true
   validates :traditional_term_type, presence: true, allow_blank: true
   validates :traditional_term_language, presence: true, allow_blank: true
+  validates :reason_for_protection, presence: true, allow_blank: true
   validates :date_application, presence: true, date: true, allow_blank: true
   validates :date_registration, presence: true, date: true
   validates :date_registration_eu, presence: true, date: true, allow_blank: true
@@ -20,6 +21,7 @@ class ProtectedFoodDrinkName < Document
     traditional_term_grapevine_product_category
     traditional_term_type
     traditional_term_language
+    reason_for_protection
     date_application
     date_registration
     date_registration_eu

--- a/app/models/protected_food_drink_name.rb
+++ b/app/models/protected_food_drink_name.rb
@@ -3,7 +3,7 @@ class ProtectedFoodDrinkName < Document
   validates :status, presence: true
   validates :class_category, presence: true
   validates :protection_type, presence: true
-  validates :country, presence: true
+  validates :country_of_origin, presence: true
   validates :traditional_term_grapevine_product_category, presence: true, allow_blank: true
   validates :traditional_term_type, presence: true, allow_blank: true
   validates :traditional_term_language, presence: true, allow_blank: true
@@ -16,7 +16,7 @@ class ProtectedFoodDrinkName < Document
     status
     class_category
     protection_type
-    country
+    country_of_origin
     traditional_term_grapevine_product_category
     traditional_term_type
     traditional_term_language

--- a/app/views/metadata_fields/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields/_protected_food_drink_names.html.erb
@@ -83,6 +83,14 @@
   %>
 <% end %>
 
+<%= render layout: "shared/form_group", locals: { f: f, field: :reason_for_protection } do %>
+  <%= f.select :reason_for_protection,
+      f.object.facet_options(:reason_for_protection),
+      { label: "Reason for protection", include_blank: 'Select reason for protection' },
+      { class: 'form-control' }
+  %>
+<% end %>
+
 <%= render layout: "shared/date_fields", locals: { f: f, field: :date_application, format: :protected_food_drink_name } do %>
 <% end %>
 

--- a/app/views/metadata_fields/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields/_protected_food_drink_names.html.erb
@@ -38,15 +38,15 @@
 <% end %>
 
 <%# You can select multiple countries so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :country } do %>
-  <%= f.select :country,
-      f.object.facet_options(:country),
-      { label: "Country" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :country_of_origin } do %>
+  <%= f.select :country_of_origin,
+      f.object.facet_options(:country_of_origin),
+      { label: "Country of origin" },
       {
         class: 'select2 form-control',
         multiple: true,
         data: {
-          placeholder: 'Select country'
+          placeholder: 'Select country of origin'
         }
       }
   %>

--- a/app/views/metadata_fields/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields/_protected_food_drink_names.html.erb
@@ -52,11 +52,18 @@
   %>
 <% end %>
 
+<%# You can select multiple traditional term grapevine product categories so this has multi-select option %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :traditional_term_grapevine_product_category } do %>
   <%= f.select :traditional_term_grapevine_product_category,
       f.object.facet_options(:traditional_term_grapevine_product_category),
-      { label: "Traditional term grapevine product category", include_blank: 'Select grapevine category' },
-      { class: 'form-control' }
+      { label: "Traditional term grapevine product category" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select grapevine category'
+        }
+      }
   %>
 <% end %>
 

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -29,7 +29,8 @@
         {"label": "Spirit drinks","value": "spirit-drinks"},
         {"label": "Wines","value": "wines"},
         {"label": "Aromatised wines","value": "aromatised-wines"},
-        {"label": "Traditional terms for wine","value": "traditional-terms-for-wine"}
+        {"label": "Traditional terms for wine","value": "traditional-terms-for-wine"},
+        {"label": "Names protected by international treaty", "value": "names-protected-by-international-treaty"}
       ]
     },
     {
@@ -157,7 +158,8 @@
         {"label": "Protected Designation of Origin (PDO)","value": "protected-designation-of-origin-pdo"},
         {"label": "Traditional Speciality Guaranteed (TSG)","value": "traditional-speciality-guaranteed-tsg"},
         {"label": "Traditional Term","value": "traditional-term"},
-        {"label": "Geographical Indication (GI)","value": "geographical-indication-gi"}
+        {"label": "Geographical Indication (GI)","value": "geographical-indication-gi"},
+        {"label": "Names protected by international treaty", "value": "name-protected-by-international-treaty"}
       ]
     },
     {

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -310,6 +310,19 @@
       ]
     },
     {
+      "key": "reason_for_protection",
+      "name": "Reason for protection",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "allowed_values": [
+        {"label": "UK geographical indication from before 2021","value": "uk-gi-before-2021"},
+        {"label": "EU agreement","value": "eu-agreement"},
+        {"label": "UK trade agreement","value": "uk-trade-agreement"},
+        {"label": "Application to UK scheme from 2021","value": "uk-gi-after-2021"}
+      ]
+    },
+    {
       "key": "date_application",
       "name": "Date of application",
       "type": "text",

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -163,10 +163,10 @@
       ]
     },
     {
-      "key": "country",
-      "name": "Country",
+      "key": "country_of_origin",
+      "name": "Country of origin",
       "type": "text",
-      "preposition": "country",
+      "preposition": "country of origin",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -325,21 +325,21 @@
     {
       "key": "date_application",
       "name": "Date of application",
-      "type": "text",
+      "type": "date",
       "display_as_result_metadata": false,
       "filterable": false
     },
     {
       "key": "date_registration",
       "name": "Date of UK registration",
-      "type": "text",
+      "type": "date",
       "display_as_result_metadata": true,
       "filterable": false
     },
     {
       "key": "date_registration_eu",
       "name": "Date of original registration with the EU",
-      "type": "text",
+      "type": "date",
       "display_as_result_metadata": false,
       "filterable": false
     },

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -24,8 +24,8 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
-        {"label": "Foods: designated origin and geographic origin","value": "foods-designated-origin-and-geographic-origin"},
-        {"label": "Foods: traditional speciality","value": "foods-traditional-speciality"},
+        {"label": "Foods: designated origin and geographical indication","value": "foods-designated-origin-and-geographical-indication"},
+        {"label": "Foods: traditional speciality guaranteed","value": "foods-traditional-speciality-guaranteed"},
         {"label": "Spirit drinks","value": "spirit-drinks"},
         {"label": "Wines","value": "wines"},
         {"label": "Aromatised wines","value": "aromatised-wines"},

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -20,7 +20,7 @@
       "name": "Register",
       "type": "text",
       "preposition": "register type",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "Foods: designated origin and geographic origin","value": "foods-designated-origin-and-geographic-origin"},
@@ -51,7 +51,7 @@
       "short_name": "Class or category",
       "type": "text",
       "preposition": "class or category",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "1.1 Fresh meat (and offal)","value": "1-1-fresh-meat-and-offal"},
@@ -149,7 +149,7 @@
       "name": "Protection type",
       "type": "text",
       "preposition": "protection type",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         {"label": "Protected Geographical Indication (PGI)","value": "protected-geographical-indication-pgi"},
@@ -239,7 +239,7 @@
       "name": "Traditional term grapevine product category",
       "short_name": "Grapevine product category",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false,
       "allowed_values": [
         {"label": "Wine","value": "wine"},
@@ -265,7 +265,7 @@
       "key": "traditional_term_type",
       "name": "Traditional term type",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false,
       "allowed_values": [
         {"label": "Description of product characteristic","value": "description-of-product-characteristic"},
@@ -276,7 +276,7 @@
       "key": "traditional_term_language",
       "name": "Traditional term language",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false,
       "allowed_values": [
         {"label": "Bulgarian","value": "bulgarian"},
@@ -310,7 +310,7 @@
       "key": "date_application",
       "name": "Date of application",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false
     },
     {
@@ -324,7 +324,7 @@
       "key": "date_registration_eu",
       "name": "Date of original registration with the EU",
       "type": "text",
-      "display_as_result_metadata": true,
+      "display_as_result_metadata": false,
       "filterable": false
     },
     {

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -8,6 +8,7 @@
   "filter": {
     "format": "protected_food_drink_name"
   },
+  "show_summaries": true,
   "signup_content_id": "cff7449e-4181-480f-93e4-91fecfb4c774",
   "signup_copy": "You'll get an email each time a food or drink name is updated or a new name is published.",
   "organisations": ["de4e9dc6-cca4-43af-a594-682023b84d6c"],

--- a/lib/importers/protected_food_drink_name/parser.rb
+++ b/lib/importers/protected_food_drink_name/parser.rb
@@ -12,7 +12,7 @@ module Importers
           status: status,
           class_category: class_category,
           protection_type: protection_type,
-          # reason_for_protection: reason_for_protection, #TODO
+          reason_for_protection: reason_for_protection,
           country_of_origin: country,
           traditional_term_grapevine_product_category: traditional_term_grapevine_product_category,
           traditional_term_type: traditional_term_type,

--- a/lib/importers/protected_food_drink_name/parser.rb
+++ b/lib/importers/protected_food_drink_name/parser.rb
@@ -13,7 +13,7 @@ module Importers
           class_category: class_category,
           protection_type: protection_type,
           # reason_for_protection: reason_for_protection, #TODO
-          country: country,
+          country_of_origin: country,
           traditional_term_grapevine_product_category: traditional_term_grapevine_product_category,
           traditional_term_type: traditional_term_type,
           traditional_term_language: traditional_term_language,

--- a/lib/importers/protected_food_drink_name/parser.rb
+++ b/lib/importers/protected_food_drink_name/parser.rb
@@ -48,7 +48,7 @@ module Importers
           if data["Protection type"] == "Traditional Specialities Guaranteed (TSG)"
             "foods-traditional-speciality"
           else
-            "foods-designated-origin-and-geographic-origin"
+            "foods-designated-origin-and-geographical-indication"
           end
         end
       end

--- a/spec/features/creating_a_protected_food_drink_name_spec.rb
+++ b/spec/features/creating_a_protected_food_drink_name_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Creating a Protected Food Drink Name", type: :feature do
     expect(page).to have_content("Status can't be blank")
     expect(page).to have_content("Class category can't be blank")
     expect(page).to have_content("Protection type can't be blank")
-    expect(page).to have_content("Country can't be blank")
+    expect(page).to have_content("Country of origin can't be blank")
     expect(page).to have_content("Date registration can't be blank")
   end
 

--- a/spec/features/creating_a_protected_food_drink_name_spec.rb
+++ b/spec/features/creating_a_protected_food_drink_name_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Creating a Protected Food Drink Name", type: :feature do
     fill_in "Title", with: title
     fill_in "Summary", with: summary
     fill_in "Body", with: ("## Header" + ("\n\nThis is the long body of an example protected food name" * 10))
-    select "Foods: designated origin and geographic origin", from: "Register"
+    select "Foods: designated origin and geographical indication", from: "Register"
     select "Registered", from: "Status"
     select "1.1 Fresh meat (and offal)", from: "Class category"
     select "Protected Geographical Indication (PGI)", from: "Protection type"

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -453,7 +453,7 @@ FactoryBot.define do
     transient do
       default_metadata do
         {
-          "register" => "foods-designated-origin-and-geographic-origin",
+          "register" => "foods-designated-origin-and-geographical-indication",
           "status" => "registered",
           "class_category" => ["1-1-fresh-meat-and-offal"],
           "protection_type" => "protected-geographical-indication-pgi",

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -457,7 +457,7 @@ FactoryBot.define do
           "status" => "registered",
           "class_category" => ["1-1-fresh-meat-and-offal"],
           "protection_type" => "protected-geographical-indication-pgi",
-          "country" => %w[united-kingdom],
+          "country_of_origin" => %w[united-kingdom],
           "date_registration" => "2020-01-01",
           "traditional_term_grapevine_product_category" => %w[new-wine-still-in-fermentation],
           "traditional_term_type" => "description-of-product-characteristic",

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -457,6 +457,7 @@ FactoryBot.define do
           "status" => "registered",
           "class_category" => ["1-1-fresh-meat-and-offal"],
           "protection_type" => "protected-geographical-indication-pgi",
+          "reason_for_protection" => "uk-gi-before-2021",
           "country_of_origin" => %w[united-kingdom],
           "date_registration" => "2020-01-01",
           "traditional_term_grapevine_product_category" => %w[new-wine-still-in-fermentation],

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -459,7 +459,7 @@ FactoryBot.define do
           "protection_type" => "protected-geographical-indication-pgi",
           "country" => %w[united-kingdom],
           "date_registration" => "2020-01-01",
-          "traditional_term_grapevine_product_category" => "new-wine-still-in-fermentation",
+          "traditional_term_grapevine_product_category" => %w[new-wine-still-in-fermentation],
           "traditional_term_type" => "description-of-product-characteristic",
           "traditional_term_language" => "english",
         }

--- a/spec/lib/importers/protected_food_drink_name/parser_spec.rb
+++ b/spec/lib/importers/protected_food_drink_name/parser_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Importers::ProtectedFoodDrinkName::Parser do
         status: "registered",
         class_category: %w[32-liqueur],
         protection_type: "geographical-indication-gi",
-        country: %w[ireland],
+        country_of_origin: %w[ireland],
         traditional_term_grapevine_product_category: [],
         traditional_term_type: nil,
         traditional_term_language: nil,

--- a/spec/lib/importers/protected_food_drink_name/parser_spec.rb
+++ b/spec/lib/importers/protected_food_drink_name/parser_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Importers::ProtectedFoodDrinkName::Parser do
         status: "registered",
         class_category: %w[32-liqueur],
         protection_type: "geographical-indication-gi",
+        reason_for_protection: nil,
         country_of_origin: %w[ireland],
         traditional_term_grapevine_product_category: [],
         traditional_term_type: nil,

--- a/spec/lib/tasks/bulk_imports_spec.rb
+++ b/spec/lib/tasks/bulk_imports_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "rake import", rake_task: true do
       it "reports any data it could not import and the error preventing it from saving" do
         expected_output = "ERROR - Document index: 1. Registered product name: . Title can't be blank\n" \
           "ERROR - Document index: 2. Registered product name: Irish Poteen/Irish Poitín. Status can't be blank\n" \
-          "ERROR - Document index: 3. Registered product name: Irish Whiskey/Uisce Beatha Eireannach/Irish Whisky. Country can't be blank\n" \
+          "ERROR - Document index: 3. Registered product name: Irish Whiskey/Uisce Beatha Eireannach/Irish Whisky. Country of origin can't be blank\n" \
           "ERROR - Document index: 4. Registered product name: Scotch Whisky. Date registration can't be blank\n" \
           "ERROR - Document index: 6. Registered product name: Tennessee whisky (Also spelled as “Tennessee whiskey”). Register can't be blank\n" \
           "3 out of 8 records imported. 5 errors reported\n"


### PR DESCRIPTION
Make changes to the protected food specialist document:
- only show the fields register, country of origin and date of registration on the search page
- update the schema to show summaries on the search page
-  change the value in the register from `Foods: designated origin and geographic origin` to `Foods: designated origin and geographical indication` and `Foods: traditional speciality` to `Foods: traditional speciality guaranteed`
- Add an option `Names protected by international treaty` to the `register` and `protection_type`
- Make `Traditional term grapevine product category` able to accept multiple values
- Rename the field `country` to `country_of_origin`
- Add a field to record `reason_for_protection`
- Change the `date_application` `date_registration` and `date_registration_eu` to be a date instead of a string

Trello card: https://trello.com/c/x2TYiSqT/2181-5-make-changes-to-protected-food-names-document-and-finder