### PR TITLE
Tag licences to industries and locations

### DIFF
--- a/lib/importers/licence_transaction/facet_tagger.rb
+++ b/lib/importers/licence_transaction/facet_tagger.rb
@@ -28,8 +28,10 @@ module Importers
       end
 
       def licence_finder_api_response
-        response = Net::HTTP.get_response(licence_finder_api_url).body
-        JSON.parse(response)
+        Rails.cache.fetch(licence_finder_api_url, expires: 1.hour) do
+          response = Net::HTTP.get_response(licence_finder_api_url).body
+          JSON.parse(response)
+        end
       end
 
       def licence_finder_api_url

--- a/lib/importers/licence_transaction/facet_tagger.rb
+++ b/lib/importers/licence_transaction/facet_tagger.rb
@@ -1,0 +1,40 @@
+require "uri"
+require "net/http"
+
+module Importers
+  module LicenceTransaction
+    class FacetTagger
+      attr_reader :licence_transaction
+
+      def initialize(licence_transaction)
+        @licence_transaction = licence_transaction
+      end
+
+      def tag
+        licence_transaction.licence_transaction_location = facets&.fetch(:locations)
+        licence_transaction.licence_transaction_industry = facets&.fetch(:industry_sectors)
+      end
+
+    private
+
+      def facets
+        licence_finder_api_data.find do |datum|
+          datum[:licence_identifier] == licence_transaction.licence_transaction_licence_identifier
+        end
+      end
+
+      def licence_finder_api_data
+        @licence_finder_api_data ||= licence_finder_api_response.map(&:deep_symbolize_keys)
+      end
+
+      def licence_finder_api_response
+        response = Net::HTTP.get_response(licence_finder_api_url).body
+        JSON.parse(response)
+      end
+
+      def licence_finder_api_url
+        URI("#{Plek.website_root}/licence-finder/licences-api")
+      end
+    end
+  end
+end

--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -1,3 +1,6 @@
+require "uri"
+require "net/http"
+
 module Importers
   module LicenceTransaction
     class LicenceImporter
@@ -25,6 +28,8 @@ module Importers
           )
 
           new_licence.change_note = "Imported from Publisher"
+
+          tag_licence_facets(new_licence)
 
           unless new_licence.valid?
             puts "[ERROR] licence: #{new_licence.base_path} has validation errors: #{new_licence.errors.inspect}"
@@ -98,6 +103,32 @@ module Importers
 
       def publish(new_content_id)
         Services.publishing_api.publish(new_content_id, "republish", locale: "en")
+      end
+
+      def tag_licence_facets(licence)
+        facets = licence_facet_data(licence)
+
+        licence.licence_transaction_location = facets[:locations]
+        licence.licence_transaction_industry = facets[:industry_sectors]
+      end
+
+      def licence_facet_data(licence)
+        licence_finder_api_data.find do |datum|
+          datum[:licence_identifier] == licence.licence_transaction_licence_identifier
+        end
+      end
+
+      def licence_finder_api_data
+        @licence_finder_api_data ||= licence_finder_api_response.map(&:deep_symbolize_keys)
+      end
+
+      def licence_finder_api_response
+        response = Net::HTTP.get_response(licence_finder_api_url).body
+        JSON.parse(response)
+      end
+
+      def licence_finder_api_url
+        URI("#{Plek.website_root}/licence-finder/licences-api")
       end
     end
   end

--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -1,5 +1,4 @@
-require "uri"
-require "net/http"
+require "importers/licence_transaction/facet_tagger"
 
 module Importers
   module LicenceTransaction
@@ -106,29 +105,7 @@ module Importers
       end
 
       def tag_licence_facets(licence)
-        facets = licence_facet_data(licence)
-
-        licence.licence_transaction_location = facets[:locations]
-        licence.licence_transaction_industry = facets[:industry_sectors]
-      end
-
-      def licence_facet_data(licence)
-        licence_finder_api_data.find do |datum|
-          datum[:licence_identifier] == licence.licence_transaction_licence_identifier
-        end
-      end
-
-      def licence_finder_api_data
-        @licence_finder_api_data ||= licence_finder_api_response.map(&:deep_symbolize_keys)
-      end
-
-      def licence_finder_api_response
-        response = Net::HTTP.get_response(licence_finder_api_url).body
-        JSON.parse(response)
-      end
-
-      def licence_finder_api_url
-        URI("#{Plek.website_root}/licence-finder/licences-api")
+        FacetTagger.new(licence).tag
       end
     end
   end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -718,4 +718,9 @@ FactoryBot.define do
       end
     end
   end
+
+  factory :licence_transaction_model, class: LicenceTransaction do
+    base_path { "/find-licences/example-document" }
+    title { "Example Licence" }
+  end
 end

--- a/spec/lib/importers/licence_transaction/facet_tagger_spec.rb
+++ b/spec/lib/importers/licence_transaction/facet_tagger_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+require "importers/licence_transaction/facet_tagger"
+
+RSpec.describe Importers::LicenceTransaction::FacetTagger do
+  describe "#tag" do
+    let(:licence_identifier) { "9150-7-1" }
+    let(:licence_transaction) { FactoryBot.build(:licence_transaction_model, licence_transaction_licence_identifier: licence_identifier) }
+
+    before do
+      stub_request(:get, "#{Plek.website_root}/licence-finder/licences-api")
+        .to_return(status: 200, body: licence_finder_api_response.to_json)
+    end
+
+    it "tags imported locations to licence" do
+      described_class.new(licence_transaction).tag
+
+      expect(licence_transaction.licence_transaction_location)
+        .to match_array(%w[
+          england
+          wales
+          scotland
+          northern-ireland
+        ])
+    end
+
+    it "tags imported industries to licence" do
+      described_class.new(licence_transaction).tag
+      expect(licence_transaction.licence_transaction_industry)
+        .to match_array(%w[
+          arts-and-entertainment
+          accommodation
+        ])
+    end
+  end
+
+  def licence_finder_api_response
+    [
+      {
+        "licence_identifier": licence_identifier,
+        "locations": %w[
+          england
+          wales
+          scotland
+          northern-ireland
+        ],
+        "industry_sectors": %w[
+          arts-and-entertainment
+          accommodation
+        ],
+      },
+    ]
+  end
+end

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -5,6 +5,7 @@ require "importers/licence_transaction/licence_importer"
 RSpec.describe Importers::LicenceTransaction::LicenceImporter do
   let(:new_content_id) { "0cc89dd8-1055-4e6b-8f64-9a772dbe28db" }
   let(:publishing_api_response) { publishing_api_licences_response }
+  let(:licence_identifier) { "9150-7-1" }
 
   before do
     allow(SecureRandom).to receive(:uuid).and_return(new_content_id)
@@ -13,6 +14,9 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
       publishing_api_response,
       { document_type: "licence", page: 1, per_page: 500, states: "published" },
     )
+
+    stub_request(:get, "#{Plek.website_root}/licence-finder/licences-api")
+      .to_return(status: 200, body: licence_finder_api_response.to_json)
   end
 
   context "when a licence is valid" do
@@ -128,8 +132,10 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
         ],
         metadata: {
           licence_transaction_continuation_link: "http://www.hpc-uk.org/apply",
-          licence_transaction_licence_identifier: "9150-7-1",
+          licence_transaction_licence_identifier: licence_identifier,
           licence_transaction_will_continue_on: "the Health and Care Professions Council (HCPC) website",
+          licence_transaction_industry: %w[arts-and-entertainment accommodation],
+          licence_transaction_location: %w[england wales scotland northern-ireland],
         },
         max_cache_time: 10,
         temporary_update_type: false,
@@ -183,7 +189,7 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
           }],
           "will_continue_on" => "the Health and Care Professions Council (HCPC) website",
           "continuation_link" => "http://www.hpc-uk.org/apply",
-          "licence_identifier" => "9150-7-1",
+          "licence_identifier" => licence_identifier,
           "external_related_links" => [],
           "licence_short_description" => "Register as an art therapist with the Health and Care Professions Council (HCPC).",
         },
@@ -235,7 +241,7 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
           "metadata" => {
             "licence_transaction_will_continue_on" => "the Health and Care Professions Council (HCPC) website",
             "licence_transaction_continuation_link" => "http://www.hpc-uk.org/apply",
-            "licence_transaction_licence_identifier" => "9150-7-1",
+            "licence_transaction_licence_identifier" => licence_identifier,
           },
           "max_cache_time" => 10,
           "temporary_update_type" => false,
@@ -267,6 +273,24 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
         "updated_at" => "2023-01-18T17:43:46Z",
         "state_history" => { "1" => "published" },
         "links" => { "finder" => %w[b8327c0c-a90d-47b6-992b-ea226b4d3306] },
+      },
+    ]
+  end
+
+  def licence_finder_api_response
+    [
+      {
+        "licence_identifier": licence_identifier,
+        "locations": %w[
+          england
+          wales
+          scotland
+          northern-ireland
+        ],
+        "industry_sectors": %w[
+          arts-and-entertainment
+          accommodation
+        ],
       },
     ]
   end

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
     )
 
     stub_request(:get, "#{Plek.website_root}/licence-finder/licences-api")
-      .to_return(status: 200, body: licence_finder_api_response.to_json)
+      .to_return(status: 200, body: [].to_json)
   end
 
   context "when a licence is valid" do
@@ -134,8 +134,6 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
           licence_transaction_continuation_link: "http://www.hpc-uk.org/apply",
           licence_transaction_licence_identifier: licence_identifier,
           licence_transaction_will_continue_on: "the Health and Care Professions Council (HCPC) website",
-          licence_transaction_industry: %w[arts-and-entertainment accommodation],
-          licence_transaction_location: %w[england wales scotland northern-ireland],
         },
         max_cache_time: 10,
         temporary_update_type: false,
@@ -273,24 +271,6 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
         "updated_at" => "2023-01-18T17:43:46Z",
         "state_history" => { "1" => "published" },
         "links" => { "finder" => %w[b8327c0c-a90d-47b6-992b-ea226b4d3306] },
-      },
-    ]
-  end
-
-  def licence_finder_api_response
-    [
-      {
-        "licence_identifier": licence_identifier,
-        "locations": %w[
-          england
-          wales
-          scotland
-          northern-ireland
-        ],
-        "industry_sectors": %w[
-          arts-and-entertainment
-          accommodation
-        ],
       },
     ]
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello: https://trello.com/c/DY5YCALU
Related to: https://github.com/alphagov/licence-finder/pull/1275

# What's changed?
Updates the Licence Transaction import script to also tag licences their industry and location facets.
The licences are tagged to the level sectors that they were previously tagged to in Licence Finder.

# Why?

Facets in specialist finders do not support nested facets, therefore only one level of sectors was required, and level two was selected by the user researchers and content designers for the first round of testing.

The tagging is being done programmatically as there are approximately 420 imported licences that need tagging.

The licences are being tagged to the same industries (sectors) that were tagged to in Licence Finder so that it's easier to test that the licences have been tagged correctly.

Any changes to industry facets (i.e. names / values) will occur outside of this change.

# Results from testing
Successful run of import script in [staging](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218499/console).

<img width="1203" alt="Screenshot 2023-02-02 at 13 54 15" src="https://user-images.githubusercontent.com/5793815/216343716-069ad060-29a9-42a8-9c7d-73fa9d5ae1f6.png">

