### PR TITLE
Revert  "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "hashdiff"
 gem "jquery-rails"
 gem "kaminari"
 gem "kaminari-mongoid"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mongo"
 gem "mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,11 +251,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     mail-notify (1.1.0)
       actionmailer (>= 5.2.4.6)
       actionpack (>= 5.2.7.1)
@@ -551,7 +548,7 @@ DEPENDENCIES
   kaminari
   kaminari-mongoid
   listen
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   mail-notify
   mongo
   mongoid


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
