### PR TITLE
Remove CDEI from AI Assurance Techniques finder

### DIFF
--- a/app/models/ai_assurance_portfolio_technique.rb
+++ b/app/models/ai_assurance_portfolio_technique.rb
@@ -24,6 +24,6 @@ class AiAssurancePortfolioTechnique < Document
   end
 
   def primary_publishing_organisation
-    "1405edcb-943d-42d2-8ec8-c51cd58335a5"
+    "c352c234-8083-47ec-8a4b-0edd45c31263"
   end
 end

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -9,11 +9,9 @@
     "format": "ai_assurance_portfolio_technique"
   },
   "organisations": [
-    "1405edcb-943d-42d2-8ec8-c51cd58335a5",
     "c352c234-8083-47ec-8a4b-0edd45c31263"
   ],
   "editing_organisations": [
-    "1405edcb-943d-42d2-8ec8-c51cd58335a5",
     "c352c234-8083-47ec-8a4b-0edd45c31263"
   ],
   "related": [


### PR DESCRIPTION
Remove 'Centre for Data Ethics and Innovation' from [AI Assurance Techniques finder](https://www.gov.uk/ai-assurance-techniques). CDEI is now part of DSIT, which is the remaining organisation on this finder.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5609840
Trello card: https://trello.com/c/tf946itm/2551-remove-centre-for-data-ethics-and-innovation-from-ai-assurance-techniques-finder

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
