### PR TITLE
Authenticate users against doc types their org can access

### DIFF
--- a/app/controllers/passthrough_controller.rb
+++ b/app/controllers/passthrough_controller.rb
@@ -14,7 +14,7 @@ class PassthroughController < ApplicationController
 private
 
   def first_permitted_format
-    @first_permitted_format ||= document_models.sort_by(&:name).find do |document_class|
+    @first_permitted_format ||= formats_user_can_access.sort_by(&:name).find do |document_class|
       DocumentPolicy.new(current_user, document_class).index?
     end
   end


### PR DESCRIPTION
The check on root path checks for users with "editor" permissions checks that the user's organisation can access the first finder in the list of schemas. This schema is AAIB reports and not all users will be able to access them.
Rather than checking against the first document model, check against the first model that the user's org can access.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️