### PR TITLE
Remove internal note feature

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -74,7 +74,7 @@ class DocumentsController < ApplicationController
   end
 
   def unpublish
-    if @document.unpublish(params[:alternative_path], params[:internal_notes])
+    if @document.unpublish(params[:alternative_path])
       flash[:success] = "Unpublished #{@document.title}"
     else
       flash[:danger] = unknown_error_message

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,7 +30,6 @@ class Document
     :first_published_at,
     :previous_version,
     :warnings,
-    :internal_notes,
   )
 
   def temporary_update_type
@@ -60,7 +59,6 @@ class Document
     bulk_published
     temporary_update_type
     warnings
-    internal_notes
   ].freeze
 
   AIR_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID = "951ece54-c6df-4fbc-aa18-1bc629815fe2".freeze
@@ -246,9 +244,9 @@ class Document
     end
   end
 
-  def unpublish(alternative_path = nil, internal_notes = nil)
+  def unpublish(alternative_path = nil)
     handle_remote_error(self) do
-      DocumentUnpublisher.unpublish(content_id, locale, base_path, alternative_path, internal_notes)
+      DocumentUnpublisher.unpublish(content_id, locale, base_path, alternative_path)
     end
   end
 

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -55,10 +55,6 @@ class ActionsPresenter
     policy.unpublish? && state == "published"
   end
 
-  def internal_notes?
-    unpublish_button_visible? && klass_name == "UK Market Conformity Assessment Bodies"
-  end
-
   def unpublish_text
     if document.first_draft?
       text = "The document has never been published."

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -17,7 +17,6 @@ class DocumentBuilder
       previous_version: payload["previous_version"],
       temporary_update_type: payload["details"]["temporary_update_type"],
       warnings: payload["warnings"] || {},
-      internal_notes: extract_unpublishing_explanation(payload),
     )
 
     set_update_type(document, payload)
@@ -36,11 +35,6 @@ class DocumentBuilder
 
     document.body = SpecialistPublisherBodyPresenter.present(document)
     document
-  end
-
-  def self.extract_unpublishing_explanation(payload)
-    unpublishing = payload["unpublishing"]
-    unpublishing["explanation"] if unpublishing
   end
 
   def self.extract_body_from_payload(payload)

--- a/app/services/document_unpublisher.rb
+++ b/app/services/document_unpublisher.rb
@@ -2,13 +2,12 @@ require "services"
 
 # Unpublish a document. Also removes attachments.
 class DocumentUnpublisher
-  def self.unpublish(content_id, locale, _base_path, alternative_path = nil, internal_notes = nil)
+  def self.unpublish(content_id, locale, _base_path, alternative_path = nil)
     if alternative_path.blank?
       Services.publishing_api.unpublish(
         content_id,
         type: "gone",
         locale:,
-        explanation: internal_notes,
       )
     else
       Services.publishing_api.unpublish(
@@ -16,7 +15,6 @@ class DocumentUnpublisher
         type: "redirect",
         locale:,
         alternative_path:,
-        explanation: internal_notes,
       )
     end
 

--- a/app/views/documents/_actions.html.erb
+++ b/app/views/documents/_actions.html.erb
@@ -32,12 +32,6 @@
             <label for="alternative_path">Redirect to alternative GOV.UK content path. For example: /the-replacement-page</label>
             <input type="text" id="alternative_path" name="alternative_path" class="form-control">
           </div>
-          <% if presenter.internal_notes? %>
-            <div class="form-group">
-              <label for="internal_notes">This field is to identify date and reason for unpublishing only</label>
-              <input type="text" name="internal_notes" class="form-control">
-            </div>
-          <% end %>
 
           <div class="form-group">
             <button name="submit" class="btn btn-warning"

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -41,10 +41,6 @@
       <dd>
         <%= content_tag(:span, state_for_frontend(@document), class: classes_for_frontend(@document)) %>
       </dd>
-      <dt>Internal notes</dt>
-      <dd>
-        <%= @document.internal_notes %>
-      </dd>
     </dl>
   </div>
 </div>


### PR DESCRIPTION
The functionality for adding an internal note was developed for the UK Market Conformity Assessment Bodies document type. The finder was unpublished alongside its documents, and in order to support that process, the internal note served the purpose of documenting the reasons why a specific document was unpublished.

We are now removing the finder code in order to prevent accidentally republishing it. Since there are no current usages of the feature as it has not been used for other finders and it is not a development priority or business request, we are removing all associated internal note implementation.

[Trello card](https://trello.com/c/cZLoKAE2/1506-close-finder-for-ukmcab)
PR to remove finder code [here](https://github.com/alphagov/specialist-publisher/pull/2588)