### PR TITLE
Add additional categories to residential decisions

### DIFF
--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -88,6 +88,14 @@
       "filterable": true,
       "allowed_values": [
         {
+          "label": "Building Safety Act",
+          "value": "building-safety-act"
+        },
+        {
+          "label": "Electronic Communications Code",
+          "value": "electronic-communications-code"
+        },
+        {
           "label": "Housing Act 2004 and Housing and Planning Act 2016",
           "value": "housing-act-2004-and-housing-and-planning-act-2016"
         },
@@ -98,6 +106,10 @@
         {
           "label": "Leasehold enfranchisement and extension",
           "value": "leasehold-enfranchisement-and-extension"
+        },
+        {
+          "label": "Leasehold Reform (Ground rent) Act 2022",
+          "value": "leasehold-reform-ground-rent-act-2022"
         },
         {
           "label": "Park homes",
@@ -130,16 +142,64 @@
       "filterable": false,
       "allowed_values": [
         {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Rent repayment orders",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---rent-repayment-orders"
+          "label": "Building Safety Act - Accountable Person",
+          "value": "building-safety-act---accountable-person"
         },
         {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Improvement notices",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---improvement-notices"
+          "label": "Building Safety Act - Failure to provide documents or information",
+          "value": "building-safety-act---failure-to-provide-documents-or-information"
         },
         {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Prohibition orders",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---prohibition-orders"
+          "label": "Building Safety Act - Landlord appeal against liability to pay a remediation amount",
+          "value": "building-safety-act---landlord-appeal-against-liability-to-pay-a-remediation-amount"
+        },
+        {
+          "label": "Building Safety Act - Remediation contribution order",
+          "value": "building-safety-act---remediation-contribution-order"
+        },
+        {
+          "label": "Building Safety Act - Remediation order",
+          "value": "building-safety-act---remediation-order"
+        },
+        {
+          "label": "Electronic Communications Code application for an order (other)",
+          "value": "electronic-communications-code---application-for-an-order-other-"
+        },
+        {
+          "label": "Electronic Communications Code Part 4 para 20",
+          "value": "electronic-communications-code---part-4-para-20"
+        },
+        {
+          "label": "Electronic Communications Code Part 4 para 26",
+          "value": "electronic-communications-code---part-4-para-26"
+        },
+        {
+          "label": "Electronic Communications Code Part 4 para 27",
+          "value": "electronic-communications-code---part-4-para-27"
+        },
+        {
+          "label": "Electronic Communications Code Part 4A - Compensation paid to landlord",
+          "value": "electronic-communications-code---part-4a-compensation-paid-to-landlord"
+        },
+        {
+          "label": "Electronic Communications Code Part 4A - Imposing agreement - Unresponsive landlord",
+          "value": "electronic-communications-code---part-4a-imposing-agreement-unresponsive-landlord"
+        },
+        {
+          "label": "Electronic Communications Code Part 5 para 33(5)",
+          "value": "electronic-communications-code---part-5-para-33-5-"
+        },
+        {
+          "label": "Electronic Communications Code Part 5 para 35(2)(c)",
+          "value": "electronic-communications-code---part-5-para-35-2-c-"
+        },
+        {
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Banning orders",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---banning-orders"
+        },
+        {
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Civil financial penalties",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---civil-financial-penalties"
         },
         {
           "label": "Housing Act 2004 and Housing and Planning Act 2016 - Demolition and closing orders",
@@ -158,16 +218,8 @@
           "value": "housing-act-2004-and-housing-and-planning-act-2016---houses-in-multiple-occupation-licensing"
         },
         {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Selective licensing",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---selective-licensing"
-        },
-        {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Banning orders",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---banning-orders"
-        },
-        {
-          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Civil financial penalties",
-          "value": "housing-act-2004-and-housing-and-planning-act-2016---civil-financial-penalties"
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Improvement notices",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---improvement-notices"
         },
         {
           "label": "Housing Act 2004 and Housing and Planning Act 2016 - Management orders",
@@ -178,8 +230,20 @@
           "value": "housing-act-2004-and-housing-and-planning-act-2016---overcrowding-notices"
         },
         {
-          "label": "Leasehold disputes (management) - Service charges",
-          "value": "leasehold-disputes-management---service-charges"
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Prohibition orders",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---prohibition-orders"
+        },
+        {
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Rent repayment orders",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---rent-repayment-orders"
+        },
+        {
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Selective licensing",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---selective-licensing"
+        },
+        {
+          "label": "Housing Act 2004 and Housing and Planning Act 2016 - Electrical Safety Standards",
+          "value": "housing-act-2004-and-housing-and-planning-act-2016---electrical-safety-standards"
         },
         {
           "label": "Leasehold disputes (management) - Administration charges",
@@ -190,20 +254,28 @@
           "value": "leasehold-disputes-management---appointment-of-manager"
         },
         {
-          "label": "Leasehold disputes (management) - Right to Manage",
-          "value": "leasehold-disputes-management---right-to-manage"
-        },
-        {
-          "label": "Leasehold disputes (management) - Variation of leases",
-          "value": "leasehold-disputes-management---variation-of-leases"
-        },
-        {
           "label": "Leasehold disputes (management) - Breach of lease/forfeiture",
           "value": "leasehold-disputes-management---breach-of-lease-forfeiture"
         },
         {
           "label": "Leasehold disputes (management) - Estate charges/estate management schemes",
           "value": "leasehold-disputes-management---estate-charges-estate-management-schemes"
+        },
+        {
+          "label": "Leasehold disputes (management) - Right to Manage",
+          "value": "leasehold-disputes-management---right-to-manage"
+        },
+        {
+          "label": "Leasehold disputes (management) - Service charges",
+          "value": "leasehold-disputes-management---service-charges"
+        },
+        {
+          "label": "Leasehold disputes (management) - Variation of leases",
+          "value": "leasehold-disputes-management---variation-of-leases"
+        },
+        {
+          "label": "Leasehold enfranchisement and extension - Flats - collective enfranchisement",
+          "value": "leasehold-enfranchisement-and-extension---flats-collective-enfranchisement"
         },
         {
           "label": "Leasehold enfranchisement and extension - Flats - lease extension",
@@ -214,28 +286,32 @@
           "value": "leasehold-enfranchisement-and-extension---houses-enfranchisement"
         },
         {
-          "label": "Leasehold enfranchisement and extension - Flats - collective enfranchisement",
-          "value": "leasehold-enfranchisement-and-extension---flats-collective-enfranchisement"
-        },
-        {
           "label": "Leasehold enfranchisement and extension - Right of first refusal",
           "value": "leasehold-enfranchisement-and-extension---right-of-first-refusal"
         },
         {
-          "label": "Park homes - Pitch fee",
-          "value": "park-homes---pitch-fee"
+          "label": "Leasehold Reform (Ground rent) Act 2022 - Declaration of the effect of the Leasehold Reform (Ground Rent) Act 2022 on provisions about ground rent",
+          "value": "leasehold-reform-ground-rent-act-2022---declaration-of-the-effect-of-the-leasehold-reform-ground-rent-act-2022-on-provisions-about-ground-rent"
         },
         {
-          "label": "Park homes - Section 4 - any Question Under Act or Agreement",
-          "value": "park-homes---section-4-any-question-under-act-or-agreement"
+          "label": "Leasehold Reform (Ground rent) Act 2022 - Financial Penalty",
+          "value": "leasehold-reform-ground-rent-act-2022---financial-penalty"
         },
         {
-          "label": "Park homes - Local authority compliance notice",
-          "value": "park-homes---local-authority-compliance-notice"
+          "label": "Leasehold Reform (Ground rent) Act 2022 - Ground rent recovery order",
+          "value": "leasehold-reform-ground-rent-act-2022---ground-rent-recovery-order"
         },
         {
           "label": "Park homes - Appeal against/alteration of a site licence condition",
           "value": "park-homes---appeal-against-alteration-of-a-site-licence-condition"
+        },
+        {
+          "label": "Park homes - Entitlement to terminate an agreement for occupation",
+          "value": "park-homes---entitlement-to-terminate-an-agreement-for-occupation"
+        },
+        {
+          "label": "Park homes - Local authority compliance notice",
+          "value": "park-homes---local-authority-compliance-notice"
         },
         {
           "label": "Park homes - Local authority decision - emergency action",
@@ -246,20 +322,20 @@
           "value": "park-homes---local-authority-site-licence-refusal-refusal-to-transfer"
         },
         {
-          "label": "Park homes - Site owner's failure to deposit site rules with local authority",
-          "value": "park-homes---site-owners-failure-to-deposit-site-rules-with-local-authority"
+          "label": "Park homes - Order relating to implied and express terms",
+          "value": "park-homes---order-relating-to-implied-and-express-terms"
         },
         {
-          "label": "Park homes - Site rule change - consultation response",
-          "value": "park-homes---site-rule-change-consultation-response"
+          "label": "Park homes - Order requiring written statement of terms",
+          "value": "park-homes---order-requiring-written-statement-of-terms"
         },
         {
           "label": "Park homes - Park home having a detrimental effect",
           "value": "park-homes---park-home-having-a-detrimental-effect"
         },
         {
-          "label": "Park homes - Order relating to implied and express terms",
-          "value": "park-homes---order-relating-to-implied-and-express-terms"
+          "label": "Park homes - Pitch fee",
+          "value": "park-homes---pitch-fee"
         },
         {
           "label": "Park homes - Recognition of residents association",
@@ -270,28 +346,32 @@
           "value": "park-homes---refusal-orders-against-giving-assigning-home"
         },
         {
+          "label": "Park homes - Section 4 - any Question Under Act or Agreement",
+          "value": "park-homes---section-4-any-question-under-act-or-agreement"
+        },
+        {
           "label": "Park homes - Site licence - payment of annual fee",
           "value": "park-homes---site-licence-payment-of-annual-fee"
         },
         {
-          "label": "Park homes - Order requiring written statement of terms",
-          "value": "park-homes---order-requiring-written-statement-of-terms"
+          "label": "Park homes - Site owner's failure to deposit site rules with local authority",
+          "value": "park-homes---site-owners-failure-to-deposit-site-rules-with-local-authority"
+        },
+        {
+          "label": "Park homes - Site rule change - consultation response",
+          "value": "park-homes---site-rule-change-consultation-response"
         },
         {
           "label": "Park homes - Temporary re-siting/return of resited park home",
           "value": "park-homes---temporary-re-siting-return-of-resited-park-home"
         },
         {
-          "label": "Park homes - Entitlement to terminate an agreement for occupation",
-          "value": "park-homes---entitlement-to-terminate-an-agreement-for-occupation"
+          "label": "Rents - Fair rent",
+          "value": "rents---fair-rent"
         },
         {
           "label": "Rents - Market rent (assured shorthold tenancy)",
           "value": "rents---market-rent-assured-shorthold-tenancy"
-        },
-        {
-          "label": "Rents - Fair rent",
-          "value": "rents---fair-rent"
         },
         {
           "label": "Right to Buy - Right to Buy appeals - elderly persons",
@@ -306,12 +386,12 @@
           "value": "tenant-associations---request-for-information"
         },
         {
-          "label": "Tenant Fees Act - Recovery of a prohibited payment",
-          "value": "tenant-fees-act---recovery-of-a-prohibited-payment"
-        },
-        {
           "label": "Tenant Fees Act - Financial Penalties",
           "value": "tenant-fees-act---financial-penalties"
+        },
+        {
+          "label": "Tenant Fees Act - Recovery of a prohibited payment",
+          "value": "tenant-fees-act---recovery-of-a-prohibited-payment"
         }
       ]
     },


### PR DESCRIPTION
Requested in Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/5402655

Trello: https://trello.com/c/iLtAxG82/1510-update-residential-property-tribunal-decisions-finder-with-new-categories-and-sub-categories

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
