### PR TITLE
Update labels on MHRA's Medical safety alerts finder 

### DIFF
--- a/app/views/metadata_fields/_medical_safety_alerts.html.erb
+++ b/app/views/metadata_fields/_medical_safety_alerts.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :alert_type } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :alert_type, label: "Message type" } do %>
   <%= f.select :alert_type,
       f.object.facet_options(:alert_type),
       {

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -55,11 +55,11 @@
       ]
     }
   ],
-  "document_noun": "alert",
+  "document_noun": "message",
   "facets": [
     {
       "key": "alert_type",
-      "name": "Alert type",
+      "name": "Message type",
       "type": "text",
       "preposition": "for",
       "display_as_result_metadata": true,


### PR DESCRIPTION
## Context
 MHRA requested via [Zendesk](https://govuk.zendesk.com/agent/tickets/4893256) that we change labels in the [Alerts, recalls and safety information: drugs and medical devices](https://www.gov.uk/drug-device-alerts).

[Trello](https://trello.com/c/JuWkv0lG/1254-updates-text-labels-on-mhra-drug-alert-finder-s)

## Changes
 - change facet name from 'Alert type' to 'Message type'
 - change document noun (used for pagination) from 'alert' to 'message'

 | Before      | After |
| ----------- | ----------- |
| <img width="749" alt="Screenshot 2022-08-24 at 17 41 34" src="https://user-images.githubusercontent.com/38078064/186638899-8c0a8182-f89b-4a40-96da-9614a2501e9a.png"> | <img width="828" alt="Screenshot 2022-08-25 at 11 04 08" src="https://user-images.githubusercontent.com/38078064/186638783-ff3a50f7-ddef-45a8-af60-0005e6a9b4d9.png"> |


 - change label in the blue box on the content itself from 'Alert type' to 'Message type'
 
 | Before      | After |
| ----------- | ----------- |
| <img width="485" alt="Screenshot 2022-08-25 at 11 06 12" src="https://user-images.githubusercontent.com/38078064/186640187-fddc90a6-0d5a-4d9c-8a80-42c0a0e27786.png"> | <img width="518" alt="Screenshot 2022-08-25 at 11 08 29" src="https://user-images.githubusercontent.com/38078064/186640251-4e988a63-2d59-4411-ac5b-2ced860d7d11.png"> |
 
 - Form label in Specialist publisher from 'Alert type' to 'Message type'

 | Before      | After |
| ----------- | ----------- |
| <img width="625" alt="Screenshot 2022-08-25 at 09 27 25" src="https://user-images.githubusercontent.com/38078064/186640618-3ad8249d-0e23-4e64-b3f2-d1174364148c.png"> | <img width="629" alt="Screenshot 2022-08-25 at 09 31 04" src="https://user-images.githubusercontent.com/38078064/186640526-ee0cd296-4984-4316-a148-41e32068b521.png"> |



## Post-deploy tasks

- [x] Republish the finder `publishing_api:publish_finder[medical_safety_alerts]`
- [x] Republish all medical safety alerts `republish:document_type[medical_safety_alert]`

 
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️