### PR TITLE
Add disease finder

### DIFF
--- a/app/models/animal_disease_case.rb
+++ b/app/models/animal_disease_case.rb
@@ -1,0 +1,34 @@
+class AnimalDiseaseCase < Document
+  validates :disease_type, presence: true
+  validates :zone_restriction, presence: true
+  validates :zone_type, presence: true
+  validates :disease_case_opened_date, presence: true, date: true, open_before_closed: true
+  validates :disease_case_closed_date, date: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    disease_type
+    zone_restriction
+    zone_type
+    virus_strain
+    disease_case_closed_date
+    disease_case_opened_date
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def taxons
+    []
+  end
+
+  def self.title
+    "Animal disease case"
+  end
+
+  def primary_publishing_organisation
+    "de4e9dc6-cca4-43af-a594-682023b84d6c"
+  end
+end

--- a/app/validators/open_before_closed_validator.rb
+++ b/app/validators/open_before_closed_validator.rb
@@ -6,8 +6,8 @@ class OpenBeforeClosedValidator < ActiveModel::EachValidator
 private
 
   def before_closed?(record)
-    opened = record.try(:opened_date) || record.try(:oim_project_opened_date)
-    closed = record.try(:closed_date) || record.try(:oim_project_closed_date)
+    opened = record.try(:opened_date) || record.try(:oim_project_opened_date) || record.try(:disease_case_opened_date)
+    closed = record.try(:closed_date) || record.try(:oim_project_closed_date) || record.try(:disease_case_closed_date)
 
     opened.blank? || closed.blank? || opened <= closed
   end

--- a/app/views/metadata_fields/_animal_disease_cases.html.erb
+++ b/app/views/metadata_fields/_animal_disease_cases.html.erb
@@ -1,0 +1,57 @@
+<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_opened_date, format: :animal_disease_case, label: "Case opened date" } do %>
+<% end %>
+
+<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_closed_date, format: :animal_disease_case, label: "Case closed date" } do %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :disease_type } do %>
+  <%= f.select :disease_type,
+      f.object.facet_options(:disease_type),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select disease type'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :zone_restriction, label: "Disease control zone restriction" } do %>
+  <%= f.select :zone_restriction,
+      f.object.facet_options(:zone_restriction),
+      {
+        include_blank: true
+      },
+      {
+        class: 'form-control',
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :zone_type } do %>
+  <%= f.select :zone_type,
+      f.object.facet_options(:zone_type),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select disease control zone type'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :virus_strain, label: "Virus strain" } do %>
+  <%= f.select :virus_strain,
+      f.object.facet_options(:virus_strain),
+      {
+        include_blank: true
+      },
+      {
+        class: 'form-control',
+      }
+  %>
+<% end %>

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -1,0 +1,195 @@
+{  
+  "content_id": "48ef3920-b877-47af-8356-44f345c22a47",
+  "base_path": "/animal-disease-cases-england",
+  "format_name": "Notifiable animal disease cases and control zone",
+  "name": "Notifiable animal disease cases and control zones",
+  "description": "Find notifiable animal disease cases and control zone declarations for England.",
+  "filter": {
+    "format": "animal_disease_case"
+  },
+  "organisations": [
+    "de4e9dc6-cca4-43af-a594-682023b84d6c",
+    "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
+  ],
+  "related": [
+    "5fe90412-7631-11e4-a3cb-005056011aef"
+  ],
+  "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
+  "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
+  "subscription_list_title_prefix": "Notifiable animal disease cases and control zones",
+  "summary": "<p>Find notifiable exotic animal disease cases and control zone declarations for England.</p><p> There are cases of bird flu (avian influenza) in England. Check if you are in a <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=8cb1883eda5547c6b91b5d5e6aeba90d\">disease control zone on the map</a>.</p><p> Find out more about cases in <a href=\"https://www.gov.scot/publications/avian-influenza-bird-flu\">Scotland</a>, cases in <a href=\"https://gov.wales/avian-influenza-bird-flu-latest-update\">Wales</a> and cases in <a href=\"https://www.daera-ni.gov.uk/ai\">Northern Ireland</a>.</p>",
+  "pre_production": true,
+  "document_noun": "case",
+  "facets": [
+    {
+      "key": "disease_type",
+      "name": "Disease Type",
+      "short_name": "type",
+      "type": "text",
+      "preposition": "of disease type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "African horse sickness",
+          "value": "african-horse-sickness"
+        },
+        {
+          "label": "African swine fever",
+          "value": "african-swine-fever"
+        },
+        {
+          "label": "Bird flu (avian influenza)",
+          "value": "bird-flu"
+        },
+        {
+          "label": "Bluetongue",
+          "value": "bluetongue"
+        },
+        {
+          "label": "Classical swine fever",
+          "value": "classical-swine-fever"
+        },
+        {
+          "label": "Foot and mouth disease",
+          "value": "foot-and-mouth-disease"
+        },
+        {
+          "label": "Newcastle disease",
+          "value": "newcastle-disease"
+        },
+        {
+          "label": "Swine vesicular disease",
+          "value": "swine-vesicular-disease"
+        }
+      ]
+    },
+    {
+      "key": "zone_restriction",
+      "name": "Disease control zone restrictions",
+      "short_name": "Control zone restriction",
+      "type": "text",
+      "preposition": "with control zone restriction",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "In force",
+          "value": "in-force"
+        },
+        {
+          "label": "No longer in force",
+          "value": "no-longer-in-force"
+        }
+      ]
+    },
+    {
+      "key": "zone_type",
+      "name": "Disease control zone type",
+      "short_name": "Control zone type",
+      "type": "text",
+      "preposition": "with control zone type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Protection zone",
+          "value": "protection"
+        },
+        {
+          "label": "Surveillance zone",
+          "value": "surveillance"
+        },
+        {
+          "label": "Restricted zone",
+          "value": "restricted"
+        },
+        {
+          "label": "Temporary control zone",
+          "value": "temporary-control"
+        },
+        {
+          "label": "Captive bird (monitoring) controlled zone",
+          "value": "captive-bird"
+        },
+        {
+          "label": "Wild bird control area",
+          "value": "wild-bird-control"
+        },
+        {
+          "label": "Wild bird monitoring area",
+          "value": "wild-bird-monitoring"
+        }
+      ]
+    },
+    {
+      "key": "virus_strain",
+      "name": "Virus strain",
+      "short_name": "Virus strain",
+      "type": "text",
+      "preposition": "of strain type",
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "allowed_values": [
+        {
+          "label": "H5Nx",
+          "value": "h5nx"
+        },
+        {
+          "label": "H5N1",
+          "value": "h5n1"
+        },
+        {
+          "label": "H5N2",
+          "value": "h5n2"
+        },
+        {
+          "label": "H5N3",
+          "value": "h5n3"
+        },
+        {
+          "label": "H5N5",
+          "value": "h5n5"
+        },
+        {
+          "label": "H5N6",
+          "value": "h5n6"
+        },
+        {
+          "label": "H5N8",
+          "value": "h5n8"
+        },
+        {
+          "label": "H7Nx",
+          "value": "h7nx"
+        },
+        {
+          "label": "H7N7",
+          "value": "h7n7"
+        },
+        {
+          "label": "Undetermined",
+          "value": "undetermined"
+        }
+      ]
+    },
+    {
+      "key": "disease_case_opened_date",
+      "name": "Case opened date",
+      "short_name": "Opened",
+      "type": "date",
+      "preposition": "opened",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "disease_case_closed_date",
+      "name": "Case closed date",
+      "short_name": "Closed",
+      "type": "date",
+      "preposition": "closed",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ]
+}

--- a/spec/features/creating_an_animal_disease_case.rb
+++ b/spec/features/creating_an_animal_disease_case.rb
@@ -1,0 +1,151 @@
+require "spec_helper"
+
+RSpec.feature "Creating an animal disease case", type: :feature do
+  let(:animal_disease_case) { FactoryBot.create(:animal_disease_case) }
+  let(:content_id) { animal_disease_case["content_id"] }
+  let(:save_button_disable_with_message) { page.find_button("Save as draft")["data-disable-with"] }
+
+  before do
+    log_in_as_editor(:animal_disease_case_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([animal_disease_case], hash_including(document_type: AnimalDiseaseCase.document_type))
+    stub_publishing_api_has_item(animal_disease_case)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "visiting the new case page" do
+    #  ? should this be animal disease cases england?
+    visit "/animal-disease-cases"
+    click_link "Add another Animal disease case"
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/animal-disease-cases/new")
+  end
+
+  scenario "creating a new animal disease case with no data" do
+    visit "/animal-disease-cases/new"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+    expect(page).to have_content("Disease type can't be blank")
+    expect(page).to have_content("Zone restriction can't be blank")
+    expect(page).to have_content("Opened date can't be blank")
+  end
+
+  scenario "creating a new animal disease case with valid data" do
+    visit "/animal-disease-cases/new"
+
+    fill_in "Title", with: "Example animal disease case"
+    fill_in "Summary", with: "This is the summary of an example animal disease case"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example animal disease case" * 2}"
+    fill_in "[animal_disease_case]disease_case_opened_date(1i)", with: "2022"
+    fill_in "[animal_disease_case]disease_case_opened_date(2i)", with: "09"
+    fill_in "[animal_disease_case]disease_case_opened_date(3i)", with: "09"
+    fill_in "[animal_disease_case]disease_case_closed_date(1i)", with: "2022"
+    fill_in "[animal_disease_case]disease_case_closed_date(2i)", with: "10"
+    fill_in "[animal_disease_case]disease_case_closed_date(3i)", with: "09"
+    select "Bird flu (avian influenza)", from: "Disease type"
+    select "In force", from: "Disease control zone restriction"
+    select "Protection zone", from: "Zone type"
+    select "H5Nx", from: "Virus strain"
+
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+    expect(save_button_disable_with_message).to eq("Saving...")
+
+    click_button "Save as draft"
+
+    expected_sent_payload = {
+      "base_path" => "/animal-disease-cases-england/example-animal-disease-case",
+      "title" => "Example animal disease case",
+      "description" => "This is the summary of an example animal disease case",
+      "document_type" => "animal_disease_case",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "government-frontend",
+      "locale" => "en",
+      "phase" => "live",
+      "details" => {
+        "body" => [
+          {
+            "content_type" => "text/govspeak",
+            "content" => "## Header\r\n\r\nThis is the long body of an example animal disease case\r\n\r\nThis is the long body of an example animal disease case",
+          },
+        ],
+        "metadata" => {
+          "disease_type" => %w[bird-flu],
+          "zone_restriction" => "in-force",
+          "zone_type" => %w[protection],
+          "virus_strain" => "h5nx",
+          "disease_case_opened_date" => "2022-09-09",
+          "disease_case_closed_date" => "2022-10-09",
+        },
+        "max_cache_time" => 10,
+        "headers" => [
+          { "text" => "Header", "level" => 2, "id" => "header" },
+        ],
+        "temporary_update_type" => false,
+      },
+      "routes" => [{ "path" => "/animal-disease-cases-england/example-animal-disease-case", "type" => "exact" }],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" => {
+        "finder" => %w[48ef3920-b877-47af-8356-44f345c22a47],
+      },
+    }
+
+    assert_publishing_api_put_content(content_id, expected_sent_payload)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example animal disease case")
+    expect(page).to have_content("Bulk published false")
+  end
+
+  scenario "creating an animal disease case with an invalid dates" do
+    visit "/animal-disease-cases/new"
+
+    fill_in "Title", with: "Example animal disease case"
+    fill_in "Summary", with: "This is the summary of an example animal disease case"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example animal disease case" * 2}"
+    fill_in "[animal_disease_case]disease_case_opened_date(1i)", with: "2021"
+    fill_in "[animal_disease_case]disease_case_opened_date(2i)", with: "02"
+    fill_in "[animal_disease_case]disease_case_opened_date(3i)", with: "31"
+    fill_in "[animal_disease_case]disease_case_closed_date(1i)", with: "2020"
+    fill_in "[animal_disease_case]disease_case_closed_date(2i)", with: "02"
+    fill_in "[animal_disease_case]disease_case_closed_date(3i)", with: "20"
+    select "Bird flu (avian influenza)", from: "Disease type"
+    select "In force", from: "Disease control zone restriction"
+    select "Protection zone", from: "Zone type"
+    select "H5Nx", from: "Virus strain"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Opened date is not a valid date")
+    expect(page).to have_content("Opened date must be before closed date")
+  end
+
+  scenario "creating an animal disease case with invalid data" do
+    visit "/animal-disease-cases/new"
+
+    fill_in "Title", with: "Example animal disease case"
+    fill_in "Summary", with: "This is the summary of an example animal disease case"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -68,6 +68,11 @@ FactoryBot.define do
     organisation_content_id { "957eb4ec-089b-4f71-ba2a-dc69ac8919ea" }
   end
 
+  factory :animal_disease_case_editor, parent: :editor do
+    organisation_slug { "department-for-environment-food-rural-affairs" }
+    organisation_content_id { "de4e9dc6-cca4-43af-a594-682023b84d6c" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }
@@ -662,6 +667,23 @@ FactoryBot.define do
           "digital_market_research_area" => %w[media-and-entertainment],
           "digital_market_research_topic" => %w[future-connectivity],
           "digital_market_research_publish_date" => "2021-02-18T10:12:26+00:00",
+        }
+      end
+    end
+  end
+
+  factory :animal_disease_case, parent: :document do
+    base_path { "/animal-disease-cases-england/example-document" }
+    document_type { "animal_disease_case" }
+    transient do
+      default_metadata do
+        {
+          "disease_type" => %w[bird-flu],
+          "zone_restriction" => "no-longer-in-force",
+          "zone_type" => %w[surveillance],
+          "virus_strain" => "h5nx",
+          "disease_case_opened_date" => "2022-08-18T10:12:26+00:00",
+          "disease_case_closed_date" => "2022-09-18T10:12:26+00:00",
         }
       end
     end


### PR DESCRIPTION
Add a new specialist document: animal disease cases

Trello card: https://trello.com/c/bXI3zWdc/584-create-new-specialist-finder-for-animal-disease-cases-and-disease-control-zones