### PR TITLE
Strip will continue on if link doesn't exist

### DIFF
--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -49,13 +49,13 @@ module Importers
 
           new_licence.change_note = "Imported from Publisher"
 
-          unless new_licence.valid?
-            puts "[ERROR] licence: #{new_licence.base_path} has validation errors: #{new_licence.errors.inspect}"
+          if new_licence_already_imported?(new_licence.base_path)
+            puts "Skipping as licence: #{new_licence.base_path} is already imported"
             next
           end
 
-          if new_licence_already_imported?(new_licence.base_path)
-            puts "Skipping as licence: #{new_licence.base_path} is already imported"
+          unless new_licence.valid?
+            puts "[ERROR] licence: #{new_licence.base_path} has validation errors: #{new_licence.errors.inspect}"
             next
           end
 

--- a/lib/importers/licence_transaction/licence_importer.rb
+++ b/lib/importers/licence_transaction/licence_importer.rb
@@ -39,7 +39,7 @@ module Importers
             update_type: "major",
             licence_transaction_location: tagging["locations"],
             licence_transaction_industry: tagging["industries"],
-            licence_transaction_will_continue_on: details["will_continue_on"].presence,
+            licence_transaction_will_continue_on: will_continue_on(details),
             licence_transaction_continuation_link: details["continuation_link"].presence,
             licence_transaction_licence_identifier: licence_identifier(details),
             primary_publishing_organisation: tagging["primary_publishing_organisation"],
@@ -205,6 +205,10 @@ module Importers
 
       def licence_identifier(details)
         details["licence_identifier"] if details["continuation_link"].blank?
+      end
+
+      def will_continue_on(details)
+        details["will_continue_on"] if details["continuation_link"].present?
       end
     end
   end

--- a/spec/lib/importers/licence_transaction/licence_importer_spec.rb
+++ b/spec/lib/importers/licence_transaction/licence_importer_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Importers::LicenceTransaction::LicenceImporter do
       publishing_api_licences_response.tap { |licences| licences.first["title"] = nil }
     end
 
+    before do
+      stub_publishing_api_has_content(
+        [],
+        { document_type: "licence_transaction", page: 1, per_page: 500, states: "published" },
+      )
+    end
+
     it "doesn't migrate the licence" do
       expect { described_class.new(tagging_path).call }
         .to output(invalid_licence_error_message).to_stdout


### PR DESCRIPTION
Tested in integration and works as expected + only shows validation errors for not already imported licences (output is large so not printing here but feel free to run the import in integration to verify changes). 

Trello:
https://trello.com/c/uf3E7dCl/1974-add-validation-to-new-licence-document-fields

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
