### PR TITLE
Update summary text for the new licence finder tool

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -4,7 +4,7 @@
   "base_path": "/find-licences",
   "format_name": "Find and apply for licences",
   "name": "Find a licence",
-  "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul>",
+  "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul><div class='application-notice info-notice'><p>This may not include all the licences you need. It will be updated with more licences.</p></div>",
   "default_order": "title",
   "filter": {
     "format": "licence_transaction"


### PR DESCRIPTION
## What

Updated the summary text for the new licence folder tool to advise users that it may not include all licences.

## Why

To help set user expectations when using the new licence finder tool.

Trello: https://trello.com/c/FzXAHU3g/2077-implement-feedback-banner-and-text-at-top-of-tool-to-manage-expectations

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
