### PR TITLE
Further protected food changes

### DIFF
--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -192,6 +192,7 @@
         {"label": "Brazil","value": "brazil"},
         {"label": "Bulgaria","value": "bulgaria"},
         {"label": "Cambodia","value": "cambodia"},
+        {"label": "Canada","value": "canada"},
         {"label": "Chile","value": "chile"},
         {"label": "China","value": "china"},
         {"label": "Colombia","value": "colombia"},

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -37,8 +37,7 @@
         {"label": "Spirit drinks","value": "spirit-drinks"},
         {"label": "Wines","value": "wines"},
         {"label": "Aromatised wines","value": "aromatised-wines"},
-        {"label": "Traditional terms for wine","value": "traditional-terms-for-wine"},
-        {"label": "Names protected by international treaty", "value": "names-protected-by-international-treaty"}
+        {"label": "Traditional terms for wine","value": "traditional-terms-for-wine"}
       ]
     },
     {

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -20,7 +20,7 @@
       "key": "registered_name",
       "name": "Registered name",
       "type": "text",
-      "display_as_result_metadata": false,
+      "display_as_result_metadata": true,
       "filterable": false
     },
     {


### PR DESCRIPTION
Adds further changes to the protected food names:

- Adds Canada to the country of origin options
- Removes Name protected by international treaty from the register field
- Displays the registered name of a protected food on the search results page

Trello card: https://trello.com/c/F3HaBQBp/2258-2-further-changes-to-protected-food-drink-names-finder