### PR TITLE
Remove duplicate guatemala entry

### DIFF
--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -209,7 +209,6 @@
         {"label": "Germany","value": "germany"},
         {"label": "Greece","value": "greece"},
         {"label": "Guatemala","value": "guatemala"},
-        {"label": "Guatemala","value": "guatemala"},
         {"label": "Guinea","value": "guinea"},
         {"label": "Guyana","value": "guyana"},
         {"label": "Honduras","value": "honduras"},


### PR DESCRIPTION
It's listed twice by accident, but we don't need that to be the case.