### PR TITLE
Fix orphaned labels, add missing H1s and link missing validation messages

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -97,6 +97,10 @@ form {
   .actions {
     margin: 20px 0;
   }
+
+  .checkbox {
+    margin: 0;
+  }
 }
 
 .summary-length-info {

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -30,7 +30,7 @@
         <% if presenter.unpublish_button_visible? %>
           <div class="form-group">
             <label for="alternative_path">Redirect to alternative GOV.UK content path. For example: /the-replacement-page</label>
-            <input type="text" name="alternative_path" class="form-control">
+            <input type="text" id="alternative_path" name="alternative_path" class="form-control">
           </div>
           <% if presenter.internal_notes? %>
             <div class="form-group">

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -11,7 +11,7 @@
   GOVUK.formChangeProtection.init($('.edit_document'), 'You have unsaved changes that will be lost if you leave this page.');
 <% end -%>
 
-<h2>Editing <%= @document.title %></h2>
+<h1>Editing <%= @document.title %></h1>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -9,7 +9,7 @@
   GOVUK.formChangeProtection.init($('.new_document'), 'You have unsaved changes that will be lost if you leave this page.');
 <% end -%>
 
-<h2>New <%= current_format.title.singularize %></h2>
+<h1>New <%= current_format.title.singularize %></h1>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/shared/_date_fields.html.erb
+++ b/app/views/shared/_date_fields.html.erb
@@ -1,25 +1,32 @@
-<% locals = { f: f, field: field } %>
-<% locals.merge!(label:label) if local_assigns[:label] %>
+<% label ||= field.to_s.humanize %>
 
-<%= render layout: "shared/form_group", locals: locals do %>
-<% date = @document.public_send(field) %>
+<div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
+  <%= f.label field, for: "#{format}_#{field}_year" do %>
+    <%= label %>
+    <% field_errors(@document, field).each do |msg| %>
+      <br>
+      <span class="elements-error-message add-label-margin"><%= msg.html_safe %></span>
+    <% end %>
+  <% end %>
+
+  <% date = @document.public_send(field) %>
   <div class="date-layout">
     <p class="form-hint">For example, 2013 03 20</p>
     <div class="row">
-      <%= f.label 'Year', class: "col-md-2" %>
-      <%= f.label 'Month', class: "col-md-2" %>
-      <%= f.label 'Day', class: "col-md-2" %>
+      <%= f.label 'Year', class: "col-md-2", for: "#{format}_#{field}_year" %>
+      <%= f.label 'Month', class: "col-md-2", for: "#{format}_#{field}_month" %>
+      <%= f.label 'Day', class: "col-md-2", for: "#{format}_#{field}_day" %>
     </div>
     <div class="form-group row">
       <div class="col-md-2">
-        <%= f.text_field field, name: "[#{format}]#{field}(1i)", id: "#{format}_#{field}_year", class: 'form-control', placeholder: '2013', value: date_value("year", date), type: "number", min: '1000', max: '9999' %>
+        <%= f.text_field field, name: "[#{format}]#{field}(1i)", id: "#{format}_#{field}_year", class: 'form-control', value: date_value("year", date), type: "number", min: '1000', max: '9999' %>
       </div>
       <div class="col-md-2">
-        <%= f.text_field field, name: "[#{format}]#{field}(2i)", id: "#{format}_#{field}_month", class: 'form-control', placeholder: '03', value: date_value("month", date), type: "number", min: '1', max: '12' %>
+        <%= f.text_field field, name: "[#{format}]#{field}(2i)", id: "#{format}_#{field}_month", class: 'form-control', value: date_value("month", date), type: "number", min: '1', max: '12' %>
       </div>
       <div class="col-md-2">
-        <%= f.text_field field, name: "[#{format}]#{field}(3i)", id: "#{format}_#{field}_day", class: "form-control", placeholder: '20', value: date_value("day", date), type: "number", min: '1', max: '31' %>
+        <%= f.text_field field, name: "[#{format}]#{field}(3i)", id: "#{format}_#{field}_day", class: "form-control", value: date_value("day", date), type: "number", min: '1', max: '31' %>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -1,17 +1,31 @@
 <% unless document.first_draft? %>
-  <div class="checkbox add-vertical-margins">
-    <%= f.radio_button :update_type, :minor, class: 'js-update-type-minor' %>
-    <%= f.label :update_type_minor %>
-    <p class="help-block">Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.</p>
-  </div>
-  <div class="checkbox add-vertical-margins">
-    <%= f.radio_button :update_type, :major, class: 'js-update-type-major' %>
-    <%= f.label :update_type_major %>
-    <p class="help-block">This will notify subscribers to <%= current_format.title.pluralize %>.</p>
-  </div>
-  <div class="<%= document.update_type != 'major' ? 'js-hidden' : nil %> js-change-note">
-    <%= f.label :change_note %>
-    <%= f.text_area :change_note, class: 'form-control short-textarea' %>
-    <p class="help-block">This will be publically viewable on GOV.UK</p>
+  <div class="form-group <%= 'elements-error' if field_has_errors(@document, :update_type) %>">
+    <%= f.label :update_type, for: "#{document.document_type}_update_type_minor" do %>
+      Update type
+      <% field_errors(document, :update_type).each do |msg| %>
+        <br>
+        <span class="elements-error-message add-label-margin"><%= msg.html_safe %></span>
+      <% end %>
+    <% end %>
+
+    <div class="checkbox">
+      <%= f.radio_button :update_type, :minor, class: 'js-update-type-minor', aria: { describedby: "hint-id" } %>
+      <%= f.label :update_type_minor do %>
+        Minor
+      <% end %>
+      <p class="help-block">Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.</p>
+    </div>
+    <div class="checkbox">
+      <%= f.radio_button :update_type, :major, class: 'js-update-type-major', aria: { describedby: "hint-id" } %>
+      <%= f.label :update_type_major do %>
+        Major
+      <% end %>
+      <p class="help-block">This will notify subscribers to <%= current_format.title.pluralize %>.</p>
+    </div>
+    <div class="<%= document.update_type != 'major' ? 'js-hidden' : nil %> js-change-note">
+      <%= f.label :change_note %>
+      <%= f.text_area :change_note, class: 'form-control short-textarea' %>
+      <p class="help-block">This will be publicly viewable on GOV.UK</p>
+    </div>
   </div>
 <% end %>

--- a/spec/features/editing_a_cma_case_spec.rb
+++ b/spec/features/editing_a_cma_case_spec.rb
@@ -93,8 +93,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     scenario "a major update adds to the change history" do
       fill_in "Title", with: "Changed title"
-
-      choose "Update type major"
+      choose "Major"
       fill_in "Change note", with: "This is a change note."
       click_button "Save as draft"
 
@@ -109,7 +108,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
     scenario "a minor update doesn't add to the change history" do
       fill_in "Summary", with: "Summary without a typo"
 
-      choose "Update type minor"
+      choose "Minor"
       click_button "Save as draft"
 
       changed_json = {
@@ -164,7 +163,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(cma_case["details"]["metadata"]["bulk_published"]).to be_truthy
         fill_in "Summary", with: "An updated summary"
 
-        choose "Update type minor"
+        choose "Minor"
         click_button "Save as draft"
 
         changed_json = {
@@ -275,7 +274,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
         expect(page).to have_content("[InlineAttachment:asylum-support-image.jpg]")
 
         fill_in "Body", with: "[InlineAttachment:asylum-support-image.jpg]"
-        choose "Update type minor"
+        choose "Minor"
 
         stub_publishing_api_has_item(updated_cma_case)
 
@@ -414,8 +413,8 @@ RSpec.feature "Editing a CMA case", type: :feature do
       within(".edit_document") do
         expect(page).to have_content("Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.")
         expect(page).to have_content("This will notify subscribers to ")
-        expect(page).to have_content("Update type minor")
-        expect(page).to have_content("Update type major")
+        expect(page).to have_content("Minor")
+        expect(page).to have_content("Major")
       end
     end
 
@@ -430,7 +429,7 @@ RSpec.feature "Editing a CMA case", type: :feature do
 
     scenario "updating the title does not update the base path" do
       fill_in "Title", with: "New title"
-      choose "Update type minor"
+      choose "Minor"
       click_button "Save as draft"
       changed_json = {
         "title" => "New title",
@@ -446,8 +445,8 @@ RSpec.feature "Editing a CMA case", type: :feature do
       within(".edit_document") do
         expect(page).not_to have_content("Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.")
         expect(page).not_to have_content("This will notify subscribers to ")
-        expect(page).not_to have_content("Update type minor")
-        expect(page).not_to have_content("Update type major")
+        expect(page).not_to have_content("Minor")
+        expect(page).not_to have_content("Major")
       end
     end
 

--- a/spec/features/publishing_a_cma_case_spec.rb
+++ b/spec/features/publishing_a_cma_case_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "Publishing a CMA case", type: :feature do
       click_link "Edit document"
 
       fill_in "Title", with: "Changed title"
-      choose "Update type major"
+      choose "Major"
       fill_in "Change note", with: "Updated change note"
 
       click_button "Save as draft"


### PR DESCRIPTION
### Description

In some places labels have not been correctly associated with the corresponding input. This means that they're not read out on screen readers. This PR fixes this issue.

It also uses fixes a few pages not having an H1 and removes some placeholders.

I've extended the existing pattern for error messaging. While it's not optimal, it will be addressed by another card in the backlog.

The build for this is currently failing due to copy changes causing an e2e test to fail. If we decide to keep the copy changes this PR updates the test to use the new copy and skips the test https://github.com/alphagov/publishing-e2e-tests/pull/446 

Once this PR is deployed and merged the test will need to be unskipped 

### Screenshots

While most of the changes aren't visible. I've tweaked the design of versioning section on the edit report page so that error messaging is consistent and it behaves properly for screen readers. Both of the screenshots have triggered a validation for version type not being selected.

|Before|After|
|------------|------------|
|<img width="324" alt="image" src="https://user-images.githubusercontent.com/42515961/154289705-a9b4daa1-0b36-40d8-aff2-2d41f04e1430.png">|<img width="469" alt="image" src="https://user-images.githubusercontent.com/42515961/154289468-d51acb79-be56-4549-90eb-f02d888c8edb.png">|

### Trello Card

https://trello.com/c/smhLoJnE/246-upgrade-orphaned-labels-specialist
