### PR TITLE
Retag BEIS finder as DBT

### DIFF
--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -11,11 +11,7 @@
   "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",
   "signup_copy": "You'll get an email each time a scheme is updated or a new scheme is published.",
   "organisations": [
-    "2bde479a-97f2-42b5-986a-287a623c2a1c",
     "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
-  ],
-  "editing_organisations": [
-    "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
   ],
   "related": ["3d582854-ffc7-4d41-9266-ee87b9e6d230", "89edffd2-3046-40bd-810c-cc1a13c05b6a"],
   "topics": [


### PR DESCRIPTION
The [Finance and support for your business][1] finder was dual-tagged as Department for Business, Energy & Industrial Strategy (BEIS) and Department for Business and Trade (DBT).

However BEIS is now closed and has been replaced by DBT, so we need to retag this finder accordingly.

This also removes an unrelated organisation which had seeminly accidentally been granted editing permissions to these documents.

After this change, DBT will be the only department with permission to edit these documents, and the only one tagged on the frontend too.

### After deployment

After this change has been deployed, I'll need to run the following Rake tasks to republish the finder and all associated documents:

```
rake publishing_api:publish_finder[business_finance_support_schemes]
rake republish:document_type[business_finance_support_scheme]
```

[1]: https://www.gov.uk/business-finance-support

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
