### PR TITLE
Add label text property

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -51,6 +51,7 @@ private
       show_summaries: file.fetch("show_summaries", false),
       signup_link: file.fetch("signup_link", nil),
       summary: file.fetch("summary", nil),
+      label_text: file.fetch("label_text", nil),
       facets: file.fetch("facets", nil),
       default_order: file.fetch("default_order", nil),
       default_documents_per_page: 50,

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -5,6 +5,7 @@
   "format_name": "Find and apply for licences",
   "name": "Find a licence",
   "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul><div class='application-notice info-notice'><p>This may not include all the licences you need. It will be updated with more licences.</p></div>",
+  "label_text": "Search keywords, <span class=\"govuk-!-display-block govuk-!-font-size-16 govuk-!-margin-bottom-2\">for example 'sell alcohol'</span>",
   "default_order": "title",
   "filter": {
     "format": "licence_transaction"


### PR DESCRIPTION
## What

https://trello.com/c/UwVqYJjP/2065-change-frontend-text-for-search-boxes

Add label text property to change the label **Search** to **Keywords**, for licence finder (specialist finder) only, which may help users with entering keywords and not treating it like a Google search box.

## Why

There were examples in user research of users confusing the main search and the industry filter box, both on mobile and desktop, but particularly on mobile. A successful iteration will improve the usability of the tool.

## Anything else

- https://github.com/alphagov/finder-frontend/pull/3091
- https://github.com/alphagov/publishing-api/pull/2415