### PR TITLE
Turn off email notifications on product safety alert report recalls for OPSS org subscribers

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -1,4 +1,5 @@
 class EmailAlertPresenter
+  DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS = %w[product_safety_alert_report_recall].freeze
   attr_reader :document
 
   def initialize(document)
@@ -40,6 +41,8 @@ private
   end
 
   def links
+    return {} if DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS.include?(document.format)
+
     DocumentLinksPresenter.new(document).to_json[:links]
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/gJnRhd1Z/879-to-unpause-when-notified-pause-email-notification-for-opps-organisation-subscriptions-when-product-safety-alerts-are-published)

We received a [departmental request](https://govuk.zendesk.com/agent/tickets/4903370) to pause email notifications for subscribers of the [OPSS](https://www.gov.uk/government/organisations/office-for-product-safety-and-standards) organisation [feed](https://www.gov.uk/email-signup?link=/government/organisations/office-for-product-safety-and-standards) when product safety alerts are published. This is because the OPSS will be bulk publishing product safety alerts shortly, and they don't want to spam their organisation feed subscribers.

See [commit message](https://github.com/alphagov/specialist-publisher/pull/1997/commits/700bf3f6c4747e43e64acc77324c56f876751a95) for further implementation details.