### PR TITLE
Finder loader via slug

### DIFF
--- a/app/lib/finder_loader.rb
+++ b/app/lib/finder_loader.rb
@@ -10,19 +10,6 @@ class FinderLoader
     end
   end
 
-  def finder(name)
-    json_schema = "lib/documents/schemas/#{name}.json"
-
-    if File.exist?(json_schema)
-      [{
-        file: MultiJson.load(File.read(json_schema)),
-        timestamp: File.mtime(json_schema),
-      }]
-    else
-      raise "Could not find file: #{json_schema}"
-    end
-  end
-
   def finder_by_slug(slug)
     schema_file = files.find do |file|
       File.foreach(file).grep(/"base_path": "\/#{slug}"/).any?

--- a/app/lib/finder_loader.rb
+++ b/app/lib/finder_loader.rb
@@ -23,6 +23,19 @@ class FinderLoader
     end
   end
 
+  def finder_by_slug(slug)
+    schema_file = files.find do |file|
+      File.foreach(file).grep(/"base_path": "\/#{slug}"/).any?
+    end
+
+    raise "Could not find any schema with slug: #{slug}" if schema_file.nil?
+
+    {
+      file: MultiJson.load(File.read(schema_file)),
+      timestamp: File.mtime(schema_file),
+    }
+  end
+
 private
 
   def files

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,34 +6,24 @@ namespace :publishing_api do
     require "finder_loader"
     require "publishing_api_finder_publisher"
 
-    finder_loader = FinderLoader.new
-
     begin
-      PublishingApiFinderPublisher.new(finder_loader.finders).call
+      PublishingApiFinderPublisher.new(FinderLoader.new.finders).call
     rescue GdsApi::HTTPServerError => e
       puts "Error publishing finder: #{e.inspect}"
     end
   end
 
   desc "Publish a single Finder to the Publishing API"
-  task :publish_finder, [:name] => :environment do |_, args|
+  task :publish_finder, [:slug] => :environment do |_, args|
     require "finder_loader"
     require "publishing_api_finder_publisher"
 
-    begin
-      finder_loader = FinderLoader.new
-      finder = finder_loader.finder(args.name)
-    rescue StandardError => e
-      puts "Error: #{e.inspect}"
-    end
-
-    if finder
-      begin
-        PublishingApiFinderPublisher.new(finder).call
-      rescue GdsApi::HTTPServerError => e
-        puts "Error publishing finder: #{e.inspect}"
-      end
-    end
+    finder = FinderLoader.new.finder_by_slug(args.slug)
+    PublishingApiFinderPublisher.new([finder]).call
+  rescue GdsApi::HTTPServerError => e
+    puts "Error publishing finder: #{e.inspect}"
+  rescue StandardError => e
+    puts "Error: #{e.inspect}"
   end
 
   desc "Patch links for all instances of specified document type in Publishing API."

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,28 +1,28 @@
 require "services"
 
 namespace :unpublish do
-  desc "Unpublish a Finder by file name and redirect the finder page to specific URL"
-  task :redirect_finder, %i[finder_file redirect_url] => :environment do |_, args|
+  desc "Unpublish a Finder by slug and redirect the finder page to specific URL"
+  task :redirect_finder, %i[slug redirect_url] => :environment do |_, args|
     require "finder_loader"
 
-    schema = FinderLoader.new.finder(args.finder_file).first[:file]
+    schema = FinderLoader.new.finder_by_slug(args.slug)[:file]
     puts "=== Finder found ==="
     puts "Slug: #{schema['base_path']}"
     puts "Finder name: #{schema['name']}"
     puts "Content ID: #{schema['content_id']}"
     puts "Redirecting to: #{args.redirect_url}"
 
-    begin
-      response = GdsApi.publishing_api.unpublish(
-        schema["content_id"],
-        type: "redirect",
-        alternative_path: args.redirect_url,
-        discard_drafts: true,
-      )
-      puts "Publishing API response #{response.code}: #{response.raw_response_body}"
-      puts "Finder unpublished"
-    rescue GdsApi::HTTPServerError => e
-      puts "Error unpublishing finder: #{e.inspect}"
-    end
+    response = GdsApi.publishing_api.unpublish(
+      schema["content_id"],
+      type: "redirect",
+      alternative_path: args.redirect_url,
+      discard_drafts: true,
+    )
+    puts "Publishing API response #{response.code}: #{response.raw_response_body}"
+    puts "Finder unpublished"
+  rescue GdsApi::HTTPServerError => e
+    puts "Error unpublishing finder: #{e.inspect}"
+  rescue StandardError => e
+    puts "Error: #{e.inspect}"
   end
 end

--- a/spec/lib/finder_loader_spec.rb
+++ b/spec/lib/finder_loader_spec.rb
@@ -3,48 +3,28 @@ require "finder_loader"
 
 RSpec.describe FinderLoader do
   it "returns matching finder data objects" do
-    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
-                      .and_return('{"name":"format-1"}')
-    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
-                      .and_return("yesterday")
-
     expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
       lib/documents/schemas/format-1.json
       lib/documents/schemas/format-2.json
     ])
+
+    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
+      .and_return('{"name":"format-1"}')
+    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
+      .and_return("yesterday")
     expect(File).to receive(:read).with("lib/documents/schemas/format-2.json")
       .and_return('{"name":"format-2"}')
     expect(File).to receive(:mtime).with("lib/documents/schemas/format-2.json")
       .and_return("today")
 
-    loader = FinderLoader.new
-    expect(loader.finders).to match_array([
+    expect(FinderLoader.new.finders).to match_array([
       {
         file: { "name" => "format-1" },
         timestamp: "yesterday",
       },
       {
-
         file: { "name" => "format-2" },
         timestamp: "today",
-      },
-    ])
-  end
-
-  it "returns one matching finder data object" do
-    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
-                      .and_return('{"name":"format-1"}')
-    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
-                      .and_return("yesterday")
-
-    expect(File).to receive(:exist?).with("lib/documents/schemas/format-1.json")
-                      .and_return(true)
-
-    loader = FinderLoader.new
-    expect(loader.finder("format-1")).to match_array([
-      {
-        file: { "name" => "format-1" },
-        timestamp: "yesterday",
       },
     ])
   end

--- a/spec/lib/finder_loader_spec.rb
+++ b/spec/lib/finder_loader_spec.rb
@@ -2,13 +2,12 @@ require "spec_helper"
 require "finder_loader"
 
 RSpec.describe FinderLoader do
-  before do
+  it "returns matching finder data objects" do
     expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
                       .and_return('{"name":"format-1"}')
     expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
                       .and_return("yesterday")
-  end
-  it "returns matching finder data objects" do
+
     expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
       lib/documents/schemas/format-1.json
       lib/documents/schemas/format-2.json
@@ -33,6 +32,11 @@ RSpec.describe FinderLoader do
   end
 
   it "returns one matching finder data object" do
+    expect(File).to receive(:read).with("lib/documents/schemas/format-1.json")
+                      .and_return('{"name":"format-1"}')
+    expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
+                      .and_return("yesterday")
+
     expect(File).to receive(:exist?).with("lib/documents/schemas/format-1.json")
                       .and_return(true)
 
@@ -43,5 +47,25 @@ RSpec.describe FinderLoader do
         timestamp: "yesterday",
       },
     ])
+  end
+
+  it "returns one matching finder data object by slug" do
+    expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
+      spec/fixtures/documents/schemas/licence_transactions.json
+    ])
+    expect(File).to receive(:mtime).with("spec/fixtures/documents/schemas/licence_transactions.json")
+                                   .and_return("today")
+
+    loaded_finder = FinderLoader.new.finder_by_slug("find-licences")
+    expect(loaded_finder[:file]).to include({ "base_path" => "/find-licences" })
+    expect(loaded_finder[:timestamp]).to eq("today")
+  end
+
+  it "errors when no finder is found with slug" do
+    expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
+      spec/fixtures/documents/schemas/licence_transactions.json
+    ])
+
+    expect { FinderLoader.new.finder_by_slug("test-slug") }.to raise_error("Could not find any schema with slug: test-slug")
   end
 end

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -43,21 +43,21 @@ RSpec.describe "publishing_api rake tasks", type: :task do
       stub_any_publishing_api_publish
     end
 
-    context "incorrect file name is given" do
+    context "incorrect slug is given" do
       it "returns an error message" do
-        error_message = %r{#<RuntimeError: Could not find file: lib/documents/schemas/aaib_reportings.json>}
+        error_message = %r{#<RuntimeError: Could not find any schema with slug: aaib-reportings>}
 
-        expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reportings") }.to output(error_message).to_stdout
+        expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib-reportings") }.to output(error_message).to_stdout
       end
     end
 
-    context "correct file name given" do
+    context "correct slug given" do
       context "no server error present" do
         it "publishes a single finder to the Publishing API" do
           schema = "lib/documents/schemas/aaib_reports.json"
           content_id = MultiJson.load(File.read(schema))["content_id"]
 
-          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reports") }.to output.to_stdout
+          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib-reports") }.to output.to_stdout
 
           assert_publishing_api_put_content(content_id)
           assert_publishing_api_patch_links(content_id)
@@ -70,7 +70,7 @@ RSpec.describe "publishing_api rake tasks", type: :task do
           stub_any_publishing_api_put_content.and_raise(GdsApi::HTTPServerError.new(500))
           error_message = %r{Error publishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>}
 
-          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib_reports") }.to output(error_message).to_stdout
+          expect { Rake::Task["publishing_api:publish_finder"].invoke("aaib-reports") }.to output(error_message).to_stdout
         end
       end
     end

--- a/spec/lib/tasks/unpublish_spec.rb
+++ b/spec/lib/tasks/unpublish_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "unpublish rake tasks", type: :task do
   describe "unpublish:redirect_finder" do
-    let(:output) { StringIO.new }
+    let(:test_output) { StringIO.new }
     let(:task) { Rake::Task["unpublish:redirect_finder"] }
-    before { $stdout = output }
+    before { $stdout = test_output }
     after { $stdout = STDOUT }
 
     before(:each) do
@@ -13,14 +13,15 @@ RSpec.describe "unpublish rake tasks", type: :task do
     end
 
     it "returns error message if incorrect finder slug is given" do
-      expect { task.invoke("aaib_testing", "https://service.gov.uk") }.to raise_error("Could not find file: lib/documents/schemas/aaib_testing.json")
+      error_message = %r{#<RuntimeError: Could not find any schema with slug: aaib-testing>}
+      expect { task.invoke("aaib-testing", "https://service.gov.uk") }.to output(error_message).to_stdout
     end
 
     it "unpublishes finder with redirect" do
       content_id = MultiJson.load(File.read("lib/documents/schemas/aaib_reports.json"))["content_id"]
-      task.invoke("aaib_reports", "https://service.gov.uk")
-      expect(output.string).to include("Publishing API response 200")
-      expect(output.string).to include("Finder unpublished")
+      task.invoke("aaib-reports", "https://service.gov.uk")
+      expect(test_output.string).to include("Publishing API response 200")
+      expect(test_output.string).to include("Finder unpublished")
       assert_publishing_api_unpublish(
         content_id,
         type: "redirect",
@@ -31,8 +32,8 @@ RSpec.describe "unpublish rake tasks", type: :task do
 
     it "returns error message if publishing API errors" do
       stub_any_publishing_api_unpublish.and_raise(GdsApi::HTTPServerError.new(500))
-      task.invoke("aaib_reports", "https://service.gov.uk")
-      expect(output.string).to include("Error unpublishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>")
+      error_message = %r{Error unpublishing finder: #<GdsApi::HTTPServerError: GdsApi::HTTPServerError>}
+      expect { task.invoke("aaib-reports", "https://service.gov.uk") }.to output(error_message).to_stdout
     end
   end
 end


### PR DESCRIPTION
Support tasks for publishing and unpublishing specialist finders were previously done via filename.
However, filename and slug are wildly different in specialist publisher. In order to minimise confusion and ease of support, slug should be used since it is external facing and will likely be used in user queries and visible on the website. 

Adding functionality to load by slug, and removing functionality to load by filename

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
