### PR TITLE
Pause email alerts on animal disease cases

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -1,4 +1,7 @@
 class EmailAlertPresenter
+  DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS =
+    %w[animal_disease_case].freeze
+
   attr_reader :document
 
   def initialize(document)
@@ -40,6 +43,8 @@ private
   end
 
   def links
+    return {} if DO_NOT_ALERT_ORGANISATION_SUBSCRIBERS.include?(document.format)
+
     DocumentLinksPresenter.new(document).to_json[:links]
   end
 

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -4,8 +4,24 @@ RSpec.describe EmailAlertPresenter do
   let(:cma_case_payload) { FactoryBot.create(:cma_case) }
   let(:medical_safety_payload) { FactoryBot.create(:medical_safety_alert) }
   let(:cma_case_redrafted_payload) { FactoryBot.create(:cma_case, :redrafted, title: "updated") }
+  let(:animal_disease_case_payload) { FactoryBot.create(:animal_disease_case) }
 
   describe "#to_json" do
+    context "animal_disease_case finder" do
+      before do
+        stub_publishing_api_has_item(animal_disease_case_payload)
+      end
+
+      it "does not send the links hash in the payload for email alert api" do
+        animal_disease_case = AnimalDiseaseCase.find(animal_disease_case_payload["content_id"], animal_disease_case_payload["locale"])
+        email_alert_presenter = described_class.new(animal_disease_case)
+        presented_data = email_alert_presenter.to_json
+        expect(presented_data[:tags][:format]).to eq(animal_disease_case_payload["document_type"])
+        expect(presented_data[:tags][:case_type]).to eq(animal_disease_case_payload["details"]["metadata"]["case_type"])
+        expect(presented_data[:links]).to eq({})
+      end
+    end
+
     context "any finders document" do
       before do
         stub_publishing_api_has_item(cma_case_payload)


### PR DESCRIPTION
The department has requested that we pause email alerts while they bulk publish new documents.

So we have amended the payload of email-alert-api temporarily to remove the animal_disease_cases.

This should be removed once the department has finished their bulk publishing.

This will only be merged when we go live with the disease finder

Trello card: https://trello.com/c/bXI3zWdc/584-create-new-specialist-finder-for-animal-disease-cases-and-disease-control-zones

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️