### PR TITLE
Implemented the length counter feature

### DIFF
--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -3,7 +3,8 @@
 <% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :summary } do %>
-  <%= f.text_area :summary, class: 'form-control short-textarea' %>
+  <%= f.text_area :summary, class: 'form-control short-textarea js-length-counter', data: { :"count-message-threshold" => 280, :"count-message-selector" => ".summary-length-info" } %>
+  <div class="summary-length-info warning" aria-live="polite">Summary text should be 280 characters or fewer. <span class="count"></span></div>
 <% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :body } do %>


### PR DESCRIPTION
This feature was already built into the javascript functionality on [this commit](https://github.com/alphagov/specialist-publisher/commit/ab747c870385fdf556a94cab1ee5d26ffe116456), but the partial needed to be updated to utilise it. 