### PR TITLE
Added DBT as an organisation for 2 specialist publishers

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -10,7 +10,10 @@
   "show_summaries": true,
   "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",
   "signup_copy": "You'll get an email each time a scheme is updated or a new scheme is published.",
-  "organisations": ["2bde479a-97f2-42b5-986a-287a623c2a1c"],
+  "organisations": [
+    "2bde479a-97f2-42b5-986a-287a623c2a1c",
+    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+  ],
   "related": ["3d582854-ffc7-4d41-9266-ee87b9e6d230", "89edffd2-3046-40bd-810c-cc1a13c05b6a"],
   "topics": [
 

--- a/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
+++ b/lib/documents/schemas/uk_market_conformity_assessment_bodies.json
@@ -10,7 +10,10 @@
   },
   "show_summaries": true,
   "default_order": "title",
-  "organisations": ["2bde479a-97f2-42b5-986a-287a623c2a1c"],
+  "organisations": [
+    "2bde479a-97f2-42b5-986a-287a623c2a1c",
+    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+  ],
   "signup_content_id": "c9102d1b-3832-40a8-9851-abe641dfd696",
   "signup_copy": "You'll get an email each time a body changes their details, or a new body is confirmed.",
   "subscription_list_title_prefix": "UK Market Conformity Assessment Bodies",


### PR DESCRIPTION
DBT users need to be able to publish both Business Finance Support Schemes and UK Market Conformity Assessments. At the moment these specialist publishers don't list DBT as organisation so editors in those organisations don't have access to the publisher. Adding the organisations should allow these users access

https://trello.com/c/XshoTuOP/1318-update-specialist-finders-permissions-to-reflect-mog-changes

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
