### PR TITLE
Replace govuk content schema test helpers with govuk schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :development, :test do
   gem "capybara-select-2"
   gem "database_cleaner"
   gem "factory_bot"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "pry-rails"
   gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,8 +157,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_admin_template (6.9.2)
       bootstrap-sass (~> 3.4)
       jquery-rails (~> 4.3)
@@ -185,6 +183,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -502,10 +502,10 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govspeak
-  govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
   govuk_frontend_toolkit
+  govuk_schemas
   govuk_sidekiq
   govuk_test
   hashdiff

--- a/spec/lib/publishing_api_finder_publisher_spec.rb
+++ b/spec/lib/publishing_api_finder_publisher_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PublishingApiFinderPublisher do
         stub_publishing_api_publish(finders[1][:file]["content_id"], {})
 
         expect(publishing_api).to receive(:put_content)
-          .with(finders[0][:file]["content_id"], be_valid_against_schema("finder"))
+          .with(finders[0][:file]["content_id"], be_valid_against_publisher_schema("finder"))
         expect(publishing_api).to receive(:patch_links)
           .with(finders[0][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
@@ -73,7 +73,7 @@ RSpec.describe PublishingApiFinderPublisher do
           .with(finders[0][:file]["signup_content_id"])
 
         expect(publishing_api).to receive(:put_content)
-          .with(finders[1][:file]["content_id"], be_valid_against_schema("finder"))
+          .with(finders[1][:file]["content_id"], be_valid_against_publisher_schema("finder"))
         expect(publishing_api).to receive(:patch_links)
           .with(finders[1][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
@@ -100,7 +100,7 @@ RSpec.describe PublishingApiFinderPublisher do
 
       it "publishes finder" do
         expect(publishing_api).to receive(:put_content)
-          .with(finders[0][:file]["content_id"], be_valid_against_schema("finder"))
+          .with(finders[0][:file]["content_id"], be_valid_against_publisher_schema("finder"))
         expect(publishing_api).to receive(:patch_links)
           .with(finders[0][:file]["content_id"], anything)
         expect(publishing_api).to receive(:publish)
@@ -127,7 +127,7 @@ RSpec.describe PublishingApiFinderPublisher do
 
       it "publishes finder" do
         expect(publishing_api).to receive(:put_content)
-          .with(content_id, be_valid_against_schema("finder"))
+          .with(content_id, be_valid_against_publisher_schema("finder"))
         expect(publishing_api).to receive(:patch_links)
           .with(content_id, anything)
         expect(publishing_api).to receive(:publish)
@@ -154,7 +154,7 @@ RSpec.describe PublishingApiFinderPublisher do
 
         it "publishes finder" do
           expect(publishing_api).to receive(:put_content)
-            .with(content_id, be_valid_against_schema("finder"))
+            .with(content_id, be_valid_against_publisher_schema("finder"))
           expect(publishing_api).to receive(:patch_links)
             .with(content_id, anything)
           expect(publishing_api).to receive(:publish)
@@ -167,7 +167,7 @@ RSpec.describe PublishingApiFinderPublisher do
       context "and is not configured to publish pre-production finders" do
         it "doesn't publish the finder" do
           expect(publishing_api).not_to receive(:put_content)
-            .with(content_id, be_valid_against_schema("finder"))
+            .with(content_id, be_valid_against_publisher_schema("finder"))
           expect(publishing_api).not_to receive(:patch_links)
             .with(content_id, anything)
           expect(publishing_api).not_to receive(:publish)

--- a/spec/models/valid_against_schema.rb
+++ b/spec/models/valid_against_schema.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples "it saves payloads that are valid against the 'specialist_
       expected_payload_sent_to_publishing_api = write_payload(payload)
 
       assert_publishing_api_put_content(instance.content_id, expected_payload_sent_to_publishing_api)
-      expect(expected_payload_sent_to_publishing_api.to_json).to be_valid_against_schema("specialist_document")
+      expect(expected_payload_sent_to_publishing_api.to_json).to be_valid_against_publisher_schema("specialist_document")
     end
   end
 end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DocumentPresenter do
 
     it "is valid against the content schemas" do
       expect(presented_data[:schema_name]).to eq("specialist_document")
-      expect(presented_data).to be_valid_against_schema("specialist_document")
+      expect(presented_data).to be_valid_against_publisher_schema("specialist_document")
     end
 
     it "does not contain attachments key" do
@@ -66,7 +66,7 @@ RSpec.describe DocumentPresenter do
 
     it "is valid against the content schemas" do
       expect(presented_data[:schema_name]).to eq("specialist_document")
-      expect(presented_data).to be_valid_against_schema("specialist_document")
+      expect(presented_data).to be_valid_against_publisher_schema("specialist_document")
     end
 
     it "contains the attachments" do
@@ -95,7 +95,7 @@ RSpec.describe DocumentPresenter do
     end
 
     it "is valid against the content schemas" do
-      expect(presented_data).to be_valid_against_schema("specialist_document")
+      expect(presented_data).to be_valid_against_publisher_schema("specialist_document")
     end
 
     it "adds the header to the payload" do
@@ -121,7 +121,7 @@ RSpec.describe DocumentPresenter do
     end
 
     it "is valid against the content schemas" do
-      expect(presented_data).to be_valid_against_schema("specialist_document")
+      expect(presented_data).to be_valid_against_publisher_schema("specialist_document")
     end
 
     it "adds the nested header to the payload" do
@@ -150,7 +150,7 @@ RSpec.describe DocumentPresenter do
     end
 
     it "is valid against the content schemas" do
-      expect(presented_data).to be_valid_against_schema("specialist_document")
+      expect(presented_data).to be_valid_against_publisher_schema("specialist_document")
     end
 
     it "does not add a headers section to the payload" do

--- a/spec/presenters/finders/finder_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_content_item_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FinderContentItemPresenter do
         presented_data = presenter.to_json
 
         expect(presented_data[:schema_name]).to eq("finder")
-        expect(presented_data).to be_valid_against_schema("finder")
+        expect(presented_data).to be_valid_against_publisher_schema("finder")
       end
     end
   end

--- a/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FinderSignupContentItemPresenter do
           presented_data = finder_signup_content_presenter.to_json
 
           expect(presented_data[:schema_name]).to eq("finder_email_signup")
-          expect(presented_data).to be_valid_against_schema("finder_email_signup")
+          expect(presented_data).to be_valid_against_publisher_schema("finder_email_signup")
         end
       end
     end

--- a/spec/support/govuk_content_schemas_spec_helpers.rb
+++ b/spec/support/govuk_content_schemas_spec_helpers.rb
@@ -1,11 +1,3 @@
-require "govuk-content-schema-test-helpers"
-require "govuk-content-schema-test-helpers/rspec_matchers"
+require "govuk_schemas/rspec_matchers"
 
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  # Can't use Rails.root as this helper is needed for some specs using
-  # fast_spec_helper, but that doesn't load Rails.
-  config.project_root = File.absolute_path(File.join(File.basename(__FILE__), ".."))
-end
-
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
## Description 

This PR replaces the govuk-content-schema-test-helpers gem with the govuk_schemas gem to validate content item schemas.

[govuk-content-schema-test-helpers] has been archived and there is a concern that it no longer receives any security updates. The advice in the govuk-content-schema-test-helpers repo is to replace it with the govuk_schemas gem.

[govuk-content-schema-test-helpers]: https://github.com/alphagov/govuk-content-schema-test-helpers

## Trello card

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️