### PR TITLE
Rename Micronesia to Federated States of Micronesia 

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -427,6 +427,12 @@
               "prechecked": false
             },
             {
+              "key": "federated-states-of-micronesia",
+              "radio_button_name": "Federated States of Micronesia",
+              "topic_name": "Federated States of Micronesia",
+              "prechecked": false
+            },
+            {
               "key": "fiji",
               "radio_button_name": "Fiji",
               "topic_name": "Fiji",

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -268,6 +268,10 @@
           "label": "Ethiopia"
         },
         {
+          "value": "federated-states-of-micronesia",
+          "label": "Federated States of Micronesia"
+        },
+        {
           "value": "fiji",
           "label": "Fiji"
         },

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -261,6 +261,10 @@
           "label": "Ethiopia"
         },
         {
+          "value": "FS",
+          "label": "Federated States of Micronesia"
+        },
+        {
           "value": "FJ",
           "label": "Fiji"
         },


### PR DESCRIPTION
Replace 'Micronesia' with 'Federated States of Micronesia' - content request [Trello](https://trello.com/c/SU6BliYA/2438-replace-micronesia-with-federated-states-of-micronesia-content-request)

Following the process outline in these [docs](https://docs.publishing.service.gov.uk/manual/rename-a-country.html#7-update-specialist-publisher)

We need to support both the old countries temporarily (during the data migration). So that is why Micronesia remains, once the transition is complete there will be a subsequent PR to remove the old values.  

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
