### PR TITLE
Remove old micronesia

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -805,12 +805,6 @@
               "prechecked": false
             },
             {
-              "key": "micronesia",
-              "radio_button_name": "Micronesia",
-              "topic_name": "Micronesia",
-              "prechecked": false
-            },
-            {
               "key": "moldova",
               "radio_button_name": "Moldova",
               "topic_name": "Moldova",
@@ -1557,7 +1551,6 @@
         {"label": "Mauritania", "value": "mauritania"},
         {"label": "Mauritius", "value": "mauritius"},
         {"label": "Mexico", "value": "mexico"},
-        {"label": "Micronesia", "value": "micronesia"},
         {"label": "Moldova", "value": "moldova"},
         {"label": "Mongolia", "value": "mongolia"},
         {"label": "Montenegro", "value": "montenegro"},

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -1494,6 +1494,7 @@
         {"label": "Eurasian Economic Union", "value": "eurasian-customs-union"},
         {"label": "Falkland Islands", "value": "falkland-islands"},
         {"label": "Faroe Islands", "value": "faroe-islands"},
+        {"label": "Federated States of Micronesia", "value": "federated-states-of-micronesia"},
         {"label": "Fiji", "value": "fiji"},
         {"label": "Finland", "value": "finland"},
         {"label": "France", "value": "france"},

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -488,10 +488,6 @@
           "label": "Mexico"
         },
         {
-          "value": "micronesia",
-          "label": "Micronesia"
-        },
-        {
           "value": "moldova",
           "label": "Moldova"
         },

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -485,10 +485,6 @@
           "label": "Mexico"
         },
         {
-          "value": "FM",
-          "label": "Micronesia"
-        },
-        {
           "value": "MD",
           "label": "Moldova"
         },


### PR DESCRIPTION
Replace 'Micronesia' with 'Federated States of Micronesia' - content request [Trello](https://trello.com/c/SU6BliYA/2438-replace-micronesia-with-federated-states-of-micronesia-content-request)

Following the process outline in these [docs](https://docs.publishing.service.gov.uk/manual/rename-a-country.html#7-update-specialist-publisher)

This is part 2 of a process started in this[ PR ](https://github.com/alphagov/specialist-publisher/pull/2592). Now that the data migration has taken place we can remove references to the old country name

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.