### PR TITLE
Outputs missing licences as list

### DIFF
--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -13,11 +13,12 @@ module Importers
       def call
         return tagging_csv_validator.errors unless tagging_csv_validator.valid?
 
+        missing_licences = []
         licences.each do |licence|
           tagging = tags_for_licence(licence["base_path"])
 
           unless tagging
-            puts "Not imported licence as missing from tagging file: #{licence['base_path']}"
+            missing_licences << licence["base_path"]
             next
           end
 
@@ -63,6 +64,10 @@ module Importers
           publish(new_content_id)
 
           puts "Published: #{new_licence.base_path}"
+        end
+
+        if missing_licences.present?
+          puts "Missing licences from tagging file: #{missing_licences}"
         end
       end
 

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
   end
 
   def licence_doesnt_exist_in_tagging
-    "Not imported licence as missing from tagging file: /non-existant\n"
+    "Missing licences from tagging file: [\"/non-existant\"]\n"
   end
 
   def csv_invalid_message


### PR DESCRIPTION
Previously, missing licences were outputted one by one which meant it was hard to deduce the full list of missing licences. We now output them all at the end which will be easier to compare.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
