### PR TITLE
Update medical safety alerts email signup

### DIFF
--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -8,7 +8,7 @@
     "format": "medical_safety_alert"
   },
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
-  "signup_title": "Drug alerts and medical device alerts",
+  "signup_title": "Alerts, recalls and safety information: drugs and medical devices",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "show_summaries": true,
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
@@ -21,7 +21,7 @@
   "email_filter_facets": [
     {
       "facet_id": "alert_type",
-      "facet_name": "Alert Type",
+      "facet_name": "Message type",
       "required": true,
       "facet_choices": [
         {


### PR DESCRIPTION
## Changes
-  filter facet name from `Alert type` to `Message type` 
- the title to  `Alerts, recalls and safety information: drugs and medical devices`

on www.gov.uk/drug-device-alerts/email-signup to make it consistent with recent changes to the finder in https://github.com/alphagov/specialist-publisher/pull/2080 

 | Before      | After |
| ----------- | ----------- |
| <img width="438" alt="Screenshot 2022-09-02 at 11 12 15" src="https://user-images.githubusercontent.com/38078064/188117949-7d7b7c5b-4e0d-4e8c-844d-3b46f6022ceb.png"> | <img width="430" alt="Screenshot 2022-09-02 at 11 13 06" src="https://user-images.githubusercontent.com/38078064/188117983-673d46fb-e328-494d-aa53-a7cf59b56917.png"> |

### Context
- [Trello](https://trello.com/c/DMi7u6WJ/1295-update-drug-and-medical-device-alerts-email-signup-page-s)
- https://govuk.zendesk.com/agent/tickets/4893256

## Post-deploy tasks
 - [x] Republish the finder `publishing_api:publish_finder[medical_safety_alerts]`

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️