### PR TITLE
Explicitely set slug for new product-safety-alerts-reports-recalls finder

### DIFF
--- a/app/models/product_safety_alert_report_recall.rb
+++ b/app/models/product_safety_alert_report_recall.rb
@@ -23,6 +23,10 @@ class ProductSafetyAlertReportRecall < Document
     "Product Safety Alerts, Reports and Recalls"
   end
 
+  def self.slug
+    "product-safety-alerts-reports-recalls"
+  end
+
   def primary_publishing_organisation
     "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
   end


### PR DESCRIPTION
Done to fix a bug with the 'new document' link caused by the use of a connective
in the format name.

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3-5