### PR TITLE
Add related links to ai techniques finder

### DIFF
--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -17,6 +17,9 @@
     "1405edcb-943d-42d2-8ec8-c51cd58335a5",
     "c352c234-8083-47ec-8a4b-0edd45c31263"
   ],
+  "related": [
+    "4519b26b-6312-4855-bc45-828123bd8a2f"
+  ],
   "document_noun": "case study",
   "facets": [
     {


### PR DESCRIPTION
CDEI have requested to add a page to the related links section on the ai assurance portfolio techniques specialist finder.

Trello card: https://trello.com/c/iKNrkLou/1387-add-a-related-link-to-the-cdei-finder