### PR TITLE
Update the content schemas rake task to build_schemas

### DIFF
--- a/docs/creating-and-editing-specialist-document-types.md
+++ b/docs/creating-and-editing-specialist-document-types.md
@@ -116,7 +116,7 @@ We often receive requests to add new fields to a specialist document. Or to add 
 
 1. In govuk-content-schemas, find the field you are amending in the [specialist_document schema](https://github.com/alphagov/govuk-content-schemas/blob/main/formats/shared/definitions/_specialist_document.jsonnet), and add the new values. See [this](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/b81ec718f52b1e6603c201c44db07f0357158723) commit for an example. 
 
-NOTE: You will need to run `bundle exec rake build` to regenerate schemas after adding the new value(s) - as is done in [this commit](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/34dd343fd7de8eb48bb842c2fc7fe3c59ae77168). 
+NOTE: You will need to run `bundle exec rake build_schemas` to regenerate schemas after adding the new value(s) - as is done in [this commit](https://github.com/alphagov/govuk-content-schemas/pull/1066/commits/34dd343fd7de8eb48bb842c2fc7fe3c59ae77168). 
 
 Once approved, this change can be merged and deployed.
 


### PR DESCRIPTION
The name of the rake task to rebuild the content-schemas has been changed from build to build_schemas when it was moved out of the govuk-content-schemas repo and into the publishing repo