### PR TITLE
Reorder licence transaction facet so Industry is first

### DIFF
--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -1,4 +1,19 @@
 <%# You can select multiple class or categories so this has multi-select option %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_industry, label: "Industry" } do %>
+  <%= f.select :licence_transaction_industry,
+      f.object.facet_options(:licence_transaction_industry),
+      { label: "Industry" },
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data: {
+          placeholder: 'Select industries'
+        }
+      }
+  %>
+<% end %>
+
+<%# You can select multiple class or categories so this has multi-select option %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_location, label: "Location" } do %>
   <%= f.select :licence_transaction_location,
       f.object.facet_options(:licence_transaction_location),
@@ -13,20 +28,6 @@
   %>
 <% end %>
 
-<%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_industry, label: "Industry" } do %>
-  <%= f.select :licence_transaction_industry,
-      f.object.facet_options(:licence_transaction_industry),
-      { label: "Industry" },
-      {
-        class: 'select2 form-control',
-        multiple: true,
-        data: {
-          placeholder: 'Select industries'
-        }
-      }
-  %>
-<% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_will_continue_on, label: "Will continue on" } do %>
   <%= f.text_field :licence_transaction_will_continue_on, class: 'form-control' %>

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -15,32 +15,6 @@
   "document_noun": "licence",
   "facets": [
     {
-      "key": "licence_transaction_location",
-      "name": "Location",
-      "type": "text",
-      "preposition": "In",
-      "display_as_result_metadata": false,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "label": "England",
-          "value": "england"
-        },
-        {
-          "label": "Wales",
-          "value": "wales"
-        },
-        {
-          "label": "Scotland",
-          "value": "scotland"
-        },
-        {
-          "label": "Northern Ireland",
-          "value": "northern-ireland"
-        }
-      ]
-    },
-    {
       "key": "licence_transaction_industry",
       "name": "Industry",
       "type": "text",
@@ -348,6 +322,32 @@
         {
           "label": "Waste management and environmental services",
           "value": "waste-management-and-environmental-services"
+        }
+      ]
+    },
+    {
+      "key": "licence_transaction_location",
+      "name": "Location",
+      "type": "text",
+      "preposition": "In",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "England",
+          "value": "england"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
         }
       ]
     },

--- a/spec/fixtures/documents/schemas/licence_transactions.json
+++ b/spec/fixtures/documents/schemas/licence_transactions.json
@@ -14,32 +14,6 @@
   "document_noun": "licence",
   "facets": [
     {
-      "key": "licence_transaction_location",
-      "name": "Location",
-      "type": "text",
-      "preposition": "In",
-      "display_as_result_metadata": false,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "label": "England",
-          "value": "england"
-        },
-        {
-          "label": "Wales",
-          "value": "wales"
-        },
-        {
-          "label": "Scotland",
-          "value": "scotland"
-        },
-        {
-          "label": "Northern Ireland",
-          "value": "northern-ireland"
-        }
-      ]
-    },
-    {
       "key": "licence_transaction_industry",
       "name": "Industry",
       "type": "text",
@@ -87,6 +61,32 @@
         {
           "label": "Arts, sports and recreation goods wholesale",
           "value": "arts-sports-and-recreation-goods-wholesale"
+        }
+      ]
+    },
+    {
+      "key": "licence_transaction_location",
+      "name": "Location",
+      "type": "text",
+      "preposition": "In",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "England",
+          "value": "england"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
         }
       ]
     },


### PR DESCRIPTION
This PR swaps the order of facets for Licences, so Industry appears before Location in the rendering app.

before
![Screenshot 2023-01-26 at 14 18 12](https://user-images.githubusercontent.com/13475227/214893874-eda607b5-ea1b-4ce1-acfd-0f86d3cc40cf.png)

after
![Screenshot 2023-01-26 at 16 33 23](https://user-images.githubusercontent.com/13475227/214893903-d23bc2ee-71c4-42b3-88d6-a59c1f38837a.png)

It also updates the order in the admin UI for parity.

[trello](https://trello.com/c/lkm9322o/1786-move-industry-filter-above-location-for-new-licence-finder)