### PR TITLE
Create a "medicines recall/notification" medical alert type

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -58,6 +58,13 @@
           "topic_name": "device safety information",
           "body": "information published by the MHRA related to device safety.",
           "prechecked": true
+        },
+        {
+          "key": "medicines-recall-notification",
+          "radio_button_name": "Medicines recall/notification",
+          "topic_name": "medicines recall/notification",
+          "body": "information published by the MHRA about defective medicines.",
+          "prechecked": true
         }
       ]
     }
@@ -76,7 +83,8 @@
         {"label": "Field safety notice", "value": "field-safety-notices"},
         {"label": "Drug alert: company-led", "value": "company-led-drugs"},
         {"label": "National patient safety alert", "value": "national-patient-safety"},
-        {"label": "Device safety information", "value": "device-safety-information"}
+        {"label": "Device safety information", "value": "device-safety-information"},
+        {"label": "Medicines recall/notification", "value": "medicines-recall-notification"}
       ]
     },
     {


### PR DESCRIPTION
Two categories of medical safety alert are to be merged into one. This creates the single new category; the next step will be to move the old documents and users into this category, and finally to remove the old categories.

https://trello.com/c/GvEQmeaW/2328-further-changes-to-mhra-finder-categories

cf. #1710 for an alert type being added, and #1780 for the scripts to move documents between alert types.