### PR TITLE
Create new specialist document type: Product safety alert

### DIFF
--- a/app/models/product_safety_alert.rb
+++ b/app/models/product_safety_alert.rb
@@ -1,0 +1,29 @@
+class ProductSafetyAlert < Document
+  validates :product_alert_type, presence: true
+  validates :product_risk_level, presence: true
+  validates :product_category, presence: true
+  validates :product_measure_type, presence: true
+  validates :product_recall_alert_date, allow_blank: true, date: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    product_alert_type
+    product_risk_level
+    product_category
+    product_measure_type
+    product_recall_alert_date
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def self.title
+    "Product Safety Alert"
+  end
+
+  def primary_publishing_organisation
+    "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
+  end
+end

--- a/app/views/metadata_fields/_product_safety_alerts.html.erb
+++ b/app/views/metadata_fields/_product_safety_alerts.html.erb
@@ -1,0 +1,14 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_alert_type, label: "Alert type" } do %>
+  <%= f.select :product_alert_type, facet_options(f, :product_alert_type), {}, { class: "form-control" } %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_risk_level, label: "Risk level" } do %>
+  <%= f.select :product_risk_level, facet_options(f, :product_risk_level), {}, { class: "form-control" } %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_category, label: "Product category" } do %>
+  <%= f.select :product_category, facet_options(f, :product_category), {}, { class: "form-control" } %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_measure_type, label: "Measure type" } do %>
+  <%= f.select :product_measure_type, facet_options(f, :product_measure_type), {}, { class: "form-control", multiple: true } %>
+<% end %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :product_recall_alert_date, format: :oim_project, label: "Recall/alert date" } do %>
+<% end %>

--- a/lib/documents/schemas/product_safety_alerts.json
+++ b/lib/documents/schemas/product_safety_alerts.json
@@ -1,0 +1,144 @@
+{
+  "content_id": "a22b3f1f-2c91-49a1-a469-ff21d465c543",
+  "base_path": "/product-safety-alerts",
+  "format_name": "Product safety alerts, unsafe products and recalls",
+  "name": "Product safety alerts, unsafe products and recalls",
+  "description": "Find product safety alerts, unsafe products and recalls",
+  "filter": {
+    "format": "product_safety_alert"
+  },
+  "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
+  "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
+  "organisations": ["a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"],
+  "topics": [],
+  "email_filter_by": "product_alert_type",
+  "email_filter_facets": [
+    {
+      "facet_id": "product_alert_type",
+      "facet_name": "Alert type",
+      "required": true,
+      "facet_choices": [
+        {
+          "key": "safety-alert",
+          "radio_button_name": "Safety alert",
+          "topic_name": "safety alert",
+          "prechecked": false
+        },
+        {
+          "key": "product-safety-report",
+          "radio_button_name": "Product safety report",
+          "topic_name": "product safety report",
+          "prechecked": false
+        },
+        {
+          "key": "recall",
+          "radio_button_name": "Recall",
+          "topic_name": "recall",
+          "prechecked": false
+        }
+      ]
+    }
+  ],
+  "pre_production": true,
+  "document_noun": "report",
+  "facets": [
+    {
+        "key": "product_alert_type",
+        "name": "Alert type",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {"label": "Safety alert", "value": "safety-alert"},
+          {"label": "Product safety report", "value": "product-safety-report"},
+          {"label": "Recall", "value": "recall"}
+        ]
+    },
+    {
+      "key": "product_risk_level",
+      "name": "Risk level",
+      "type": "text",
+      "preposition": "that are",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Serious", "value": "serious"},
+        {"label": "High", "value": "high"},
+        {"label": "Medium", "value": "medium"},
+        {"label": "Low", "value": "low"}
+      ]
+    },
+    {
+      "key": "product_category",
+      "name": "Product category",
+      "type": "text",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Adaptors, Plugs and Sockets", "value": "adaptors-plugs-sockets"},
+        {"label": "Chemical products", "value": "chemical-products"},
+        {"label": "Childcare articles and children's equipment", "value": "childcare-articles-childrens-equipment"},
+        {"label": "Clothing, textiles and fashion items", "value": "clothing-textiles-fashion"},
+        {"label": "Communication and media equipment", "value": "communication-media-equipment"},
+        {"label": "Computers and computer accessories", "value": "computers-and-accessories"},
+        {"label": "Construction products", "value": "construction-products"},
+        {"label": "Cosmetics", "value": "cosmetics"},
+        {"label": "Electrical appliances and equipment", "value": "electrical-appliances-equipment"},
+        {"label": "Entertainment and leisure products (indoors)", "value": "entertainment-leisure-products-indoors"},
+        {"label": "Entertainment and leisure products (outdoors)", "value": "entertainment-leisure-products-outdoors"},
+        {"label": "Explosive atmospheres equipment", "value": "explosive-atmospheres-equipment"},
+        {"label": "Fireworks and Pyrotechnic Articles", "value": "fireworks-and-pyrotechnic-articles"},
+        {"label": "Food imitating products", "value": "food-imitating-products"},
+        {"label": "Furniture", "value": "furniture"},
+        {"label": "Gas appliances and components", "value": "gas-appliances-and-components"},
+        {"label": "Hand tools", "value": "hand-tools"},
+        {"label": "Household decorative articles", "value": "household-decorative-articles"},
+        {"label": "Hobby / sports equipment", "value": "hobby-sports-equipment"},
+        {"label": "Jewellery", "value": "jewellery"},
+        {"label": "Kitchen / cooking accessories", "value": "kitchen-cooking-accessories"},
+        {"label": "Lifts", "value": "lifts"},
+        {"label": "Lighting Products", "value": "lighting-products"},
+        {"label": "Machinery", "value": "machinery"},
+        {"label": "Measuring instruments", "value": "measuring-instruments"},
+        {"label": "Motor vehicles", "value": "motor-vehicles"},
+        {"label": "Other", "value": "other"},
+        {"label": "Pressure equipment / vessels", "value": "pressure-equipment-vessels"},
+        {"label": "Personal protective equipment (PPE)", "value": "personal-protective-equipment-ppe"},
+        {"label": "Recreational crafts", "value": "recreational-crafts"},
+        {"label": "Stationery", "value": "stationery"},
+        {"label": "Toys", "value": "toys"}
+      ]
+    },
+    {
+      "key": "product_measure_type",
+      "name": "Measure type",
+      "type": "text",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Ban on the marketing of the product and any accompanying measures", "value": "ban-marketing-of-product-and-accompanying-measures"},
+        {"label": "Destruction of the product", "value": "destruction-of-the-product"},
+        {"label": "Import rejected at border", "value": "import-rejected-at-border"},
+        {"label": "Making the marketing of the product subject to prior conditions", "value": "making-marketing-of-product-subject-to-prior-conditions"},
+        {"label": "Marking the product with appropriate warnings on the risks", "value": "marking-product-with-appropriate-warnings-on-risks"},
+        {"label": "Recall of the product from end users", "value": "recall-of-product-from-end-users"},
+        {"label": "Removal of the listing by the online marketplace", "value": "removal-of-listing-by-online-marketplace"},
+        {"label": "Temporary ban on the supply, offer to supply and display of the product", "value": "temporary-ban-on-supply-offer-and-display-of-product"},
+        {"label": "Warning consumers of the risks", "value": "warning-consumers-of-risks"},
+        {"label": "Withdrawal of the product from the market", "value": "withdrawal-of-product-from-market"},
+        {"label": "Other", "value": "other"}
+      ]
+    },
+    {
+      "key": "product_recall_alert_date",
+      "name": "Recall/alert date",
+      "type": "date",
+      "preposition": "recalled/alerted",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -58,6 +58,11 @@ FactoryBot.define do
     organisation_content_id { "b1123ceb-77e4-40fc-9526-83ad0ba7cf01" }
   end
 
+  factory :product_safety_alert_editor, parent: :editor do
+    organisation_slug { "office-for-product-safety-and-standards" }
+    organisation_content_id { "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }
@@ -289,6 +294,23 @@ FactoryBot.define do
           "oim_project_closed_date" => "2015-01-01",
           "oim_project_type" => "annual-report",
           "oim_project_state" => "closed",
+        }
+      end
+    end
+  end
+
+  factory :product_safety_alert, parent: :document do
+    base_path { "/product-safety-alerts/example-document" }
+    document_type { "product_safety_alert" }
+
+    transient do
+      default_metadata do
+        {
+          "product_alert_type" => "safety-alert",
+          "product_risk_level" => "serious",
+          "product_category" => "adaptors-plugs-sockets",
+          "product_measure_type" => %w[ban-marketing-of-product-and-accompanying-measures warning-consumers-of-risks],
+          "product_recall_alert_date" => "2014-01-01",
         }
       end
     end

--- a/spec/models/product_safety_alert_spec.rb
+++ b/spec/models/product_safety_alert_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe ProductSafetyAlert do
+  let(:payload) { FactoryBot.create(:product_safety_alert) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+
+  it "is valid for the default factory" do
+    expect(described_class.from_publishing_api(payload)).to be_valid
+  end
+end

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DocumentLinksPresenter do
     DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     OimProject => "b1123ceb-77e4-40fc-9526-83ad0ba7cf01",
+    ProductSafetyAlert => "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752",
     ProtectedFoodDrinkName => "de4e9dc6-cca4-43af-a594-682023b84d6c",
     RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
     ResearchForDevelopmentOutput => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",


### PR DESCRIPTION
This is for the new "Product safety alerts, unsafe products and
recalls" finder. I've followed https://docs.publishing.service.gov.uk/apps/specialist-publisher/creating-a-new-specialist-document-type.html,
but also taken inspiration from the most recent PR #1910.

Screenshots:

## Index page

> ![Screenshot 2021-10-29 at 10 50 27](https://user-images.githubusercontent.com/5111927/139464252-7e619640-d25d-4228-b6f9-9fd831140a44.png)

## New page

> ![Screenshot 2021-10-29 at 10 52 15](https://user-images.githubusercontent.com/5111927/139464292-147de3c3-f9b1-42d0-9cd0-605dda1d4b75.png)

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3