### PR TITLE
Refactor custom validator to accept options

### DIFF
--- a/app/models/animal_disease_case.rb
+++ b/app/models/animal_disease_case.rb
@@ -2,8 +2,9 @@ class AnimalDiseaseCase < Document
   validates :disease_type, presence: true
   validates :zone_restriction, presence: true
   validates :zone_type, presence: true
-  validates :disease_case_opened_date, presence: true, date: true, open_before_closed: true
+  validates :disease_case_opened_date, presence: true, date: true
   validates :disease_case_closed_date, date: true
+  validates_with OpenBeforeClosedValidator, opened_date: :disease_case_opened_date, closed_date: :disease_case_closed_date
 
   FORMAT_SPECIFIC_FIELDS = %i[
     disease_type

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -1,9 +1,10 @@
 class CmaCase < Document
-  validates :opened_date, allow_blank: true, date: true, open_before_closed: true
   validates :market_sector, presence: true
   validates :case_type, presence: true
   validates :case_state, presence: true
+  validates :opened_date, allow_blank: true, date: true
   validates :closed_date, allow_blank: true, date: true
+  validates_with OpenBeforeClosedValidator, opened_date: :opened_date, closed_date: :closed_date
 
   FORMAT_SPECIFIC_FIELDS = %i[
     opened_date

--- a/app/models/oim_project.rb
+++ b/app/models/oim_project.rb
@@ -1,8 +1,10 @@
 class OimProject < Document
-  validates :oim_project_opened_date, allow_blank: true, date: true, open_before_closed: true
-  validates :oim_project_closed_date, allow_blank: true, date: true
   validates :oim_project_type, presence: true
   validates :oim_project_state, presence: true
+  validates :oim_project_opened_date, allow_blank: true, date: true
+  validates :oim_project_closed_date, allow_blank: true, date: true
+  validates_with OpenBeforeClosedValidator, opened_date: :oim_project_opened_date, closed_date: :oim_project_closed_date
+
   FORMAT_SPECIFIC_FIELDS = %i[
     oim_project_opened_date
     oim_project_closed_date

--- a/app/validators/open_before_closed_validator.rb
+++ b/app/validators/open_before_closed_validator.rb
@@ -1,13 +1,13 @@
-class OpenBeforeClosedValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, _value)
-    record.errors.add(attribute, error_message) unless before_closed?(record)
+class OpenBeforeClosedValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add(options[:opened_date], error_message) unless before_closed?(record)
   end
 
 private
 
   def before_closed?(record)
-    opened = record.try(:opened_date) || record.try(:oim_project_opened_date) || record.try(:disease_case_opened_date)
-    closed = record.try(:closed_date) || record.try(:oim_project_closed_date) || record.try(:disease_case_closed_date)
+    opened = record.try(options[:opened_date])
+    closed = record.try(options[:closed_date])
 
     opened.blank? || closed.blank? || opened <= closed
   end


### PR DESCRIPTION
The 'open before closed dated' custom validator now accepts options to specify the field names that represent 'opened' and 'closed' dates.

Rather than 'guessing' field names from within the validator, the model now tells the validator what fields to look for.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️