### PR TITLE
Add 'open_filter_on_load' property to finder

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -47,6 +47,7 @@ private
       document_noun: file.fetch("document_noun"),
       filter: file.fetch("filter", nil),
       format_name: file.fetch("format_name", nil),
+      open_filter_on_load: file.fetch("open_filter_on_load", nil),
       logo_path: file.fetch("logo_path", nil),
       show_summaries: file.fetch("show_summaries", false),
       signup_link: file.fetch("signup_link", nil),

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -9,6 +9,7 @@
   "filter": {
     "format": "licence_transaction"
   },
+  "open_filter_on_load": true,
   "show_summaries": true,
   "organisations": [
     "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"


### PR DESCRIPTION
## What

https://trello.com/c/p6FCqlHs/2042-expand-filter-and-location-facets-by-default-on-mobile

Add `open_filter_on_load` property to open filters, on page load, on mobile. Configured for **Find a licence** (specialist finder) only.

## Why

During user research, a common observation has emerged that mobile users do not interact with the 'Filter' button.

## Anything else

https://github.com/alphagov/finder-frontend/pull/3131
https://github.com/alphagov/publishing-api/pull/2471