### PR TITLE
Order by title for licences

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -4,6 +4,7 @@
   "base_path": "/find-licences",
   "format_name": "Find and apply for licences",
   "name": "Find a licence",
+  "default_order": "title",
   "filter": {
     "format": "licence_transaction"
   },


### PR DESCRIPTION
Currently results are being ordered by when they were created which is confusing to users, as this information isn't displayed. Ordering by the title alphabetically is easier to understand.

<img width="1069" alt="Screenshot 2023-01-16 at 11 24 52" src="https://user-images.githubusercontent.com/24479188/212667371-936f7ca9-5968-4aef-99c1-78a3560e0d1e.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
