### PR TITLE
Remove old MHRA alert categories

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -25,24 +25,10 @@
       "required": true,
       "facet_choices": [
         {
-          "key": "drugs",
-          "radio_button_name": "Drug alerts",
-          "topic_name": "drug alerts",
-          "body": "information published by the MHRA about defective medicines.",
-          "prechecked": true
-        },
-        {
           "key": "field-safety-notices",
           "radio_button_name": "Field safety notice",
           "topic_name": "field safety notice",
           "body": "information from medical device manufacturers.",
-          "prechecked": true
-        },
-        {
-          "key": "company-led-drugs",
-          "radio_button_name": "Drug alert: company-led",
-          "topic_name": "drug alert: company-led",
-          "body": "recalls of medicines issued by manufacturers.",
           "prechecked": true
         },
         {


### PR DESCRIPTION
A new category was created in #1807; once all data has been moved into that category, the old ones can be removed.

This should only be merged after the documents have been recategorised in production.

https://trello.com/c/GvEQmeaW/2328-further-changes-to-mhra-finder-categories
