### PR TITLE
Move location to first facet

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -15,6 +15,32 @@
   "document_noun": "licence",
   "facets": [
     {
+      "key": "licence_transaction_location",
+      "name": "Location",
+      "type": "text",
+      "preposition": "In",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "England",
+          "value": "england"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
+        }
+      ]
+    },
+    {
       "key": "licence_transaction_industry",
       "name": "Industry",
       "type": "text",
@@ -322,32 +348,6 @@
         {
           "label": "Waste management and environmental services",
           "value": "waste-management-and-environmental-services"
-        }
-      ]
-    },
-    {
-      "key": "licence_transaction_location",
-      "name": "Location",
-      "type": "text",
-      "preposition": "In",
-      "display_as_result_metadata": false,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "label": "England",
-          "value": "england"
-        },
-        {
-          "label": "Wales",
-          "value": "wales"
-        },
-        {
-          "label": "Scotland",
-          "value": "scotland"
-        },
-        {
-          "label": "Northern Ireland",
-          "value": "northern-ireland"
         }
       ]
     },


### PR DESCRIPTION
Previously, the location facet was beneath industries in the specialist finder. We've now swapped the ordering following a design recommendation.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
