### PR TITLE
Add browser titles for each page

### DIFF
--- a/app/views/attachments/edit.html.erb
+++ b/app/views/attachments/edit.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Edit attachment" %>
+
 <%= render partial: "attachments/breadcrumbs"%>
 
 <h1 class="page-header">Edit attachment</h1>
@@ -11,5 +13,3 @@
     ),
     method: 'put'
 }) %>
-
-

--- a/app/views/attachments/new.html.erb
+++ b/app/views/attachments/new.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Add attachment" %>
+
 <%= render partial: "attachments/breadcrumbs" %>
 
 <h1 class="page-header">Add attachment</h1>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Edit #{@document.title}" %>
+
 <% content_for :breadcrumbs do %>
     <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
     <li><%= link_to @document.title, document_path(document_type_slug: params[:document_type_slug],

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, current_format.title.pluralize %>
+
 <% content_for :breadcrumbs do %>
   <li class='active'><%= current_format.title.pluralize %></li>
 <% end %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "New #{current_format.title.singularize}" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
   <li class='active'>New document</li>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Summary" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
   <li class='active'><%= @document.title %></li>

--- a/app/views/exports/show.html.erb
+++ b/app/views/exports/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Export as CSV" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= current_format.title.pluralize %></li>
   <li class="active">Export as CSV</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <%= csrf_meta_tags %>
 <% end %>
 
-<% content_for :page_title, "Specialist Publisher" %>
+<% content_for :page_title, " | Specialist Publisher" %>
 <% content_for :app_title, "GOV.UK Specialist Publisher" %>
 
 <% content_for :navbar_items do %>


### PR DESCRIPTION
### Description

When you navigate through a service the browser title should be descriptive of the primary function of the page you’re on.

This adds a browser title for each view and ensures that the format follows the `page title | service name` pattern. For example

|Before|After
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/153005515-7ae2005c-dc03-47ed-9332-5834e5c9261a.png)|![image](https://user-images.githubusercontent.com/42515961/153005319-f7245718-646a-4330-b2f4-3db022862ff8.png)|

### Trello card 

https://trello.com/c/5EBSgwl4/361-browser-title-is-not-descriptive-of-pages-function

### Guidance to review

It's probably easiest to just run the branch locally and click around checking that the browser titles for each page (new/edit/index/show for docs and attachments make sense). And are appropriate for different types of reports