### PR TITLE
Add email filters to flood reports

### DIFF
--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -10,6 +10,55 @@
   },
   "organisations": [],
   "document_noun": "research report",
+  "signup_content_id": "0b3468bb-ccbe-4c97-9d94-870ae02e977d",
+  "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "subscription_list_title_prefix": "Flood and Coastal Erosion Risk Management Research Reports",
+  "email_filter_by": "category",
+  "email_filter_facets": [
+    {
+      "facet_id": "category",
+      "facet_name": "Categories",
+      "required": true,
+      "facet_choices": [
+        {
+          "key": "environmental-management-and-sustainability",
+          "radio_button_name": "Environmental management and sustainability",
+          "topic_name": "environmental management and sustainability",
+          "prechecked": false
+        },
+        {
+          "key": "increasing-resilience-to-flooding",
+          "radio_button_name": "Increasing resilience to flooding",
+          "topic_name": "increasing resilience to flooding",
+          "prechecked": false
+        },
+        {
+          "key": "managing-flood-incidents",
+          "radio_button_name": "Managing flood incidents",
+          "topic_name": "managing flood incidents",
+          "prechecked": false
+        },
+        {
+          "key": "policy-governance-and-funding",
+          "radio_button_name": "Policy, governance and funding",
+          "topic_name": "policy, governance and funding",
+          "prechecked": false
+        },
+        {
+          "key": "understanding-risks-from-all-sources-of-flooding",
+          "radio_button_name": "Understanding risks from all sources of flooding",
+          "topic_name": "understanding risks from all sources of flooding",
+          "prechecked": false
+        },
+        {
+          "key": "whole-life-asset-management",
+          "radio_button_name": "Whole life asset management",
+          "topic_name": "whole life asset management",
+          "prechecked": false
+        }
+      ]
+    }
+  ],
   "facets": [
     {
       "key": "category",


### PR DESCRIPTION
Add ability to receive emails on particular categories of flood and
coastal erosion reports. I've updated a few lines of code from Becca's
original commit.

* I've changed `required` to `true` which forces users to select a
  category when they're on the email sign-up page (they can select all
  categories too) - see an [example] page where this is enabled. This
  seems reasonable as it makes sure users make an active choice about
  what they want to receive.

* I've added `signup_content_id` which was missing (can't verify this is
  unique due to not having VPN access).

`email_filter_by` was mentioned in the card as being potentially
deprecated so may be not be needed, I assume because of [the TODO
comment]. However `email_filter_by` is still used by Finder Frontend to
determine whether the email facet selection can be [modified or not]
when signing up for emails.

Co-authored: @beccapearce 

[example]: https://www.gov.uk/european-structural-investment-funds/email-signup
[the TODO comment]: https://github.com/alphagov/specialist-publisher/blob/1ea8b91c3d3fbe66560dcb573d0ee4dc719de54c/app/presenters/finder_signup_content_item_presenter.rb#L75
[modified or not]: https://github.com/alphagov/finder-frontend/blob/bc6dbbc959a9f0c18401354d0f8614a6650ac34c/app/presenters/subscriber_list_params_presenter.rb#L36-L38

Trello:
https://trello.com/c/rWJ6jhKH/2317-3-add-email-subscription-filters-to-flood-research-report-finder