### PR TITLE
Set license_transaction rendering app as frontend

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -116,6 +116,10 @@ class Document
     truncate(@base_path, length: 250, omission: "")
   end
 
+  def rendering_app
+    "government-frontend"
+  end
+
   def document_type
     self.class.document_type
   end

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -30,4 +30,8 @@ class LicenceTransaction < Document
   def self.slug
     "licences"
   end
+
+  def rendering_app
+    "frontend"
+  end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -14,7 +14,7 @@ class DocumentPresenter
       change_note: document.change_note,
       schema_name: "specialist_document",
       publishing_app: "specialist-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: document.rendering_app,
       locale: document.locale || "en",
       phase: document.phase,
       details:,

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -447,6 +447,7 @@ FactoryBot.define do
   factory :licence_transaction, parent: :document do
     base_path { "/find-licences/example-document" }
     document_type { "licence_transaction" }
+    rendering_app { "frontend" }
 
     transient do
       default_metadata do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe Document do
         expect(document.first_published_at).to eq(payload["first_published_at"])
         expect(document.update_type).to eq(nil)
         expect(document.state_history).to eq(payload["state_history"])
+        expect(document.rendering_app).to eq("government-frontend")
       end
 
       context "when bulk published is true" do

--- a/spec/models/licence_transaction_spec.rb
+++ b/spec/models/licence_transaction_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe LicenceTransaction do
   it "is not exportable" do
     expect(subject.class).not_to be_exportable
   end
+
+  it "should have a rendering app of frontend" do
+    expect(subject.rendering_app).to eq "frontend"
+  end
 end


### PR DESCRIPTION
This PR sets the rendering app for the LicenseTransaction to"frontend". It removes the default hard-coded rendering_app from the DocumentPresenter, and adds a method to the parent Document class to default the rendering_app to "government-frontend.

[trello](https://trello.com/c/iPGhPygc/1675-use-frontend-as-the-rendering-app-for-licences-in-specialist-publisher)