### PR TITLE
Add new land use option

### DIFF
--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -40,6 +40,7 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
+        {"label": "Air quality", "value": "air-quality"},
         {"label": "Arable land", "value": "arable-land"},
         {"label": "Boundaries", "value": "boundaries"},
         {"label": "Coast", "value": "coast"},


### PR DESCRIPTION
- requested by a user in support ticket 4431297
- should add a new option to the filters under 'Land use' on https://www.gov.uk/countryside-stewardship-grants