### PR TITLE
Bump select2-rails from 3.5.9.1 to 3.5.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,8 +422,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    select2-rails (3.5.10)
-      thor (~> 0.14)
+    select2-rails (3.5.11)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -452,7 +451,7 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringex (2.8.5)
-    thor (0.20.3)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)


### PR DESCRIPTION
Bumping `select2-rails` to the latest patch of version 3.5 to remove the requirement for `thor (~> 0.14)`, which was blocking dependabot from raising a PR to upgrade rails to 6.1.

We cannot upgrade to version 4 without a substantial amount of front end work, as the styling and marking up of elements has changed significantly in this version.

[Trello card](https://trello.com/c/V56Gndqj)