### PR TITLE
Add new "Up to £10,000" option and rename "Up to £100,000" option

### DIFF
--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -945,7 +945,8 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
-        {"label": "Up to £100,000", "value": "up-to-100000"},
+        {"label": "Up to £10,000", "value": "up-to-10000"},
+        {"label": "£10,001 to £100,000", "value": "10001-to-100000"},
         {"label": "£100,001 to £500,000", "value": "100001-500000"},
         {"label": "£500,001 to £1,000,000", "value": "500001-to-1000000"},
         {"label": "More than £1,000,000", "value": "more-than-1000000"}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -381,7 +381,7 @@ FactoryBot.define do
           "location" => %w[ghana],
           "development_sector" => %w[climate-change],
           "eligible_entities" => %w[non-governmental-organisations],
-          "value_of_funding" => %w[up-to-100000],
+          "value_of_funding" => %w[up-to-10000],
         }
       end
     end


### PR DESCRIPTION
Dependent on https://github.com/alphagov/govuk-content-schemas/pull/1043 (which is why the tests are currently failing; after merging that, these tests should pass).

Users want to be able to search for smaller international development funds.

We'd normally need to write a data migration in the app for existing values, but Specialist Publisher uses Publishing API as its database, so that migration has been raised here: https://github.com/alphagov/publishing-api/pull/1901

Trello: https://trello.com/c/eDFwuCFY/2356-5-changes-to-international-development-funding-finder