### PR TITLE
Add PR template to warn about CD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
+(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
This PR is part of the ticket for [enabling CD on Specialist Publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher)

Adds the warning message about Continuous Deployment to the PR template. [Similar PR in Manuals Publisher](https://github.com/alphagov/manuals-publisher/pull/1688)