### PR TITLE
Add short names for product recall finder

### DIFF
--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -44,6 +44,7 @@
     {
         "key": "product_alert_type",
         "name": "Alert type",
+        "short_name": "Alert type",
         "type": "text",
         "preposition": "of type",
         "display_as_result_metadata": true,
@@ -57,6 +58,7 @@
     {
       "key": "product_risk_level",
       "name": "Risk level",
+      "short_name": "Risk level",
       "type": "text",
       "preposition": "that are",
       "display_as_result_metadata": true,
@@ -114,6 +116,7 @@
     {
       "key": "product_measure_type",
       "name": "Measure type",
+      "short_name": "Measure type",
       "type": "text",
       "preposition": "of type",
       "display_as_result_metadata": true,
@@ -135,6 +138,7 @@
     {
       "key": "product_recall_alert_date",
       "name": "Recall/alert date",
+      "short_name": "Recall/alert date",
       "type": "date",
       "preposition": "recalled/alerted",
       "display_as_result_metadata": true,


### PR DESCRIPTION
When showing results on the finder we were previously showing rather
clunky names such as:

"Product alert type", "Product measure type", "Product recall alert
date"

As it seems these were generated automatically from the "key" value,
rather than defaulting to the "name" value - as one might expect.

This adds the short names that match the filters for a cleaner, more
consistent, user experience.

## Before:

<img width="688" alt="Screenshot 2022-04-06 at 12 49 23" src="https://user-images.githubusercontent.com/282717/161968370-1eaf51de-d87f-4d73-91c7-8df6c32960ef.png">

## After:

<img width="670" alt="Screenshot 2022-04-06 at 12 42 27" src="https://user-images.githubusercontent.com/282717/161968360-1f2b666f-45ce-480b-97ad-28ea4755505b.png">


