### PR TITLE
Migrate to Dart Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ coverage
 /coverage
 node_modules
 yarn-error.log
+
 public/assets
+/app/assets/builds/*
+!/app/assets/builds/.keep
 
 # https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/*

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "7.1.3"
 
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
+gem "dartsass-rails"
 gem "fog-aws"
 gem "gds-api-adapters"
 gem "gds-sso"
@@ -22,7 +23,6 @@ gem "mongo"
 gem "mongoid"
 gem "plek"
 gem "pundit"
-gem "sassc-rails"
 gem "select2-rails", "< 4" # v4 changes the generated HTML and breaks the e2e tests
 gem "sentry-sidekiq"
 gem "stringex"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-core (2.0.1)
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
@@ -683,14 +686,17 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    sass-embedded (1.70.0)
+      google-protobuf (~> 3.25)
+      rake (>= 13.0.0)
+    sass-embedded (1.70.0-aarch64-linux-gnu)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm64-darwin)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     select2-rails (3.5.11)
     selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -728,7 +734,6 @@ GEM
     stringex (2.8.6)
     stringio (3.1.0)
     thor (1.3.0)
-    tilt (2.0.11)
     timecop (0.9.8)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -766,6 +771,7 @@ DEPENDENCIES
   bootsnap
   bootstrap-kaminari-views
   capybara-select-2
+  dartsass-rails
   database_cleaner-mongoid
   factory_bot
   fog-aws
@@ -795,7 +801,6 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   rubocop-govuk
-  sassc-rails
   select2-rails (< 4)
   sentry-sidekiq
   simplecov

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
+require "sprockets/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,1 @@
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
## Description 

LibSass has been deprecated. We're moving to Dart Sass. This follows the upgrade guide found here
https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

I've deployed it out to integration and tested it's working

## Trello card

https://trello.com/c/qeNHFPZN/1667-migrate-to-dart-sass

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade
