### PR TITLE
Update related links

### DIFF
--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -13,8 +13,7 @@
     "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
   ],
   "related": [
-    "5bdde33c-c200-4245-925b-8d5dcd075546",
-    "975ad786-7d28-4189-b635-961395e19954"
+    "5e91c0bf-187d-4fa0-a6ef-992736d5644c"
   ],
   "summary": "<p>Find options, supplements and capital items to include in your application for Countryside Stewardship. See <a href=\"government/collections/countryside-stewardship-information-for-agreement-holders\">information for agreement holders</a> for earlier versions. Check your <a href=\"/government/publications/check-evidence-and-record-keeping-requirements-countryside-stewardship\">evidence and record keeping requirements</a> before you apply.</p>",
   "document_noun": "grant",


### PR DESCRIPTION
- Updated on request of the Rural Payments Agency.
- Removes existing links and now links to: https://www.gov.uk/government/collections/countryside-stewardship-get-paid-for-environmental-land-management.
- Once this PR is merged, a Rake task needs to be run to re publish the Countryside Stewardship Grant finder.