### PR TITLE
Strips licence identifier if continuation link exists 

### DIFF
--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -22,7 +22,7 @@ module Importers
             licence_transaction_industry: [],
             licence_transaction_will_continue_on: details["will_continue_on"],
             licence_transaction_continuation_link: details["continuation_link"],
-            licence_transaction_licence_identifier: details["licence_identifier"],
+            licence_transaction_licence_identifier: (details["licence_identifier"] unless details["continuation_link"]),
             imported: true,
           )
 

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -132,7 +132,6 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
         ],
         metadata: {
           licence_transaction_continuation_link: "http://www.hpc-uk.org/apply",
-          licence_transaction_licence_identifier: licence_identifier,
           licence_transaction_will_continue_on: "the Health and Care Professions Council (HCPC) website",
         },
         max_cache_time: 10,
@@ -239,7 +238,6 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
           "metadata" => {
             "licence_transaction_will_continue_on" => "the Health and Care Professions Council (HCPC) website",
             "licence_transaction_continuation_link" => "http://www.hpc-uk.org/apply",
-            "licence_transaction_licence_identifier" => licence_identifier,
           },
           "max_cache_time" => 10,
           "temporary_update_type" => false,


### PR DESCRIPTION
If a continuation link is present then the external website template is rendered which doesn't require the licence identifier, as the identifier is used for non-external link journeys (postcode lookup).

This work is a prerequisite for adding validation to the bespoke fields for licences (continuation_link, will_continue_on and licence_identifier).

Trello:
https://trello.com/c/p1DbDyxZ/2021-strip-licence-identifier-from-imported-licences-if-continuation-link-present

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
