### PR TITLE
Add additional judges to filter for utaac_decisisons finder

### DIFF
--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -2176,6 +2176,10 @@
           "value": "church-th"
         },
         {
+          "label": "Citron, Z",
+          "value": "citron-z"
+        },
+        {
           "label": "Clough, J",
           "value": "clough-j"
         },
@@ -2310,6 +2314,10 @@
         {
           "label": "Machin, K",
           "value": "machin-k"
+        },
+        {
+          "label": "Macmillan, M",
+          "value": "macmillan-m"
         },
         {
           "label": "Mark, M",


### PR DESCRIPTION
## Description

We've had a request to add some judges to the judges filter on the `utaac_decsisions` finder

## Trello card 

https://trello.com/c/SqwF3iHI/826-5106299-add-2-judges-to-filter-on-administrative-appeals-tribunal-decisions-content-change-request-hm-courts-tribunals-service-h

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
