### PR TITLE
Skip identifier unique validation for same licence

### DIFF
--- a/app/validators/licence_identifier_unique_validator.rb
+++ b/app/validators/licence_identifier_unique_validator.rb
@@ -5,6 +5,8 @@ class LicenceIdentifierUniqueValidator < ActiveModel::EachValidator
     existing_licence_identifiers = []
 
     record.class.find_each do |licence|
+      next if record.content_id == licence.content_id
+
       existing_licence_identifiers << licence.licence_transaction_licence_identifier
     end
 

--- a/spec/validators/licence_identifier_unique_validator_spec.rb
+++ b/spec/validators/licence_identifier_unique_validator_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe LicenceIdentifierUniqueValidator do
     end
   end
 
+  context "when the same, existing record is validated" do
+    it "validates successfully" do
+      subject.validate_each(
+        existing_record,
+        :licence_transaction_licence_identifier,
+        existing_record.licence_transaction_licence_identifier,
+      )
+
+      expect(existing_record.errors).to be_blank
+    end
+  end
+
   context "when the records identifier is not unique" do
     let(:record) do
       LicenceTransaction.new(licence_transaction_licence_identifier: existing_identifier)


### PR DESCRIPTION
Previously, the validation failed if the same licence was saved after creation. We now remove the validation record's identifier from the list when checked which mitigates the issue.

Trello:
https://trello.com/c/uf3E7dCl/1974-add-validation-to-new-licence-document-fields

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
