### PR TITLE
Migrate missing archived licences

### DIFF
--- a/lib/data/licence_transaction/missing_licences_and_tagging.csv
+++ b/lib/data/licence_transaction/missing_licences_and_tagging.csv
@@ -1,0 +1,8 @@
+Primary publishing organisation,Organisation 1,Organisation 2,Locations,Link,Industry 1,Industry 2,Industry 3,Industry 4,Industry 5,Industry 6,Industry 7,Industry 8,Industry 9,Industry 10,Industry 11,Industry 12,Industry 13,Industry 14,Industry 15,Industry 16,Industry 17,Industry 18,Industry 19
+"Department for Culture, Media and Sport",,,"England, Wales, Scotland",https://www.gov.uk/safety-certificates-for-sports-grounds,Sports,,,,,,,,,,,,,,,,,,
+Welsh Government,,,Wales,https://www.gov.uk/hazardous-waste-producer-registration-wales,Environment: management and waste,,,,,,,,,,,,,,,,,,
+Northern Ireland Executive,,,Northern Ireland,https://www.gov.uk/licence-to-photograph-wildlife-northern-ireland,Environment: conservation and wildlife,,,,,,,,,,,,,,,,,,
+Northern Ireland Executive,,,Northern Ireland,https://www.gov.uk/auctioneer-s-permit-firearms-and-ammunition-northern-ireland,Security,,,,,,,,,,,,,,,,,,
+Northern Ireland Executive,,,Northern Ireland,https://www.gov.uk/chaperone-licence-northern-ireland,Social care: childcare,,,,,,,,,,,,,,,,,,
+Northern Ireland Executive,,,Northern Ireland,https://www.gov.uk/slaughterman-licence-northern-ireland,Agriculture: animals,,,,,,,,,,,,,,,,,,
+The Scottish Government,,,Scotland,https://www.gov.uk/sqa-qualifications-approval-scotland,Education including tutoring and training,,,,,,,,,,,,,,,,,,

--- a/lib/tasks/licence_transaction.rake
+++ b/lib/tasks/licence_transaction.rake
@@ -11,4 +11,20 @@ namespace :licence_transaction do
   task import_licences: :environment do
     Importers::LicenceTransaction::LicenceImporter.new.call
   end
+
+  desc "Migrate missing archived licences"
+  task migrate_missing_archived_licences: :environment do
+    archived_base_paths = %w[
+      /safety-certificates-for-sports-grounds
+      /hazardous-waste-producer-registration-wales
+      /licence-to-photograph-wildlife-northern-ireland
+      /auctioneer-s-permit-firearms-and-ammunition-northern-ireland
+      /chaperone-licence-northern-ireland
+      /slaughterman-licence-northern-ireland
+      /sqa-qualifications-approval-scotland
+    ]
+
+    missing_tagging_path = Rails.root.join("lib/data/licence_transaction/missing_licences_and_tagging.csv")
+    Importers::LicenceTransaction::LicenceImporter.new(missing_tagging_path, archived_base_paths).call
+  end
 end


### PR DESCRIPTION
We received a complaint that a licence was missing from the original migration from a LA (safety-certificates-for-sports-grounds). We did archive some intentionally, without migrating them to SP as a result of the instructions from DBT but it now seems that some of them should be live, we reached out to DBT with the archived licences list and they sent us back which ones we should reinstate and the tagging data to use. 

I've included all the licences DBT suggested bar https://www.gov.uk/pet-shop-licence-wales-scotland as DBT indicate this page should be split into a Welsh and Scottish version, which seems like it should be handled by the owning departments (The Scottish Government + Welsh Government).

I've piggy backed off the old importer code which has 95% the functionality we need. The entire importer code will be deleted soon as the main migration has been completed 🔥  

Successfully run in Staging (04/08/2023):
```
peter.hartshorn at GDS12251 in ~
$ krake -s specialist-publisher licence_transaction:migrate_missing_archived_licences
Switched to context "staging".
Defaulted container "app" out of: app, nginx
INFO: with_tmpdir_for_ruby: execing rake with TMPDIR=/tmp/ruby-app-3Htp9sN5
W, [2023-08-04T10:11:52.615828 #60]  WARN -- : Instrumentation: OpenTelemetry::Instrumentation::Trilogy failed to install
...
W, [2023-08-04T10:11:52.621933 #60]  WARN -- : Instrumentation: OpenTelemetry::Instrumentation::Sinatra failed to install
Published: /find-licences/chaperone-licence-northern-ireland
Published: /find-licences/licence-to-photograph-wildlife-northern-ireland
Published: /find-licences/safety-certificates-for-sports-grounds
Published: /find-licences/slaughterman-licence-northern-ireland
Published: /find-licences/hazardous-waste-producer-registration-wales
Published: /find-licences/sqa-qualifications-approval-scotland
Published: /find-licences/auctioneer-s-permit-firearms-and-ammunition-northern-ireland
peter.hartshorn at GDS12251 in ~
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
