### PR TITLE
Allow signing up to employment tribunal decisions by category

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -21,6 +21,340 @@
   "subscription_list_title_prefix": "Employment tribunal decisions",
   "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-employment-and-immigration-tribunals-eagle-building'>Glasgow Employment and Immigration Tribunals</a> for cases in Scotland.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
   "document_noun": "decision",
+  "email_filter_by": "tribunal_decision_categories",
+  "email_filter_facets": [
+    {
+      "facet_id": "tribunal_decision_categories",
+      "facet_name": "Jurisdiction codes",
+      "required": true,
+      "facet_choices": [
+        {
+          "radio_button_name": "Age Discrimination",
+          "topic_name": "age discrimination",
+          "key": "age-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Agency Workers",
+          "topic_name": "agency workers",
+          "key": "agency-workers",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Blacklisting Regulations",
+          "topic_name": "blacklisting regulations",
+          "key": "blacklisting-regulations",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Breach of Contract",
+          "topic_name": "breach of contract",
+          "key": "breach-of-contract",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Central Arbitration Committee (CAC)",
+          "topic_name": "central arbitration committee (CAC)",
+          "key": "central-arbitration-committee-cac",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Certification Officer",
+          "topic_name": "certification officer",
+          "key": "certification-officer",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Contract of Employment",
+          "topic_name": "contract of employment",
+          "key": "contract-of-employment",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Disability Discrimination",
+          "topic_name": "disability discrimination",
+          "key": "disability-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Employment Agencies Act 1973",
+          "topic_name": "employment agencies act 1973",
+          "key": "employment-agencies-act-1973",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Equal Pay Act",
+          "topic_name": "equal pay act",
+          "key": "equal-pay-act",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "European Material",
+          "topic_name": "european material",
+          "key": "european-material",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Fixed Term Regulations",
+          "topic_name": "fixed term regulations",
+          "key": "fixed-term-regulations",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Flexible Working",
+          "topic_name": "flexible working",
+          "key": "flexible-working",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Harassment",
+          "topic_name": "harassment",
+          "key": "harassment",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Health & Safety",
+          "topic_name": "health & safety",
+          "key": "health-safety",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Human Rights",
+          "topic_name": "human rights",
+          "key": "human-rights",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Improvement Notice",
+          "topic_name": "improvement notice",
+          "key": "improvement-notice",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Interim Relief",
+          "topic_name": "interim relief",
+          "key": "interim-relief",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Jurisdictional Points",
+          "topic_name": "jurisdictional points",
+          "key": "jurisdictional-points",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Maternity and Pregnancy Rights",
+          "topic_name": "maternity and pregnancy rights",
+          "key": "maternity-and-pregnancy-rights",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "National Minimum Wage",
+          "topic_name": "national minimum wage",
+          "key": "national-minimum-wage",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "National Security",
+          "topic_name": "national security",
+          "key": "national-security",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Notice Appeal",
+          "topic_name": "notice appeal",
+          "key": "notice-appeal",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Parental and Maternity Leave",
+          "topic_name": "parental and maternity leave",
+          "key": "parental-and-maternity-leave",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Part Time Workers",
+          "topic_name": "part time workers",
+          "key": "part-time-workers",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Pension",
+          "topic_name": "pension",
+          "key": "pension",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Practice and Procedure Issues",
+          "topic_name": "practice and procedure issues",
+          "key": "practice-and-procedure-issues",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Protective Award",
+          "topic_name": "protective award",
+          "key": "protective-award",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Public Interest Disclosure",
+          "topic_name": "public interest disclosure",
+          "key": "public-interest-disclosure",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Race Discrimination",
+          "topic_name": "race discrimination",
+          "key": "race-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Redundancy",
+          "topic_name": "redundancy",
+          "key": "redundancy",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Religion or Belief Discrimination",
+          "topic_name": "religion or belief discrimination",
+          "key": "religion-or-belief-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Renumeration",
+          "topic_name": "renumeration",
+          "key": "renumeration",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Reorganisation",
+          "topic_name": "reorganisation",
+          "key": "reorganisation",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Reserved Forces Act",
+          "topic_name": "reserved forces act",
+          "key": "reserved-forces-act",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Right To Be Accompanied",
+          "topic_name": "right to be accompanied",
+          "key": "right-to-be-accompanied",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Rights on Insolvency",
+          "topic_name": "rights on insolvency",
+          "key": "rights-on-insolvency",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Sex Discrimination",
+          "topic_name": "sex discrimination",
+          "key": "sex-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Sexual Orientation Discrimination/Transexualism",
+          "topic_name": "sexual orientation discrimination/transexualism",
+          "key": "sexual-orientation-discrimination-transexualism",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Statutory Discipline and Grievance Procedures",
+          "topic_name": "statutory discipline and grievance procedures",
+          "key": "statutory-discipline-and-grievance-procedures",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Tax",
+          "topic_name": "tax",
+          "key": "tax",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Temporary Employment",
+          "topic_name": "temporary employment",
+          "key": "temporary-employment",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Time Limits",
+          "topic_name": "time limits",
+          "key": "time-limits",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Time Off",
+          "topic_name": "time off",
+          "key": "time-off",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Time to Train",
+          "topic_name": "time to train",
+          "key": "time-to-train",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Trade Union Membership",
+          "topic_name": "trade union membership",
+          "key": "trade-union-membership",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Trade Union Rights",
+          "topic_name": "trade union rights",
+          "key": "trade-union-rights",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Transfer of Undertakings",
+          "topic_name": "transfer of undertakings",
+          "key": "transfer-of-undertakings",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Unfair Dismissal",
+          "topic_name": "unfair dismissal",
+          "key": "unfair-dismissal",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Unlawful Deduction from Wages",
+          "topic_name": "unlawful deduction from wages",
+          "key": "unlawful-deduction-from-wages",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Victimisation Discrimination",
+          "topic_name": "victimisation discrimination",
+          "key": "victimisation-discrimination",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Working Time Regulations",
+          "topic_name": "working time regulations",
+          "key": "working-time-regulations",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Written Pay Statement",
+          "topic_name": "written pay statement",
+          "key": "written-pay-statement",
+          "prechecked": false
+        },
+        {
+          "radio_button_name": "Written Statements",
+          "topic_name": "written statements",
+          "key": "written-statements",
+          "prechecked": false
+        }
+      ]
+    }
+  ],
   "facets": [
     {
       "key": "tribunal_decision_country",


### PR DESCRIPTION
This makes it possible to pick a category (or "Jurisdiction code") when signing up to emails. This was apparently something that used to work, but I can't see it in the history of this file.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4441728)