### PR TITLE
Amendments to disease finder

### DIFF
--- a/app/views/metadata_fields/_animal_disease_cases.html.erb
+++ b/app/views/metadata_fields/_animal_disease_cases.html.erb
@@ -44,14 +44,6 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :virus_strain, label: "Virus strain" } do %>
-  <%= f.select :virus_strain,
-      f.object.facet_options(:virus_strain),
-      {
-        include_blank: true
-      },
-      {
-        class: 'form-control',
-      }
-  %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :virus_strain } do %>
+  <%= f.text_field :virus_strain, class: 'form-control' %>
 <% end %>

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -7,6 +7,9 @@
   "filter": {
     "format": "animal_disease_case"
   },
+  "editing_organisations":[
+    "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
+  ],
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c",
     "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -123,55 +123,31 @@
       ]
     },
     {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        }
+      ]
+    },
+    {
       "key": "virus_strain",
       "name": "Virus strain",
       "short_name": "Virus strain",
       "type": "text",
       "preposition": "of strain type",
       "display_as_result_metadata": true,
-      "filterable": false,
-      "allowed_values": [
-        {
-          "label": "H5Nx",
-          "value": "h5nx"
-        },
-        {
-          "label": "H5N1",
-          "value": "h5n1"
-        },
-        {
-          "label": "H5N2",
-          "value": "h5n2"
-        },
-        {
-          "label": "H5N3",
-          "value": "h5n3"
-        },
-        {
-          "label": "H5N5",
-          "value": "h5n5"
-        },
-        {
-          "label": "H5N6",
-          "value": "h5n6"
-        },
-        {
-          "label": "H5N8",
-          "value": "h5n8"
-        },
-        {
-          "label": "H7Nx",
-          "value": "h7nx"
-        },
-        {
-          "label": "H7N7",
-          "value": "h7n7"
-        },
-        {
-          "label": "Undetermined",
-          "value": "undetermined"
-        }
-      ]
+      "filterable": false
     },
     {
       "key": "disease_case_opened_date",

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -12,7 +12,8 @@
     "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
   ],
   "related": [
-    "5fe90412-7631-11e4-a3cb-005056011aef"
+    "5fe90412-7631-11e4-a3cb-005056011aef",
+    "5f664bc2-7631-11e4-a3cb-005056011aef"
   ],
   "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -113,30 +113,36 @@
           "value": "captive-bird"
         },
         {
+          "label": "Avian influenza prevention zone",
+          "value": "avian-influenza-prevention"
+        },
+        {
+          "label": "Temporary movement restriction zone",
+          "value": "temporary-movement-restriction"
+        },
+        {
+          "label": "Low pathogenic avian influenza restricted zone",
+          "value": "low-pathogenic-avian-influenza-restricted"
+        },
+        {
+          "label": "Infection zone",
+          "value": "infection"
+        },
+        {
+          "label": "Vaccination zone",
+          "value": "vaccination"
+        },
+        {
+          "label": "Supplementary movement control zone",
+          "value": "supplementary-movement-control"
+        },
+        {
           "label": "Wild bird control area",
           "value": "wild-bird-control"
         },
         {
           "label": "Wild bird monitoring area",
           "value": "wild-bird-monitoring"
-        }
-      ]
-    },
-    {
-        },
-        {
-        },
-        {
-        },
-        {
-        },
-        {
-        },
-        {
-        },
-        {
-        },
-        {
         }
       ]
     },

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -18,7 +18,7 @@
   "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
   "subscription_list_title_prefix": "Notifiable animal disease cases and control zones",
-  "summary": "<p>Find notifiable exotic animal disease cases and control zone declarations for England.</p><p> There are cases of bird flu (avian influenza) in England. Check if you are in a <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=8cb1883eda5547c6b91b5d5e6aeba90d\">disease control zone on the map</a>.</p><p> Find out more about cases in <a href=\"https://www.gov.scot/publications/avian-influenza-bird-flu\">Scotland</a>, cases in <a href=\"https://gov.wales/avian-influenza-bird-flu-latest-update\">Wales</a> and cases in <a href=\"https://www.daera-ni.gov.uk/ai\">Northern Ireland</a>.</p>",
+  "summary": "<p>Find notifiable exotic animal disease cases and control zone declarations for England.</p><p> There are cases of bird flu (avian influenza) in England. Check if you are in a <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=8cb1883eda5547c6b91b5d5e6aeba90d\">disease control zone on the map</a>. Find out more about <a href=\"https://www.gov.scot/publications/avian-influenza-bird-flu\">cases in Scotland</a>, <a href=\"https://gov.wales/avian-influenza-bird-flu-latest-update\">cases in Wales</a> and <a href=\"https://www.daera-ni.gov.uk/ai\">cases in Northern Ireland</a>.</p><p>Find details of <a href=\"https://www.nationalarchives.gov.uk\">older bird flu (avian influenza) cases in England</a>.</p>",
   "pre_production": true,
   "document_noun": "case",
   "facets": [


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Publisher requested amendments to the disease finder:
- Make virus strain a free text field
- add new disease zone types
- add a new related piece of content
- edit the finder description

Trello card: https://trello.com/c/bXI3zWdc/584-create-new-specialist-finder-for-animal-disease-cases-and-disease-control-zones