### PR TITLE
Modify AAIB finder for space reports

### DIFF
--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -14,9 +14,9 @@
   "facets": [
     {
       "key": "aircraft_category",
-      "name": "Aircraft category",
+      "name": "Category",
       "type": "text",
-      "preposition": "in aircraft category",
+      "preposition": "in category",
       "display_as_result_metadata": true,
       "filterable": true,
       "allowed_values": [
@@ -24,6 +24,7 @@
         {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
         {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
         {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
+        {"label": "Space", "value": "space"},
         {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"},
         {"label": "Unmanned Aircraft Systems (UAS)", "value": "unmanned-aircraft-systems"}
       ]
@@ -42,6 +43,7 @@
         {"label": "Bulletin - Pre-1997 uncategorised monthly report", "value": "pre-1997-monthly-report"},
         {"label": "Foreign report", "value": "foreign-report"},
         {"label": "Formal report", "value": "formal-report"},
+        {"label": "Space", "value": "space"},
         {"label": "Special bulletin", "value": "special-bulletin"},
         {"label": "Safety study", "value": "safety-study"}
       ]


### PR DESCRIPTION
Changes:

- Facet "Aircraft category" becomes "Category"
- Adds "Space" as a category and a report type

Requested in https://govuk.zendesk.com/agent/tickets/4729912

Result:

Metadata "Space" can be set

<img width="399" alt="Screenshot 2021-10-04 at 11 01 13" src="https://user-images.githubusercontent.com/8124374/135832853-8eb4579e-b880-4c9f-a9a4-8bacb0c3f60f.png">

After republishing the finder with `publishing_api:publish_finder[aaib_reports]`, one can filter by "Space" in two facets:

<img width="968" alt="Screenshot 2021-10-04 at 11 04 30" src="https://user-images.githubusercontent.com/8124374/135832984-f681e536-65ad-47b4-9632-6dd3627f73ba.png">

