### PR TITLE
Remove Mailer as a direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "hashdiff"
 gem "jquery-rails"
 gem "kaminari"
 gem "kaminari-mongoid"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mongo"
 gem "mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,7 +550,6 @@ DEPENDENCIES
   kaminari
   kaminari-mongoid
   listen
-  mail (~> 2.8.0)
   mail-notify
   mongo
   mongoid


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

This has been resolved in 2.8.0.1 so we can remove the comment and use the latest stable release.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
