### PR TITLE
Edit product safety alert

### DIFF
--- a/app/models/product_safety_alert_report_recall.rb
+++ b/app/models/product_safety_alert_report_recall.rb
@@ -1,4 +1,4 @@
-class ProductSafetyAlert < Document
+class ProductSafetyAlertReportRecall < Document
   validates :product_alert_type, presence: true
   validates :product_risk_level, presence: true
   validates :product_category, presence: true
@@ -20,7 +20,7 @@ class ProductSafetyAlert < Document
   end
 
   def self.title
-    "Product Safety Alert"
+    "Product Safety Alerts, Reports and Recalls"
   end
 
   def primary_publishing_organisation

--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -1,11 +1,11 @@
 {
   "content_id": "a22b3f1f-2c91-49a1-a469-ff21d465c543",
-  "base_path": "/product-safety-alerts",
+  "base_path": "/product-safety-alerts-reports-recalls",
   "format_name": "Product safety alerts, unsafe products and recalls",
   "name": "Product safety alerts, unsafe products and recalls",
   "description": "Find product safety alerts, unsafe products and recalls",
   "filter": {
-    "format": "product_safety_alert"
+    "format": "product_safety_alerts_reports_recalls"
   },
   "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
@@ -19,9 +19,9 @@
       "required": true,
       "facet_choices": [
         {
-          "key": "safety-alert",
-          "radio_button_name": "Safety alert",
-          "topic_name": "safety alert",
+          "key": "product-safety-alert",
+          "radio_button_name": "Product safety alert",
+          "topic_name": "product safety alert",
           "prechecked": false
         },
         {
@@ -31,9 +31,9 @@
           "prechecked": false
         },
         {
-          "key": "recall",
-          "radio_button_name": "Recall",
-          "topic_name": "recall",
+          "key": "product-recall",
+          "radio_button_name": "Product recall",
+          "topic_name": "product recall",
           "prechecked": false
         }
       ]
@@ -50,9 +50,9 @@
         "display_as_result_metadata": true,
         "filterable": true,
         "allowed_values": [
-          {"label": "Safety alert", "value": "safety-alert"},
+          {"label": "Product safety alert", "value": "product-safety-alert"},
           {"label": "Product safety report", "value": "product-safety-report"},
-          {"label": "Recall", "value": "recall"}
+          {"label": "Product recall", "value": "product-recall"}
         ]
     },
     {
@@ -66,7 +66,8 @@
         {"label": "Serious", "value": "serious"},
         {"label": "High", "value": "high"},
         {"label": "Medium", "value": "medium"},
-        {"label": "Low", "value": "low"}
+        {"label": "Low", "value": "low"},
+        {"label": "Not provided", "value": "not-provided"}
       ]
     },
     {

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -299,14 +299,14 @@ FactoryBot.define do
     end
   end
 
-  factory :product_safety_alert, parent: :document do
-    base_path { "/product-safety-alerts/example-document" }
-    document_type { "product_safety_alert" }
+  factory :product_safety_alert_report_recall, parent: :document do
+    base_path { "/product-safety-alerts-reports-recalls/example-document" }
+    document_type { "product_safety_alert_report_recall" }
 
     transient do
       default_metadata do
         {
-          "product_alert_type" => "safety-alert",
+          "product_alert_type" => "product-safety-alert",
           "product_risk_level" => "serious",
           "product_category" => "adaptors-plugs-sockets",
           "product_measure_type" => %w[ban-marketing-of-product-and-accompanying-measures warning-consumers-of-risks],

--- a/spec/models/product_safety_alert_report_recall_spec.rb
+++ b/spec/models/product_safety_alert_report_recall_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 require "models/valid_against_schema"
 
-RSpec.describe ProductSafetyAlert do
-  let(:payload) { FactoryBot.create(:product_safety_alert) }
+RSpec.describe ProductSafetyAlertReportRecall do
+  let(:payload) { FactoryBot.create(:product_safety_alert_report_recall) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it "is not exportable" do

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DocumentLinksPresenter do
     DrugSafetyUpdate => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     MedicalSafetyAlert => "240f72bd-9a4d-4f39-94d9-77235cadde8e",
     OimProject => "b1123ceb-77e4-40fc-9526-83ad0ba7cf01",
-    ProductSafetyAlert => "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752",
+    ProductSafetyAlertReportRecall => "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752",
     ProtectedFoodDrinkName => "de4e9dc6-cca4-43af-a594-682023b84d6c",
     RaibReport => "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
     ResearchForDevelopmentOutput => "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",


### PR DESCRIPTION
Edit product safety alert specialist document and finder after feedback.

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3-5