### PR TITLE
Editor content tweaks

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -308,6 +308,11 @@ class Document
     title.parameterize.pluralize
   end
 
+  # Singularize and downcase but maintaining initials
+  def self.title_for_new_document
+    title.singularize.split(" ").map { |p| p.upcase == p ? p : p.downcase }.join(" ")
+  end
+
   def content_id_and_locale
     "#{content_id}:#{locale}"
   end

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -32,6 +32,11 @@ class StatutoryInstrument < Document
     "EU Withdrawal Act 2018 statutory instrument"
   end
 
+  # Keep name of act titleized
+  def self.title_for_new_document
+    title
+  end
+
   def links
     super.merge(
       organisations: organisations | [primary_publishing_organisation],

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="sidebar col-md-3">
-    <%= link_to "Add another #{current_format.title}", new_document_path(current_format.slug), class: 'action-link' %>
+    <%= link_to "Add another #{current_format.title_for_new_document}", new_document_path(current_format.slug), class: 'action-link' %>
     <%= form_tag(documents_path(current_format.slug), method: :get, class: "add-vertical-margins well") do %>
       <%= label_tag "query", "Search" %>
       <%= text_field_tag("query", params[:query], class: "form-control add-bottom-margin") %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "New #{current_format.title.singularize}" %>
+<%= content_for :page_title, "New #{current_format.title_for_new_document}" %>
 
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your documents", documents_path(current_format.slug) %></li>
@@ -9,7 +9,7 @@
   GOVUK.formChangeProtection.init($('.new_document'), 'You have unsaved changes that will be lost if you leave this page.');
 <% end -%>
 
-<h1>New <%= current_format.title.singularize %></h1>
+<h1>New <%= current_format.title_for_new_document %></h1>
 
 <div class="row">
   <div class="col-md-8">

--- a/spec/features/creating_a_cma_case_spec.rb
+++ b/spec/features/creating_a_cma_case_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Creating a CMA case", type: :feature do
 
   scenario "getting to the new document page" do
     visit "/cma-cases"
-    click_link "Add another CMA Case"
+    click_link "Add another CMA case"
 
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/cma-cases/new")

--- a/spec/features/creating_a_oim_project.rb
+++ b/spec/features/creating_a_oim_project.rb
@@ -14,7 +14,7 @@ RSpec.feature "Creating an OIM project", type: :feature do
 
   scenario "visiting the new project page" do
     visit "/oim-projects"
-    click_link "Add another OIM Project"
+    click_link "Add another OIM project"
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/oim-projects/new")
   end

--- a/spec/features/creating_a_product_safety_alert_report_recall.rb
+++ b/spec/features/creating_a_product_safety_alert_report_recall.rb
@@ -17,7 +17,7 @@ RSpec.feature "Creating a product safety alert recall", type: :feature do
 
   scenario "visiting the new recall page" do
     visit "/product-safety-alerts-reports-recalls"
-    click_link "Add another Product Safety Alerts, Reports and Recalls"
+    click_link "Add another product safety alerts, reports and recalls"
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/product-safety-alerts-reports-recalls/new")
   end

--- a/spec/features/creating_an_animal_disease_case.rb
+++ b/spec/features/creating_an_animal_disease_case.rb
@@ -18,7 +18,7 @@ RSpec.feature "Creating an animal disease case", type: :feature do
   scenario "visiting the new case page" do
     #  ? should this be animal disease cases england?
     visit "/animal-disease-cases"
-    click_link "Add another Animal disease case"
+    click_link "Add another animal disease case"
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/animal-disease-cases/new")
   end

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Creating a Licence", type: :feature do
 
   scenario "adding a new licence" do
     visit "/find-licences"
-    click_link "Add another Licence"
+    click_link "Add another licence"
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/licences/new")
   end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
 
       click_link("CMA Cases")
 
-      expect(page).to have_text("Add another CMA Case")
+      expect(page).to have_text("Add another CMA case")
     end
 
     it "has expected finders" do
@@ -79,7 +79,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
 
       click_link("CMA Cases")
 
-      expect(page).to have_content("Add another CMA Case")
+      expect(page).to have_content("Add another CMA case")
     end
   end
 end

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
 
   context "a new document" do
     before do
-      click_on "Add another CMA Case"
+      click_on "Add another CMA case"
 
       fill_in "Title", with: "Example CMA Case"
       fill_in "Summary", with: "This is the summary of an example CMA case"

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe Document do
     expect(MyDocumentType.document_type).to eq("my_document_type")
   end
 
+  describe ".title_for_new_document" do
+    it "sets the document title in lowercase and singular for new document" do
+      expect(MyDocumentType.title_for_new_document).to eq("my document type")
+    end
+
+    context "with initials in the title" do
+      let(:document_sub_class_initialis) do
+        Class.new(MyDocumentType) do
+          def self.title
+            "XYZ Reports"
+          end
+        end
+      end
+
+      before { stub_const("MyDocumentTypeInitials", document_sub_class_initialis) }
+
+      it "sets the document title in lowercase and singular for new document but retains the initialism" do
+        expect(MyDocumentTypeInitials.title_for_new_document).to eq("XYZ report")
+      end
+    end
+  end
+
   describe "parsing date params" do
     it "sets a date string from rails date select style params" do
       doc = MyDocumentType.new("field1(1i)": "2016", "field1(2i)": "09", "field1(3i)": "07")

--- a/spec/models/statutory_instrument_spec.rb
+++ b/spec/models/statutory_instrument_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe StatutoryInstrument do
     expect(described_class).not_to be_exportable
   end
 
+  describe ".title_for_new_document" do
+    it "retains the capitalisation of the act name" do
+      expect(StatutoryInstrument.title_for_new_document).to eq("EU Withdrawal Act 2018 statutory instrument")
+    end
+  end
+
   describe "sift_end_date" do
     subject(:instance) do
       StatutoryInstrument.new(body: "", sift_end_date: "2016-01-01", sifting_status: "withdrawn")


### PR DESCRIPTION
Adds content tweaks mentioned here https://docs.google.com/document/d/1b64gBYFuuSGBPZ8B4Poy0UH57NKuLDVBn9WkLi7dANk/edit#heading=h.jz5m30507l7y to the editor.

These changes affect all document editor pages in Specialist publisher.

- Alter New document type titles so they'll be downcased (except initials, and special case for EU Withdrawal Act 2018)

Before:

<img width="785" alt="Screenshot 2023-04-20 at 09 38 24" src="https://user-images.githubusercontent.com/4225737/233310213-760a568d-45fb-4607-ac57-f369b7110158.png">

After:
<img width="784" alt="Screenshot 2023-04-18 at 15 13 49" src="https://user-images.githubusercontent.com/4225737/232804930-e023e0c8-0e81-423a-b98a-6dc19b0f1398.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/BWE1XxzY/1937-backend-devs-review-effort-of-suggested-name-changes-to-backend-of-specialist-publisher-tool