### PR TITLE
Add CDEI Assurance Techniques finder

### DIFF
--- a/app/models/ai_assurance_portfolio_technique.rb
+++ b/app/models/ai_assurance_portfolio_technique.rb
@@ -1,0 +1,27 @@
+class AiAssurancePortfolioTechnique < Document
+  FORMAT_SPECIFIC_FIELDS = %i[
+    use_case
+    sector
+    principle
+    key_function
+    ai_assurance_technique
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+
+  def taxons
+    []
+  end
+
+  def self.title
+    "Portfolio of Assurance Techniques"
+  end
+
+  def primary_publishing_organisation
+    "1405edcb-943d-42d2-8ec8-c51cd58335a5"
+  end
+end

--- a/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
+++ b/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
@@ -1,0 +1,75 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :use_case } do %>
+  <%= f.select :use_case,
+      facet_options(f, :use_case),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a use case'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :sector } do %>
+  <%= f.select :sector,
+      facet_options(f, :sector),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a sector'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :principle } do %>
+  <%= f.select :principle,
+      facet_options(f, :principle),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a principle'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :key_function } do %>
+  <%= f.select :key_function,
+      facet_options(f, :key_function),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select a function'
+        }
+      }
+  %>
+<% end %>
+
+<%= render layout: "shared/form_group", locals: { f: f, field: :ai_assurance_technique } do %>
+  <%= f.select :ai_assurance_technique,
+      facet_options(f, :ai_assurance_technique),
+      {},
+      {
+        class: 'select2 form-control',
+        multiple: true,
+        data:
+        {
+          placeholder: 'Select an assurance technique'
+        }
+      }
+  %>
+<% end %>
+

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -1,4 +1,5 @@
 {
+  "pre_production": true,
   "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
   "base_path": "/ai-assurance-techniques",
   "format_name": "Find out about artificial intelligence (AI) assurance techniques",

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -1,0 +1,280 @@
+{
+  "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
+  "base_path": "/ai-assurance-techniques",
+  "format_name": "Find out about artificial intelligence (AI) assurance techniques",
+  "name": "Find out about artificial intelligence (AI) assurance techniques",
+  "description": "Find out what AI assurance is and what AI assurance techniques you can use in your organisation.",
+  "summary": "Find out what AI assurance is and what effective AI assurance techniques you can use in your organisation. You can also read examples of AI assurance in practice across a variety of sectors.",
+  "filter": {
+    "format": "ai_assurance_portfolio_technique"
+  },
+  "organisations": [
+    "1405edcb-943d-42d2-8ec8-c51cd58335a5",
+    "c352c234-8083-47ec-8a4b-0edd45c31263"
+  ],
+  "editing_organisations": [
+    "1405edcb-943d-42d2-8ec8-c51cd58335a5",
+    "c352c234-8083-47ec-8a4b-0edd45c31263"
+  ],
+  "document_noun": "case study",
+  "facets": [
+    {
+      "key": "use_case",
+      "name": "Use case",
+      "type": "text",
+      "preposition": "Use case",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Big data analytics",
+          "value": "big-data-analytics"
+        },
+        {
+          "label": "Data-driven profiling",
+          "value": "data-driven-profiling"
+        },
+        {
+          "label": "Natural language processing and generation",
+          "value": "natural-language-processing-and-generation"
+        },
+        {
+          "label": "Image recognition and video processing",
+          "value": "image-recognition-and-video-processing"
+        },
+        {
+          "label": "Machine learning",
+          "value": "machine-learning"
+        },
+        {
+          "label": "Deep learning",
+          "value": "deep-learning"
+        },
+        {
+          "label": "Virtual agents or artificial conversational interfaces",
+          "value": "virtual-agents-or-artificial-conversational-interfaces"
+        },
+        {
+          "label": "Robotic process automation and decision management",
+          "value": "robotic-process-automation-and-decision-management"
+        },
+        {
+          "label": "Robotics and autonomous vehicles/systems",
+          "value": "robotics-and-autonomous-vehicles-systems"
+        }
+      ]
+    },
+    {
+      "key": "sector",
+      "name": "Sector",
+      "type": "text",
+      "preposition": "sector",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Agriculture, Forestry and Fishing (SIC Code Section A)",
+          "value": "agriculture-forestry-and-fishing"
+        },
+        {
+          "label": "Mining and Quarrying (SIC Code Section B)",
+          "value": "mining-and-quarrying"
+        },
+        {
+          "label": "Manufacturing (SIC Code Section C)",
+          "value": "manufacturing"
+        },
+        {
+          "label": "Energy & Utilities (SIC Code Sections D & E)",
+          "value": "energy-and-utilities"
+        },
+        {
+          "label": "Construction (SIC Code Section F)",
+          "value": "construction"
+        },
+        {
+          "label": "Retail (SIC Code Section G)",
+          "value": "retail"
+        },
+        {
+          "label": "Transportation & Storage (SIC Code Section H)",
+          "value": "transportation-and-storage"
+        },
+        {
+          "label": "Accommodation and Food Service (SIC Code Section I)",
+          "value": "accommodation-and-food-service"
+        },
+        {
+          "label": "Digital & Comms (SIC Code Section J)",
+          "value": "digital-and-comms"
+        },
+        {
+          "label": "Financial and Insurance (SIC Code Section K)",
+          "value": "financial-and-insurance"
+        },
+        {
+          "label": "Real Estate (SIC Code Section L)",
+          "value": "real-estate"
+        },
+        {
+          "label": "Professional, Scientific & Professional Activities (SIC Code Section M)",
+          "value": "professional-scientific-and-professional-activities"
+        },
+        {
+          "label": "Administrative & Support Services (SIC Code Section N)",
+          "value": "administrative-and-support-services"
+        },
+        {
+          "label": "Public Administration & Defence (SIC Code Section O)",
+          "value": "public-administration-and-defence"
+        },
+        {
+          "label": "Education (SIC Code Section P)",
+          "value": "education"
+        },
+        {
+          "label": "Healthcare & Social Work (SIC Code Section Q)",
+          "value": "healthcare-and-social-work"
+        },
+        {
+          "label": "Arts, Entertainment & Recreation (SIC Code Section R)",
+          "value": "arts-entertainment-and-recreation"
+        },
+        {
+          "label": "Other Services (SIC Code Section S)",
+          "value": "other-services"
+        }
+      ]
+    },
+    {
+      "key": "principle",
+      "name": "Principle",
+      "type": "text",
+      "preposition": "Principle",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Safety, security and robustness",
+          "value": "safety-security-and-robustness"
+        },
+        {
+          "label": "Appropriate transparency and explainability",
+          "value": "appropriate-transparency-and-explainability"
+        },
+        {
+          "label": "Fairness",
+          "value": "fairness"
+        },
+        {
+          "label": "Accountability and governance",
+          "value": "accountability-and-governance"
+        },
+        {
+          "label": "Contestability and redress",
+          "value": "contestability-and-redress"
+        }
+      ]
+    },
+    {
+      "key": "key_function",
+      "name": "Key function",
+      "type": "text",
+      "preposition": "function",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "R&D",
+          "value": "r-and-d"
+        },
+        {
+          "label": "Product and service development",
+          "value": "product-and-service-development"
+        },
+        {
+          "label": "Manufacturing",
+          "value": "manufacturing"
+        },
+        {
+          "label": "Service operations",
+          "value": "service-operations"
+        },
+        {
+          "label": "Supply chain management",
+          "value": "supply-chain-management"
+        },
+        {
+          "label": "Human Resources",
+          "value": "human-resources"
+        },
+        {
+          "label": "Marketing and sales",
+          "value": "marketing-and-sales"
+        },
+        {
+          "label": "Customer services",
+          "value": "customer-services"
+        },
+        {
+          "label": "Risk management",
+          "value": "risk-management"
+        },
+        {
+          "label": "Strategy and corporate finance",
+          "value": "strategy-and-corporate-finance"
+        }
+      ]
+    },
+    {
+      "key": "ai_assurance_technique",
+      "name": "AI Assurance Technique",
+      "type": "text",
+      "preposition": "AI Assurance Technique",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Data assurance",
+          "value": "data-assurance"
+        },
+        {
+          "label": "Compliance audit",
+          "value": "compliance-audit"
+        },
+        {
+          "label": "Formal verification",
+          "value": "formal-verification"
+        },
+        {
+          "label": "Performance testing",
+          "value": "performance-testing"
+        },
+        {
+          "label": "Certification",
+          "value": "certification"
+        },
+        {
+          "label": "Risk Assessment",
+          "value": "risk-assessment"
+        },
+        {
+          "label": "Impact Assessment",
+          "value": "impact-assessment"
+        },
+        {
+          "label": "Impact Evaluation",
+          "value": "impact-evaluation"
+        },
+        {
+          "label": "Conformity Assessment",
+          "value": "conformity-assessment"
+        },
+        {
+          "label": "Bias Audit",
+          "value": "bias-audit"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Following the Developer Docs on creating a specialist finder, this commit updates the relevant files in specialist publisher.

Trello card link:
https://trello.com/c/1LeqkG5a/1245-create-a-cdei-finder

Link to steps followed in Developer Docs:
https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-and-editing-specialist-document-types.html#2-create-a-new-specialist-document-format-in-specialist-publisher

Co-authored-by: Johnny Young <jonathan.young@digital.cabinet-office.gov.uk>