### PR TITLE
Remove pre-production flag from new licence finder.

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -1,5 +1,4 @@
 {
-  "pre_production": true,
   "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
   "base_path": "/find-licences",
   "format_name": "Find and apply for licences",


### PR DESCRIPTION
Merge only when licence-finder is ready to go live.

https://trello.com/c/I7mdsWfU/2048-create-pr-removing-preproduction-flag-for-new-licence-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
