### PR TITLE
Update key to be more descriptive

### DIFF
--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -13,10 +13,10 @@
   "signup_content_id": "0b3468bb-ccbe-4c97-9d94-870ae02e977d",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "subscription_list_title_prefix": "Flood and Coastal Erosion Risk Management Research Reports",
-  "email_filter_by": "category",
+  "email_filter_by": "flood_and_coastal_erosion_category",
   "email_filter_facets": [
     {
-      "facet_id": "category",
+      "facet_id": "flood_and_coastal_erosion_category",
       "facet_name": "Categories",
       "required": true,
       "facet_choices": [
@@ -61,7 +61,7 @@
   ],
   "facets": [
     {
-      "key": "category",
+      "key": "flood_and_coastal_erosion_category",
       "name": "Category",
       "type": "text",
       "preposition": "with category",


### PR DESCRIPTION
The previous key name was a bit vague and as these values get passed
around different apps it'd be good to be more specific. The driver for
this change was that we need to add a tag to the [allowed list] in Email
Alert API which allows a SubscriberList to be created for the facets.

[allowed list]: https://github.com/alphagov/email-alert-api/blob/master/lib/valid_tags.rb#L2

Trello:
https://trello.com/c/rWJ6jhKH/2317-3-add-email-subscription-filters-to-flood-research-report-finder