### PR TITLE
Update licence field display names

### DIFF
--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -29,11 +29,11 @@
 <% end %>
 
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_will_continue_on, label: "Will continue on" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_will_continue_on, label: "Name of website where you apply" } do %>
   <%= f.text_field :licence_transaction_will_continue_on, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_continuation_link, label: "Continuation link" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_continuation_link, label: "URL for \"Start Now\" button" } do %>
   <%= f.text_field :licence_transaction_continuation_link, class: 'form-control' %>
 <% end %>
 

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -44,8 +44,8 @@ RSpec.feature "Creating a Licence", type: :feature do
     fill_in "Body", with: "## Header#{"\n\nThis is the long body of a licence" * 2}"
     select "England", from: "Location"
     select "Publishing", from: "Industry"
-    fill_in "Continuation link", with: "https://www.gov.uk"
-    fill_in "Will continue on", with: "on GOV.UK"
+    fill_in "URL for \"Start Now\" button", with: "https://www.gov.uk"
+    fill_in "Name of website where you apply", with: "on GOV.UK"
 
     click_button "Save as draft"
     assert_publishing_api_put_content(content_id)


### PR DESCRIPTION
Update licence field names that appear in the editor to make them more understandable to content editors. This only affects the new licence document types.

https://trello.com/c/BWE1XxzY/1937-backend-devs-review-effort-of-suggested-name-changes-to-backend-of-specialist-publisher-tool

Before:

<img width="818" alt="Screenshot 2023-04-20 at 13 34 54" src="https://user-images.githubusercontent.com/4225737/233367540-0993429e-e085-40d3-8b09-1a2b087baf21.png">

After:

<img width="798" alt="Screenshot 2023-04-20 at 13 28 32" src="https://user-images.githubusercontent.com/4225737/233366298-9cc12a7d-74c3-419c-8938-57c5c6de80f7.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
