### PR TITLE
Add a rake task to move medical alerts from one category to another

### DIFF
--- a/lib/tasks/medical_safety_alerts.rake
+++ b/lib/tasks/medical_safety_alerts.rake
@@ -1,0 +1,12 @@
+namespace :medical_safety_alerts do
+  desc "Change type of medical alerts"
+  task :change_alert_type, %i[old new] => :environment do |_, args|
+    MedicalSafetyAlert.find_each do |doc|
+      next unless doc.alert_type == args[:old]
+
+      RepublishService.new.call(doc.content_id, doc.locale) do |payload|
+        payload[:details][:metadata][:alert_type] = args[:new]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This could probably be made more general and thus more useful in future (it's based on the country-rename tasks) but that seems like overkill for the current situation

https://trello.com/c/xnGP5kS0/2236-5-mhra-request-to-rename-specialist-publisher-alert-categories