### PR TITLE
Make slug in heading mid-grey

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -4,7 +4,7 @@
   border-bottom: none;
 
   .document-slug {
-    color: $text-muted;
+    color: $gray;
     font-size: $font-size-large;
     display: block;
     margin-top: 5px;


### PR DESCRIPTION
 At the moment, the slugs in the headings are light grey and do not meet WCAG standards due to lack of colour contrast. This makes then a mid-grey.