### PR TITLE
Change to a Defra specialist document

### DIFF
--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -50,7 +50,8 @@
         {"label": "Registered","value": "registered"},
         {"label": "Applied for","value": "applied-for"},
         {"label": "In consultation","value": "in-consultation"},
-        {"label": "Rejected","value": "rejected"}
+        {"label": "Rejected","value": "rejected"},
+        {"label": "Cancelled","value": "cancelled"}
       ]
     },
     {


### PR DESCRIPTION
This will add Cancelled option to the status field.
Related PRs:
https://github.com/alphagov/govuk-content-schemas/pull/1115
https://github.com/alphagov/search-api/pull/2430

[Trello card](https://trello.com/c/ZGpx4wvb/653-5046102-making-changes-to-the-protected-food-and-drink-names-register-on-specialist-publisher-defra-department-for-environment-f)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️