### PR TITLE
Add new facet to AI assurance techniques finder

### DIFF
--- a/app/models/ai_assurance_portfolio_technique.rb
+++ b/app/models/ai_assurance_portfolio_technique.rb
@@ -6,6 +6,7 @@ class AiAssurancePortfolioTechnique < Document
     key_function
     ai_assurance_technique
     assurance_technique_approach
+    focus_sector
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
+++ b/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
@@ -88,3 +88,18 @@
   %>
 <% end %>
 
+<%= render layout: "shared/form_group", locals: { f: f, field: :focus_sector } do %>
+  <%= f.select :focus_sector,
+               facet_options(f, :focus_sector),
+               {},
+               {
+                 class: 'select2 form-control',
+                 multiple: true,
+                 data:
+                   {
+                     placeholder: 'Select a focus sector'
+                   }
+               }
+  %>
+<% end %>
+

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -304,6 +304,20 @@
           "value": "educational"
         }
       ]
+    },
+    {
+      "key": "focus_sector",
+      "name": "Focus Sector",
+      "type": "text",
+      "preposition": "Focus Sector",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Financial Services",
+          "value": "financial-services"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add new facet with a single value.

Tested in integration by deploying all the PRs (see trello card) and running the publish rake task. 

[Trello card](https://trello.com/c/0b8JWG7E/2437-update-to-ai-assurance-techniques-finder)

![Screenshot 2024-04-16 at 16 04 53](https://github.com/alphagov/specialist-publisher/assets/91544378/e399a248-f46c-4a1e-a6c2-81771fa7b8a3)
![Screenshot 2024-04-16 at 16 04 11](https://github.com/alphagov/specialist-publisher/assets/91544378/17494719-3a7f-43bd-98be-30954efdbf4c)
![Screenshot 2024-04-16 at 16 04 32](https://github.com/alphagov/specialist-publisher/assets/91544378/a703c10b-0f44-4339-99ca-a3c0bcdc33b9)
![Screenshot 2024-04-16 at 16 04 42](https://github.com/alphagov/specialist-publisher/assets/91544378/193e4339-d94e-4833-8ea5-254db228286c)



