### PR TITLE
Add the none option to disease control zone types

### DIFF
--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -147,6 +147,10 @@
         {
           "label": "Wild bird monitoring area",
           "value": "wild-bird-monitoring"
+        },
+        {
+          "label": "None",
+          "value": "none"
         }
       ]
     },


### PR DESCRIPTION
Add a new option in the animal disease finder, within the disease control zone types section.

Trello card: https://trello.com/c/wYsvb5vV
