### PR TITLE
Change required fields in farming grant finder

### DIFF
--- a/app/models/farming_grant_option.rb
+++ b/app/models/farming_grant_option.rb
@@ -1,7 +1,5 @@
 class FarmingGrantOption < Document
   validates :open_or_closed, presence: true
-  validates :areas_of_interest, presence: true
-  validates :land_types, presence: true
   validates :funding_types, presence: true
   validates :grant_schemes, presence: true
   validates :payment_types, presence: true

--- a/spec/models/farming_grant_option_spec.rb
+++ b/spec/models/farming_grant_option_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe FarmingGrantOption do
       expect(farming_grant_option).not_to be_valid
     end
 
-    it "is invalid if the areas of interest field is missing" do
-      farming_grant_option.areas_of_interest = nil
-      expect(farming_grant_option).not_to be_valid
-    end
-
-    it "is invalid if the land types field is missing" do
-      farming_grant_option.land_types = nil
-      expect(farming_grant_option).not_to be_valid
-    end
-
     it "is invalid if the funding types field is missing" do
       farming_grant_option.funding_types = nil
       expect(farming_grant_option).not_to be_valid


### PR DESCRIPTION
The department has asked that we remove the requirement for areas of interest and land types to be mandatory fields.