### PR TITLE
Comment out GovukContentSecurityPolicy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,1 +1,6 @@
-GovukContentSecurityPolicy.configure
+# Eventually we'll want to use the GOV.UK Content Security Policy in this app,
+# however as of January 2023 we're scoping it to only frontend apps
+#
+# For more info on the GOV.UK CSP see: https://docs.publishing.service.gov.uk/manual/content-security-policy.html
+#
+# GovukContentSecurityPolicy.configure


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

GOV.UK hadn't intended for this app to have the GOV.UK Content Security Policy yet, with us first planning to roll out this to frontend app. It looks like this was added as part of an outsourced Rails update [1], where the dev couldn't have known about our nuanced context.

As this is an app that doesn't receive a lot of developer attention I'm disabling this as I don't want breaking changes to the CSP [2] to end up in this app.

[1]: https://github.com/alphagov/specialist-publisher/pull/1676
[2]: https://github.com/alphagov/govuk_app_config/pull/279

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
