### PR TITLE
Review and revise README to refer to GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,4 @@ $ bundle exec rake
 - [Email alerts](/docs/email-alerts.md)
 - [Rake tasks](/docs/tasks.md)
 - [Creating a new specialist document type](/docs/creating-a-new-specialist-document-type.md)
-
-## Phase 2 migration
-
-There is tonnes of information on our learnings from migrating this app to
-"phase 2" [here](./docs/phase-2-migration/README.md).
+- [Historical info about migrating to use the Publishing API](/docs/phase-2-migration/README.md)

--- a/README.md
+++ b/README.md
@@ -43,19 +43,13 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 **Use GOV.UK Docker to run any commands that follow.**
 
-### Granting permissions
+### Before running the app
 
 You may find that you can't see any documents after replicating data. To fix
 this, you need to grant user permissions in this application:
 
 ```bash
 bundle exec rake permissions:grant['Chris Patuzzo'] # Or whichever user you're logged in as.
-```
-
-You also need to set the `app_name` for the Dummy API User in Publishing API:
-
-```ruby
-User.find_by(email: "dummyapiuser@domain.com").update!(app_name: "specialist-publisher")
 ```
 
 ### Running the test suite

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Publishing App for Specialist Documents.
 
 This application does not store documents in a database of its own. Instead it uses Publishing API to store and retrieve documents. MongoDB is used for storing local user records.
 
+Formats can be [flagged](https://github.com/alphagov/specialist-publisher/blob/f8e93142dfad6f3971a73c923b01f2e7352bdb54/lib/documents/schemas/tax_tribunal_decisions.json#L64) as `pre-production`. `pre-production` documents are only publishable on development and integration.
+
 ## Screenshots
 
 ![Specialist Documents - CMA Case Format](docs/specialist-publisher-screenshot.png)
@@ -40,10 +42,6 @@ This is a Ruby on Rails app, and should follow [our Rails app conventions](https
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
 **Use GOV.UK Docker to run any commands that follow.**
-
-## Pre-production
-
-A number of formats are [flagged](https://github.com/alphagov/specialist-publisher/blob/f8e93142dfad6f3971a73c923b01f2e7352bdb54/lib/documents/schemas/tax_tribunal_decisions.json#L64) as `pre-production`. `pre-production` documents are only publishable on development and integration.
 
 ### Granting permissions
 

--- a/README.md
+++ b/README.md
@@ -35,24 +35,9 @@ This application does not store documents in a database of its own. Instead it u
 
 ## Technical documentation
 
-
 ## Pre-production
 
 A number of formats are [flagged](https://github.com/alphagov/specialist-publisher/blob/f8e93142dfad6f3971a73c923b01f2e7352bdb54/lib/documents/schemas/tax_tribunal_decisions.json#L64) as `pre-production`. `pre-production` documents are only publishable on development and integration.
-
-## Dependencies
-
-- [alphagov/asset-manager](http://github.com/alphagov/asset-manager): provides uploading for static files
-- [alphagov/publishing-api](http://github.com/alphagov/publishing-api): documents are sent here, persisted and then requested.
-- [alphagov/email-alert-api](http://github.com/alphagov/email-alert-api): sends emails to subscribed users when documents are published
-- [These Gems](https://github.com/alphagov/specialist-publisher-rebuild/blob/master/Gemfile)
-
-### Running the application
-
-```
-$ ./startup.sh
-```
-If you are using the GDS development virtual machine then the application will be available on the host at http://specialist-publisher.dev.gov.uk/
 
 ### Granting permissions
 
@@ -68,18 +53,6 @@ You also need to set the `app_name` for the Dummy API User in Publishing API:
 ```ruby
 User.find_by(email: "dummyapiuser@domain.com").update!(app_name: "specialist-publisher")
 ```
-
-### Populate development database
-
-If you're starting from a blank database, you can quickly get your local database into working order with:
-
-```
-$ bundle exec rake db:seed
-```
-
-Currently this:
-* creates a default user record with basic permissions that allows you to log in and create a new document
-
 
 ### Running the test suite
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Publishing App for Specialist Documents.
 
+This application does not store documents in a database of its own. Instead it uses Publishing API to store and retrieve documents. MongoDB is used for storing local user records.
+
 ## Screenshots
 
 ![Specialist Documents - CMA Case Format](docs/specialist-publisher-screenshot.png)
@@ -33,13 +35,6 @@ Publishing App for Specialist Documents.
 
 ## Technical documentation
 
-Specialist Publisher is a Ruby on Rails application used to create and manage documents. This application does not store documents in a database of its own. Instead it sends JSON data to the publishing-api where it is persisted in a Postgres datastore. This data is then requested from the publishing-api and displayed to the user.
-
-Another result of publishing a document is that a call is made to the Email Alert Api which will notify Gov Delivery to send an email to subscribers. These emails are sent when a document is first published and also when an editor makes a major update. This is true for all formats other than Drug Safety Updates which are instead sent via a monthly email newsletter.
-
-Attachments are sent to and then handled by Asset Manager. When an attachment is uploaded, Asset Manager will scan the attachment for viruses and then return a URL from which the attachment can be viewed. When an attachment is deleted it will be 'soft' deleted from Asset Manager so as to be no longer viewable by a user.
-
-The original Specialist-Publisher codebase contained Manuals and Finders in the same application. Manuals are now being managed by [Manuals Publisher](https://github.com/alphagov/manuals-publisher).
 
 ## Pre-production
 
@@ -50,7 +45,6 @@ A number of formats are [flagged](https://github.com/alphagov/specialist-publish
 - [alphagov/asset-manager](http://github.com/alphagov/asset-manager): provides uploading for static files
 - [alphagov/publishing-api](http://github.com/alphagov/publishing-api): documents are sent here, persisted and then requested.
 - [alphagov/email-alert-api](http://github.com/alphagov/email-alert-api): sends emails to subscribed users when documents are published
-- Mongo: mongodb used for storing local users
 - [These Gems](https://github.com/alphagov/specialist-publisher-rebuild/blob/master/Gemfile)
 
 ### Running the application

--- a/README.md
+++ b/README.md
@@ -66,55 +66,11 @@ User.find_by(email: "dummyapiuser@domain.com").update!(app_name: "specialist-pub
 $ bundle exec rake
 ```
 
-## Adding a new Specialist Document format
+### Further documentation
 
-👉 [Creating a new specialist document type](/docs/creating-a-new-specialist-document-type.md)
-
-## Running tasks
-
-You can use the Jenkins rake task runner to run these tasks.
-
-### Discarding a draft document
-
-If a document has been created in draft, it can be discarded with this task:
-`ops:discard['some-content-id']`
-
-Drafts can also be discarded by running a similar task from the Publishing API:
-
-`discard_draft['some-content-id']`
-
-See [Admin Tasks](https://github.com/alphagov/publishing-api/blob/master/doc/admin-tasks.md)
-
-### Triggering an email notification
-
-If an email has not been sent for a document, it can be re-triggered with this task:
-`ops:email['some-content-id']`
-
-### Setting the public_updated_at
-
-If a document has an incorrect public_updated_at, it can be set with this task:
-`ops:set_public_updated_at['some-content-id','2016-01-01']`
-
-This is useful if a published document is appearing with an incorrect published time on GOV.UK. This is not something users of the publishing app can set manually and so occasionally we get support requests to change this.
-
-Rails will call `DateTime.parse` on the string provided, so most formats should work. You can also pass ‘now’ to use the current time.
-
-You can’t currently set the `public_updated_at` field if a publisher has created a new draft for the document. You’ll either need to discard it or publish it first for this task to succeed.
-
-### Republishing
-
-Republishing is useful if content failed to make its way through the system. This might be the case if an error was thrown somewhere along the way. Republishing a document will notify Publishing API of the change (which will in turn notify RUMMAGER via a notifaction queue). It will not send email notifications.
-
-You can republish a single document with this task:
-`republish:one['some-content-id']`
-
-You can republish all documents for a document_type with this task:
-`republish:document_type['some_document_type']`
-
-You can republish all specialist documents with this task:
-`republish:all`
-
-These last two tasks place a large number of items on Specialist Publisher’s sidekiq queue. These tasks could take a very long time to complete. You can’t currently republish published documents if a publisher has created a new draft for the document.
+- [Email alerts](/docs/email-alerts.md)
+- [Rake tasks](/docs/tasks.md)
+- [Creating a new specialist document type](/docs/creating-a-new-specialist-document-type.md)
 
 ## Phase 2 migration
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ This application does not store documents in a database of its own. Instead it u
 
 ## Technical documentation
 
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
+
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
+
+**Use GOV.UK Docker to run any commands that follow.**
+
 ## Pre-production
 
 A number of formats are [flagged](https://github.com/alphagov/specialist-publisher/blob/f8e93142dfad6f3971a73c923b01f2e7352bdb54/lib/documents/schemas/tax_tribunal_decisions.json#L64) as `pre-production`. `pre-production` documents are only publishable on development and integration.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,43 @@
+# Rake tasks
+
+## Discarding a draft document
+
+If a document has been created in draft, it can be discarded with this task:
+`ops:discard['some-content-id']`
+
+Drafts can also be discarded by running a similar task from the Publishing API:
+
+`discard_draft['some-content-id']`
+
+See [Admin Tasks](https://github.com/alphagov/publishing-api/blob/master/doc/admin-tasks.md)
+
+## Triggering an email notification
+
+If an email has not been sent for a document, it can be re-triggered with this task:
+`ops:email['some-content-id']`
+
+## Setting the public_updated_at
+
+If a document has an incorrect public_updated_at, it can be set with this task:
+`ops:set_public_updated_at['some-content-id','2016-01-01']`
+
+This is useful if a published document is appearing with an incorrect published time on GOV.UK. This is not something users of the publishing app can set manually and so occasionally we get support requests to change this.
+
+Rails will call `DateTime.parse` on the string provided, so most formats should work. You can also pass ‘now’ to use the current time.
+
+You can’t currently set the `public_updated_at` field if a publisher has created a new draft for the document. You’ll either need to discard it or publish it first for this task to succeed.
+
+## Republishing
+
+Republishing is useful if content failed to make its way through the system. This might be the case if an error was thrown somewhere along the way. Republishing a document will notify Publishing API of the change (which will in turn notify RUMMAGER via a notifaction queue). It will not send email notifications.
+
+You can republish a single document with this task:
+`republish:one['some-content-id']`
+
+You can republish all documents for a document_type with this task:
+`republish:document_type['some_document_type']`
+
+You can republish all specialist documents with this task:
+`republish:all`
+
+These last two tasks place a large number of items on Specialist Publisher’s sidekiq queue. These tasks could take a very long time to complete. You can’t currently republish published documents if a publisher has created a new draft for the document.

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3064


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This follows the pattern established in [1].

Please see the commit messages for more details.

[1]: https://github.com/alphagov/content-publisher/pull/2257