### PR TITLE
Adding a rake task to unpublish and redirect a finder.

### DIFF
--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,0 +1,35 @@
+require "services"
+
+namespace :unpublish do
+  desc "Unpublish a Finder by slug and redirect the finder page to specific URL"
+  task :redirect_finder, %i[finder_slug redirect_url] => :environment do |_, args|
+    schema_file = Dir.glob("lib/documents/schemas/*.json").find do |file|
+      File.foreach(file).grep(/"base_path": "\/#{args.finder_slug}"/).any?
+    end
+
+    if schema_file.nil?
+      puts "Could not find any finders with that slug. Please check again."
+      next
+    end
+
+    schema = MultiJson.load(File.read(schema_file))
+    puts "=== Finder found ==="
+    puts "Slug: #{args.finder_slug}"
+    puts "Finder name: #{schema['name']}"
+    puts "Content ID: #{schema['content_id']}"
+    puts "Redirecting to: #{args.redirect_url}"
+
+    begin
+      response = GdsApi.publishing_api.unpublish(
+        schema["content_id"],
+        type: "redirect",
+        alternative_path: args.redirect_url,
+        discard_drafts: true,
+      )
+      puts "Publishing API response #{response.code}: #{response.raw_response_body}"
+      puts "Finder unpublished"
+    rescue GdsApi::HTTPServerError => e
+      puts "Error unpublishing finder: #{e.inspect}"
+    end
+  end
+end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,20 +1,13 @@
 require "services"
 
 namespace :unpublish do
-  desc "Unpublish a Finder by slug and redirect the finder page to specific URL"
-  task :redirect_finder, %i[finder_slug redirect_url] => :environment do |_, args|
-    schema_file = Dir.glob("lib/documents/schemas/*.json").find do |file|
-      File.foreach(file).grep(/"base_path": "\/#{args.finder_slug}"/).any?
-    end
+  desc "Unpublish a Finder by file name and redirect the finder page to specific URL"
+  task :redirect_finder, %i[finder_file redirect_url] => :environment do |_, args|
+    require "finder_loader"
 
-    if schema_file.nil?
-      puts "Could not find any finders with that slug. Please check again."
-      next
-    end
-
-    schema = MultiJson.load(File.read(schema_file))
+    schema = FinderLoader.new.finder(args.finder_file).first[:file]
     puts "=== Finder found ==="
-    puts "Slug: #{args.finder_slug}"
+    puts "Slug: #{schema['base_path']}"
     puts "Finder name: #{schema['name']}"
     puts "Content ID: #{schema['content_id']}"
     puts "Redirecting to: #{args.redirect_url}"

--- a/spec/lib/tasks/unpublish_spec.rb
+++ b/spec/lib/tasks/unpublish_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "unpublish rake tasks", type: :task do
+  describe "unpublish:redirect_finder" do
+    let(:output) { StringIO.new }
+    let(:task) { Rake::Task["unpublish:redirect_finder"] }
+    before { $stdout = output }
+    after { $stdout = STDOUT }
+
+    before(:each) do
+      task.reenable
+      stub_any_publishing_api_unpublish
+    end
+
+    it "returns error message if incorrect finder slug is given" do
+      task.invoke("aaib-testing", "https://service.gov.uk")
+      expect(output.string).to include("Could not find any finders with that slug. Please check again.")
+    end
+
+    it "unpublishes finder with redirect" do
+      content_id = MultiJson.load(File.read("lib/documents/schemas/aaib_reports.json"))["content_id"]
+      task.invoke("aaib-reports", "https://service.gov.uk")
+      expect(output.string).to include("Publishing API response 200")
+      expect(output.string).to include("Finder unpublished")
+      assert_publishing_api_unpublish(
+        content_id,
+        type: "redirect",
+        alternative_path: "https://service.gov.uk",
+        discard_drafts: true,
+      )
+    end
+
+    it "returns error message if publishing API errors" do
+      stub_any_publishing_api_unpublish.and_raise(GdsApi::HTTPServerError.new(500))
+      task.invoke("aaib-reports", "https://service.gov.uk")
+      expect(output.string).to include("Error unpublishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>")
+    end
+  end
+end

--- a/spec/lib/tasks/unpublish_spec.rb
+++ b/spec/lib/tasks/unpublish_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe "unpublish rake tasks", type: :task do
     end
 
     it "returns error message if incorrect finder slug is given" do
-      task.invoke("aaib-testing", "https://service.gov.uk")
-      expect(output.string).to include("Could not find any finders with that slug. Please check again.")
+      expect { task.invoke("aaib_testing", "https://service.gov.uk") }.to raise_error("Could not find file: lib/documents/schemas/aaib_testing.json")
     end
 
     it "unpublishes finder with redirect" do
       content_id = MultiJson.load(File.read("lib/documents/schemas/aaib_reports.json"))["content_id"]
-      task.invoke("aaib-reports", "https://service.gov.uk")
+      task.invoke("aaib_reports", "https://service.gov.uk")
       expect(output.string).to include("Publishing API response 200")
       expect(output.string).to include("Finder unpublished")
       assert_publishing_api_unpublish(
@@ -32,7 +31,7 @@ RSpec.describe "unpublish rake tasks", type: :task do
 
     it "returns error message if publishing API errors" do
       stub_any_publishing_api_unpublish.and_raise(GdsApi::HTTPServerError.new(500))
-      task.invoke("aaib-reports", "https://service.gov.uk")
+      task.invoke("aaib_reports", "https://service.gov.uk")
       expect(output.string).to include("Error unpublishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>")
     end
   end


### PR DESCRIPTION
There is request coming from departments to decommisssion a finder and redirect it to a different part of service.gov.uk. The rake task will enable us to get this work done in time, with the aim to expand and support unpublishing documents later on.

https://trello.com/c/ZBF26F1U/1322-redirect-and-potentially-archive-old-finder-by-30th-may

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
