### PR TITLE
Skip validation for licence with link but no text

### DIFF
--- a/app/validators/link_or_identifier_validator.rb
+++ b/app/validators/link_or_identifier_validator.rb
@@ -32,6 +32,11 @@ private
   end
 
   def will_continue_on_blank_and_link_exists?(record)
-    record.licence_transaction_will_continue_on.blank? && record.licence_transaction_continuation_link.present?
+    # TODO: remove after licences have been imported, currently ~40 licences don't have will
+    # continue on text but do have a link. Next time these licences are edited, they will need
+    # the link text to save and publish
+    unless record.imported
+      record.licence_transaction_will_continue_on.blank? && record.licence_transaction_continuation_link.present?
+    end
   end
 end

--- a/spec/validators/link_or_identifier_validator_spec.rb
+++ b/spec/validators/link_or_identifier_validator_spec.rb
@@ -4,16 +4,19 @@ class LicenceTransaction
   include ActiveModel::API
   attr_accessor :licence_transaction_continuation_link,
                 :licence_transaction_will_continue_on,
-                :licence_transaction_licence_identifier
+                :licence_transaction_licence_identifier,
+                :imported
 end
 
 RSpec.describe LinkOrIdentifierValidator do
+  let(:imported) { false }
   let(:record) do
     LicenceTransaction.new(
       {
         licence_transaction_continuation_link: link,
         licence_transaction_will_continue_on: will_continue_on,
         licence_transaction_licence_identifier: identifier,
+        imported:,
       },
     )
   end
@@ -39,6 +42,18 @@ RSpec.describe LinkOrIdentifierValidator do
     it "validates successfully" do
       subject.validate(record)
       expect(record.errors).to be_blank
+    end
+  end
+
+  context "when a link exists without will continue on text for an imported licence" do
+    let(:link) { "https://www.gov.uk" }
+    let(:will_continue_on) { nil }
+    let(:identifier) { nil }
+    let(:imported) { true }
+
+    it "validates successfully" do
+      subject.validate(record)
+      expect(record.errors[:licence_transaction_continuation_link]).to be_blank
     end
   end
 


### PR DESCRIPTION
Currently ~40 licences in Publisher don't have will continue on text but do have a link as this validation doesn't exist in Publisher. Now we've implemented it here, we need to skip that certain validation for the import to successfully import all licences. Next time these licences are edited, they will need the link text to save and publish so the situation will resolve in time.

Tested on integration and all licence now imported successfully. 

Trello:
https://trello.com/c/FUHCUnxO/2096-skip-validation-for-will-continue-on-text-when-importing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
