### PR TITLE
Add orgs to metadata if present

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,6 +1,10 @@
 module OrganisationsHelper
+  def all_organisations
+    @all_organisations ||= Organisation.all
+  end
+
   def organisations_options
-    Organisation.all.map { |o| [o.title, o.content_id] }.sort_by { |title, _id| title.downcase.strip }
+    all_organisations.map { |o| [o.title, o.content_id] }.sort_by { |title, _id| title.downcase.strip }
   end
 
   def organisations_options_with_all
@@ -9,5 +13,9 @@ module OrganisationsHelper
 
   def selected_organisation_or_current(organisation)
     (organisation.presence || current_user.organisation_content_id)
+  end
+
+  def organisation_name(content_id)
+    all_organisations.select { |o| o.content_id == content_id }.first&.title
   end
 end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -27,6 +27,14 @@
           <% end %>
         <% end %>
       <% end %>
+      <% if @document.class.has_organisations? %>
+        <dt>Publishing organisation</dt>
+        <dd><%= organisation_name(@document.primary_publishing_organisation) %></dd>
+        <dt>Other associated Organisations</dt>
+            <% @document.organisations.each do |org| %>
+            <dd><%= organisation_name(org) %></dd>
+          <% end %>
+      <% end %>
       <dt>Bulk published</dt>
       <dd><%= @document.bulk_published %></dd>
       <dt>Publication state</dt>

--- a/spec/features/viewing_a_licence_spec.rb
+++ b/spec/features/viewing_a_licence_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.feature "Viewing a Licence", type: :feature do
+  let(:licence_transaction) { FactoryBot.create(:licence_transaction) }
+  let(:content_id)          { licence_transaction["content_id"] }
+  let(:organisations) do
+    [
+      { "content_id" => "6de6b795-9d30-4bd8-a257-ab9a6879e1ea", "title" => "PPO Org" },
+      { "content_id" => "d31d9806-2644-4023-be70-5376cae84a06", "title" => "Other Org" },
+    ]
+  end
+
+  before do
+    log_in_as_editor(:licence_transaction_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([licence_transaction], hash_including(document_type: LicenceTransaction.document_type))
+    stub_publishing_api_has_item(licence_transaction)
+    stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+  end
+
+  scenario "has organisation metadata" do
+    visit "/licences"
+    click_link "Example document"
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("PPO Org")
+    expect(page).to have_content("Other Org")
+  end
+end


### PR DESCRIPTION
Where documents may have Primary Publishing Organisation / Organisations, show these in the metadata so that editors don't have to edit the document to see the owning orgs.

https://trello.com/c/q5FMBg6c/2167-add-owning-organisations-to-licence-overview-page-in-specialist-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
