### PR TITLE
This sets the asset path to include the application name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module SpecialistPublisher
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/specialist-publisher"
+
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/specialist-publisher",
   "srcFiles": [
     "govuk-admin-template-*.js",
     "application-*.js"


### PR DESCRIPTION
Background to this change can be found here:
https://github.com/alphagov/manuals-publisher/pull/2004

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
