### PR TITLE
Add healthchecks for S3 and Mongoid

### DIFF
--- a/app/lib/s3_file_uploader.rb
+++ b/app/lib/s3_file_uploader.rb
@@ -1,17 +1,19 @@
 class S3FileUploader
   def self.save_file_to_s3(filename, csv)
-    connection = Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
-
     directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
 
     directory.files.create(
       key: filename,
       body: csv,
+    )
+  end
+
+  def self.connection
+    @connection ||= Fog::Storage.new(
+      provider: "AWS",
+      region: ENV["AWS_REGION"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
     )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
+require "healthcheck/s3"
+
 Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,
+    GovukHealthcheck::Mongoid,
+    Healthcheck::S3,
   )
 
   post "/preview", to: "govspeak#preview"

--- a/lib/healthcheck/s3.rb
+++ b/lib/healthcheck/s3.rb
@@ -1,0 +1,16 @@
+module Healthcheck
+  class S3
+    def name
+      :s3
+    end
+
+    def status
+      connection = S3FileUploader.connection
+      connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end


### PR DESCRIPTION
This PR is part of the ticket for [enabling CD on Specialist Publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher)

Following similar work done in [this PR](https://github.com/alphagov/support-api/commit/0043bd7a1591ac4b1f25ff89fec8073d7af2927c). It [adds a Healthcheck module](https://github.com/alphagov/specialist-publisher/commit/f474c726d424a40d7d4cdb517ec2de6e645ac1d9), which can be used to check S3 connectivity. It [refactors the s3_file_uploader.rb](https://github.com/alphagov/specialist-publisher/commit/29bafb9fe70b3fe5dbe21cb9392b09e9dd399589) file. Finally it [adds healthchecks for S3 and Mongoid](https://github.com/alphagov/specialist-publisher/commit/68679eecd95095354ebb6457b8cbaef83a87cfc3).