### PR TITLE
Update intro to tribunal decision finder

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -19,7 +19,7 @@
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
   "signup_copy": "You'll get an email each time a decision is updated or a new decision is published.",
   "subscription_list_title_prefix": "Employment tribunal decisions",
-  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017, contact <a href='https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> for cases in England or Wales, or <a href='https://courttribunalfinder.service.gov.uk/courts/glasgow-employment-and-immigration-tribunals-eagle-building'>Glasgow Employment and Immigration Tribunals</a> for cases in Scotland.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>If the decision was made before February 2017 in England or Wales, Bury St Edmunds County Court might have it on record. Only the most requested decisions are currently available. Contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a> to check.</p><p>If the decision was made before February 2017 in Scotland, contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/glasgow-tribunals-centre'>Glasgow Tribunals Centre</a>.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
   "document_noun": "decision",
   "email_filter_by": "tribunal_decision_categories",
   "email_filter_facets": [


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/5115052
https://trello.com/c/OyOeZNvt/4266-update-to-content-content-change-request

1) England and Wales are having an issue with their database and users can’t currently access copies, apart from some of the most requested ones which are kept on a separate database. There’s currently no expected date for the system to start working again.

2) I’ve updated the link for Scotland, as the responsibility for this has shifted over to a different tribunal building.
