### PR TITLE
Remove 'medical device alerts' from email subscription filter

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -25,13 +25,6 @@
       "required": true,
       "facet_choices": [
         {
-          "key": "devices",
-          "radio_button_name": "Medical device alerts",
-          "topic_name": "medical device alerts",
-          "body": "information published by the MHRA about defective medical devices.",
-          "prechecked": true
-        },
-        {
           "key": "drugs",
           "radio_button_name": "Drug alerts",
           "topic_name": "drug alerts",


### PR DESCRIPTION
https://trello.com/c/xnGP5kS0/2236-5-mhra-request-to-rename-specialist-publisher-alert-categories