### PR TITLE
Use live phase for "UK Market Conformity Assessment Bodies"

### DIFF
--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -4,7 +4,7 @@
   "format_name": "UK Market Conformity Assessment Body",
   "name": "UK Market Conformity Assessment Bodies",
   "description": "",
-  "phase": "alpha",
+  "phase": "live",
   "filter": {
     "format": "uk_market_conformity_assessment_body"
   },


### PR DESCRIPTION
This was set with an alpha phase and we've not been able to understand why, we think it was likely a mistake.

A check has occurred with UKMCAB who also don't know why this was flagged as alpha.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
