### PR TITLE
Fix "No class or category" in import script

### DIFF
--- a/lib/importers/protected_food_drink_name/parser.rb
+++ b/lib/importers/protected_food_drink_name/parser.rb
@@ -50,7 +50,7 @@ module Importers
         when "Traditional term" then "traditional-terms-for-wine"
         when "Food"
           if data["Protection type"] == "Traditional Specialities Guaranteed (TSG)"
-            "foods-traditional-speciality"
+            "foods-traditional-speciality-guaranteed"
           else
             "foods-designated-origin-and-geographical-indication"
           end

--- a/lib/importers/protected_food_drink_name/parser.rb
+++ b/lib/importers/protected_food_drink_name/parser.rb
@@ -315,7 +315,7 @@ module Importers
           "2. Aromatised wine-based drink" => "2-aromatised-wine-based-drink",
           "Traditional term" => "traditional-term",
           "Spirit drink" => "spirit-drink",
-          "No class or category" => "no-class-or-category",
+          "No class or category" => "no-class-category",
         }
       end
 


### PR DESCRIPTION
The correct value for this should be `no-class-category` rather than `no-class-or-category`, as per: https://github.com/alphagov/govuk-content-schemas/commit/a5859ee5fd3649601ba035a628487fda320f65e9