### PR TITLE
Add Assurance Warrantee to the AI Assurance Facet

### DIFF
--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -276,6 +276,10 @@
         {
           "label": "Bias Audit",
           "value": "bias-audit"
+        },
+        {
+          "label": "Assurance Warrantee",
+          "value": "assurance-warrantee"
         }
       ]
     },


### PR DESCRIPTION
## Description

We’ve got a requirement from Dept of Science, Innovation & Technology to add a new facet to their Specialist Finder:

https://www.gov.uk/ai-assurance-techniques?use_case%5B%5D=robotic-process-automation-and-decision-management

The area to be updated is under Assurance Techniques and the new addition is Assurance Warrantee.

This field was updated for content schemas in this [PR](https://github.com/alphagov/publishing-api/pull/2550) on Publishing API.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
