### PR TITLE
Upgrade Rails cache format version to 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,10 +23,7 @@ module SpecialistPublisher
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
-    # Once this application is fully deployed to Rails 7.1 and you have no plans to rollback
-    # replace the line below with config.active_support.cache_format_version = 7.1
-    # This will mean that we can revert back to rails 7.0 if there is an issue
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
## Description

Rails was upgraded to 7.1.2 a couple of weeks ago now so as per the instructions in https://trello.com/c/PhGra6VR/1809-epic-rails-712-upgrade this can be bumped.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
