### PR TITLE
Replace Fog with aws-sdk-s3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem "factory_bot"
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "multi_json"
   gem "pry-rails"
   gem "puma"
   gem "rspec-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source "https://rubygems.org"
 
 gem "rails", "7.1.3.2"
 
+gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "dartsass-rails"
-gem "fog-aws"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govspeak"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,22 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.905.0)
+    aws-sdk-core (3.191.5)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.78.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.146.1)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
@@ -130,7 +146,6 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    excon (0.110.0)
     execjs (2.8.1)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -139,22 +154,6 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
-    fog-aws (3.22.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-core (2.4.0)
-      builder
-      excon (~> 0.71)
-      formatador (>= 0.2, < 2.0)
-      mime-types
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-xml (0.1.4)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (1.1.0)
     gds-api-adapters (95.0.1)
       addressable
       link_header
@@ -243,6 +242,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -308,7 +308,6 @@ GEM
       mongo (>= 2.18.0, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
     msgpack (1.7.2)
-    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -782,6 +781,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap
@@ -790,7 +790,6 @@ DEPENDENCIES
   dartsass-rails
   database_cleaner-mongoid
   factory_bot
-  fog-aws
   gds-api-adapters
   gds-sso
   govspeak

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ GEM
       mongo (>= 2.18.0, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -808,6 +809,7 @@ DEPENDENCIES
   mail-notify
   mongo
   mongoid
+  multi_json
   plek
   pry-rails
   puma

--- a/app/lib/s3_file_uploader.rb
+++ b/app/lib/s3_file_uploader.rb
@@ -1,19 +1,13 @@
 class S3FileUploader
   def self.save_file_to_s3(filename, csv)
-    directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+    s3 = Aws::S3::Client.new
 
-    directory.files.create(
+    s3.put_object({
       key: filename,
       body: csv,
-    )
-  end
-
-  def self.connection
-    @connection ||= Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
+      bucket: ENV["AWS_S3_BUCKET_NAME"],
+      content_disposition: "attachment; filename=\"#{filename}\"",
+      content_type: "text/csv",
+    })
   end
 end

--- a/spec/controllers/document_list_export_request_controller_spec.rb
+++ b/spec/controllers/document_list_export_request_controller_spec.rb
@@ -1,32 +1,21 @@
 require "rails_helper"
 
 RSpec.describe DocumentListExportRequestController, type: :controller do
+  let(:stubbed_client) { Aws::S3::Client.new(stub_responses: true) }
   before do
     log_in_as_gds_editor
 
-    Fog.mock!
-    ENV["AWS_REGION"] = "eu-west-1"
-    ENV["AWS_ACCESS_KEY_ID"] = "test"
-    ENV["AWS_SECRET_ACCESS_KEY"] = "test"
-    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+    allow(Aws::S3::Client).to receive(:new).and_return(stubbed_client)
 
-    # Create an S3 bucket so the code being tested can find it
-    connection = Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
-    @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
   end
 
   describe "GET show" do
     it "responds successfully if there is a valid file" do
       document_type_slug = "asylum-support-decisions"
       export_id = "1234-5678"
-      filename = "document_list_#{document_type_slug}_#{export_id}.csv"
 
-      @directory.files.create(key: filename, body: "hello world")
+      stubbed_client.stub_responses(:get_object, { body: "hello world" })
 
       get :show, params: { document_type_slug:, export_id: }
       expect(response.status).to eq(200)
@@ -34,6 +23,8 @@ RSpec.describe DocumentListExportRequestController, type: :controller do
     end
 
     it "returns an error if there is no request" do
+      stubbed_client.stub_responses(:get_object, "NoSuchKey")
+
       get :show, params: { document_type_slug: "asylum-support-decisions", export_id: "aaaa-bbbb" }
       expect(response.status).to eq(404)
     end

--- a/spec/features/exporting_a_csv_spec.rb
+++ b/spec/features/exporting_a_csv_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Exporting a list of documents as CSV" do
+  let(:stubbed_client) { Aws::S3::Client.new(stub_responses: true) }
+
   let(:documents) do
     3.times.map do |i|
       FactoryBot.create(
@@ -23,20 +25,10 @@ RSpec.feature "Exporting a list of documents as CSV" do
 
     stub_publishing_api_has_content(documents, hash_including(document_type: BusinessFinanceSupportScheme.document_type))
 
-    Fog.mock!
-    ENV["AWS_REGION"] = "eu-west-1"
-    ENV["AWS_ACCESS_KEY_ID"] = "test"
-    ENV["AWS_SECRET_ACCESS_KEY"] = "test"
-    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+    stubbed_client = Aws::S3::Client.new(stub_responses: true)
+    allow(Aws::S3::Client).to receive(:new).and_return(stubbed_client)
 
-    # Create an S3 bucket so the code being tested can find it
-    connection = Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
-    @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
   end
 
   scenario "I can export a list of documents and they are emailed to me" do

--- a/spec/lib/s3_file_uploader_spec.rb
+++ b/spec/lib/s3_file_uploader_spec.rb
@@ -1,28 +1,26 @@
 require "spec_helper"
 
 RSpec.describe S3FileUploader do
-  before do
-    Fog.mock!
-    ENV["AWS_REGION"] = "eu-west-1"
-    ENV["AWS_ACCESS_KEY_ID"] = "test"
-    ENV["AWS_SECRET_ACCESS_KEY"] = "test"
-    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+  let(:stubbed_client) { Aws::S3::Client.new(stub_responses: true) }
 
-    # Create an S3 bucket so the code being tested can find it
-    connection = Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
-    @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+  before do
+    @mock_bucket = {}
+    stubbed_client = Aws::S3::Client.new(stub_responses: true)
+    allow(Aws::S3::Client).to receive(:new).and_return(stubbed_client)
+
+    mock_s3_bucket(stubbed_client, @mock_bucket)
+    ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
   end
 
   it "has the expected filename and content" do
-    s3_file = described_class.save_file_to_s3("test_file_name.txt", "hello, world\n")
-    expect(s3_file.key).to eq "test_file_name.txt"
-    file = @directory.files.get("test_file_name.txt")
-    expect(file).not_to be nil
-    expect(file.body).to eq "hello, world\n"
+    filename = "test_file_name.txt"
+    body = "hello, world\n"
+    described_class.save_file_to_s3(filename, body)
+
+    obj = stubbed_client.get_object(
+      bucket: ENV["AWS_S3_BUCKET_NAME"],
+      key: filename,
+    )
+    expect(obj.body.read).to eq body
   end
 end

--- a/spec/support/aws_s3_helpers.rb
+++ b/spec/support/aws_s3_helpers.rb
@@ -1,0 +1,14 @@
+module AwsHelpers
+  def mock_s3_bucket(client, bucket)
+    client.stub_responses(:get_object, lambda { |context|
+                                         obj = bucket[context.params[:key]]
+                                         obj || "NoSuchKey"
+                                       })
+    client.stub_responses(:put_object, lambda { |context|
+      bucket[context.params[:key]] = { body: context.params[:body] }
+      {}
+    })
+  end
+end
+
+RSpec.configuration.include AwsHelpers

--- a/spec/workers/document_list_export_worker_spec.rb
+++ b/spec/workers/document_list_export_worker_spec.rb
@@ -18,21 +18,12 @@ RSpec.describe DocumentListExportWorker do
       ]
     end
 
-    before do
-      Fog.mock!
-      ENV["AWS_REGION"] = "eu-west-1"
-      ENV["AWS_ACCESS_KEY_ID"] = "test"
-      ENV["AWS_SECRET_ACCESS_KEY"] = "test"
-      ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
+    let(:stubbed_client) { Aws::S3::Client.new(stub_responses: true) }
 
-      # Create an S3 bucket so the code being tested can find it
-      connection = Fog::Storage.new(
-        provider: "AWS",
-        region: ENV["AWS_REGION"],
-        aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-      )
-      @directory = connection.directories.get(ENV["AWS_S3_BUCKET_NAME"]) || connection.directories.create(key: ENV["AWS_S3_BUCKET_NAME"])
+    before do
+      allow(Aws::S3::Client).to receive(:new).and_return(stubbed_client)
+
+      ENV["AWS_S3_BUCKET_NAME"] = "test-bucket"
     end
 
     it "raises an error if the user does not have permission to see the document type" do


### PR DESCRIPTION
This allows us to use short lived AWS credentials via authentication methods such as instance profiles or IRSA.

No functionality changes.