### PR TITLE
Switch date filters to be only published data

### DIFF
--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -33,7 +33,7 @@
       "name": "Start date",
       "type": "date",
       "display_as_result_metadata": true,
-      "filterable": true
+      "filterable": false
     },
 
     {
@@ -41,7 +41,7 @@
       "name": "Completion date",
       "type": "date",
       "display_as_result_metadata": true,
-      "filterable": true
+      "filterable": false
     },
 
     {

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -29,6 +29,15 @@
     },
 
     {
+      "key": "first_published_at",
+      "name": "Published",
+      "short_name": "Published",
+      "type": "date",
+      "display_as_result_metadata": false,
+      "filterable": true
+    },
+
+    {
       "key": "date_of_start",
       "name": "Start date",
       "type": "date",


### PR DESCRIPTION
Originally the finder had date filters on the project start and completion date, but actually the department would like only one date filter on the first published at date.

[Trello Card](https://trello.com/c/atDp5GQO/2199-3-add-flood-and-coastal-erosion-specialist-document)