### PR TITLE
Add organisation filter for documents that allow organisation tagging

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,6 +4,7 @@ class DocumentsController < ApplicationController
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::UrlHelper
+  include OrganisationsHelper
 
   before_action :fetch_document, except: %i[index new create]
   before_action :check_authorisation, if: :document_type_slug
@@ -12,7 +13,10 @@ class DocumentsController < ApplicationController
     page = filtered_page_param(params[:page])
     per_page = filtered_per_page_param(params[:per_page])
     @query = params[:query]
-    @response = current_format.all(page, per_page, query: @query)
+    if current_format.has_organisations?
+      @organisation = selected_organisation_or_current(params[:organisation])
+    end
+    @response = current_format.all(page, per_page, query: @query, organisation: @organisation)
     @paged_documents = PaginationPresenter.new(@response, per_page)
   end
 

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -3,6 +3,10 @@ module OrganisationsHelper
     Organisation.all.map { |o| [o.title, o.content_id] }
   end
 
+  def organisations_options_with_all
+    [["All organisations", "all"]].concat(organisations_options)
+  end
+
   def selected_organisation_or_current(organisation)
     (organisation.presence || current_user.organisation_content_id)
   end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -3,9 +3,7 @@ module OrganisationsHelper
     Organisation.all.map { |o| [o.title, o.content_id] }
   end
 
-  def primary_publishing_organisation_options(form)
-    return {} if form.object.primary_publishing_organisation.present?
-
-    { selected: current_user.organisation_content_id }
+  def selected_organisation_or_current(organisation)
+    (organisation.presence || current_user.organisation_content_id)
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,6 +1,6 @@
 module OrganisationsHelper
   def organisations_options
-    Organisation.all.map { |o| [o.title, o.content_id] }
+    Organisation.all.map { |o| [o.title, o.content_id] }.sort_by { |title, _id| title.downcase.strip }
   end
 
   def organisations_options_with_all

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -219,8 +219,8 @@ class Document
     DocumentBuilder.build(self, payload)
   end
 
-  def self.all(page, per_page, query: nil)
-    AllDocumentsFinder.all(page, per_page, query, document_type)
+  def self.all(page, per_page, query: nil, organisation: nil)
+    AllDocumentsFinder.all(page, per_page, query, document_type, organisation)
   end
 
   def self.find_each(&block)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -354,7 +354,7 @@ class Document
     false
   end
 
-  def has_organisations?
+  def self.has_organisations?
     false
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -186,16 +186,14 @@ class Document
     finder_schema.options_for(facet)
   end
 
-  def schema_organisations
-    finder_schema.organisations
-  end
+  delegate :organisations, to: :finder_schema
 
   def schema_editing_organisations
     finder_schema.editing_organisations
   end
 
   def self.schema_organisations
-    new.schema_organisations
+    finder_schema.organisations
   end
 
   def self.schema_editing_organisations

--- a/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
+++ b/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
@@ -35,7 +35,7 @@ class FloodAndCoastalErosionRiskManagementResearchReport < Document
     )
   end
 
-  def has_organisations?
+  def self.has_organisations?
     true
   end
 end

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -25,7 +25,7 @@ class LicenceTransaction < Document
     "Licence"
   end
 
-  def has_organisations?
+  def self.has_organisations?
     true
   end
 

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -39,7 +39,7 @@ class StatutoryInstrument < Document
     )
   end
 
-  def has_organisations?
+  def self.has_organisations?
     true
   end
 

--- a/app/presenters/document_links_presenter.rb
+++ b/app/presenters/document_links_presenter.rb
@@ -7,7 +7,7 @@ class DocumentLinksPresenter
     {
       content_id: document.content_id,
       links: {
-        organisations: document.schema_organisations,
+        organisations: document.organisations | [document.primary_publishing_organisation],
         primary_publishing_organisation: [document.primary_publishing_organisation],
         taxons: document.taxons,
       },

--- a/app/services/all_documents_finder.rb
+++ b/app/services/all_documents_finder.rb
@@ -11,7 +11,7 @@ class AllDocumentsFinder
     }
   end
 
-  def self.all(page, per_page, query, document_type)
+  def self.all(page, per_page, query, document_type, organisation)
     params = default_find_params(document_type).merge(
       fields: %i[
         base_path
@@ -26,7 +26,11 @@ class AllDocumentsFinder
       per_page:,
       order: "-last_edited_at",
     )
-    params[:q] = query if query.present?
+
+    (params[:q] = query) if query.present?
+    if organisation != "all" && organisation
+      params[:link_organisations] = organisation
+    end
 
     Services.publishing_api.get_content_items(params)
   end

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -22,7 +22,7 @@ class DocumentBuilder
 
     set_update_type(document, payload)
 
-    if document.has_organisations?
+    if klass.has_organisations?
       primary_organisation_ary = payload["links"]["primary_publishing_organisation"]
       document.primary_publishing_organisation = primary_organisation_ary.first
       document.organisations = payload["links"]["organisations"] - primary_organisation_ary

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -10,12 +10,20 @@
   <div class="sidebar col-md-3">
     <%= link_to "Add another #{current_format.title}", new_document_path(current_format.slug), class: 'action-link' %>
     <%= form_tag(documents_path(current_format.slug), method: :get, class: "add-vertical-margins well") do %>
+      <% if current_format.has_organisations? %>
+        <%= label_tag "organisation", "Organisation" %>
+        <%= select_tag "organisation",
+              options_for_select(organisations_options_with_all, selected_organisation_or_current(@organisation)),
+              class: "select2 form-control add-bottom-margin" %>
+      <% end %>
+
       <%= label_tag "query", "Search" %>
-      <%= text_field_tag("query", params[:query], class: "form-control add-bottom-margin") %>
+      <%= text_field_tag("query", @query, class: "form-control add-bottom-margin") %>
+
       <%= submit_tag "Search", name: nil, class: "btn btn-default" %>
     <% end %>
     <% if current_format.exportable? %>
-      <%= link_to "Export document list to CSV", export_documents_path(current_format.slug, query: params[:query]) %>
+      <%= link_to "Export document list to CSV", export_documents_path(current_format.slug, query: @query) %>
     <% end %>
   </div>
 

--- a/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_eu_withdrawal_act_2018_statutory_instruments.html.erb
@@ -24,7 +24,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      primary_publishing_organisation_options(f),
+      { selected: selected_organisation_or_current(@document.primary_publishing_organisation) },
       {
         class: "select2 form-control",
         multiple: false,

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -41,7 +41,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      primary_publishing_organisation_options(f),
+      { selected: selected_organisation_or_current(@document.primary_publishing_organisation) },
       {
         class: "select2 form-control",
         multiple: false,

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -43,7 +43,7 @@
 <%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
-      primary_publishing_organisation_options(f),
+      { selected: selected_organisation_or_current(@document.primary_publishing_organisation) },
       {
         class: "select2 form-control",
         multiple: false,

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -56,6 +56,7 @@ RSpec.feature "Access control", type: :feature do
 
   context "as a statutory instrument editor" do
     before do
+      stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
       log_in_as_editor(:statutory_instrument_editor)
     end
 

--- a/spec/features/creating_a_licence_spec.rb
+++ b/spec/features/creating_a_licence_spec.rb
@@ -24,8 +24,8 @@ RSpec.feature "Creating a Licence", type: :feature do
     stub_any_publishing_api_patch_links
   end
 
-  scenario "adding a new licence" do
-    visit "/find-licences"
+  scenario "creating a new licence" do
+    visit "/licences"
     click_link "Add another Licence"
     expect(page.status_code).to eq(200)
     expect(page.current_path).to eq("/licences/new")

--- a/spec/features/filtering_by_organisation_spec.rb
+++ b/spec/features/filtering_by_organisation_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.feature "Searching and filtering by organisation", type: :feature do
+  let(:current_user_org_content_id) { "e338f02d-82a3-4c6c-8a36-df3050869d97" }
+  let(:org_content_id_two) { "79e140cc-2303-43c2-8c5f-fa41fbf5e319" }
+  let(:org_content_id_three) { "aada63d7-c570-4306-9ce2-a2c340d807a1" }
+  let(:org_content_id_four) { "728344bc-69b4-4049-bf4b-e58196b82fc8" }
+  let!(:request) do
+    current_user_org_licence = FactoryBot.create(:licence_transaction,
+                                                 title: "Example licence 1",
+                                                 primary_publishing_org_content_id: current_user_org_content_id,
+                                                 organisation_content_id: org_content_id_two)
+
+    stub_publishing_api_has_content(
+      [current_user_org_licence],
+      hash_including(document_type: LicenceTransaction.document_type, link_organisations: current_user_org_content_id),
+    )
+  end
+
+  before do
+    organisations = [
+      { "title" => "Current users org", "content_id" => current_user_org_content_id },
+      { "title" => "Diabolical org", "content_id" => org_content_id_three },
+      { "title" => "Excellent org", "content_id" => org_content_id_two },
+      { "title" => "Mysterious org", "content_id" => org_content_id_four },
+    ]
+
+    stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+    log_in_as_editor(:licence_transaction_editor)
+  end
+
+  context "visiting the licence index page without selecting an organisation" do
+    scenario "viewing licences from current users organisation" do
+      visit "/licences"
+
+      expect(page.status_code).to eq(200)
+      expect(request).to have_been_requested
+      expect(page).to have_selector("li.document", count: 1)
+      expect(page).to have_content("Example licence 1")
+      expect(page).to have_select(
+        "Organisation",
+        selected: "Current users org",
+        options: ["All organisations", "Current users org", "Diabolical org", "Excellent org", "Mysterious org"],
+      )
+    end
+  end
+
+  context "visiting the licence index page and selecting an organisation" do
+    let!(:second_request) do
+      other_org_licence = FactoryBot.create(:licence_transaction,
+                                            title: "Example licence 2",
+                                            primary_publishing_org_content_id: org_content_id_three,
+                                            organisation_content_id: org_content_id_four)
+
+      stub_publishing_api_has_content(
+        [other_org_licence],
+        hash_including(document_type: LicenceTransaction.document_type, link_organisations: org_content_id_four),
+      )
+    end
+
+    scenario "viewing licences from selected organisation" do
+      visit "/licences"
+
+      select "Mysterious org", from: "Organisation"
+
+      click_button "Search"
+
+      expect(page.status_code).to eq(200)
+      expect(second_request).to have_been_requested
+      expect(page).to have_select("Organisation", selected: "Mysterious org")
+      expect(page).to have_selector("li.document", count: 1)
+      expect(page).to have_content("Example licence 2")
+    end
+  end
+end

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -79,6 +79,8 @@ RSpec.feature "Searching and filtering", type: :feature do
 
       visit "/cma-cases"
 
+      expect(page).not_to have_select("Organisation")
+
       fill_in "Search", with: "0"
       click_button "Search"
       expect(page).to have_content("Example CMA Case 0")

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
 
   factory :licence_transaction_editor, parent: :user do
     permissions { %w[signin licence_transaction_editor] }
+    organisation_content_id { "e338f02d-82a3-4c6c-8a36-df3050869d97" }
   end
 
   factory :statutory_instrument_editor, parent: :user do

--- a/spec/presenters/document_links_presenter_spec.rb
+++ b/spec/presenters/document_links_presenter_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe DocumentLinksPresenter do
     it "set primary publishing organisations for #{klass}" do
       document = klass.new
       document.content_id = "a-content-id"
-      allow(document).to receive(:schema_organisations).and_return("an-organisation-id")
+      allow(document).to receive(:organisations).and_return(%w[an-organisation-id])
 
       presenter = DocumentLinksPresenter.new(document)
       presented_data = presenter.to_json
 
       expect(presented_data[:content_id]).to eq("a-content-id")
-      expect(presented_data[:links][:organisations]).to eq("an-organisation-id")
+      expect(presented_data[:links][:organisations]).to eq(["an-organisation-id", primary_publishing_organisation_id])
       expect(presented_data[:links][:primary_publishing_organisation]).to eq([primary_publishing_organisation_id])
     end
   end

--- a/spec/services/all_documents_finder_spec.rb
+++ b/spec/services/all_documents_finder_spec.rb
@@ -3,6 +3,62 @@ require "spec_helper"
 RSpec.describe AllDocumentsFinder do
   subject { described_class }
 
+  describe ".all" do
+    let(:documents) do
+      [
+        FactoryBot.create(
+          :business_finance_support_scheme,
+          base_path: "/bfss/1",
+          title: "Scheme #1",
+        ),
+      ]
+    end
+
+    let(:request_params) do
+      {
+        publishing_app: "specialist-publisher",
+        document_type: "business_finance_support_scheme",
+        order: "-last_edited_at",
+        locale: "all",
+        fields: %i[base_path content_id locale last_edited_at title publication_state state_history],
+        page: 1,
+        per_page: 1,
+      }
+    end
+
+    it "returns all documents without organisation filter or search query" do
+      request = stub_publishing_api_has_content(documents, request_params)
+
+      response = subject.all(1, 1, nil, "business_finance_support_scheme", nil)
+
+      expect(request).to have_been_requested
+      expect(response["results"].length).to eq(1)
+      expect(response["results"][0]["title"]).to eq "Scheme #1"
+    end
+
+    it "returns all documents from all organisations" do
+      request = stub_publishing_api_has_content(documents, request_params)
+
+      response = subject.all(1, 1, nil, "business_finance_support_scheme", "all")
+
+      expect(request).to have_been_requested
+      expect(response["results"].length).to eq(1)
+      expect(response["results"][0]["title"]).to eq "Scheme #1"
+    end
+
+    it "returns all documents with search and organisation filter" do
+      request_params[:q] = "Scheme"
+      request_params[:link_organisations] = "12345"
+      request = stub_publishing_api_has_content(documents, request_params)
+
+      response = subject.all(1, 1, "Scheme", "business_finance_support_scheme", "12345")
+
+      expect(request).to have_been_requested
+      expect(response["results"].length).to eq(1)
+      expect(response["results"][0]["title"]).to eq "Scheme #1"
+    end
+  end
+
   describe ".find_each" do
     it "does not yield anything if the publishing api response is empty" do
       publishing_api_has_no_content(BusinessFinanceSupportScheme)


### PR DESCRIPTION
Licences, flood management reports and statutory instrument document types allow tagging to organisations as part of document creation, as these editions could be tagged to any organisation, it makes sense to add an organisation filter on each documents index page. We expect licences to be tagged by 20+ organisations.

We select the users current signon org for the default value and include an "all" value which will return all documents.     

## Before

<img width="427" alt="Screenshot 2023-06-20 at 10 14 01" src="https://github.com/alphagov/specialist-publisher/assets/24479188/1e1f4d40-80dd-4e21-ac72-63cd45344e22">

## After

<img width="897" alt="Screenshot 2023-06-20 at 10 11 30" src="https://github.com/alphagov/specialist-publisher/assets/24479188/474721b2-3d27-415b-bde7-397a8be19928">
<img width="927" alt="Screenshot 2023-06-20 at 10 11 42" src="https://github.com/alphagov/specialist-publisher/assets/24479188/3d74e72e-b128-4244-bbb4-499a29ff9387">
<img width="853" alt="Screenshot 2023-06-20 at 10 11 59" src="https://github.com/alphagov/specialist-publisher/assets/24479188/d290a38c-9bd2-4e30-88ed-95cd3070baac">


Trello:
https://trello.com/c/Bposa6QR/2063-add-organisation-filter-to-the-backend-of-specialist-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
