### PR TITLE
Add additional judges to utaac decisions finder

### DIFF
--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -2136,6 +2136,10 @@
           "value": "beech-j"
         },
         {
+          "label": "Brewer, M",
+          "value": "brewer-m"
+        },
+        {
           "label": "Broderick, M",
           "value": "broderick-m"
         },
@@ -2162,6 +2166,10 @@
         {
           "label": "Burton, F",
           "value": "burton-f"
+        },
+        {
+          "label": "Butler, J",
+          "value": "butler-j"
         },
         {
           "label": "Caldwell, M",
@@ -2472,6 +2480,10 @@
           "value": "skinner-j"
         },
         {
+          "label": "Smith, J",
+          "value": "smith-j"
+        },
+        {
           "label": "Smith, R",
           "value": "smith-r"
         },
@@ -2482,6 +2494,10 @@
         {
           "label": "Stockman, O",
           "value": "stockman-o"
+        },
+        {
+          "label": "Stout, H",
+          "value": "stout-h"
         },
         {
           "label": "Thomas, J",


### PR DESCRIPTION
## Description

We've been asked to add some new judges via zendesk 

## Trello ticket

https://trello.com/c/GGuJwlAe/2251-update-specialist-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
