### PR TITLE
Update medical safety alerts name

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -2,7 +2,7 @@
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "base_path": "/drug-device-alerts",
   "format_name": "Medical safety alert",
-  "name": "Alerts and recalls for drugs and medical devices",
+  "name": "Alerts, recalls and safety information: drugs and medical devices",
   "description": "Find alerts and recalls issued by MHRA",
   "filter": {
     "format": "medical_safety_alert"


### PR DESCRIPTION
Change the medical saftey alerts name from 'Alerts and recalls for drugs and medical devices'
to 'Alerts, recalls and safety information: drugs and medical devices'.

See https://govuk.zendesk.com/agent/tickets/4587261