### PR TITLE
Import level two licence sectors into Specialist Publisher

### DIFF
--- a/lib/data/licence_transaction/industry_sectors.txt
+++ b/lib/data/licence_transaction/industry_sectors.txt
@@ -1,0 +1,75 @@
+Accommodation                                                                    
+Adult and other education                                                      
+Advertising and marketing services                                               
+Agricultural materials wholesale                                                 
+Agriculture                                                                      
+Architectural and other building services                                        
+Arts and entertainment                                                           
+Arts, antiques and second-hand goods retail                                      
+Arts, sports and recreation goods manufacturing                                  
+Arts, sports and recreation goods wholesale                                      
+Bars                                                                             
+Books, stationery and gifts retail                                               
+Books, stationery and gifts wholesale                                            
+Building construction                                                            
+Building materials and hardware wholesale
+Building materials manufacturing
+Building trades
+Business support services
+Catering
+Chemical and petroleum products manufacturing
+Clothing, footwear and accessories manufacturing
+Clothing, footwear and accessories retail, hire and repair
+Clothing, footwear and accessories wholesale
+Complementary therapy services
+Computer services
+Cosmetics, medicinal and chemical products wholesale
+Design and photographic services
+Electric and electronic appliance retail, hire and repair
+Electric and electronic equipment wholesale
+Electrical equipment manufacturing
+Electronic equipment and computer manufacturing
+Energy utilities
+Film production and distribution
+Financial services
+Fishing and hunting
+Food, drink and tobacco manufacturing
+Food, drink and tobacco retail
+Food, drink and tobacco wholesale
+Forestry
+Formal education
+Gambling facilities operation
+Health services
+Home and garden products retail, hire and repair
+Internet services
+Jewellery, watch and clock manufacturing
+Jewellery, watch and clock retail and repair
+Jewellery, watches and clocks wholesale
+Legal services
+Machinery manufacturing
+Machinery wholesale
+Management consultancy
+Metal and metal ores wholesale
+Metal and metal products manufacturing
+Mining and oil and gas extraction
+Motor vehicle and fuel retail, hire and repair
+Motor vehicle and parts wholesale
+Music production and publishing
+Non store retail
+Paper products manufacturing
+Personal care services
+Petroleum and fuel products wholesale
+Pharmaceuticals, health and beauty products retail
+Printing and printing support activities
+Publishing
+Real estate services
+Social care services
+Sports and recreation
+Sports and recreation goods retail, hire and repair
+Telecommunications services
+Television and radio broadcasting
+Textiles and furniture manufacturing
+Textiles, furniture and furnishings wholesale
+Timber and timber products wholesale
+Vehicle manufacturing
+Waste management and environmental services

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -8,7 +8,9 @@
     "format": "licence_transaction"
   },
   "show_summaries": true,
-  "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
+  "organisations": [
+    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  ],
   "document_noun": "licence",
   "facets": [
     {
@@ -19,10 +21,22 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
-        { "label": "England", "value": "england" },
-        { "label": "Wales", "value": "wales" },
-        { "label": "Scotland", "value": "scotland" },
-        { "label": "Northern Ireland", "value": "northern-ireland" }
+        {
+          "label": "England",
+          "value": "england"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
+        }
       ]
     },
     {
@@ -34,20 +48,306 @@
       "display_as_result_metadata": false,
       "filterable": true,
       "allowed_values": [
-        { "label": "Agriculture, forestry and fishing", "value": "agriculture-forestry-fishing" },
-        { "label": "Arts, sports and recreation", "value": "arts-sports-and-recreation" },
-        { "label": "Catering and accommodation", "value": "catering-and-accomodation" },
-        { "label": "Construction", "value": "construction" },
-        { "label": "Education", "value": "education" },
-        { "label": "Health and social care services", "value": "health-and-social-care-services" },
-        { "label": "IT and telecommunications services", "value": "it-and-telecommunications-services" },
-        { "label": "Manufacturing", "value": "manufacturing" },
-        { "label": "Media and creative services", "value": "media-and-creative-services" },
-        { "label": "Mining, energy and utilities", "value": "mining-energy-utilities" },
-        { "label": "Personal services", "value": "personal-services" },
-        { "label": "Professional and business services", "value": "professional-and-business-services" },
-        { "label": "Retail, hire and repair", "value": "retail-hire-and-repair" },
-        { "label": "Wholesale", "value": "wholesale" }
+        {
+          "label": "Accommodation",
+          "value": "accommodation"
+        },
+        {
+          "label": "Adult and other education",
+          "value": "adult-and-other-education"
+        },
+        {
+          "label": "Advertising and marketing services",
+          "value": "advertising-and-marketing-services"
+        },
+        {
+          "label": "Agricultural materials wholesale",
+          "value": "agricultural-materials-wholesale"
+        },
+        {
+          "label": "Agriculture",
+          "value": "agriculture"
+        },
+        {
+          "label": "Architectural and other building services",
+          "value": "architectural-and-other-building-services"
+        },
+        {
+          "label": "Arts and entertainment",
+          "value": "arts-and-entertainment"
+        },
+        {
+          "label": "Arts, antiques and second-hand goods retail",
+          "value": "arts-antiques-and-second-hand-goods-retail"
+        },
+        {
+          "label": "Arts, sports and recreation goods manufacturing",
+          "value": "arts-sports-and-recreation-goods-manufacturing"
+        },
+        {
+          "label": "Arts, sports and recreation goods wholesale",
+          "value": "arts-sports-and-recreation-goods-wholesale"
+        },
+        {
+          "label": "Bars",
+          "value": "bars"
+        },
+        {
+          "label": "Books, stationery and gifts retail",
+          "value": "books-stationery-and-gifts-retail"
+        },
+        {
+          "label": "Books, stationery and gifts wholesale",
+          "value": "books-stationery-and-gifts-wholesale"
+        },
+        {
+          "label": "Building construction",
+          "value": "building-construction"
+        },
+        {
+          "label": "Building materials and hardware wholesale",
+          "value": "building-materials-and-hardware-wholesale"
+        },
+        {
+          "label": "Building materials manufacturing",
+          "value": "building-materials-manufacturing"
+        },
+        {
+          "label": "Building trades",
+          "value": "building-trades"
+        },
+        {
+          "label": "Business support services",
+          "value": "business-support-services"
+        },
+        {
+          "label": "Catering",
+          "value": "catering"
+        },
+        {
+          "label": "Chemical and petroleum products manufacturing",
+          "value": "chemical-and-petroleum-products-manufacturing"
+        },
+        {
+          "label": "Clothing, footwear and accessories manufacturing",
+          "value": "clothing-footwear-and-accessories-manufacturing"
+        },
+        {
+          "label": "Clothing, footwear and accessories retail, hire and repair",
+          "value": "clothing-footwear-and-accessories-retail-hire-and-repair"
+        },
+        {
+          "label": "Clothing, footwear and accessories wholesale",
+          "value": "clothing-footwear-and-accessories-wholesale"
+        },
+        {
+          "label": "Complementary therapy services",
+          "value": "complementary-therapy-services"
+        },
+        {
+          "label": "Computer services",
+          "value": "computer-services"
+        },
+        {
+          "label": "Cosmetics, medicinal and chemical products wholesale",
+          "value": "cosmetics-medicinal-and-chemical-products-wholesale"
+        },
+        {
+          "label": "Design and photographic services",
+          "value": "design-and-photographic-services"
+        },
+        {
+          "label": "Electric and electronic appliance retail, hire and repair",
+          "value": "electric-and-electronic-appliance-retail-hire-and-repair"
+        },
+        {
+          "label": "Electric and electronic equipment wholesale",
+          "value": "electric-and-electronic-equipment-wholesale"
+        },
+        {
+          "label": "Electrical equipment manufacturing",
+          "value": "electrical-equipment-manufacturing"
+        },
+        {
+          "label": "Electronic equipment and computer manufacturing",
+          "value": "electronic-equipment-and-computer-manufacturing"
+        },
+        {
+          "label": "Energy utilities",
+          "value": "energy-utilities"
+        },
+        {
+          "label": "Film production and distribution",
+          "value": "film-production-and-distribution"
+        },
+        {
+          "label": "Financial services",
+          "value": "financial-services"
+        },
+        {
+          "label": "Fishing and hunting",
+          "value": "fishing-and-hunting"
+        },
+        {
+          "label": "Food, drink and tobacco manufacturing",
+          "value": "food-drink-and-tobacco-manufacturing"
+        },
+        {
+          "label": "Food, drink and tobacco retail",
+          "value": "food-drink-and-tobacco-retail"
+        },
+        {
+          "label": "Food, drink and tobacco wholesale",
+          "value": "food-drink-and-tobacco-wholesale"
+        },
+        {
+          "label": "Forestry",
+          "value": "forestry"
+        },
+        {
+          "label": "Formal education",
+          "value": "formal-education"
+        },
+        {
+          "label": "Gambling facilities operation",
+          "value": "gambling-facilities-operation"
+        },
+        {
+          "label": "Health services",
+          "value": "health-services"
+        },
+        {
+          "label": "Home and garden products retail, hire and repair",
+          "value": "home-and-garden-products-retail-hire-and-repair"
+        },
+        {
+          "label": "Internet services",
+          "value": "internet-services"
+        },
+        {
+          "label": "Jewellery, watch and clock manufacturing",
+          "value": "jewellery-watch-and-clock-manufacturing"
+        },
+        {
+          "label": "Jewellery, watch and clock retail and repair",
+          "value": "jewellery-watch-and-clock-retail-and-repair"
+        },
+        {
+          "label": "Jewellery, watches and clocks wholesale",
+          "value": "jewellery-watches-and-clocks-wholesale"
+        },
+        {
+          "label": "Legal services",
+          "value": "legal-services"
+        },
+        {
+          "label": "Machinery manufacturing",
+          "value": "machinery-manufacturing"
+        },
+        {
+          "label": "Machinery wholesale",
+          "value": "machinery-wholesale"
+        },
+        {
+          "label": "Management consultancy",
+          "value": "management-consultancy"
+        },
+        {
+          "label": "Metal and metal ores wholesale",
+          "value": "metal-and-metal-ores-wholesale"
+        },
+        {
+          "label": "Metal and metal products manufacturing",
+          "value": "metal-and-metal-products-manufacturing"
+        },
+        {
+          "label": "Mining and oil and gas extraction",
+          "value": "mining-and-oil-and-gas-extraction"
+        },
+        {
+          "label": "Motor vehicle and fuel retail, hire and repair",
+          "value": "motor-vehicle-and-fuel-retail-hire-and-repair"
+        },
+        {
+          "label": "Motor vehicle and parts wholesale",
+          "value": "motor-vehicle-and-parts-wholesale"
+        },
+        {
+          "label": "Music production and publishing",
+          "value": "music-production-and-publishing"
+        },
+        {
+          "label": "Non store retail",
+          "value": "non-store-retail"
+        },
+        {
+          "label": "Paper products manufacturing",
+          "value": "paper-products-manufacturing"
+        },
+        {
+          "label": "Personal care services",
+          "value": "personal-care-services"
+        },
+        {
+          "label": "Petroleum and fuel products wholesale",
+          "value": "petroleum-and-fuel-products-wholesale"
+        },
+        {
+          "label": "Pharmaceuticals, health and beauty products retail",
+          "value": "pharmaceuticals-health-and-beauty-products-retail"
+        },
+        {
+          "label": "Printing and printing support activities",
+          "value": "printing-and-printing-support-activities"
+        },
+        {
+          "label": "Publishing",
+          "value": "publishing"
+        },
+        {
+          "label": "Real estate services",
+          "value": "real-estate-services"
+        },
+        {
+          "label": "Social care services",
+          "value": "social-care-services"
+        },
+        {
+          "label": "Sports and recreation",
+          "value": "sports-and-recreation"
+        },
+        {
+          "label": "Sports and recreation goods retail, hire and repair",
+          "value": "sports-and-recreation-goods-retail-hire-and-repair"
+        },
+        {
+          "label": "Telecommunications services",
+          "value": "telecommunications-services"
+        },
+        {
+          "label": "Television and radio broadcasting",
+          "value": "television-and-radio-broadcasting"
+        },
+        {
+          "label": "Textiles and furniture manufacturing",
+          "value": "textiles-and-furniture-manufacturing"
+        },
+        {
+          "label": "Textiles, furniture and furnishings wholesale",
+          "value": "textiles-furniture-and-furnishings-wholesale"
+        },
+        {
+          "label": "Timber and timber products wholesale",
+          "value": "timber-and-timber-products-wholesale"
+        },
+        {
+          "label": "Vehicle manufacturing",
+          "value": "vehicle-manufacturing"
+        },
+        {
+          "label": "Waste management and environmental services",
+          "value": "waste-management-and-environmental-services"
+        }
       ]
     },
     {

--- a/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
+++ b/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
@@ -1,12 +1,19 @@
 module Importers
   module LicenceTransaction
     class BulkIndustrySectorsImporter
+      attr_accessor :data_file_path, :schema_file_path
+
+      def initialize(data_file_path: nil, schema_file_path: nil)
+        @data_file_path = (data_file_path.presence || file_path)
+        @schema_file_path = (schema_file_path.presence || schema_path)
+      end
+
       def call
         update_industry_sectors_in_schema(imported_json_data)
       end
 
       def imported_json_data
-        lines = File.new(file_path).readlines(chomp: true)
+        lines = File.new(data_file_path).readlines(chomp: true)
         formatted = lines.map do |line|
           {
             label: line.strip.to_s,
@@ -18,13 +25,15 @@ module Importers
       end
 
       def update_industry_sectors_in_schema(industry_sectors)
-        json_blob = File.new(schema_path).read
+        json_blob = File.new(schema_file_path).read
         schema = JSON.parse(json_blob)
         licence_transaction_industry = schema["facets"].select { |facet| facet["key"] == "licence_transaction_industry" }
         licence_transaction_industry.first["allowed_values"] = industry_sectors
 
-        File.write(schema_path, JSON.dump(schema))
+        File.write(schema_file_path, JSON.dump(schema))
       end
+
+    private
 
       def file_path
         Rails.root.join("lib/data/licence_transaction/industry_sectors.txt")

--- a/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
+++ b/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
@@ -12,6 +12,8 @@ module Importers
         update_industry_sectors_in_schema(imported_json_data)
       end
 
+    private
+
       def imported_json_data
         lines = File.new(data_file_path).readlines(chomp: true)
         formatted = lines.map do |line|
@@ -32,8 +34,6 @@ module Importers
 
         File.write(schema_file_path, JSON.dump(schema))
       end
-
-    private
 
       def file_path
         Rails.root.join("lib/data/licence_transaction/industry_sectors.txt")

--- a/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
+++ b/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
@@ -1,0 +1,21 @@
+module Importers
+  module LicenceTransaction
+    class BulkIndustrySectorsImporter
+      def call
+        lines = File.new(file_path).readlines(chomp: true)
+        formatted = lines.map do |line|
+          {
+            label: line.strip.to_s,
+            value: line.parameterize.to_s,
+          }
+        end
+
+        formatted.as_json
+      end
+
+      def file_path
+        Rails.root.join("lib/data/licence_transaction/industry_sectors.txt")
+      end
+    end
+  end
+end

--- a/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
+++ b/lib/importers/licence_transaction/bulk_industry_sectors_importer.rb
@@ -2,6 +2,10 @@ module Importers
   module LicenceTransaction
     class BulkIndustrySectorsImporter
       def call
+        update_industry_sectors_in_schema(imported_json_data)
+      end
+
+      def imported_json_data
         lines = File.new(file_path).readlines(chomp: true)
         formatted = lines.map do |line|
           {
@@ -13,8 +17,21 @@ module Importers
         formatted.as_json
       end
 
+      def update_industry_sectors_in_schema(industry_sectors)
+        json_blob = File.new(schema_path).read
+        schema = JSON.parse(json_blob)
+        licence_transaction_industry = schema["facets"].select { |facet| facet["key"] == "licence_transaction_industry" }
+        licence_transaction_industry.first["allowed_values"] = industry_sectors
+
+        File.write(schema_path, JSON.dump(schema))
+      end
+
       def file_path
         Rails.root.join("lib/data/licence_transaction/industry_sectors.txt")
+      end
+
+      def schema_path
+        Rails.root.join("lib/documents/schemas/licence_transactions.json")
       end
     end
   end

--- a/lib/tasks/licence_transaction.rake
+++ b/lib/tasks/licence_transaction.rake
@@ -1,0 +1,8 @@
+require "importers/licence_transaction/bulk_industry_sectors_importer"
+
+namespace :licence_transaction do
+  desc "Imports all industry sectors from file and updates the licence transaction schema"
+  task :import_industry_sectors, %i[data_file_path schema_file_path] => :environment do |_, args|
+    Importers::LicenceTransaction::BulkIndustrySectorsImporter.new(data_file_path: args.data_file_path, schema_file_path: args.schema_file_path).call
+  end
+end

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Creating a Licence", type: :feature do
     fill_in "Summary", with: "This is the summary of a licence"
     fill_in "Body", with: "## Header#{"\n\nThis is the long body of a licence" * 2}"
     select "England", from: "Location"
-    select "Education", from: "Industry"
+    select "Publishing", from: "Industry"
     fill_in "Continuation link", with: "https://www.gov.uk"
     fill_in "Will continue on", with: "on GOV.UK"
 

--- a/spec/fixtures/documents/schemas/licence_transactions.json
+++ b/spec/fixtures/documents/schemas/licence_transactions.json
@@ -1,0 +1,74 @@
+{
+  "pre_production": true,
+  "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
+  "base_path": "/find-licences",
+  "format_name": "Find and apply for licences",
+  "name": "Find a licence",
+  "filter": {
+    "format": "licence_transaction"
+  },
+  "show_summaries": true,
+  "organisations": [
+    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  ],
+  "document_noun": "licence",
+  "facets": [
+    {
+      "key": "licence_transaction_location",
+      "name": "Location",
+      "type": "text",
+      "preposition": "In",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "England",
+          "value": "england"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
+        }
+      ]
+    },
+    {
+      "key": "licence_transaction_industry",
+      "name": "Industry",
+      "type": "text",
+      "preposition": "For",
+      "show_option_select_filter": true,
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": []
+    },
+    {
+      "key": "licence_transaction_will_continue_on",
+      "name": "Will continue on",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "licence_transaction_continuation_link",
+      "name": "Link to competent authority",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "licence_transaction_licence_identifier",
+      "name": "Licence identifier",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    }
+  ]
+}

--- a/spec/fixtures/documents/schemas/licence_transactions.json
+++ b/spec/fixtures/documents/schemas/licence_transactions.json
@@ -47,7 +47,48 @@
       "show_option_select_filter": true,
       "display_as_result_metadata": false,
       "filterable": true,
-      "allowed_values": []
+      "allowed_values": [
+        {
+          "label": "Accommodation",
+          "value": "accommodation"
+        },
+        {
+          "label": "Adult and other education",
+          "value": "adult-and-other-education"
+        },
+        {
+          "label": "Advertising and marketing services",
+          "value": "advertising-and-marketing-services"
+        },
+        {
+          "label": "Agricultural materials wholesale",
+          "value": "agricultural-materials-wholesale"
+        },
+        {
+          "label": "Agriculture",
+          "value": "agriculture"
+        },
+        {
+          "label": "Architectural and other building services",
+          "value": "architectural-and-other-building-services"
+        },
+        {
+          "label": "Arts and entertainment",
+          "value": "arts-and-entertainment"
+        },
+        {
+          "label": "Arts, antiques and second-hand goods retail",
+          "value": "arts-antiques-and-second-hand-goods-retail"
+        },
+        {
+          "label": "Arts, sports and recreation goods manufacturing",
+          "value": "arts-sports-and-recreation-goods-manufacturing"
+        },
+        {
+          "label": "Arts, sports and recreation goods wholesale",
+          "value": "arts-sports-and-recreation-goods-wholesale"
+        }
+      ]
     },
     {
       "key": "licence_transaction_will_continue_on",

--- a/spec/fixtures/licence-transaction/industry_sectors.txt
+++ b/spec/fixtures/licence-transaction/industry_sectors.txt
@@ -1,0 +1,10 @@
+Accommodation                                                                    
+Adult and other education                                                      
+Advertising and marketing services                                               
+Agricultural materials wholesale                                                 
+Agriculture                                                                      
+Architectural and other building services                                        
+Arts and entertainment                                                           
+Arts, antiques and second-hand goods retail                                      
+Arts, sports and recreation goods manufacturing                                  
+Arts, sports and recreation goods wholesale

--- a/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "importers/licence_transaction/bulk_industry_sectors_importer"
+
+RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
+  describe "#call" do
+    let(:subject) { described_class.new }
+
+    before do
+      @sectors_data_file = File.open(subject.file_path, "r")
+    end
+
+    it "returns all of the level 2 sectors" do
+      sectors = JSON.parse(subject.call)
+
+      expect(sectors.size).to eq(@sectors_data_file.readlines.size)
+    end
+
+    it "returns a label and value for each sector" do
+      sectors = JSON.parse(subject.call)
+
+      expect(sectors.first).to have_key("label")
+      expect(sectors.first).to have_key("value")
+    end
+  end
+end

--- a/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 require "importers/licence_transaction/bulk_industry_sectors_importer"
 
 RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
+  let(:data_file_path) { Rails.root.join("spec/fixtures/licence-transaction/industry_sectors.txt") }
+  let(:schema_file_path) { Rails.root.join("spec/fixtures/documents/schemas/licence_transactions.json") }
+
+  let(:subject) { described_class.new(data_file_path:, schema_file_path:) }
+
   describe "#imported_json_data" do
-    let(:data_file_path) { Rails.root.join("spec/fixtures/licence-transaction/industry_sectors.txt") }
-    let(:schema_file_path) { Rails.root.join("spec/fixtures/document/schemas/licence-transactions.json") }
-
-    let(:subject) { described_class.new(data_file_path:, schema_file_path:) }
-
     it "returns all of the level 2 sectors" do
       sectors = subject.imported_json_data
       sectors_data_file = File.open(subject.data_file_path, "r")
@@ -20,6 +20,17 @@ RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
 
       expect(sectors.first).to have_key("label")
       expect(sectors.first).to have_key("value")
+    end
+  end
+
+  describe "#update_industry_sectors_in_schema" do
+    it "writes imported sectors to JSON file" do
+      json_blob = File.new(schema_file_path).read
+      expected_schema = JSON.dump(JSON.parse(json_blob))
+      sectors = subject.imported_json_data
+
+      expect(File).to receive(:write).with(schema_file_path, expected_schema)
+      subject.update_industry_sectors_in_schema(sectors)
     end
   end
 end

--- a/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "importers/licence_transaction/bulk_industry_sectors_importer"
 
 RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
-  describe "#call" do
+  describe "#imported_json_data" do
     let(:subject) { described_class.new }
 
     before do
@@ -10,13 +10,13 @@ RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
     end
 
     it "returns all of the level 2 sectors" do
-      sectors = JSON.parse(subject.call)
+      sectors = subject.imported_json_data
 
       expect(sectors.size).to eq(@sectors_data_file.readlines.size)
     end
 
     it "returns a label and value for each sector" do
-      sectors = JSON.parse(subject.call)
+      sectors = subject.imported_json_data
 
       expect(sectors.first).to have_key("label")
       expect(sectors.first).to have_key("value")

--- a/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
@@ -2,35 +2,17 @@ require "spec_helper"
 require "importers/licence_transaction/bulk_industry_sectors_importer"
 
 RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
-  let(:data_file_path) { Rails.root.join("spec/fixtures/licence-transaction/industry_sectors.txt") }
-  let(:schema_file_path) { Rails.root.join("spec/fixtures/documents/schemas/licence_transactions.json") }
+  describe "#call" do
+    it "writes imported sectors to JSON schema file" do
+      data_file_path = Rails.root.join("spec/fixtures/licence-transaction/industry_sectors.txt")
+      schema_file_path = Rails.root.join("spec/fixtures/documents/schemas/licence_transactions.json")
+      subject = described_class.new(data_file_path:, schema_file_path:)
 
-  let(:subject) { described_class.new(data_file_path:, schema_file_path:) }
-
-  describe "#imported_json_data" do
-    it "returns all of the level 2 sectors" do
-      sectors = subject.imported_json_data
-      sectors_data_file = File.open(subject.data_file_path, "r")
-
-      expect(sectors.size).to eq(sectors_data_file.readlines.size)
-    end
-
-    it "returns a label and value for each sector" do
-      sectors = subject.imported_json_data
-
-      expect(sectors.first).to have_key("label")
-      expect(sectors.first).to have_key("value")
-    end
-  end
-
-  describe "#update_industry_sectors_in_schema" do
-    it "writes imported sectors to JSON file" do
       json_blob = File.new(schema_file_path).read
       expected_schema = JSON.dump(JSON.parse(json_blob))
-      sectors = subject.imported_json_data
 
       expect(File).to receive(:write).with(schema_file_path, expected_schema)
-      subject.update_industry_sectors_in_schema(sectors)
+      subject.call
     end
   end
 end

--- a/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/bulk_industry_sectors_importer_spec.rb
@@ -3,16 +3,16 @@ require "importers/licence_transaction/bulk_industry_sectors_importer"
 
 RSpec.describe Importers::LicenceTransaction::BulkIndustrySectorsImporter do
   describe "#imported_json_data" do
-    let(:subject) { described_class.new }
+    let(:data_file_path) { Rails.root.join("spec/fixtures/licence-transaction/industry_sectors.txt") }
+    let(:schema_file_path) { Rails.root.join("spec/fixtures/document/schemas/licence-transactions.json") }
 
-    before do
-      @sectors_data_file = File.open(subject.file_path, "r")
-    end
+    let(:subject) { described_class.new(data_file_path:, schema_file_path:) }
 
     it "returns all of the level 2 sectors" do
       sectors = subject.imported_json_data
+      sectors_data_file = File.open(subject.data_file_path, "r")
 
-      expect(sectors.size).to eq(@sectors_data_file.readlines.size)
+      expect(sectors.size).to eq(sectors_data_file.readlines.size)
     end
 
     it "returns a label and value for each sector" do


### PR DESCRIPTION
Trello: https://trello.com/c/TiYLM2hE

# What's changed and why?

It has been agreed with Content Designers and User Researchers to tag migrated licences in Specialist Publisher to only level two sectors (from Licence Finder).

The hierarchical structure for sectors (3 levels) is being dropped and licence documents will just be tagged to the 2nd level. This is due to limitations to support hierarchical tagging in Specialist Publisher / Finder Frontend and to mitigate bespoke work just for User Research.

Activities do not need to be imported as activities don't make complete sense. They mostly map 1-2-1 with individual licences but have different names to the licences.

Country tagging will remain and is already configured in Specialist Publisher.

The tagging of licence documents to the level sectors will be accomplished in a future data migration.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
