### PR TITLE
Add format validation for licence identifier

### DIFF
--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -18,9 +18,13 @@ class LicenceTransaction < Document
 
   validates_with LinkOrIdentifierValidator
   validates :primary_publishing_organisation, presence: true
-  validates :licence_transaction_licence_identifier, licence_identifier_unique: true
   validates :licence_transaction_industry, presence: true
   validates :licence_transaction_location, presence: true
+  validates :licence_transaction_licence_identifier, format: {
+    with: /\A[0-9]{3,4}-[1-7]-[1-9]\z/,
+    allow_blank: true,
+  }
+  validates :licence_transaction_licence_identifier, licence_identifier_unique: true
   validates :licence_transaction_continuation_link, format: {
     with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
     allow_blank: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
               link_and_identifier_exists: Enter either the website where users can apply for the licence or the licence identifier
             licence_transaction_licence_identifier:
               taken: This licence identifier is already in use
+              invalid: Enter a licence identifier. This is a 5 or 6 digit number
             licence_transaction_industry:
               blank: Select an industry
             licence_transaction_location:

--- a/spec/models/licence_transaction_spec.rb
+++ b/spec/models/licence_transaction_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe LicenceTransaction do
       expect(subject).to be_valid
     end
 
-    it "is valid with a unique identifier" do
+    it "is valid with a unique and correctly formated identifier" do
       stub_publishing_api_has_content([payload], hash_including(document_type: "licence_transaction"))
 
-      subject.licence_transaction_licence_identifier = "7777-7-7"
+      subject.licence_transaction_licence_identifier = "1234-5-6"
+      expect(subject).to be_valid
 
+      subject.licence_transaction_licence_identifier = "543-2-1"
       expect(subject).to be_valid
     end
 
@@ -53,6 +55,25 @@ RSpec.describe LicenceTransaction do
       expect(subject.errors[:licence_transaction_continuation_link]).to eq(
         [subject.errors.generate_message(:licence_transaction_continuation_link, :invalid)],
       )
+    end
+
+    it "is invalid with an incorrectly formated identifier" do
+      stub_publishing_api_has_content([payload], hash_including(document_type: "licence_transaction"))
+
+      subject.licence_transaction_licence_identifier = "1-2345-6-2"
+      expect(subject).to be_invalid
+
+      subject.licence_transaction_licence_identifier = "1234-8-2"
+      expect(subject).to be_invalid
+
+      subject.licence_transaction_licence_identifier = "12-1-1"
+      expect(subject).to be_invalid
+
+      subject.licence_transaction_licence_identifier = "1234-1-0"
+      expect(subject).to be_invalid
+
+      subject.licence_transaction_licence_identifier = "https://www.gov.uk"
+      expect(subject).to be_invalid
     end
   end
 end


### PR DESCRIPTION
We've previously been informed of a rendering issue that was caused by the publisher inputting random text into the licence identifier field. Previously there was only a uniqueness validator for the field which accepted any format, now we're validating that the format is correct.

The accepted format is XXX-Y-B or XXXX-Y-B where:
- X is a formality code (3 or 4 digits)
- Y is a country code (1 to 7, 1 digit)
- B is a number in sequence (if more than 1 'type' [quite rare], 1 digit)

## Screenshots

<img width="1251" alt="Screenshot 2024-02-23 at 15 23 52" src="https://github.com/alphagov/specialist-publisher/assets/24479188/638f7880-c548-4286-88ba-3ade323cfd7e">
<img width="906" alt="Screenshot 2024-02-23 at 15 23 57" src="https://github.com/alphagov/specialist-publisher/assets/24479188/7a2f341d-6b75-4d39-9830-be9c006665f9">


Trello:
https://trello.com/c/uFIvraIX/2288-validate-licence-identifer-format

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
