### PR TITLE
Renames field name

### DIFF
--- a/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
+++ b/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
@@ -1,5 +1,5 @@
 class FloodAndCoastalErosionRiskManagementResearchReport < Document
-  validates :category, presence: true
+  validates :flood_and_coastal_erosion_category, presence: true
   validates :date_of_completion, date: true
   validates :date_of_start, date: true
   validates :project_code, presence: true
@@ -8,7 +8,7 @@ class FloodAndCoastalErosionRiskManagementResearchReport < Document
   validates :primary_publishing_organisation, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
-    category
+    flood_and_coastal_erosion_category
     date_of_completion
     date_of_start
     project_code

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :category } do %>
-  <%= f.select :category,
-      f.object.facet_options(:category),
+  <%= f.select :flood_and_coastal_erosion_category,
+      f.object.facet_options(:flood_and_coastal_erosion_category),
       {},
       { class: "form-control" }
   %>

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -394,7 +394,7 @@ FactoryBot.define do
     transient do
       default_metadata do
         {
-          "category" => "managing-flood-incidents",
+          "flood_and_coastal_erosion_category" => "managing-flood-incidents",
           "project_code" => "code",
           "project_status" => "ongoing",
           "topics" => %w[big-data carbon],


### PR DESCRIPTION
Renames the field 'category' to 'flood_and_coastal_erosion_category'
which is used when creating a flood and coastal erosion document. These
changes are needed when changing the relevant local [flood schema].

[flood schema]: https://github.com/alphagov/specialist-publisher/pull/1810

Related [GOVUK Content Schemas change](https://github.com/alphagov/govuk-content-schemas/pull/1038).

Trello:
https://trello.com/c/rWJ6jhKH/2317-3-add-email-subscription-filters-to-flood-research-report-finder