### PR TITLE
Add description to licence finder

### DIFF
--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -4,6 +4,7 @@
   "format_name": "Find and apply for licences",
   "name": "Find a licence",
   "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul><div class='application-notice info-notice'><p>This may not include all the licences you need. It will be updated with more licences.</p></div>",
+  "description": "Find licences, permits or certifications you may need for yourself or your business.",
   "label_text": "Search keywords <span class=\"govuk-!-display-block govuk-!-font-size-16 govuk-!-margin-bottom-2\">for example 'sell alcohol'</span>",
   "default_order": "title",
   "filter": {


### PR DESCRIPTION
The description field will be indexed by search and displayed under the title in sitewide search. This will also help old and 
new search in understanding the content.

## Before

<img width="698" alt="Screenshot 2023-10-05 at 11 56 04" src="https://github.com/alphagov/specialist-publisher/assets/24479188/7dc0f6b4-12a6-4bb7-9999-9c6c96de99c9">

## After

<img width="921" alt="Screenshot 2023-10-10 at 11 28 00" src="https://github.com/alphagov/specialist-publisher/assets/24479188/2e8075db-6617-4e49-9905-b47835b65b2a">

Trello:
https://trello.com/c/PChxiF3E/2223-add-description-to-licence-schema-so-it-can-be-indexed-by-search

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
