### PR TITLE
Replace master with main

### DIFF
--- a/docs/creating-a-new-specialist-document-type.md
+++ b/docs/creating-a-new-specialist-document-type.md
@@ -9,7 +9,7 @@ applications.
 
 ### Create the schema
 
-See [CMA cases](https://github.com/alphagov/specialist-publisher/blob/master/lib/documents/schemas/cma_cases.json).
+See [CMA cases](https://github.com/alphagov/specialist-publisher/blob/main/lib/documents/schemas/cma_cases.json).
 
 You'll need to generate your own UUIDs for it, e.g.:
 ```
@@ -22,11 +22,11 @@ irb(main):002:0> SecureRandom.uuid
 
 ### Create the model
 
-See [CMA cases](https://github.com/alphagov/specialist-publisher/blob/master/app/models/cma_case.rb)
+See [CMA cases](https://github.com/alphagov/specialist-publisher/blob/main/app/models/cma_case.rb)
 
 ### Create the view template
 
-[CMA cases](https://github.com/alphagov/specialist-publisher/blob/master/app/views/metadata_fields/_cma_cases.html.erb)
+[CMA cases](https://github.com/alphagov/specialist-publisher/blob/main/app/views/metadata_fields/_cma_cases.html.erb)
 
 ## Configure rummager
 
@@ -34,14 +34,14 @@ See [CMA cases](https://github.com/alphagov/specialist-publisher/blob/master/app
 
 Rummager needs a copy of a schema very similar to the one in Specialist Publisher.
 
-See [the CMA case schema](https://github.com/alphagov/rummager/blob/master/config/schema/elasticsearch_types/cma_case.json), [the main ES types list](https://github.com/alphagov/rummager/blob/master/config/schema/indexes/govuk.json) and [the field definitions](https://github.com/alphagov/rummager/blob/1700c85e1484d1d9b2c1d46f276326bc06b51a14/config/schema/field_definitions.json).
+See [the CMA case schema](https://github.com/alphagov/rummager/blob/main/config/schema/elasticsearch_types/cma_case.json), [the main ES types list](https://github.com/alphagov/rummager/blob/main/config/schema/indexes/govuk.json) and [the field definitions](https://github.com/alphagov/rummager/blob/1700c85e1484d1d9b2c1d46f276326bc06b51a14/config/schema/field_definitions.json).
 
 ### Tell Rummager about the format
 
-- [migrated_formats.yaml](https://github.com/alphagov/rummager/blob/master/config/govuk_index/migrated_formats.yaml)
-- [mapped_document_types.yaml](https://github.com/alphagov/rummager/blob/master/config/govuk_index/mapped_document_types.yaml)
-- [elasticsearch_presenter.rb](https://github.com/alphagov/rummager/blob/master/lib/govuk_index/presenters/elasticsearch_presenter.rb)
-- [specialist_presenter.rb](https://github.com/alphagov/rummager/blob/master/lib/govuk_index/presenters/specialist_presenter.rb)
+- [migrated_formats.yaml](https://github.com/alphagov/rummager/blob/main/config/govuk_index/migrated_formats.yaml)
+- [mapped_document_types.yaml](https://github.com/alphagov/rummager/blob/main/config/govuk_index/mapped_document_types.yaml)
+- [elasticsearch_presenter.rb](https://github.com/alphagov/rummager/blob/main/lib/govuk_index/presenters/elasticsearch_presenter.rb)
+- [specialist_presenter.rb](https://github.com/alphagov/rummager/blob/main/lib/govuk_index/presenters/specialist_presenter.rb)
 
 ## Add a schema to govuk-content-schemas
 

--- a/docs/email-alerts.md
+++ b/docs/email-alerts.md
@@ -11,7 +11,7 @@ www.gov.uk/raib-reports
 ![RAIB Reports - Email Notification Subscribe Link](email-subscribe-link.png)
 *Email Notification Subscribe Link*
 
-The categories that can be signed up for are specified within the [schema](https://github.com/alphagov/specialist-publisher/blob/master/lib/documents/schemas/raib_reports.json#L20) for the document type.
+The categories that can be signed up for are specified within the [schema](https://github.com/alphagov/specialist-publisher/blob/main/lib/documents/schemas/raib_reports.json#L20) for the document type.
 
 ![Subscription Categories](subscription-categories.png)
 

--- a/docs/phase-2-migration/composed-states.md
+++ b/docs/phase-2-migration/composed-states.md
@@ -31,4 +31,4 @@ history of that content item, e.g.
 
 All of the information needed to render the state label can be retrieved from
 the highest two keys in this hash. Currently, this is handled in the
-[StateHelper](https://github.com/alphagov/specialist-publisher-rebuild/blob/master/app/helpers/state_helper.rb).
+[StateHelper](https://github.com/alphagov/specialist-publisher-rebuild/blob/main/app/helpers/state_helper.rb).


### PR DESCRIPTION
[Trello](https://trello.com/c/Kl1Z73RJ/371-change-default-branch-from-master-to-main-for-specialist-publisher)

The `master` branch has been renamed to `main`.

"Both Conservancy and the Git project are aware that the initial branch name,
‘master’, is offensive to some people and we empathize with those hurt by the
 use of that term" [Software Freedom Conservancy](https://sfconservancy.org/news/2020/jun/23/gitbranchname/).

This PR updates the URLs for repos with a default branch of `main`. If these URLS were left
as they were before then Github would cleverly redirect them. However, this reduces our use of
the term and will help to keep naming consistent going forward.