### PR TITLE
Updates licence transaction config

### DIFF
--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -1,11 +1,10 @@
 class LicenceTransaction < Document
   FORMAT_SPECIFIC_FIELDS = %i[
-    country
-    sector
-    activity
-    will_continue_on
-    continuation_link
-    licence_identifier
+    licence_transaction_continuation_link
+    licence_transaction_industry
+    licence_transaction_licence_identifier
+    licence_transaction_location
+    licence_transaction_will_continue_on
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -1,56 +1,41 @@
 <%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :country } do %>
-  <%= f.select :country,
-      f.object.facet_options(:country),
-      { label: "Country" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_location, label: "Location" } do %>
+  <%= f.select :licence_transaction_location,
+      f.object.facet_options(:licence_transaction_location),
+      { label: "Location" },
       {
         class: 'select2 form-control',
         multiple: true,
         data: {
-          placeholder: 'Select countries'
+          placeholder: 'Select locations'
         }
       }
   %>
 <% end %>
 
 <%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :sector } do %>
-  <%= f.select :sector,
-      f.object.facet_options(:sector),
-      { label: "Sector" },
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_industry, label: "Industry" } do %>
+  <%= f.select :licence_transaction_industry,
+      f.object.facet_options(:licence_transaction_industry),
+      { label: "Industry" },
       {
         class: 'select2 form-control',
         multiple: true,
         data: {
-          placeholder: 'Select sectors'
+          placeholder: 'Select industries'
         }
       }
   %>
 <% end %>
 
-<%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :activity } do %>
-  <%= f.select :activity,
-      f.object.facet_options(:activity),
-      { label: "Activity" },
-      {
-        class: 'select2 form-control',
-        multiple: true,
-        data: {
-          placeholder: 'Select activities'
-        }
-      }
-  %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_will_continue_on, label: "Will continue on" } do %>
+  <%= f.text_field :licence_transaction_will_continue_on, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on } do %>
-  <%= f.text_field :will_continue_on, class: 'form-control' %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_continuation_link, label: "Continuation link" } do %>
+  <%= f.text_field :licence_transaction_continuation_link, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :continuation_link } do %>
-  <%= f.text_field :continuation_link, class: 'form-control' %>
-<% end %>
-
-<%= render layout: "shared/form_group", locals: { f: f, field: :licence_identifier } do %>
-  <%= f.text_field :licence_identifier, class: 'form-control' %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_licence_identifier, label: "Licence identifier" } do %>
+  <%= f.text_field :licence_transaction_licence_identifier, class: 'form-control' %>
 <% end %>

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -3,8 +3,7 @@
   "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
   "base_path": "/find-licences",
   "format_name": "Find and apply for licences",
-  "name": "Find and apply for licences",
-  "description": "Find licences for business activities and other activities",
+  "name": "Find a licence",
   "filter": {
     "format": "licence_transaction"
   },
@@ -13,11 +12,11 @@
   "document_noun": "licence",
   "facets": [
     {
-      "key": "country",
-      "name": "Country",
+      "key": "licence_transaction_location",
+      "name": "Location",
       "type": "text",
-      "preposition": "in country",
-      "display_as_result_metadata": true,
+      "preposition": "In",
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         { "label": "England", "value": "england" },
@@ -27,12 +26,12 @@
       ]
     },
     {
-      "key": "sector",
-      "name": "Sector",
+      "key": "licence_transaction_industry",
+      "name": "Industry",
       "type": "text",
-      "preposition": "of sector",
-      "display_as_result_metadata": true,
+      "preposition": "For",
       "show_option_select_filter": true,
+      "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
         { "label": "Agriculture, forestry and fishing", "value": "agriculture-forestry-fishing" },
@@ -52,39 +51,21 @@
       ]
     },
     {
-      "key": "activity",
-      "name": "Activity",
-      "type": "text",
-      "preposition": "regarding",
-      "display_as_result_metadata": true,
-      "show_option_select_filter": true,
-      "filterable": true,
-      "allowed_values": [
-        {  "label": "Operate as a bookmaker", "value": "operate-as-a-bookmaker" },
-        {  "label": "Play background music in your premises", "value": "play-background-music-in-your-premises" },
-        {  "label": "Use CCTV systems", "value": "use-cctv-systems" },
-        {  "label": "Carry out construction or building work", "value": "carry-out-construction-or-building-work" },
-        {  "label": "Fish in fresh water", "value": "fish-in-fresh-water" },
-        {  "label": "Hold an ad hoc event", "value": "hold-an-ad-hoc-event" },
-        {  "label": "Offer care services", "value": "offer-care-services" }
-      ]
-    },
-    {
-      "key": "will_continue_on",
+      "key": "licence_transaction_will_continue_on",
       "name": "Will continue on",
       "type": "text",
       "display_as_result_metadata": false,
       "filterable": false
     },
     {
-      "key": "continuation_link",
+      "key": "licence_transaction_continuation_link",
       "name": "Link to competent authority",
       "type": "text",
       "display_as_result_metadata": false,
       "filterable": false
     },
     {
-      "key": "licence_identifier",
+      "key": "licence_transaction_licence_identifier",
       "name": "Licence identifier",
       "type": "text",
       "display_as_result_metadata": false,

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -42,9 +42,8 @@ RSpec.feature "Creating a Licence", type: :feature do
     fill_in "Title", with: "Example licence"
     fill_in "Summary", with: "This is the summary of a licence"
     fill_in "Body", with: "## Header#{"\n\nThis is the long body of a licence" * 2}"
-    select "England", from: "Country"
-    select "Education", from: "Sector"
-    select "Use CCTV systems", from: "Activity"
+    select "England", from: "Location"
+    select "Education", from: "Industry"
     fill_in "Continuation link", with: "https://www.gov.uk"
     fill_in "Will continue on", with: "on GOV.UK"
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -451,11 +451,10 @@ FactoryBot.define do
     transient do
       default_metadata do
         {
-          "country" => %w[england],
-          "sector" => %w[catering-and-accomodation],
-          "activity" => %w[hold-an-ad-hoc-event],
-          "continuation_link" => "https://www.gov.uk",
-          "will_continue_on" => "GOV.UK",
+          "licence_transaction_continuation_link" => "https://www.gov.uk",
+          "licence_transaction_industry" => %w[catering-and-accomodation],
+          "licence_transaction_location" => %w[england],
+          "licence_transaction_will_continue_on" => "GOV.UK",
         }
       end
     end


### PR DESCRIPTION
The below comes from a content review of the finder and its facets (more info in the [Trello card](https://trello.com/c/zGnVczSU/1721-update-finder-content-tagging-for-licences)):

* renames sector to industry

* renames country to location

* removes activity

* updates preproposition text for industry and location

* doesn't display industry / location for each search result in finder (display_as_result_metadata)

* updates title of finder

* removes finder description 

We've also prefixed the fields with the document which is explained in the following PR: https://github.com/alphagov/publishing-api/pull/2244/commits/5d6ae41c639e6da41e79164185aa765fa283da21.

[1]: https://github.com/alphagov/publishing-api/pull/2244

This PR will fail a validator spec until [publishing api PR][1] is merged. Passes tests locally (using pub api branch):

<img width="886" alt="Screenshot 2023-01-09 at 12 15 26" src="https://user-images.githubusercontent.com/24479188/211315075-8ef8bb6a-a33b-4a5e-91c2-2cc83cab30ba.png">

### Updated finder screenshots

<img width="1087" alt="Screenshot 2023-01-10 at 12 10 44" src="https://user-images.githubusercontent.com/24479188/211548559-14bcb5b7-b419-4669-a90f-ad37e1eeb6d2.png">

<img width="1122" alt="Screenshot 2023-01-10 at 12 10 59" src="https://user-images.githubusercontent.com/24479188/211548566-a02431b9-caf6-418f-b7fc-64677d3eb357.png">

<img width="1097" alt="Screenshot 2023-01-10 at 12 11 20" src="https://user-images.githubusercontent.com/24479188/211548569-5c23f7cf-ffb5-4aa3-b2d1-1cdce0169c36.png">

Trello:
https://trello.com/c/zGnVczSU/1721-update-finder-content-tagging-for-licences

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
