### PR TITLE
Update the factory for farming grants

### DIFF
--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -749,7 +749,7 @@ FactoryBot.define do
       default_metadata do
         {
           "areas_of_interest" => %w[air-quality],
-          "land_types" => %w[arable-land],
+          "land_types" => %w[grassland],
           "payment_types" => %w[capital],
         }
       end


### PR DESCRIPTION
We have renamed a facet value, `arable-land`, to `land`. That value was nonetheless still used in the factory, causing the schema tests in publishing-api to fail. Using a different value from the ones that were requested to be changed, so we can merge publishing-api in.

[Trello](https://trello.com/c/OViwwpK2/2529-changes-to-defra-grant-finder)
[Publishing api PR here](https://github.com/alphagov/publishing-api/pull/2717)
