### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do
       )
 
   get "/rebuild-healthcheck", to: proc { [200, {}, %w[OK]] }
+
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::SidekiqRedis,
+  )
+
   post "/preview", to: "govspeak#preview"
   get "/error", to: "passthrough#error"
 


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)