### PR TITLE
Update UK scheme date/time field labels

### DIFF
--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -348,14 +348,14 @@
     },
     {
       "key": "date_registration",
-      "name": "Date of UK registration",
+      "name": "Date of registration (UK scheme)",
       "type": "date",
       "display_as_result_metadata": true,
       "filterable": false
     },
     {
       "key": "time_registration",
-      "name": "Time of UK registration",
+      "name": "Time of registration (UK scheme)",
       "type": "text",
       "display_as_result_metadata": true,
       "filterable": false

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -327,19 +327,6 @@
       ]
     },
     {
-      "key": "reason_for_protection",
-      "name": "Reason for protection",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false,
-      "allowed_values": [
-        {"label": "UK geographical indication from before 2021","value": "uk-gi-before-2021"},
-        {"label": "EU agreement","value": "eu-agreement"},
-        {"label": "UK trade agreement","value": "uk-trade-agreement"},
-        {"label": "Application to UK scheme from 2021","value": "uk-gi-after-2021"}
-      ]
-    },
-    {
       "key": "date_application",
       "name": "Date of application",
       "type": "date",
@@ -366,6 +353,19 @@
       "type": "date",
       "display_as_result_metadata": false,
       "filterable": false
+    },
+    {
+      "key": "reason_for_protection",
+      "name": "Reason for protection",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "allowed_values": [
+        {"label": "UK geographical indication from before 2021","value": "uk-gi-before-2021"},
+        {"label": "EU agreement","value": "eu-agreement"},
+        {"label": "UK trade agreement","value": "uk-trade-agreement"},
+        {"label": "Application to UK scheme from 2021","value": "uk-gi-after-2021"}
+      ]
     },
     {
       "key": "internal_notes",


### PR DESCRIPTION
The department would prefer them to be labelled like this as its clearer for their users.

[Trello Card](https://trello.com/c/W9Sp5XMs/2267-change-date-time-labels-on-protected-food-names-finder)