### PR TITLE
Bump govuk_frontend_toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,9 +173,8 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_frontend_toolkit (9.0.0)
+    govuk_frontend_toolkit (9.0.1)
       railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (24.10.3)
       govuk_app_config
       kramdown
@@ -409,11 +408,6 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)


### PR DESCRIPTION
This removes the dependency on end-of-life Ruby Sass