### PR TITLE
Create new specialist document type: OIM Project

### DIFF
--- a/app/models/oim_project.rb
+++ b/app/models/oim_project.rb
@@ -1,0 +1,30 @@
+class OimProject < Document
+  validates :oim_project_opened_date, allow_blank: true, date: true, open_before_closed: true
+  validates :oim_project_closed_date, allow_blank: true, date: true
+  validates :oim_project_type, presence: true
+  validates :oim_project_state, presence: true
+  FORMAT_SPECIFIC_FIELDS = %i[
+    oim_project_opened_date
+    oim_project_closed_date
+    oim_project_type
+    oim_project_state
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def taxons
+    []
+  end
+
+  def self.title
+    "OIM Project"
+  end
+
+  def primary_publishing_organisation
+    "b1123ceb-77e4-40fc-9526-83ad0ba7cf01"
+  end
+end

--- a/app/validators/open_before_closed_validator.rb
+++ b/app/validators/open_before_closed_validator.rb
@@ -6,8 +6,8 @@ class OpenBeforeClosedValidator < ActiveModel::EachValidator
 private
 
   def before_closed?(record)
-    opened = record.opened_date
-    closed = record.closed_date
+    opened = record.try(:opened_date) || record.try(:oim_project_opened_date)
+    closed = record.try(:closed_date) || record.try(:oim_project_closed_date)
 
     opened.blank? || closed.blank? || opened <= closed
   end

--- a/app/views/metadata_fields/_oim_projects.html.erb
+++ b/app/views/metadata_fields/_oim_projects.html.erb
@@ -1,0 +1,10 @@
+<%= render layout: "shared/date_fields", locals: { f: f, field: :oim_project_opened_date, format: :oim_project, label: "Project opened date" } do %>
+<% end %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :oim_project_closed_date, format: :oim_project, label: "Project closed date" } do %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :oim_project_type, label: "Project type" } do %>
+  <%= f.select :oim_project_type, facet_options(f, :oim_project_type), {}, { class: 'form-control' } %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :oim_project_state, label: "Project state" } do %>
+  <%= f.select :oim_project_state, facet_options(f, :oim_project_state), {}, { class: 'form-control' } %>
+<% end %>

--- a/app/views/shared/_date_fields.html.erb
+++ b/app/views/shared/_date_fields.html.erb
@@ -1,4 +1,7 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: field } do %>
+<% locals = { f: f, field: field } %>
+<% locals.merge!(label:label) if local_assigns[:label] %>
+
+<%= render layout: "shared/form_group", locals: locals do %>
 <% date = @document.public_send(field) %>
   <div class="date-layout">
     <p class="form-hint">For example, 2013 03 20</p>

--- a/docs/creating-a-new-specialist-document-type.md
+++ b/docs/creating-a-new-specialist-document-type.md
@@ -50,6 +50,10 @@ See [the CMA case schema](https://github.com/alphagov/search-api/blob/main/confi
 3. Add examples [as instructed](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/adding-a-new-schema.md#examples)
 4. Follow the rest of [the workflow](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/suggested-workflows.md)
 
+## Configure the email sign up page
+
+The email sign up page is rendered by finder frontend using the configuration in the new schema added to specialist publisher. However, if the email sign up page has check boxes (eg [cma-cases](https://www.gov.uk/cma-cases/email-signup)), you must add the new tags to [this file](https://github.com/alphagov/email-alert-api/blob/3e0018510ea85f5d561e2865ad149832b94688a1/lib/valid_tags.rb#L2) in email-alert-api.
+
 ## Deploy and publish
 
 Once you're ready to ship your code to an environment,

--- a/lib/documents/schemas/oim_projects.json
+++ b/lib/documents/schemas/oim_projects.json
@@ -1,0 +1,113 @@
+{
+  "content_id": "4e4e33ff-271a-468a-b7a8-92d25f3f8ac0",
+  "base_path": "/oim-projects",
+  "format_name": "Office for the Internal Market project",
+  "name": "Office for the Internal Market projects",
+  "description": "Find reports and updates on current and historical OIM projects",
+  "filter": {
+    "format": "oim_project"
+  },
+  "signup_content_id": "c0c20b63-039b-4cc4-a341-38c41efb611f",
+  "signup_copy": "You'll get an email each time a project is updated or a new project is published.",
+  "organisations": ["b1123ceb-77e4-40fc-9526-83ad0ba7cf01"],
+  "topics": [],
+  "subscription_list_title_prefix": {
+    "singular": "OIM project with the following project type: ",
+    "plural": "OIM projects with the following project types: ",
+    "many": "Office for the Internal Market (OIM) projects: "
+  },
+  "email_filter_by": "oim_project_type",
+  "email_filter_facets": [
+    {
+      "facet_id": "oim_project_type",
+      "facet_name": "OIM Project type",
+      "required": true,
+      "facet_choices": [
+        {
+          "key": "annual-report",
+          "radio_button_name": "Annual report",
+          "topic_name": "annual report",
+          "prechecked": false
+        },
+        {
+          "key": "five-yearly-report",
+          "radio_button_name": "Five-yearly report",
+          "topic_name": "five-yearly report",
+          "prechecked": false
+        },
+        {
+          "key": "discretionary-report",
+          "radio_button_name": "Discretionary report",
+          "topic_name": "discretionary report",
+          "prechecked": false
+        },
+        {
+          "key": "report-on-proposed-regulatory-provision",
+          "radio_button_name": "Advice/report on proposed regulatory provision",
+          "topic_name": "report on proposed regulatory provision",
+          "prechecked": false
+        },
+        {
+          "key": "report-after-regulatory-provision-is-passed-or-made",
+          "radio_button_name": "Report after regulatory provision is passed or made",
+          "topic_name": "report after regulatory provision is passed or made",
+          "prechecked": false
+        },
+        {
+          "key": "report-on-provision-considered-to-have-detrimental-effects",
+          "radio_button_name": "Report on provision considered to have detrimental effects",
+          "topic_name": "report on provision considered to have detrimental effects",
+          "prechecked": false
+        }
+      ]
+    }
+  ],
+  "document_noun": "project",
+  "facets": [
+    {
+        "key": "oim_project_type",
+        "name": "OIM Project type",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {"label": "Annual report", "value": "annual-report"},
+          {"label": "Five-yearly report", "value": "five-yearly-report"},
+          {"label": "Discretionary report", "value": "discretionary-report"},
+          {"label": "Advice/report on proposed regulatory provision", "value": "report-on-proposed-regulatory-provision"},
+          {"label": "Report after regulatory provision is passed or made", "value": "report-after-regulatory-provision-is-passed-or-made"},
+          {"label": "Report on provision considered to have detrimental effects", "value": "report-on-provision-considered-to-have-detrimental-effects"}
+        ]
+    },
+    {
+      "key": "oim_project_state",
+      "name": "OIM Project state",
+      "type": "text",
+      "preposition": "which are",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Open", "value": "open"},
+        {"label": "Closed", "value": "closed"}
+      ]
+    },
+    {
+      "key": "oim_project_opened_date",
+      "name": "OIM Project opened",
+      "short_name": "Opened",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "oim_project_closed_date",
+      "name": "OIM Project closed",
+      "short_name": "Closed",
+      "type": "date",
+      "preposition": "closed",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/features/creating_a_oim_project.rb
+++ b/spec/features/creating_a_oim_project.rb
@@ -1,0 +1,117 @@
+require "spec_helper"
+
+RSpec.feature "Creating an OIM project", type: :feature do
+  let(:oim_project) { FactoryBot.create(:oim_project) }
+  let(:content_id) { oim_project["content_id"] }
+
+  before do
+    log_in_as_editor(:oim_editor)
+    stub_publishing_api_has_content([oim_project], hash_including(document_type: OimProject.document_type))
+    stub_publishing_api_has_item(oim_project)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "visiting the new project page" do
+    visit "/oim-projects"
+    click_link "Add another OIM Project"
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/oim-projects/new")
+  end
+
+  scenario "creating a project with valid data" do
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    visit "/oim-projects/new"
+
+    fill_in "Title", with: "Example OIM Project"
+    fill_in "Summary", with: "This is the summary of an example OIM project"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example OIM project" * 2}"
+    fill_in "[oim_project]oim_project_opened_date(1i)", with: "2014"
+    fill_in "[oim_project]oim_project_opened_date(2i)", with: "01"
+    fill_in "[oim_project]oim_project_opened_date(3i)", with: "01"
+    select "Annual report", from: "Project type"
+
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+
+    save_button_disable_with_message = page.find_button("Save as draft")["data-disable-with"]
+    expect(save_button_disable_with_message).to eq("Saving...")
+
+    click_button "Save as draft"
+
+    expected_sent_payload = {
+      "base_path" => "/oim-projects/example-oim-project",
+      "title" => "Example OIM Project",
+      "description" => "This is the summary of an example OIM project",
+      "document_type" => "oim_project",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "government-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header\r\n\r\nThis is the long body of an example OIM project\r\n\r\nThis is the long body of an example OIM project",
+          },
+        ],
+        "metadata" => {
+          "oim_project_opened_date" => "2014-01-01",
+          "oim_project_type" => "annual-report",
+          "oim_project_state" => "open",
+        },
+        "max_cache_time" => 10,
+        "temporary_update_type" => false,
+        "headers" => [
+          { "text" => "Header", "level" => 2, "id" => "header" },
+        ],
+      },
+      "routes" => [{ "path" => "/oim-projects/example-oim-project", "type" => "exact" }],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" => {
+        "finder" => %w[4e4e33ff-271a-468a-b7a8-92d25f3f8ac0],
+      },
+    }
+
+    assert_publishing_api_put_content(content_id, expected_sent_payload)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example OIM Project")
+    expect(page).to have_content("Bulk published false")
+  end
+
+  scenario "creating a project with with no data" do
+    visit "/oim-projects/new"
+    expect(page.status_code).to eq(200)
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+  end
+
+  scenario "creating a project with with invalid data" do
+    visit "/oim-projects/new"
+    expect(page.status_code).to eq(200)
+
+    fill_in "Title", with: "Example OIM Project"
+    fill_in "Summary", with: "This is the summary of an example OIM project"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+    fill_in "[oim_project]oim_project_opened_date(1i)", with: "2014"
+    fill_in "[oim_project]oim_project_opened_date(2i)", with: "01"
+    fill_in "[oim_project]oim_project_opened_date(3i)", with: "01"
+    fill_in "[oim_project]oim_project_closed_date(1i)", with: "2013"
+    fill_in "[oim_project]oim_project_closed_date(2i)", with: "01"
+    fill_in "[oim_project]oim_project_closed_date(3i)", with: "01"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+    expect(page).to have_content("Opened date must be before closed date")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -53,6 +53,11 @@ FactoryBot.define do
     organisation_content_id { "de4e9dc6-cca4-43af-a594-682023b84d6c" }
   end
 
+  factory :oim_editor, parent: :editor do
+    organisation_slug { "office-for-the-internal-market" }
+    organisation_content_id { "b1123ceb-77e4-40fc-9526-83ad0ba7cf01" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }
@@ -268,6 +273,22 @@ FactoryBot.define do
           "case_state" => "closed",
           "market_sector" => %w[energy],
           "outcome_type" => "ca98-no-grounds-for-action-non-infringement",
+        }
+      end
+    end
+  end
+
+  factory :oim_project, parent: :document do
+    base_path { "/oim-projects/example-document" }
+    document_type { "oim_project" }
+
+    transient do
+      default_metadata do
+        {
+          "oim_project_opened_date" => "2014-01-01",
+          "oim_project_closed_date" => "2015-01-01",
+          "oim_project_type" => "annual-report",
+          "oim_project_state" => "closed",
         }
       end
     end

--- a/spec/models/oim_project_spec.rb
+++ b/spec/models/oim_project_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe OimProject do
+  let(:payload) { FactoryBot.create(:oim_project) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+
+  describe "validations" do
+    subject { described_class.from_publishing_api(payload) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid if the opened date is after the closed date" do
+      subject.oim_project_opened_date = "2016-01-01"
+      subject.oim_project_closed_date = "2015-12-31"
+
+      expect(subject).to be_invalid
+      expect(subject.errors[:oim_project_opened_date]).to eq ["must be before closed date"]
+    end
+
+    it "is valid if opened/closed date are nil" do
+      subject.oim_project_opened_date = nil
+      subject.oim_project_closed_date = nil
+      expect(subject).to be_valid
+
+      subject.oim_project_opened_date = "2016-01-01"
+      expect(subject).to be_valid
+
+      subject.oim_project_opened_date = nil
+      subject.oim_project_closed_date = "2015-12-31"
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DocumentLinksPresenter do
     UtaacDecision => "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
+    OimProject => "b1123ceb-77e4-40fc-9526-83ad0ba7cf01",
     ProtectedFoodDrinkName => "de4e9dc6-cca4-43af-a594-682023b84d6c",
     RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
     ResearchForDevelopmentOutput => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",


### PR DESCRIPTION
### What

Extend specialist publisher to allow a new type of document called `OIM Projects` to be published.

### Why

Department [request](https://govuk.zendesk.com/agent/tickets/4690504)

### Related PR's
- [govuk_content_schemas](https://github.com/alphagov/govuk-content-schemas/pull/1071)
- [search_api](https://github.com/alphagov/search-api/pull/2326)
- [email-alert-api](https://github.com/alphagov/email-alert-api/pull/1664)

### Screenshots
<img width="839" alt="Screenshot 2021-09-08 at 15 42 10" src="https://user-images.githubusercontent.com/17908089/132531088-c266e5ff-6887-4026-af10-096e051caa80.png">
<img width="668" alt="Screenshot 2021-09-08 at 15 42 20" src="https://user-images.githubusercontent.com/17908089/132531093-a1c118a9-58c4-44dd-90f0-76dcbde8b1c2.png">


[trello](https://trello.com/c/vN0SFEyb/2700-create-new-specialist-document-and-finder-office-for-the-internal-market-projects)