### PR TITLE
Change Locale label to Language

### DIFF
--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -11,7 +11,7 @@
   <%= f.text_area :body, rows: 20, class: 'form-control body-text' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :locale } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :locale, label: "Language" } do %>
   <%= f.select(
     :locale,
     options_for_select(


### PR DESCRIPTION
(Split from https://github.com/alphagov/specialist-publisher/pull/2262 to get this change out while we consider a more consistent way of handling document titles)

Adds content tweaks mentioned here https://docs.google.com/document/d/1b64gBYFuuSGBPZ8B4Poy0UH57NKuLDVBn9WkLi7dANk/edit#heading=h.jz5m30507l7y to the editor.

These changes affect all document editor pages in Specialist publisher.

- Alter Locale label to Language

Before: 

<img width="784" alt="Screenshot 2023-04-18 at 13 16 57" src="https://user-images.githubusercontent.com/4225737/233307404-96e3ecf0-33b9-4781-93de-0820a27c1096.png">

After:

<img width="785" alt="Screenshot 2023-04-20 at 09 38 24" src="https://user-images.githubusercontent.com/4225737/233309851-6ee74bf0-5971-4beb-94e5-5c09c5eb6fda.png">

https://trello.com/c/BWE1XxzY/1937-backend-devs-review-effort-of-suggested-name-changes-to-backend-of-specialist-publisher-tool

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
