### PR TITLE
Add related link to Animal Disease Cases finder

### DIFF
--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -1,4 +1,4 @@
-{  
+{
   "content_id": "48ef3920-b877-47af-8356-44f345c22a47",
   "base_path": "/animal-disease-cases-england",
   "format_name": "Notifiable animal disease cases and control zone",
@@ -7,7 +7,7 @@
   "filter": {
     "format": "animal_disease_case"
   },
-  "editing_organisations":[
+  "editing_organisations": [
     "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
   ],
   "organisations": [
@@ -16,6 +16,7 @@
   ],
   "related": [
     "5fe90412-7631-11e4-a3cb-005056011aef",
+    "af8eee5a-632a-4b8e-bb59-8fc5204892bc",
     "5f664bc2-7631-11e4-a3cb-005056011aef"
   ],
   "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",


### PR DESCRIPTION
Link to [Bird flu: rules in disease control and prevention zones in England][1].

Requested in Zendesk ticket [#5140740][2].

### Screenshot

I've tested these changes in integration and it worked as expected.

![Screenshot from integration](https://user-images.githubusercontent.com/7735945/208154391-90d5d445-1793-432b-89a2-f2b4c976b025.png)


[1]: https://www.gov.uk/guidance/avian-influenza-bird-flu-cases-and-disease-control-zones-in-england
[2]: https://govuk.zendesk.com/agent/tickets/5140740

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
