### PR TITLE
Add config to support auto merging govuk dependencies

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,50 @@
+api_version: 1
+auto_merge:
+  - dependency: gds-api-adapters
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: gds-sso
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govspeak
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_admin_template
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - munor
+  - dependency: govuk_frontend_toolkit
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_publishing_components
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_sidekiq
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_schemas
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_test
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
## Description

We're now able to automerge govuk dependencies via [govuk dependabot merger](https://github.com/alphagov/govuk-dependabot-merger).

This adds the required config.

The easiest way to review is is to check this file against the gemfile to make sure i've captured all the internal dependencies we use.

## Trello card

https://trello.com/c/csiNeakx/2320-add-all-applications-to-automatic-dependabot-merger-configuration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
