### PR TITLE
Update FCERM finder to filter on date of completion

### DIFF
--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -176,7 +176,7 @@
 
     {
       "key": "date_of_start",
-      "name": "Start date",
+      "name": "Date of start",
       "type": "date",
       "display_as_result_metadata": true,
       "filterable": false

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -171,7 +171,7 @@
       "short_name": "Date",
       "type": "date",
       "display_as_result_metadata": false,
-      "filterable": true
+      "filterable": false
     },
 
     {
@@ -184,10 +184,10 @@
 
     {
       "key": "date_of_completion",
-      "name": "Completion date",
+      "name": "Date of completion",
       "type": "date",
       "display_as_result_metadata": true,
-      "filterable": false
+      "filterable": true
     }
   ]
 }


### PR DESCRIPTION
The FCERM (Flood and Coastal Erosion Risk Management) finder currently uses the published date as a filter facet. This changes that to the date of completion, which is more useful to the users of this finder.

Make live by running this rake task:
```
publishing_api:publish_finder[flood_and_coastal_erosion_risk_management_research_reports]
```

Trello card: https://trello.com/c/yNBVwh6S