### PR TITLE
Add an example URL for redirecting

### DIFF
--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -29,7 +29,7 @@
 
         <% if presenter.unpublish_button_visible? %>
           <div class="form-group">
-            <label for="alternative_path">Redirect to alternative GOV.UK content path</label>
+            <label for="alternative_path">Redirect to alternative GOV.UK content path. For example: /the-replacement-page</label>
             <input type="text" name="alternative_path" class="form-control">
           </div>
 


### PR DESCRIPTION
This adds an example URL to the unpublish/redirect field. 

Redirect paths need to be of the form `/the-replacement-page` (without https://www.gov.uk) - this has caused confusion in the past, and the error message isn't clear. We want to see if simply adding this hint solves the problem, without needing to change validation etc. 

[Trello](https://trello.com/c/c4rjzhaI/1183-improve-field-description-for-adding-redirects-in-specialist-publisher)