### PR TITLE
Change report type for Marine Accident Investigation Branch reports

### DIFF
--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -84,7 +84,7 @@
        {"label": "Investigation report", "value": "investigation-report"},
        {"label": "Investigation report on behalf of Red Ensign Group", "value": "investigation-report-on-behalf-of-red-ensign-group"},
        {"label": "Safety bulletin", "value": "safety-bulletin"},
-       {"label": "Completed preliminary examination", "value": "completed-preliminary-examination"},
+       {"label": "Completed preliminary assessment", "value": "completed-preliminary-assessment"},
        {"label": "Overseas report", "value": "overseas-report"},
        {"label": "Discontinued investigation", "value": "discontinued-investigation"}
      ]


### PR DESCRIPTION
As requested [Trello card](https://trello.com/c/6OoRo5vK/708-change-report-type-for-marine-accident-investigation-branch-reports)

Related PR:
https://github.com/alphagov/govuk-content-schemas/pull/1120

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️