### PR TITLE
Allow deletion of attachments where the asset does not exist in Asset Manager

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -75,6 +75,9 @@ class Attachment < Document
 
   def destroy
     Services.asset_api.delete_asset(id_from_url)
+  rescue GdsApi::HTTPNotFound
+    logger.warn "The asset that we are attempting to delete does not exist in asset manager"
+    true
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     false

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -224,4 +224,36 @@ RSpec.describe Attachment do
       end
     end
   end
+
+  describe "#destroy" do
+    let(:asset_id) { "some-asset-id" }
+    let(:url) { "/#{asset_id}/document.pdf" }
+    let(:attachment) do
+      Attachment.new(
+        title: "test attachment",
+        url:,
+      )
+    end
+
+    context "when the request to delete the attachment asset from AssetManager succeeds" do
+      it "returns a truthy value" do
+        stub_asset_manager_delete_asset(asset_id)
+        expect(attachment.destroy).to be_truthy
+      end
+    end
+
+    context "when the attachment does not exist in Asset Manager" do
+      it "returns a truthy value" do
+        stub_asset_manager_delete_asset_missing(asset_id)
+        expect(attachment.destroy).to be_truthy
+      end
+    end
+
+    context "when the request to delete the attachment asset in Asset Manager fails for other reasons" do
+      it "returns false" do
+        stub_asset_manager_delete_asset_failure(asset_id)
+        expect(attachment.destroy).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
An attachment which does not have a corresponding asset in Asset Manager is effectively broken. Prior to this commit, it wasn't possible for users to delete these broken attachments.

Being unable to delete the broken attachments prevents users from discarding any draft documents associated with them.

To resolve this, we return a boolean "true" from the Attachment#destroy method when the asset cannot be found, as to all intents and purposes the asset is deleted anyway.

I haven't included a feature test for this as it feels like an edge case that is not valuable enough to cover with an expensive feature test.

It is not clear how the asset has been removed from Asset Manager whilst the attachment is still present.

Trello: https://trello.com/c/epa4vl02

Depends on https://github.com/alphagov/gds-api-adapters/pull/1248 to be merged
