### PR TITLE
Set default Publishing Org on two document types

### DIFF
--- a/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
@@ -24,7 +24,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      {},
+      primary_publishing_organisation_options(f),
       {
         class: "select2 form-control",
         multiple: false,

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -41,7 +41,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      {},
+      primary_publishing_organisation_options(f),
       {
         class: "select2 form-control",
         multiple: false,


### PR DESCRIPTION
- Statutory Instruments
- Flood and Coastal Erosion Risk Management Research Reports

Updates these to select the current user's organisation as the primary publishing organisation in new records, using code introduced with the new Licence Transaction model. We have confirmed with content second line that a default is desirable for these document types.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
