### PR TITLE
Update timings per environment

### DIFF
--- a/docs/creating-a-new-specialist-document-type.md
+++ b/docs/creating-a-new-specialist-document-type.md
@@ -55,5 +55,5 @@ See [the CMA case schema](https://github.com/alphagov/rummager/blob/main/config/
 Once you're ready to ship your code to an environment,
 
 1. Deploy Specialist Publisher, Rummager, and govuk-content-schemas.
-2. Run the "Search reindex for new schema" Jenkins job.  This takes around 45 minutes.
+2. Run the "Search reindex for new schema" Jenkins job.  This takes around 30-45 minutes on Production, or 3-4 hours on Integration.
 3. Use the "Run rake task" Jenkins job to run `publishing_api:publish_finders` or `publishing_api:publish_finder[your_format_name_based_on_the_schema_file]` against the specialist publisher app on a backend machine.


### PR DESCRIPTION
I was still waiting 1.5 hours later, and checked the build history to find Integration regularly takes well over 3 hours to complete the job.

The only example job on production took 34 minutes, and on Staging 1 hour 14 minutes.