### PR TITLE
Add "Greater Cambridge Partnership" to Algorithmic Transparency Records

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -151,6 +151,10 @@
         {
           "label": "Department for Education",
           "value": "department-for-education"
+        },
+        {
+          "label": "Greater Cambridge Partnership",
+          "value": "greater-cambridge-partnership"
         }
       ]
     },


### PR DESCRIPTION
Trello: https://trello.com/c/pZucErjg/2550-add-a-new-organisation-to-the-arts-finders-organisations-facet

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
