### PR TITLE
Update old github links

### DIFF
--- a/docs/creating-and-editing-specialist-document-types.md
+++ b/docs/creating-and-editing-specialist-document-types.md
@@ -14,9 +14,9 @@ applications.
 
 See example [PR for adding `product_safety_alert`](https://github.com/alphagov/govuk-content-schemas/pull/1077).
 
-1. Add the format to [this list](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document.jsonnet#L2-L22) and to [this list](https://github.com/alphagov/govuk-content-schemas/blob/main/lib/govuk_content_schemas/allowed_document_types.yml)
-2. Add any new field definitions to [this file](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/_specialist_document.jsonnet)
-3. Add examples [as instructed](https://github.com/alphagov/govuk-content-schemas/blob/master/docs/adding-a-new-schema.md#examples).
+1. Add the format to [this list](https://github.com/alphagov/govuk-content-schemas/blob/main/formats/specialist_document.jsonnet#L2-L31) and to [this list](https://github.com/alphagov/govuk-content-schemas/blob/main/lib/govuk_content_schemas/allowed_document_types.yml)
+2. Add any new field definitions to [this file](https://github.com/alphagov/govuk-content-schemas/blob/main/formats/shared/definitions/_specialist_document.jsonnet)
+3. Add examples [as instructed](https://github.com/alphagov/govuk-content-schemas/blob/main/docs/adding-a-new-schema.md#examples).
    You can copy and paste from another specialist document format, only changing what is necessary (you can leave the body and headers unchanged).
 
 You'll need to generate your own UUIDs for the `content_id` and `signup_content_id` fields:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -9,7 +9,7 @@ Drafts can also be discarded by running a similar task from the Publishing API:
 
 `discard_draft['some-content-id']`
 
-See [Admin Tasks](https://github.com/alphagov/publishing-api/blob/master/doc/admin-tasks.md)
+See [Admin Tasks](https://github.com/alphagov/publishing-api/blob/main/docs/admin-tasks.md)
 
 ## Triggering an email notification
 


### PR DESCRIPTION
Spotted that some of these documentation links were still pointing to
the master branch rather than the main one. And some of them are
slightly outdated or broken.