### PR TITLE
Present LicenceTransaction route type as 'prefix'

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -341,6 +341,10 @@ class Document
     }
   end
 
+  def route_type
+    "exact"
+  end
+
   def self.exportable?
     false
   end

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -26,6 +26,10 @@ class LicenceTransaction < Document
     "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   end
 
+  def route_type
+    "prefix"
+  end
+
   def self.slug
     "licences"
   end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -21,7 +21,7 @@ class DocumentPresenter
       routes: [
         {
           path: document.base_path,
-          type: "exact",
+          type: document.route_type,
         },
       ],
       redirects: [],

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -448,6 +448,15 @@ FactoryBot.define do
     base_path { "/find-licences/example-document" }
     document_type { "licence_transaction" }
 
+    routes do
+      [
+        {
+          "path" => base_path,
+          "type" => "prefix",
+        },
+      ]
+    end
+
     transient do
       default_metadata do
         {


### PR DESCRIPTION
Licences previously published by LicencePublisher used 'prefix' rather than 'exact' routes.

A 'prefix' route tells Router to direct all paths that start with a certain pattern to a certain application. A prefixed route for e.g '/find-licences/new-licence' would direct all request starting with that path, e.g 'licences/new-licence/council' to the same application as '/licences/new-licence'.

The full list of routes for a licence page are dynamically generated as they rely on postcode lookups, so we do not know the full list of possible routes.

This commit allows LicenceTransactions to present as 'prefix' routes, whilst maintaining other documents to maintain 'exact' routing.

[trello](https://trello.com/c/51k4iW5A/1677-update-specialist-publisher-licence-to-use-prefix-routes)
