### PR TITLE
Update govuk_publishing_components to resolve Plek warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (31.0.0)
+    govuk_publishing_components (31.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
This resolves the "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead." warning on initialisation.

This gem doesn't get updated automatically by dependabot as it's an indirect dependency through Govspeak.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
