### PR TITLE
Ensure Sidekiq is 7.0.0 compliant

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -16,7 +16,7 @@ class ExportsController < ApplicationController
 
   def create
     @query = params[:query]
-    DocumentListExportWorker.perform_async(current_format.slug, current_user.id, @query)
+    DocumentListExportWorker.perform_async(current_format.slug, current_user.id.to_s, @query)
     flash[:info] = "The document list is being exported"
     redirect_to documents_path(current_format.slug, query: @query)
   end

--- a/app/services/document_publisher.rb
+++ b/app/services/document_publisher.rb
@@ -19,7 +19,7 @@ class DocumentPublisher
       # normal email-alert-service path for sending email alerts.
       document_with_public_updated_at = document
       document_with_public_updated_at.public_updated_at = published_document.public_updated_at
-      EmailAlertApiWorker.perform_async(EmailAlertPresenter.new(document_with_public_updated_at).to_json)
+      EmailAlertApiWorker.perform_async(EmailAlertPresenter.new(document_with_public_updated_at).to_json.deep_stringify_keys)
     end
 
     if previously_unpublished?(document)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,2 @@
+# Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7
+Sidekiq.strict_args!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,5 @@
 ---
 :verbose: true
 :concurrency: 2
-<% if ENV.key?('SIDEKIQ_LOGFILE') %>
-:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
-<% end %>
 :queues:
   - default

--- a/spec/workers/email_alert_api_worker_spec.rb
+++ b/spec/workers/email_alert_api_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EmailAlertApiWorker do
   end
 
   it "asynchronously sends a notification to email alert api" do
-    described_class.perform_async(some: "payload")
+    described_class.perform_async("some" => "payload")
 
     expect(described_class.jobs.size).to eq(1)
     described_class.drain


### PR DESCRIPTION
## Description

We recently merged the bump of the GOV.UK Sidekiq gem to 6.0.0 in https://github.com/alphagov/specialist-publisher/pull/2202

We're going through our repos that use Sidekiq, removing logging, enforcing strict args and applying fixes to that they're 7.0.0 compliant.

## Trello card 

https://trello.com/c/JXAvbpOX/1103-upgrade-apps-to-sidekiq-v6



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
