### PR TITLE
Changes to UKMCAB specialist document/finder

### DIFF
--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -68,6 +68,10 @@
         {
           "label": "Third country body",
           "value": "third-country-body"
+        },
+        {
+          "label": "Notified body (NI)",
+          "value": "notified-body-ni"
         }
       ]
     },
@@ -981,6 +985,10 @@
         {
           "label": "Measuring instruments",
           "value": "measuring-instruments"
+        },
+        {
+          "label": "Medical devices",
+          "value": "medical-devices"
         },
         {
           "label": "Noise emissions in the environment by equipment for use outdoors",


### PR DESCRIPTION
Adding some fields for the UK Market Conformity Assessment Body finder
as per a department request.

Trello: https://trello.com/c/4W4xAbEq/2260-changes-to-ukmcab-specialist-document-finder

Related PR's:

alphagov/govuk-content-schemas#1035
alphagov/search-api#2230
