### PR TITLE
Allow big assets

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -15,6 +15,7 @@ module Services
     @asset_api ||= GdsApi::AssetManager.new(
       Plek.current.find("asset-manager"),
       bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || "12345678",
+      timeout: 30,
     )
   end
 


### PR DESCRIPTION
This allows users to upload larger files, which take longer to send to Asset Manager. A corresponding Nginx config change will be made to enable this.