### PR TITLE
Add new fields to UKMCAB documents and update finder

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -70,7 +70,7 @@ class DocumentsController < ApplicationController
   end
 
   def unpublish
-    if @document.unpublish(params[:alternative_path])
+    if @document.unpublish(params[:alternative_path], params[:internal_notes])
       flash[:success] = "Unpublished #{@document.title}"
     else
       flash[:danger] = unknown_error_message
@@ -124,7 +124,6 @@ private
 
   def fetch_document
     @document = current_format.find(content_id_param, locale_param)
-
     if params[:content_id_and_locale].split(":")[1] != @document.locale
       redirect_to(
         document_path(

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,6 +30,7 @@ class Document
     :first_published_at,
     :previous_version,
     :warnings,
+    :internal_notes,
   )
 
   def temporary_update_type
@@ -59,6 +60,7 @@ class Document
     bulk_published
     temporary_update_type
     warnings
+    internal_notes
   ].freeze
 
   AIR_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID = "951ece54-c6df-4fbc-aa18-1bc629815fe2".freeze
@@ -242,9 +244,9 @@ class Document
     end
   end
 
-  def unpublish(alternative_path = nil)
+  def unpublish(alternative_path = nil, internal_notes = nil)
     handle_remote_error(self) do
-      DocumentUnpublisher.unpublish(content_id, locale, base_path, alternative_path)
+      DocumentUnpublisher.unpublish(content_id, locale, base_path, alternative_path, internal_notes)
     end
   end
 

--- a/app/models/uk_market_conformity_assessment_body.rb
+++ b/app/models/uk_market_conformity_assessment_body.rb
@@ -19,6 +19,7 @@ class UkMarketConformityAssessmentBody < Document
     uk_market_conformity_assessment_body_email
     uk_market_conformity_assessment_body_phone
     uk_market_conformity_assessment_body_legislative_area
+    uk_market_conformity_assessment_body_notified_body_number
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/models/uk_market_conformity_assessment_body.rb
+++ b/app/models/uk_market_conformity_assessment_body.rb
@@ -20,6 +20,7 @@ class UkMarketConformityAssessmentBody < Document
     uk_market_conformity_assessment_body_phone
     uk_market_conformity_assessment_body_legislative_area
     uk_market_conformity_assessment_body_notified_body_number
+    uk_market_conformity_assessment_body_address
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -55,6 +55,10 @@ class ActionsPresenter
     policy.unpublish? && state == "published"
   end
 
+  def internal_notes?
+    unpublish_button_visible? && klass_name == "UK Market Conformity Assessment Bodies"
+  end
+
   def unpublish_text
     if document.first_draft?
       text = "The document has never been published."

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -17,6 +17,7 @@ class DocumentBuilder
       previous_version: payload["previous_version"],
       temporary_update_type: payload["details"]["temporary_update_type"],
       warnings: payload["warnings"] || {},
+      internal_notes: extract_unpublishing_explanation(payload),
     )
 
     set_update_type(document, payload)
@@ -35,6 +36,11 @@ class DocumentBuilder
 
     document.body = SpecialistPublisherBodyPresenter.present(document)
     document
+  end
+
+  def self.extract_unpublishing_explanation(payload)
+    unpublishing = payload["unpublishing"]
+    unpublishing["explanation"] if unpublishing
   end
 
   def self.extract_body_from_payload(payload)

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -2,15 +2,21 @@ require "services"
 
 # Unpublish a document. Also removes attachments.
 class DocumentUnpublisher
-  def self.unpublish(content_id, locale, _base_path, alternative_path = nil)
+  def self.unpublish(content_id, locale, _base_path, alternative_path = nil, internal_notes = nil)
     if alternative_path.blank?
-      Services.publishing_api.unpublish(content_id, type: "gone", locale: locale)
+      Services.publishing_api.unpublish(
+        content_id,
+        type: "gone",
+        locale: locale,
+        explanation: internal_notes,
+      )
     else
       Services.publishing_api.unpublish(
         content_id,
         type: "redirect",
         locale: locale,
         alternative_path: alternative_path,
+        explanation: internal_notes,
       )
     end
 

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -32,6 +32,12 @@
             <label for="alternative_path">Redirect to alternative GOV.UK content path. For example: /the-replacement-page</label>
             <input type="text" name="alternative_path" class="form-control">
           </div>
+          <% if presenter.internal_notes? %>
+            <div class="form-group">
+              <label for="internal_notes">This field is to identify date and reason for unpublishing only</label>
+              <input type="text" name="internal_notes" class="form-control">
+            </div>
+          <% end %>
 
           <div class="form-group">
             <button name="submit" class="btn btn-warning"

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -31,6 +31,10 @@
       <dd>
         <%= content_tag(:span, state_for_frontend(@document), class: classes_for_frontend(@document)) %>
       </dd>
+      <dt>Internal notes</dt>
+      <dd>
+        <%= @document.internal_notes %>
+      </dd>
     </dl>
   </div>
 </div>

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -5,6 +5,11 @@
       { class: 'form-control' }
   %>
 <% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_notified_body_number, label: "Notified body number (NI)" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_notified_body_number,
+      { class: 'form-control' }
+  %>
+<% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_type, label: "Body Type" } do %>
   <%= f.select :uk_market_conformity_assessment_body_type,
       f.object.facet_options(:uk_market_conformity_assessment_body_type),

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -5,7 +5,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_notified_body_number, label: "Notified body number (NI)" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_notified_body_number, label: "NI Notified body number" } do %>
   <%= f.text_field :uk_market_conformity_assessment_body_notified_body_number,
       { class: 'form-control' }
   %>

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -10,7 +10,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_type, label: "Body Type" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_type, label: "Body type(s)" } do %>
   <%= f.select :uk_market_conformity_assessment_body_type,
       f.object.facet_options(:uk_market_conformity_assessment_body_type),
       {},
@@ -57,7 +57,7 @@
       { class: 'form-control' }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_email, label: "Email address" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_email, label: "Email" } do %>
   <%= f.text_field :uk_market_conformity_assessment_body_email,
       { class: 'form-control' }
   %>

--- a/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
+++ b/app/views/metadata_fields/_uk_market_conformity_assessment_bodies.html.erb
@@ -52,6 +52,11 @@
       }
   %>
 <% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_address, label: "Address" } do %>
+  <%= f.text_field :uk_market_conformity_assessment_body_address,
+      { class: 'form-control' }
+  %>
+<% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :uk_market_conformity_assessment_body_website, label: "Website" } do %>
   <%= f.text_field :uk_market_conformity_assessment_body_website,
       { class: 'form-control' }

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -9,11 +9,12 @@
     "format": "uk_market_conformity_assessment_body"
   },
   "show_summaries": true,
+  "default_order": "title",
   "organisations": ["2bde479a-97f2-42b5-986a-287a623c2a1c"],
   "signup_content_id": "c9102d1b-3832-40a8-9851-abe641dfd696",
   "signup_copy": "You'll get an email each time a body changes their details, or a new body is confirmed.",
   "subscription_list_title_prefix": "UK Market Conformity Assessment Bodies",
-  "summary": "",
+  "summary": "<p>The UK Market Conformity Assessment Bodies (UKMCAB) database serves as the UK’s database of Conformity Assessment Bodies (CABs). It is the definitive source and a register of UK Government appointed CABs who can certify goods for both the GB and NI markets.</p><p>The term Approved Body is used generically in the database and should be read to include Appointed Bodies which apply to some CABs appointed by the Department for Transport that perform the same role as Approved Bodies.</p><p>Please send any queries on the information in UKMCAB to <a href='mailto:approvedbodies@beis.gov.uk'>approvedbodies@beis.gov.uk</a></p>",
   "document_noun": "body",
   "facets": [
     {

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -938,6 +938,14 @@
       ]
     },
     {
+      "key": "uk_market_conformity_assessment_body_address",
+      "name": "Address",
+      "short_name": "Address",
+      "type": "text",
+      "filterable": false,
+      "display_as_result_metadata": false
+    },
+    {
       "key": "uk_market_conformity_assessment_body_website",
       "name": "Website",
       "short_name": "Website",

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -75,8 +75,8 @@
           "value": "recognised-third-party-organisation"
         },
         {
-          "label": "Third country body",
-          "value": "third-country-body"
+          "label": "Overseas Body",
+          "value": "overseas-body"
         },
         {
           "label": "NI Notified body",

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -72,6 +72,26 @@
         {
           "label": "Notified body (NI)",
           "value": "notified-body-ni"
+        },
+        {
+          "label": "UK body designated under MRA: Australia",
+          "value": "uk-body-mra-australia"
+        },
+        {
+          "label": "UK body designated under MRA: New Zealand",
+          "value": "uk-body-mra-new-zealand"
+        },
+        {
+          "label": "UK body designated under MRA: USA",
+          "value": "uk-body-mra-usa"
+        },
+        {
+          "label": "UK body designated under MRA: Japan",
+          "value": "uk-body-mra-japan"
+        },
+        {
+          "label": "UK body designated under MRA: Canada",
+          "value": "uk-body-mra-canada"
         }
       ]
     },

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -33,6 +33,14 @@
       "filterable": false
     },
     {
+      "key": "uk_market_conformity_assessment_body_notified_body_number",
+      "name": "Notified body number",
+      "short_name": "Notified body number",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
       "key": "updated_at",
       "name": "Last updated",
       "short_name": "Last updated",

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -79,7 +79,7 @@
           "value": "third-country-body"
         },
         {
-          "label": "Notified body (NI)",
+          "label": "NI Notified body",
           "value": "notified-body-ni"
         },
         {

--- a/spec/features/unpublishing_a_uk_market_conformity_assessment_body_spec.rb
+++ b/spec/features/unpublishing_a_uk_market_conformity_assessment_body_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.feature "Unpublishing a UK market conformity assessment body", type: :feature do
+  let(:content_id) { item["content_id"] }
+  let(:locale) { item["locale"] }
+
+  before do
+    log_in_as_editor(:gds_editor)
+    stub_publishing_api_has_item(item)
+  end
+
+  context "a published document" do
+    let(:item) do
+      FactoryBot.create(
+        :uk_market_conformity_assessment_body,
+        title: "Example UKMCAB",
+        publication_state: "published",
+      )
+    end
+
+    scenario "entering a reason for unpublishing in the internal note field" do
+      stub_publishing_api_unpublish(content_id, body: { type: "gone", explanation: "foo", locale: locale })
+      visit "/uk-market-conformity-assessment-bodies/#{content_id}:#{locale}"
+
+      fill_in "internal_notes", with: "foo"
+      click_button "Unpublish document"
+      expect(page).to have_content("Unpublished Example UKMCAB")
+      expect(page.status_code).to eq(200)
+      assert_publishing_api_unpublish(content_id)
+
+      expect(page).to have_content("Internal notes")
+      expect(page).to have_content("Foo")
+    end
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -560,6 +560,7 @@ FactoryBot.define do
           "uk_market_conformity_assessment_body_email" => "info@example.com",
           "uk_market_conformity_assessment_body_phone" => "0800 000 000",
           "uk_market_conformity_assessment_body_legislative_area" => "explosives",
+          "uk_market_conformity_assessment_body_notified_body_number" => "AB 1111",
         }
       end
     end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -561,6 +561,7 @@ FactoryBot.define do
           "uk_market_conformity_assessment_body_phone" => "0800 000 000",
           "uk_market_conformity_assessment_body_legislative_area" => "explosives",
           "uk_market_conformity_assessment_body_notified_body_number" => "AB 1111",
+          "uk_market_conformity_assessment_body_address" => "123 Fun Street",
         }
       end
     end


### PR DESCRIPTION
### 1. Amend labels in the UKMCAB form and add new fields
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="916" alt="Screenshot 2021-08-12 at 22 53 51" src="https://user-images.githubusercontent.com/17908089/129274997-f4a37b19-4931-48bd-9b78-9daa44610a11.png"></td>
<td>
<img width="708" alt="Screenshot 2021-08-19 at 11 09 43" src="https://user-images.githubusercontent.com/5111927/130051078-437ff5b8-3e9f-4f6c-bb5f-dea76f053d38.png">
</td>
</tr>
</table>

### 2. Add a new internal notes field to the un-publishing form

<img width="815" alt="Screenshot 2021-08-12 at 22 58 47" src="https://user-images.githubusercontent.com/17908089/129275417-eab89e83-1e36-493f-84da-27834a16fd18.png">

### 3. Amend finder to sort alphabetically, and adds a new summary
<table>
<tr><td>Before</td><td>After</td></tr>
<tr><td><img width="1037" alt="Screenshot 2021-08-12 at 12 39 07" src="https://user-images.githubusercontent.com/17908089/129190705-86128480-a92c-45c0-9bc7-1b37ec898fe3.png"></td><td><img src="https://user-images.githubusercontent.com/5111927/130052231-9f2f705c-3498-48d1-b4a2-8ca1814f8d78.png" width="1037" /></td></tr>
</table>

Trello: https://trello.com/c/DvVWCPT7/2644-changes-to-ukmcab-specialist-document-and-finder-5