### PR TITLE
Set industries facet to open and use large height

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -48,6 +48,8 @@
       "show_option_select_filter": true,
       "display_as_result_metadata": false,
       "filterable": true,
+      "large": true,
+      "open_on_load": true,
       "allowed_values": [
         {
           "label": "Accommodation",

--- a/spec/fixtures/documents/schemas/licence_transactions.json
+++ b/spec/fixtures/documents/schemas/licence_transactions.json
@@ -21,6 +21,8 @@
       "show_option_select_filter": true,
       "display_as_result_metadata": false,
       "filterable": true,
+      "large": true,
+      "open_on_load": true,
       "allowed_values": [
         {
           "label": "Accommodation",


### PR DESCRIPTION
## What
Set the Industries facet to always be open and use the large variation of the option-select component.

## Why
We would like the Industries facet to be open on when the page loads and make better use of the space available.

## Anything else
This PR depends on changes being made in `publishing-api`, a PR is open for this - https://github.com/alphagov/publishing-api/pull/2325.

The failing tests in this PR should pass once the changes are merged in `publishing-api`.

### Related Trello cards:
- https://trello.com/c/WpDLBxS1/1885-expand-both-location-and-industry-filters-by-default
- https://trello.com/c/Urpavm6J/1886-increase-the-height-of-the-industries-facet-filter-box 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
