### PR TITLE
Set licence primary_publishing_organisation from current user.

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -2,4 +2,10 @@ module OrganisationsHelper
   def organisations_options
     Organisation.all.map { |o| [o.title, o.content_id] }
   end
+
+  def primary_publishing_organisation_options(form)
+    return {} if form.object.primary_publishing_organisation.present?
+
+    { selected: current_user.organisation_content_id }
+  end
 end

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -1,4 +1,6 @@
 class LicenceTransaction < Document
+  validates :primary_publishing_organisation, presence: true
+
   FORMAT_SPECIFIC_FIELDS = %i[
     licence_transaction_continuation_link
     licence_transaction_industry
@@ -7,10 +9,12 @@ class LicenceTransaction < Document
     licence_transaction_will_continue_on
   ].freeze
 
-  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS, :organisations, :primary_publishing_organisation)
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    @primary_publishing_organisation = params[:primary_publishing_organisation]
+    @organisations = params[:organisations]
   end
 
   def taxons
@@ -21,9 +25,15 @@ class LicenceTransaction < Document
     "Licence"
   end
 
-  def primary_publishing_organisation
-    # Set to GDS for testing
-    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  def has_organisations?
+    true
+  end
+
+  def links
+    super.merge(
+      organisations: organisations | [primary_publishing_organisation],
+      primary_publishing_organisation: [primary_publishing_organisation],
+    )
   end
 
   def route_type

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -28,7 +28,6 @@
   %>
 <% end %>
 
-
 <%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_will_continue_on, label: "Name of website where you apply" } do %>
   <%= f.text_field :licence_transaction_will_continue_on, class: 'form-control' %>
 <% end %>
@@ -39,4 +38,31 @@
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_licence_identifier, label: "Licence identifier" } do %>
   <%= f.text_field :licence_transaction_licence_identifier, class: 'form-control' %>
+<% end %>
+
+<%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
+  <%= f.select :primary_publishing_organisation,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control",
+        multiple: false,
+        data: {
+          placeholder: "Select a primary publishing organisation"
+        }
+      }
+  %>
+<% end %>
+<%= render "shared/form_group", f: f, field: :organisations, label: "Other associated organisations" do %>
+  <%= f.select :organisations,
+      organisations_options,
+      {},
+      {
+        class: "select2 form-control select-all-disabled",
+        multiple: true,
+        data: {
+          placeholder: "Select organisations"
+        }
+      }
+  %>
 <% end %>

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -43,7 +43,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      {},
+      primary_publishing_organisation_options(f),
       {
         class: "select2 form-control",
         multiple: false,

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -11,7 +11,7 @@
   },
   "show_summaries": true,
   "organisations": [
-    "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
   ],
   "document_noun": "licence",
   "facets": [

--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -39,6 +39,8 @@ module Importers
             licence_transaction_will_continue_on: details["will_continue_on"].presence,
             licence_transaction_continuation_link: details["continuation_link"].presence,
             licence_transaction_licence_identifier: licence_identifier(details),
+            primary_publishing_organisation: tagging["primary_publishing_organisation"] || ::LicenceTransaction.schema_organisations.first,
+            organisations: tagging["organisations"]&.split(";") || [],
             imported: true,
           )
 

--- a/spec/features/licence_transaction_spec.rb
+++ b/spec/features/licence_transaction_spec.rb
@@ -5,6 +5,12 @@ RSpec.feature "Creating a Licence", type: :feature do
   let(:licence_transaction) { FactoryBot.create(:licence_transaction) }
   let(:content_id)          { licence_transaction["content_id"] }
   let(:public_updated_at)   { licence_transaction["public_updated_at"] }
+  let(:organisations) do
+    [
+      { "content_id" => "12345", "title" => "Org 1" },
+      { "content_id" => "67890", "title" => "Org 2" },
+    ]
+  end
 
   before do
     log_in_as_editor(:licence_transaction_editor)
@@ -12,6 +18,8 @@ RSpec.feature "Creating a Licence", type: :feature do
 
     stub_publishing_api_has_content([licence_transaction], hash_including(document_type: LicenceTransaction.document_type))
     stub_publishing_api_has_item(licence_transaction)
+    stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
   end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -487,6 +487,19 @@ FactoryBot.define do
           "licence_transaction_will_continue_on" => "GOV.UK",
         }
       end
+
+      organisation_content_id { "6de6b795-9d30-4bd8-a257-ab9a6879e1ea" }
+      primary_publishing_org_content_id { "d31d9806-2644-4023-be70-5376cae84a06" }
+    end
+
+    initialize_with do
+      attributes.merge(
+        links: {
+          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          organisations: [organisation_content_id, primary_publishing_org_content_id],
+          primary_publishing_organisation: [primary_publishing_org_content_id],
+        },
+      )
     end
   end
 

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -183,22 +183,26 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
       ],
       redirects: [],
       update_type: "major",
-      links: { finder: %w[b8327c0c-a90d-47b6-992b-ea226b4d3306] },
+      links: {
+        finder: %w[b8327c0c-a90d-47b6-992b-ea226b4d3306],
+        organisations: %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
+        primary_publishing_organisation: %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
+      },
     }
   end
 
   def expected_patch_links_payload
     {
-      organisations: %w[af07d5a5-df63-4ddc-9383-6a666845ebe9],
-      primary_publishing_organisation: %w[af07d5a5-df63-4ddc-9383-6a666845ebe9],
+      organisations: %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
+      primary_publishing_organisation: %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
       taxons: [],
     }
   end
 
   def publising_api_get_links_response
     {
-      "organisations" => %w[af07d5a5-df63-4ddc-9383-6a666845ebe9],
-      "primary_publishing_organisation" => %w[af07d5a5-df63-4ddc-9383-6a666845ebe9],
+      "organisations" => %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
+      "primary_publishing_organisation" => %w[aa750cdf-7925-429d-a2b3-0d9fa47d2c48],
       "taxons" => [],
     }
   end


### PR DESCRIPTION
- As individual licences will be owned by several different organisations, we can't hardcode ownership as with other documents.
- Update to use the has_organisations? option as used by Statutory Instruments
- Set the initial Primary Publishing Organisation to the creating user's organisation.

https://trello.com/c/Y6GnGLLM/2007-use-current-users-department-as-primary-publisher-for-licences-in-specialist-publisher

## Screenshots

### In a new licence (edited by a GDS member, so GDS is auto-selected as Primary Publishing Organisation)
<img width="850" alt="Screenshot 2023-05-25 at 14 14 58" src="https://github.com/alphagov/specialist-publisher/assets/4225737/d839bbab-0879-4509-8dc0-688670b11de1">

### Editing an existing licence (created by another department, so GDS is not auto-selected as Primary Publishing Organisation), with additional organisations
<img width="835" alt="Screenshot 2023-05-25 at 14 36 23" src="https://github.com/alphagov/specialist-publisher/assets/4225737/f9158ed7-fd7a-42dd-ac9e-343cd6402e23">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
