### PR TITLE
Added new filter option to the cma_cases schema

### DIFF
--- a/docs/creating-and-editing-specialist-document-types.md
+++ b/docs/creating-and-editing-specialist-document-types.md
@@ -112,7 +112,11 @@ We often receive requests to add new fields to a specialist document. Or to add 
 
 ## Adding or amending values for existing fields on a specialist document
 
-1. In govuk-content-schemas, find the field you are amending in the [specialist_document schema](https://github.com/alphagov/govuk-content-schemas/blob/main/formats/shared/definitions/_specialist_document.jsonnet), and add the new values. See [this](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/b81ec718f52b1e6603c201c44db07f0357158723) commit for an example. Once approved, this change can be merged and deployed.
+1. In govuk-content-schemas, find the field you are amending in the [specialist_document schema](https://github.com/alphagov/govuk-content-schemas/blob/main/formats/shared/definitions/_specialist_document.jsonnet), and add the new values. See [this](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/b81ec718f52b1e6603c201c44db07f0357158723) commit for an example. 
+
+NOTE: You will need to run `bundle exec rake build` to regenerate schemas after adding the new value(s) - as is done in [this commit](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/34dd343fd7de8eb48bb842c2fc7fe3c59ae77168). 
+
+Once approved, this change can be merged and deployed.
 
 2. In specialist-publisher, add the new values to the relevant file in the [schema](https://github.com/alphagov/specialist-publisher/tree/main/lib/documents/schemas) directory. See [this](https://github.com/alphagov/specialist-publisher/pull/1899/commits/97c8d713f8e62b0cb8763fe26e1dcf5a0435c12d) commit for an example.
 

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -48,6 +48,12 @@
           "prechecked": false
         },
         {
+          "key": "information-and-advice-to-government",
+          "radio_button_name": "Information and advice to government",
+          "topic_name": "information and advice to government",
+          "prechecked": false
+        },
+        {
           "key": "markets",
           "radio_button_name": "Markets",
           "topic_name": "markets",
@@ -93,6 +99,7 @@
           {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"},
           {"label": "Competition disqualification", "value": "competition-disqualification"},
           {"label": "Criminal cartels", "value": "criminal-cartels"},
+          {"label": "Information and advice to government", "value": "information-and-advice-to-government"},
           {"label": "Markets", "value": "markets"},
           {"label": "Mergers", "value": "mergers"},
           {"label": "Consumer enforcement", "value": "consumer-enforcement"},


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/RqdVvCSV/548-add-a-new-option-to-case-type-filter-on-cma-cases-specialist-finder)

This PR adds the option "Information and Advice for Government" to the case_type filter on CMA cases. It also adds this option to the email signup list.

This allows publishers to select "Information and Advice for Government" as an option for case_type, and for users to get alerts about this type of CMA case.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️