### PR TITLE
Move Service Standard Reports to CDDO

### DIFF
--- a/app/models/service_standard_report.rb
+++ b/app/models/service_standard_report.rb
@@ -20,6 +20,6 @@ class ServiceStandardReport < Document
   end
 
   def primary_publishing_organisation
-    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
   end
 end

--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -5,7 +5,7 @@
   "format_name": "Service Assessment and Self Certification",
   "description": "A list of service assessments and self certifications",
   "show_summaries": true,
-  "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
+  "organisations": ["2fb482e7-3c4d-496f-887d-f8a55a15e89a"],
   "document_noun": "report",
   "default_order": "-assessment_date",
   "filter": {

--- a/lib/tasks/gds_to_cddo_tmp.rake
+++ b/lib/tasks/gds_to_cddo_tmp.rake
@@ -1,0 +1,19 @@
+desc "Migrate Service Standard Reports from GDS to CDDO "
+task gds_to_cddo_tmp: :environment do
+  content_ids = Republisher.content_id_and_locale_pairs_for_document_type("service_standard_report")
+
+  content_ids.each do |content_id, locale|
+    RepublishService.new.call(content_id, locale) do |payload|
+      gds_markdown = "From: | [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service)"
+      cddo_markdown = "From: | [Central Digital and Data Office](https://www.gov.uk/government/organisations/central-digital-and-data-office)"
+
+      payload[:details][:body].each do |data|
+        if data[:content].present?
+          data[:content] = data[:content].gsub(gds_markdown, cddo_markdown)
+        end
+      end
+
+      payload
+    end
+  end
+end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DocumentLinksPresenter do
     CountrysideStewardshipGrant => "e8fae147-6232-4163-a3f1-1c15b755a8a4",
     BusinessFinanceSupportScheme => "2bde479a-97f2-42b5-986a-287a623c2a1c",
     AsylumSupportDecision => "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    ServiceStandardReport => "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+    ServiceStandardReport => "2fb482e7-3c4d-496f-887d-f8a55a15e89a",
     InternationalDevelopmentFund => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
   }
 


### PR DESCRIPTION
The PR does two things, it transfers ownership from GDS to CDDO of:

* the [Service Standard Reports finder][1]
* [Service Standard Reports themselves][2] and updates relevant page content 

For these change to take effect we will have to republish the Service Standard Reports finder 
and run the rake task contained within this PR.

## Primary organisation change

<img width="762" alt="Screenshot 2021-04-08 at 11 20 12" src="https://user-images.githubusercontent.com/24479188/114014305-5d07b280-9860-11eb-9937-520a63865b7e.png">

## Content change

<img width="881" alt="Screenshot 2021-04-07 at 17 13 25" src="https://user-images.githubusercontent.com/24479188/114014307-5e38df80-9860-11eb-9c9b-6e760920775e.png">

## Finder change

<img width="1124" alt="Screenshot 2021-04-07 at 16 34 34" src="https://user-images.githubusercontent.com/24479188/114014310-5f6a0c80-9860-11eb-823c-2df3fdcf5862.png">

Trello:
https://trello.com/c/rKlR91M9/2463-content-tagging-for-gds-mog-change-cddo-specialist-publisher-content

[1]: https://www.gov.uk/service-standard-reports
[2]: https://www.gov.uk/service-standard-reports/file-your-confirmation-statement-alpha-assessment-report