### PR TITLE
Remove pre-production flag for farming grant options

### DIFF
--- a/lib/documents/schemas/farming_grant_options.json
+++ b/lib/documents/schemas/farming_grant_options.json
@@ -1,5 +1,4 @@
 {
-  "pre_production": true,
   "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
   "base_path": "/farming-grant-options",
   "format_name": "Farming grant options",


### PR DESCRIPTION
Ready to release the finder in production. 

[Trello card](https://trello.com/c/cJDwKAx3/2393-release-defra-finder)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
