### PR TITLE
Create DRCF digital markets research finder

### DIFF
--- a/app/models/drcf_digital_markets_research.rb
+++ b/app/models/drcf_digital_markets_research.rb
@@ -1,4 +1,8 @@
 class DrcfDigitalMarketsResearch < Document
+  validates :digital_market_research_category, presence: true
+  validates :digital_market_research_publisher, presence: true
+  validates :digital_market_research_area, presence: true
+  validates :digital_market_research_topic, presence: true
   validates :digital_market_research_publish_date,
             presence: true,
             date: true

--- a/app/models/drcf_digital_markets_research.rb
+++ b/app/models/drcf_digital_markets_research.rb
@@ -24,4 +24,8 @@ class DrcfDigitalMarketsResearch < Document
   def self.title
     "DRCF digital markets research"
   end
+
+  def primary_publishing_organisation
+    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+  end
 end

--- a/app/models/drcf_digital_markets_research.rb
+++ b/app/models/drcf_digital_markets_research.rb
@@ -1,0 +1,23 @@
+class DrcfDigitalMarketsResearch < Document
+  validates :digital_market_research_publish_date,
+            presence: true,
+            date: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    digital_market_research_category
+    digital_market_research_publisher
+    digital_market_research_area
+    digital_market_research_topic
+    digital_market_research_publish_date
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def self.title
+    "DRCF digital markets research"
+  end
+end

--- a/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
+++ b/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
@@ -1,0 +1,62 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_category, label: "Category" } do %>
+  <%= f.select :digital_market_research_category,
+      f.object.facet_options(:digital_market_research_category),
+      {},
+      {
+        class: 'form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a category'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_publisher, label: "Publisher" } do %>
+  <%= f.select :digital_market_research_publisher,
+      f.object.facet_options(:digital_market_research_publisher),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a publisher'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_area, label: "Research area" } do %>
+  <%= f.select :digital_market_research_area,
+      f.object.facet_options(:digital_market_research_area),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a research area'
+        }
+      }
+  %>
+<% end %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_topic, label: "Research topic" } do %>
+  <%= f.select :digital_market_research_topic,
+      f.object.facet_options(:digital_market_research_topic),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a research topic'
+        }
+      }
+  %>
+<% end %>
+<%= render "shared/date_fields",
+  f: f,
+  field: :digital_market_research_publish_date,
+  format: :drcf_digital_markets_research,
+  label: "Research publish date"
+%>

--- a/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
+++ b/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
@@ -1,10 +1,11 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_category, label: "Category" } do %>
   <%= f.select :digital_market_research_category,
       f.object.facet_options(:digital_market_research_category),
-      {},
+      {
+        include_blank: true
+      },
       {
         class: 'form-control',
-        multiple: true,
         data:
         {
           placeholder: 'Select a category'

--- a/lib/documents/schemas/drcf_digital_markets_researches.json
+++ b/lib/documents/schemas/drcf_digital_markets_researches.json
@@ -1,0 +1,118 @@
+{
+  "content_id": "380def5e-bed2-4501-967e-334767ac270d",
+  "base_path": "/find-digital-market-research",
+  "format_name": "DRCF digital markets research",
+  "name": "DRCF digital markets research",
+  "description": "DRCF digital markets research finder",
+  "filter": {
+    "format": "drcf_digital_markets_research"
+  },
+  "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "digital_market_research_category",
+      "name": "Category",
+      "short_name": "Category",
+      "type": "text",
+      "preposition": "",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Ad hoc research", "value": "ad-hoc-research"},
+        {"label": "Ongoing research", "value": "ongoing-research"}
+      ]
+    },
+    {
+      "key": "digital_market_research_publisher",
+      "name": "Original publisher",
+      "short_name": "Publisher",
+      "type": "text",
+      "preposition": "",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Advertising Standards Authority", "value": "advertising-standards-authority"},
+        {"label": "Bank of England", "value": "bank-of-england"},
+        {"label": "Competition and Markets Authority", "value": "competition-and-markets-authority"},
+        {"label": "Financial Conduct Authority - Insight", "value": "financial-conduct-authority-insight"},
+        {"label": "Financial Conduct Authority", "value": "financial-conduct-authority"},
+        {"label": "Gambling Commission", "value": "gambling-commission"},
+        {"label": "Information Commissioner's Office", "value": "information-commissioner's-office"},
+        {"label": "Intellectual Property Office", "value": "intellectual-property-office"},
+        {"label": "Ofcom", "value": "ofcom"}
+      ]
+    },
+    {
+      "key": "digital_market_research_area",
+      "name": "Research area",
+      "short_name": "Research area",
+      "type": "text",
+      "preposition": "",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Advertising and marketing", "value": "advertising-and-marketing"},
+        {"label": "Financial services", "value": "financial-services"},
+        {"label": "Future connectivity and internet", "value": "future-connectivity-and-internet"},
+        {"label": "Media and entertainment", "value": "media-and-entertainment"},
+        {"label": "Retail and digital commerce", "value": "retail-and-digital-commerce"},
+        {"label": "Technology", "value": "technology"}
+      ]
+    },
+    {
+      "key": "digital_market_research_topic",
+      "name": "Research topic",
+      "short_name": "Research topic",
+      "type": "text",
+      "preposition": "",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Adtech", "value": "adtech"},
+        {"label": "Advertising spend", "value": "advertising-spend"},
+        {"label": "Application programming interface", "value": "application-programming-interface"},
+        {"label": "Artificial intelligence", "value": "artificial-intelligence"},
+        {"label": "Audio and radio", "value": "audio-and-radio"},
+        {"label": "Blockchain", "value": "blockchain"},
+        {"label": "Cloud computing", "value": "cloud-computing"},
+        {"label": "Data and AI", "value": "data-and-ai"},
+        {"label": "Data privacy, access and control", "value": "data-privacy-access-and-control"},
+        {"label": "Digital currencies", "value": "digital-currencies"},
+        {"label": "Digital economy", "value": "digital-economy"},
+        {"label": "Digital transformation", "value": "digital-transformation"},
+        {"label": "Distributed ledger technology", "value": "distributed-ledger-technology"},
+        {"label": "Edge computing", "value": "edge-computing"},
+        {"label": "Fintech", "value": "fintech"},
+        {"label": "Future connectivity", "value": "future-connectivity"},
+        {"label": "Gambling", "value": "gambling"},
+        {"label": "Gaming", "value": "gaming"},
+        {"label": "General and vertical search", "value": "general-and-vertical-search"},
+        {"label": "Intellectual property", "value": "intellectual-property"},
+        {"label": "Internet of things", "value": "internet-of-things"},
+        {"label": "Internet usage and attitudes", "value": "internet-usage-and-attitudes"},
+        {"label": "Measuring advertising effectiveness", "value": "measuring-advertising-effectiveness"},
+        {"label": "Music streaming", "value": "music-streaming"},
+        {"label": "News and publishing", "value": "news-and-publishing"},
+        {"label": "Online retail", "value": "online-retail"},
+        {"label": "Open banking", "value": "open-banking"},
+        {"label": "Personalisation algorithm", "value": "personalisation-algorithm"},
+        {"label": "Privacy enhancing technology", "value": "privacy-enhancing-technology"},
+        {"label": "Quantum computing", "value": "quantum-computing"},
+        {"label": "Regtech", "value": "regtech"},
+        {"label": "Safety and harms", "value": "safety-and-harms"},
+        {"label": "Social media and instant messaging", "value": "social-media-and-instant-messaging"},
+        {"label": "TV, video and on-demand", "value": "tv-video-and-on-demand"}
+      ]
+    },
+    {
+      "key": "digital_market_research_publish_date",
+      "name": "Research publish date",
+      "short_name": "Research published",
+      "type": "date",
+      "preposition": "research published",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/features/creating_a_drcf_digital_markets_research_spec.rb
+++ b/spec/features/creating_a_drcf_digital_markets_research_spec.rb
@@ -1,0 +1,144 @@
+require "spec_helper"
+
+RSpec.feature "Creating a DRCF digital markets research", type: :feature do
+  let(:drcf_digital_markets_research) { FactoryBot.create(:drcf_digital_markets_research) }
+  let(:content_id) { drcf_digital_markets_research["content_id"] }
+  let(:save_button_disable_with_message) { page.find_button("Save as draft")["data-disable-with"] }
+
+  before do
+    log_in_as_editor(:drcf_digital_markets_research_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([drcf_digital_markets_research], hash_including(document_type: DrcfDigitalMarketsResearch.document_type))
+    stub_publishing_api_has_item(drcf_digital_markets_research)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "visiting the new research page" do
+    visit "/drcf-digital-markets-researches"
+    click_link "Add another DRCF digital markets research"
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/drcf-digital-markets-researches/new")
+  end
+
+  scenario "creating the new DRCF digital markets research with no data" do
+    visit "/drcf-digital-markets-researches/new"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+    expect(page).to have_content("Digital market research category can't be blank")
+    expect(page).to have_content("Digital market research publisher can't be blank")
+    expect(page).to have_content("Digital market research area can't be blank")
+    expect(page).to have_content("Digital market research topic can't be blank")
+    expect(page).to have_content("Digital market research publish date can't be blank")
+  end
+
+  scenario "creating the new DRCF digital markets research with valid data" do
+    visit "/drcf-digital-markets-researches/new"
+
+    fill_in "Title", with: "Example DRCF digital markets research"
+    fill_in "Summary", with: "This is the summary of an example DRCF digital markets research"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example DRCF digital markets research" * 2}"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(1i)", with: "2022"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(2i)", with: "02"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(3i)", with: "02"
+    select "Ad hoc research", from: "Category"
+    select "Gambling Commission", from: "Publisher"
+    select "Media and entertainment", from: "Research area"
+    select "Future connectivity", from: "Research topic"
+
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+    expect(save_button_disable_with_message).to eq("Saving...")
+
+    click_button "Save as draft"
+
+    expected_sent_payload = {
+      "base_path" => "/find-digital-market-research/example-drcf-digital-markets-research",
+      "title" => "Example DRCF digital markets research",
+      "description" => "This is the summary of an example DRCF digital markets research",
+      "document_type" => "drcf_digital_markets_research",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "government-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header\r\n\r\nThis is the long body of an example DRCF digital markets research\r\n\r\nThis is the long body of an example DRCF digital markets research",
+          },
+        ],
+        "metadata" => {
+          "digital_market_research_category" => "ad-hoc-research",
+          "digital_market_research_publisher" => %w[gambling-commission],
+          "digital_market_research_area" => %w[media-and-entertainment],
+          "digital_market_research_topic" => %w[future-connectivity],
+          "digital_market_research_publish_date" => "2022-02-02",
+        },
+        "max_cache_time" => 10,
+        "headers" => [
+          { "text" => "Header", "level" => 2, "id" => "header" },
+        ],
+        "temporary_update_type" => false,
+      },
+      "routes" => [{ "path" => "/find-digital-market-research/example-drcf-digital-markets-research", "type" => "exact" }],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" => {
+        "finder" => %w[380def5e-bed2-4501-967e-334767ac270d],
+      },
+    }
+
+    assert_publishing_api_put_content(content_id, expected_sent_payload)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example DRCF digital markets research")
+    expect(page).to have_content("Bulk published false")
+  end
+
+  scenario "creating the new DRCF digital markets research with an invalid date" do
+    visit "/drcf-digital-markets-researches/new"
+
+    fill_in "Title", with: "Example DRCF digital markets research"
+    fill_in "Summary", with: "This is the summary of an example DRCF digital markets research"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example DRCF digital markets research" * 2}"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(1i)", with: "2021"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(2i)", with: "02"
+    fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(3i)", with: "31"
+    select "Ad hoc research", from: "Category"
+    select "Gambling Commission", from: "Publisher"
+    select "Media and entertainment", from: "Research area"
+    select "Future connectivity", from: "Research topic"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Digital market research publish date is not a valid date")
+  end
+
+  scenario "creating the new DRCF digital markets research with invalid data" do
+    visit "/drcf-digital-markets-researches/new"
+
+    fill_in "Title", with: "Example DRCF digital markets research"
+    fill_in "Summary", with: "This is the summary of an example DRCF digital markets research"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
 
       expect(page).to have_text("CMA Cases")
 
-      expect(page).to have_css(".navbar-nav li a", count: 1)
+      expect(page).to have_css(".navbar-nav li a", count: 2)
 
       click_link("CMA Cases")
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -63,6 +63,11 @@ FactoryBot.define do
     organisation_content_id { "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752" }
   end
 
+  factory :drcf_digital_markets_research_editor, parent: :editor do
+    organisation_slug { "competition-and-markets-authority" }
+    organisation_content_id { "957eb4ec-089b-4f71-ba2a-dc69ac8919ea" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }
@@ -644,5 +649,21 @@ FactoryBot.define do
 
     initialize_with { attributes }
     to_create(&:deep_stringify_keys!)
+  end
+
+  factory :drcf_digital_markets_research, parent: :document do
+    base_path { "/find-digital-market-research/example-document" }
+    document_type { "drcf_digital_markets_research" }
+    transient do
+      default_metadata do
+        {
+          "digital_market_research_category" => "ad-hoc-research",
+          "digital_market_research_publisher" => %w[gambling-commission],
+          "digital_market_research_area" => %w[media-and-entertainment],
+          "digital_market_research_topic" => %w[future-connectivity],
+          "digital_market_research_publish_date" => "2021-02-18T10:12:26+00:00",
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
Following CMA request to create a specialist finder to bring together research from several organisations.

[Trello card](https://trello.com/c/0LHrDag7/157-create-new-specialist-finder-for-competition-and-markets-authority)