### PR TITLE
Added the "not applicable" market sector option to CMA case schema

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -166,6 +166,7 @@
         {"label": "Household goods, furniture and furnishings", "value": "household-goods-furniture-and-furnishings"},
         {"label": "Mineral extraction, mining and quarrying", "value": "mineral-extraction-mining-and-quarrying"},
         {"label": "Motor industry", "value": "motor-industry"},
+        {"label": "Not applicable", "value": "not-applicable"},
         {"label": "Oil and gas refining and petrochemicals", "value": "oil-and-gas-refining-and-petrochemicals"},
         {"label": "Paper printing and packaging", "value": "paper-printing-and-packaging"},
         {"label": "Pharmaceuticals", "value": "pharmaceuticals"},


### PR DESCRIPTION
The Competition and Markets authority have recently started including Office for the Internal Market projects and Subsidy Advice Unit referrals in their CMA case specialist finder. However, the market sector field in the CMA case data type does not apply to these new types. Therefore, we are adding a new "not applicable" option to the CMA case market sector field.

Trello card: https://trello.com/c/SdjSO9PB
