### PR TITLE
Bug fix Product Safety Alerts finder

### DIFF
--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -5,7 +5,7 @@
   "name": "Product Safety Alerts, Reports and Recalls",
   "description": "Find product safety alerts, unsafe products and recalls",
   "filter": {
-    "format": "product_safety_alerts_reports_recalls"
+    "format": "product_safety_alert_report_recall"
   },
   "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",


### PR DESCRIPTION
Update filter format to match the correct schema name in search_api 

related PR: https://github.com/alphagov/search-api/pull/2369

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4903370

Link to fixed finder in integration: https://www.integration.publishing.service.gov.uk/product-safety-alerts-reports-recalls
