### PR TITLE
Remove 'medical device alerts' from finder

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -73,7 +73,6 @@
       "filterable": true,
       "allowed_values": [
         {"label": "Drug alert", "value": "drugs"},
-        {"label": "Medical device alert", "value": "devices"},
         {"label": "Field safety notice", "value": "field-safety-notices"},
         {"label": "Drug alert: company-led", "value": "company-led-drugs"},
         {"label": "National patient safety alert", "value": "national-patient-safety"},


### PR DESCRIPTION
https://trello.com/c/xnGP5kS0/2236-5-mhra-request-to-rename-specialist-publisher-alert-categories