### PR TITLE
Increase RSpec test coverage to >95% for CD

### DIFF
--- a/spec/lib/importers/protected_food_drink_name/parser_spec.rb
+++ b/spec/lib/importers/protected_food_drink_name/parser_spec.rb
@@ -55,4 +55,96 @@ RSpec.describe Importers::ProtectedFoodDrinkName::Parser do
       expect(subject.get_attributes).to eq(expected_result)
     end
   end
+
+  describe "#register" do
+    let(:data) do
+      [
+        { "Product type" => "Wine", "Protection type" => "American viticultural area" },
+        { "Product type" => "Wine", "Protection type" => "US spirit drink" },
+        { "Product type" => "Wine", "Protection type" => "Name protected by international treaty" },
+        { "Product type" => "Aromatised wine" },
+        { "Product type" => "Spirit drink" },
+        { "Product type" => "Wine" },
+        { "Product type" => "Traditional term" },
+        { "Product type" => "Food", "Protection type" => "Traditional Specialities Guaranteed (TSG)" },
+        { "Product type" => "Food" },
+      ]
+    end
+
+    it "parses product types and protection types correctly" do
+      expected_results = %w[
+        american-viticultural-areas
+        american-viticultural-areas
+        names-protected-by-international-treaty
+        aromatised-wines
+        spirit-drinks
+        wines
+        traditional-terms-for-wine
+        foods-traditional-speciality-guaranteed
+        foods-designated-origin-and-geographical-indication
+      ]
+
+      results = data.map { |datum| described_class.new(datum).get_attributes[:register] }
+
+      expect(results).to eq(expected_results)
+    end
+  end
+
+  describe "#summary" do
+    let(:data) do
+      [
+        {
+          "Protection type" => "Geographical indication (GI)",
+          "Product type" => "Spirit drink",
+        },
+        {
+          "Protection type" => "Geographical indication (GI)",
+          "Product type" => "Aromatised wine",
+        },
+        {
+          "Protection type" => "Protected Geographical Indication (PGI)",
+          "Product type" => "Food",
+        },
+        {
+          "Protection type" => "Protected Geographical Indication (PGI)",
+          "Product type" => "Wine",
+        },
+        {
+          "Protection type" => "Protected Designation of Origin (PDO)",
+          "Product type" => "Food",
+        },
+        {
+          "Protection type" => "Protected Designation of Origin (PDO)",
+          "Product type" => "Wine",
+        },
+        { "Protection type" => "Protected Designation of Origin (PDO)" },
+        { "Protection type" => "Traditional Specialities Guaranteed (TSG)" },
+        { "Protection type" => "Traditional Term" },
+        { "Protection type" => "Name protected by international treaty" },
+        { "Protection type" => "American viticultural area" },
+        { "Protection type" => "US spirit drink" },
+      ]
+    end
+
+    it "parses product types and protection types correctly" do
+      expected_results = [
+        "Protected spirit drink name",
+        "Protected aromatised wine name",
+        "Protected food name with Protected Geographical Indication (PGI)",
+        "Protected wine name with Protected Geographical Indication (PGI)",
+        "Protected food name with Protected Designation of Origin (PDO)",
+        "Protected wine name with Protected Designation of Origin (PDO)",
+        "",
+        "Protected food name with Traditional Speciality Guaranteed (TSG)",
+        "Traditional term for wine",
+        "Name protected by international treaty",
+        "American viticultural area",
+        "Protected spirit drink name",
+      ]
+
+      results = data.map { |datum| described_class.new(datum).get_attributes[:summary] }
+
+      expect(results).to eq(expected_results)
+    end
+  end
 end

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -148,13 +148,8 @@ RSpec.describe PublishingApiFinderPublisher do
 
       context "and the app is configured to publish pre-production finders" do
         before do
-          Rails.application.config.publish_pre_production_finders = true
-
+          allow(Rails.application.config).to receive(:publish_pre_production_finders).and_return(true)
           stub_publishing_api_publish(content_id, {})
-        end
-
-        after do
-          Rails.application.config.publish_pre_production_finders = false
         end
 
         it "publishes finder" do

--- a/spec/lib/tasks/bulk_imports_spec.rb
+++ b/spec/lib/tasks/bulk_imports_spec.rb
@@ -1,7 +1,9 @@
-require "spec_helper"
+require "rails_helper"
 
-RSpec.describe "rake import", rake_task: true do
-  context "import:protected_food_and_drink_names" do
+RSpec.describe "rake bulk_imports", type: :task do
+  before { Rake::Task["bulk_imports:protected_food_and_drink_names"].reenable }
+
+  context "bulk_imports:protected_food_and_drink_names" do
     let(:csv_file) { Rails.root.join("spec/support/csvs/spirits_for_import.csv") }
 
     before do

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "publishing_api rake tasks", type: :task do
+  describe "publishing_api:publish_finders" do
+    before(:each) do
+      Rake::Task["publishing_api:publish_finders"].reenable
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      stub_any_publishing_api_publish
+    end
+
+    it "publishes all finders to the Publishing API" do
+      allow(Rails.application.config).to receive(:publish_pre_production_finders).and_return(true)
+      finders = Dir.glob("lib/documents/schemas/*.json")
+      content_ids = finders.map do |json_schema|
+        MultiJson.load(File.read(json_schema))["content_id"]
+      end
+
+      expect { Rake::Task["publishing_api:publish_finders"].invoke }.to output.to_stdout
+
+      content_ids.each do |content_id|
+        assert_publishing_api_put_content(content_id)
+        assert_publishing_api_patch_links(content_id)
+        assert_publishing_api_publish(content_id)
+      end
+    end
+
+    context "an error triggers the rescue state" do
+      it "returns an error message" do
+        stub_any_publishing_api_put_content.and_raise(GdsApi::HTTPServerError.new(500))
+        error_message = %r{Error publishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>}
+
+        expect { Rake::Task["publishing_api:publish_finders"].invoke }.to output(error_message).to_stdout
+      end
+    end
+  end
+
+  describe "publishing_api:publish_finder" do
+    before(:each) do
+      Rake::Task["publishing_api:publish_finder"].reenable
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      stub_any_publishing_api_publish
+    end
+
+    context "incorrect file name is given" do
+      it "returns an error message" do
+        error_message = %r{#<RuntimeError: Could not find file: lib/documents/schemas/aaib_reportings.json>}
+
+        expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reportings") }.to output(error_message).to_stdout
+      end
+    end
+
+    context "correct file name given" do
+      context "no server error present" do
+        it "publishes a single finder to the Publishing API" do
+          schema = "lib/documents/schemas/aaib_reports.json"
+          content_id = MultiJson.load(File.read(schema))["content_id"]
+
+          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reports") }.to output.to_stdout
+
+          assert_publishing_api_put_content(content_id)
+          assert_publishing_api_patch_links(content_id)
+          assert_publishing_api_publish(content_id)
+        end
+      end
+
+      context "server error present" do
+        it "returns an error message" do
+          stub_any_publishing_api_put_content.and_raise(GdsApi::HTTPServerError.new(500))
+          error_message = %r{Error publishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>}
+
+          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reports") }.to output(error_message).to_stdout
+        end
+      end
+    end
+  end
+
+  describe "publishing_api:patch_document_type_links" do
+    let(:cma_cases) { FactoryBot.create_list(:cma_case, 10) }
+
+    before(:each) do
+      Rake::Task["publishing_api:patch_document_type_links"].reenable
+      stub_any_publishing_api_patch_links
+      stub_publishing_api_has_content(cma_cases, hash_including(document_type: CmaCase.document_type))
+    end
+
+    it "patches links for all CMA cases" do
+      message = %r{Links patched for #{cma_cases.count} cma_case documents}
+
+      expect {
+        Rake::Task["publishing_api:patch_document_type_links"].invoke("cma_case")
+      }.to output(message).to_stdout
+
+      cma_cases.each do |cma_case|
+        assert_publishing_api_patch_links(cma_case["content_id"])
+      end
+    end
+  end
+
+  describe "publishing_api:publish_finder_and_patch_documents_links" do
+    let(:cma_cases) { [FactoryBot.create(:cma_case)] }
+
+    it "publishes a finder and patches document type links by delegating to tasks" do
+      expect(Rake::Task["publishing_api:publish_finder"]).to receive(:invoke).with("cma_cases")
+      expect(Rake::Task["publishing_api:patch_document_type_links"]).to receive(:invoke).with("cma_case")
+
+      Rake::Task["publishing_api:publish_finder_and_patch_documents_links"].invoke("cma_cases")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,3 @@
-require "simplecov"
-SimpleCov.start "rails"
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
@@ -7,6 +5,8 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
+
+Rails.application.load_tasks
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RepublishService do
   let(:document) { FactoryBot.create(:cma_case) }
   let(:content_id) { document["content_id"] }
   let(:locale) { document["locale"] }
+  let(:publication_state) { document["publication_state"] }
 
   let(:uses_republish_update_type) do
     request_json_includes("update_type" => "republish")
@@ -112,6 +113,14 @@ RSpec.describe RepublishService do
   context "when the document is unpublished" do
     let(:document) do
       FactoryBot.create(:cma_case, :unpublished)
+    end
+
+    it "logs a warning with a message" do
+      allow(Rails.logger).to receive(:warn).and_return true
+
+      subject.call(content_id, locale)
+
+      expect(Rails.logger).to have_received(:warn).with(/#{content_id}|#{publication_state}/)
     end
 
     it "skips republishing of the document" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), "..")
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start "rails"
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/support/load_rake_tasks.rb
+++ b/spec/support/load_rake_tasks.rb
@@ -1,6 +1,0 @@
-RSpec.configure do |config|
-  config.before :each, rake_task: true do
-    Rake.application.clear
-    Rails.application.load_tasks
-  end
-end


### PR DESCRIPTION
For the ticket on [enabling CD for specialist publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher)

This PR contains changes to improve the RSpec test coverage, pushing it up past the 95% threshold required for CD. The following commits are to improve coverage:
- [republish_service.rb specs](https://github.com/alphagov/specialist-publisher/commit/efba05b467089b75e17b1cc011c600ad2794afd3)
- [publishing_api.rake specs](https://github.com/alphagov/specialist-publisher/commit/6005784d27ed75a01731060f6ae8a0c467edca99)
- [parser.rb specs](https://github.com/alphagov/specialist-publisher/commit/5f35d58164775853c9c60f8e3cdbfad08ae59aa2)
- [attachments_controller.rb specs](https://github.com/alphagov/specialist-publisher/commit/1fbd940b43185b4c82812f5cf7bbb642e9238297)

This PR also fixes issues with some RSpec tests: one to avoid altering the system state by [mocking the Rails config](https://github.com/alphagov/specialist-publisher/commit/6e7a7f4f959ef05e452865e77576ee5306a16c51), as this was perpetuating the altered state to subsequent tests, causing them to fail; and one to [stop reloading rake tasks between specs](https://github.com/alphagov/specialist-publisher/commit/02f7e503fd62c3377d5f8842e71f5d1a40eac160), as this was causing issues with fluctuating test coverage reports due to coverage data of rake tasks being wiped with the reload.

Finally, it [consolidates the loading of SimpleCov into one spec helper](https://github.com/alphagov/specialist-publisher/commit/01bbdc172cd4e1daabe9d77645bc37c70f877c09). 