### PR TITLE
Add Albania to Country of Origin for Protected Food Names

### DIFF
--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -183,6 +183,7 @@
       "filterable": true,
       "allowed_values": [
         {"label": "United Kingdom","value": "united-kingdom"},
+        {"label": "Albania","value": "albania"},
         {"label": "Andorra","value": "andorra"},
         {"label": "Armenia","value": "armenia"},
         {"label": "Australia","value": "australia"},


### PR DESCRIPTION
Adds Albania to the country of origin options for Protected Food Names

[Trello](https://trello.com/c/SSBGIovv/2277-add-albania-to-protected-food-drink-names-finder)

