### PR TITLE
Add new report type for `Marine Accident Investigation Branch reports`.

### DIFF
--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -82,6 +82,7 @@
       "filterable": true,
      "allowed_values": [
        {"label": "Investigation report", "value": "investigation-report"},
+       {"label": "Investigation report on behalf of Red Ensign Group", "value": "investigation-report-on-behalf-of-red-ensign-group"},
        {"label": "Safety bulletin", "value": "safety-bulletin"},
        {"label": "Completed preliminary examination", "value": "completed-preliminary-examination"},
        {"label": "Overseas report", "value": "overseas-report"},


### PR DESCRIPTION
Added a new report type: 'Investigation report on behalf of Red Ensign Group', following 'Investigation report' type.

[Trello card](https://trello.com/c/GLTNl1B4/2709-add-new-report-type-for-marine-accident-investigation-branch-reports-3)

Related PR's:
https://github.com/alphagov/govuk-content-schemas/pull/1075
https://github.com/alphagov/search-api/pull/2333