### PR TITLE
Revert "Temporarily pause notifications to users subscribed to CMA org feed"

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -1,8 +1,5 @@
 class EmailAlertPresenter
-  DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS = %w[
-    product_safety_alert_report_recall
-    drcf_digital_markets_research
-  ].freeze
+  DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS = %w[product_safety_alert_report_recall].freeze
   attr_reader :document
 
   def initialize(document)

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe EmailAlertPresenter do
   let(:cma_case_redrafted_payload) { FactoryBot.create(:cma_case, :redrafted, title: "updated") }
 
   let(:product_safety_alert_payload) { FactoryBot.create(:product_safety_alert_report_recall) }
-  let(:drcf_digital_markets_research_payload) { FactoryBot.create(:drcf_digital_markets_research) }
 
   describe "#to_json" do
     context "product_safety_alert_report_recall finder" do
@@ -18,26 +17,9 @@ RSpec.describe EmailAlertPresenter do
         product_safety_alert = ProductSafetyAlertReportRecall.find(product_safety_alert_payload["content_id"], product_safety_alert_payload["locale"])
         email_alert_presenter = described_class.new(product_safety_alert)
         presented_data = email_alert_presenter.to_json
-
         expect(presented_data[:tags][:format]).to eq(product_safety_alert_payload["document_type"])
         expect(presented_data[:tags][:case_type]).to eq(product_safety_alert_payload["details"]["metadata"]["case_type"])
         expect(presented_data[:links]).to eq({})
-      end
-
-      context "drcf_digital_markets_research finder" do
-        before do
-          stub_publishing_api_has_item(drcf_digital_markets_research_payload)
-        end
-
-        it "does not send the links hash in the payload for email alert api" do
-          drcf_digital_markets_research = DrcfDigitalMarketsResearch.find(drcf_digital_markets_research_payload["content_id"], drcf_digital_markets_research_payload["locale"])
-          email_alert_presenter = described_class.new(drcf_digital_markets_research)
-          presented_data = email_alert_presenter.to_json
-
-          expect(presented_data[:tags][:format]).to eq(drcf_digital_markets_research_payload["document_type"])
-          expect(presented_data[:tags][:digital_market_research_category]).to eq(drcf_digital_markets_research_payload["details"]["metadata"]["digital_market_research_category"])
-          expect(presented_data[:links]).to eq({})
-        end
       end
     end
 


### PR DESCRIPTION
Reverts alphagov/specialist-publisher#1999

CMA have now completed the bulk publishing of `drcf_digital_markets_research` reports and have requested that CMA organisation subscribers are once again notified when changes are made to these document types.

https://govuk.zendesk.com/agent/tickets/4906432