### PR TITLE
Ignore empty strings for licence import

### DIFF
--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -36,9 +36,9 @@ module Importers
             update_type: "major",
             licence_transaction_location: tagging["locations"],
             licence_transaction_industry: tagging["industries"],
-            licence_transaction_will_continue_on: details["will_continue_on"],
-            licence_transaction_continuation_link: details["continuation_link"],
-            licence_transaction_licence_identifier: (details["licence_identifier"] unless details["continuation_link"]),
+            licence_transaction_will_continue_on: details["will_continue_on"].presence,
+            licence_transaction_continuation_link: details["continuation_link"].presence,
+            licence_transaction_licence_identifier: licence_identifier(details),
             imported: true,
           )
 
@@ -144,6 +144,10 @@ module Importers
 
       def tagging_csv_validator
         @tagging_csv_validator ||= TaggingCsvValidator.new(licences_tagging)
+      end
+
+      def licence_identifier(details)
+        details["licence_identifier"] if details["continuation_link"].blank?
       end
     end
   end


### PR DESCRIPTION
continuation_link / will_continue_on can be empty strings which previously led to the identifier not being saved if these were present. This commit updates the conditional to `present?` which ignores empty strings.

We're also not saving will_continue_on / continuation_link if their value is an empty string which is cleaner.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
