### PR TITLE
Create new licence document

### DIFF
--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -1,0 +1,33 @@
+class LicenceTransaction < Document
+  FORMAT_SPECIFIC_FIELDS = %i[
+    country
+    sector
+    activity
+    will_continue_on
+    continuation_link
+    licence_identifier
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def taxons
+    []
+  end
+
+  def self.title
+    "Licence"
+  end
+
+  def primary_publishing_organisation
+    # Set to GDS for testing
+    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  end
+
+  def self.slug
+    "licences"
+  end
+end

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -1,0 +1,56 @@
+<%# You can select multiple class or categories so this has multi-select option %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :country } do %>
+  <%= f.select :country,
+      f.object.facet_options(:country),
+      { label: "Country" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select countries'
+        }
+      }
+  %>
+<% end %>
+
+<%# You can select multiple class or categories so this has multi-select option %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :sector } do %>
+  <%= f.select :sector,
+      f.object.facet_options(:sector),
+      { label: "Sector" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select sectors'
+        }
+      }
+  %>
+<% end %>
+
+<%# You can select multiple class or categories so this has multi-select option %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :activity } do %>
+  <%= f.select :activity,
+      f.object.facet_options(:activity),
+      { label: "Activity" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select activities'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on } do %>
+  <%= f.text_field :will_continue_on, class: 'form-control' %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :continuation_link } do %>
+  <%= f.text_field :continuation_link, class: 'form-control' %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_identifier } do %>
+  <%= f.text_field :licence_identifier, class: 'form-control' %>
+<% end %>

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -32,6 +32,7 @@
       "type": "text",
       "preposition": "of sector",
       "display_as_result_metadata": true,
+      "show_option_select_filter": true,
       "filterable": true,
       "allowed_values": [
         { "label": "Agriculture, forestry and fishing", "value": "agriculture-forestry-fishing" },
@@ -56,6 +57,7 @@
       "type": "text",
       "preposition": "regarding",
       "display_as_result_metadata": true,
+      "show_option_select_filter": true,
       "filterable": true,
       "allowed_values": [
         {  "label": "Operate as a bookmaker", "value": "operate-as-a-bookmaker" },

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -1,0 +1,91 @@
+{
+  "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
+  "base_path": "/find-licences",
+  "format_name": "Find and apply for licences",
+  "name": "Find and apply for licences",
+  "description": "Find licences for business activities and other activities",
+  "filter": {
+    "format": "licence_transaction"
+  },
+  "show_summaries": true,
+  "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
+  "document_noun": "licence",
+  "facets": [
+    {
+      "key": "country",
+      "name": "Country",
+      "type": "text",
+      "preposition": "in country",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        { "label": "England", "value": "england" },
+        { "label": "Wales", "value": "wales" },
+        { "label": "Scotland", "value": "scotland" },
+        { "label": "Northern Ireland", "value": "northern-ireland" }
+      ]
+    },
+    {
+      "key": "sector",
+      "name": "Sector",
+      "type": "text",
+      "preposition": "of sector",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        { "label": "Agriculture, forestry and fishing", "value": "agriculture-forestry-fishing" },
+        { "label": "Arts, sports and recreation", "value": "arts-sports-and-recreation" },
+        { "label": "Catering and accommodation", "value": "catering-and-accomodation" },
+        { "label": "Construction", "value": "construction" },
+        { "label": "Education", "value": "education" },
+        { "label": "Health and social care services", "value": "health-and-social-care-services" },
+        { "label": "IT and telecommunications services", "value": "it-and-telecommunications-services" },
+        { "label": "Manufacturing", "value": "manufacturing" },
+        { "label": "Media and creative services", "value": "media-and-creative-services" },
+        { "label": "Mining, energy and utilities", "value": "mining-energy-utilities" },
+        { "label": "Personal services", "value": "personal-services" },
+        { "label": "Professional and business services", "value": "professional-and-business-services" },
+        { "label": "Retail, hire and repair", "value": "retail-hire-and-repair" },
+        { "label": "Wholesale", "value": "wholesale" }
+      ]
+    },
+    {
+      "key": "activity",
+      "name": "Activity",
+      "type": "text",
+      "preposition": "regarding",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {  "label": "Operate as a bookmaker", "value": "operate-as-a-bookmaker" },
+        {  "label": "Play background music in your premises", "value": "play-background-music-in-your-premises" },
+        {  "label": "Use CCTV systems", "value": "use-cctv-systems" },
+        {  "label": "Carry out construction or building work", "value": "carry-out-construction-or-building-work" },
+        {  "label": "Fish in fresh water", "value": "fish-in-fresh-water" },
+        {  "label": "Hold an ad hoc event", "value": "hold-an-ad-hoc-event" },
+        {  "label": "Offer care services", "value": "offer-care-services" }
+      ]
+    },
+    {
+      "key": "will_continue_on",
+      "name": "Will continue on",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "continuation_link",
+      "name": "Link to competent authority",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "licence_identifier",
+      "name": "Licence identifier",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    }
+  ]
+}

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -1,4 +1,5 @@
 {
+  "pre_production": true,
   "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
   "base_path": "/find-licences",
   "format_name": "Find and apply for licences",

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.feature "Creating a Licence", type: :feature do
+  let(:fields)              { %i[base_path content_id public_updated_at title publication_state] }
+  let(:licence_transaction) { FactoryBot.create(:licence_transaction) }
+  let(:content_id)          { licence_transaction["content_id"] }
+  let(:public_updated_at)   { licence_transaction["public_updated_at"] }
+
+  before do
+    log_in_as_editor(:licence_transaction_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([licence_transaction], hash_including(document_type: LicenceTransaction.document_type))
+    stub_publishing_api_has_item(licence_transaction)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "adding a new licence" do
+    visit "/find-licences"
+    click_link "Add another Licence"
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/licences/new")
+  end
+
+  scenario "saving a new licence case with no data" do
+    visit "/licences/new"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_content("Please fix the following errors")
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+  end
+
+  scenario "saving a new licence with valid data" do
+    visit "/licences/new"
+
+    fill_in "Title", with: "Example licence"
+    fill_in "Summary", with: "This is the summary of a licence"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of a licence" * 2}"
+    select "England", from: "Country"
+    select "Education", from: "Sector"
+    select "Use CCTV systems", from: "Activity"
+    fill_in "Continuation link", with: "https://www.gov.uk"
+    fill_in "Will continue on", with: "on GOV.UK"
+
+    click_button "Save as draft"
+    assert_publishing_api_put_content(content_id)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example licence")
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
       expect(page).to have_text("EU Withdrawal Act 2018 statutory instruments")
       expect(page).to have_text("Export health certificates")
       expect(page).to have_text("International Development Funds")
+      expect(page).to have_text("Licences")
       expect(page).to have_text("MAIB Reports")
       expect(page).to have_text("Medical Safety Alerts")
       expect(page).to have_text("Protected Geographical Food and Drink Name")

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -440,6 +440,23 @@ FactoryBot.define do
     end
   end
 
+  factory :licence_transaction, parent: :document do
+    base_path { "/find-licences/example-document" }
+    document_type { "licence_transaction" }
+
+    transient do
+      default_metadata do
+        {
+          "country" => %w[england],
+          "sector" => %w[catering-and-accomodation],
+          "activity" => %w[hold-an-ad-hoc-event],
+          "continuation_link" => "https://www.gov.uk",
+          "will_continue_on" => "GOV.UK",
+        }
+      end
+    end
+  end
+
   factory :flood_and_coastal_erosion_risk_management_research_report, parent: :document do
     base_path { "/flood-and-coastal-erosion-risk-management-research-reports/example-document" }
     document_type { "flood_and_coastal_erosion_risk_management_research_report" }

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     permissions { %w[signin gds_editor] }
   end
 
+  factory :licence_transaction_editor, parent: :user do
+    permissions { %w[signin licence_transaction_editor] }
+  end
+
   factory :statutory_instrument_editor, parent: :user do
     permissions { %w[signin statutory_instrument_editor] }
   end

--- a/spec/models/licence_transaction_spec.rb
+++ b/spec/models/licence_transaction_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe LicenceTransaction do
+  let(:payload) { FactoryBot.create(:licence_transaction) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+
+  it "is not exportable" do
+    expect(subject.class).not_to be_exportable
+  end
+end


### PR DESCRIPTION
This PR is concerned with setting up the basic fields / schema / templates needed to create a licence in Specialist Publisher, there will be follow up tasks, e.g adding the ability for these documents to be rendered in Frontend / adding model validations etc. 

We need to setup the new document type as we're looking to migrate away from the current [Licence Finder](https://www.gov.uk/licence-finder). We'll be running user testing against the new licence finder created by Specialist Publisher.

The test build will fail until https://github.com/alphagov/publishing-api/pull/2211 is merged. 

## Screenshots

<img width="1291" alt="Screenshot 2022-12-13 at 23 34 30" src="https://user-images.githubusercontent.com/24479188/207563509-0318e7d2-9154-49bb-8e22-07999a7e0ebb.png">

<img width="671" alt="Screenshot 2022-12-13 at 23 35 02" src="https://user-images.githubusercontent.com/24479188/207563517-3f0439f1-309c-4bc0-8a81-b6f214bbb3de.png">

<img width="1252" alt="Screenshot 2022-12-13 at 19 25 38" src="https://user-images.githubusercontent.com/24479188/207563563-5fe57fe3-cacc-4be0-8866-d19c7d9bc0a0.png">

<img width="324" alt="Screenshot 2022-12-13 at 19 28 13" src="https://user-images.githubusercontent.com/24479188/207563567-a76089cb-ae78-4155-816d-e13413dd3dcc.png">


Trello:
https://trello.com/c/mGJ5DIsI/1659-create-licence-document-type-in-specialist-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
