### PR TITLE
Rename farming grant options finder

### DIFF
--- a/app/models/farming_grant.rb
+++ b/app/models/farming_grant.rb
@@ -1,4 +1,4 @@
-class FarmingGrantOption < Document
+class FarmingGrant < Document
   validates :payment_types, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i[

--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -6,7 +6,7 @@
   "name": "Find funding for land or farms",
   "description": "Find out about grants and funding for farmers and land managers in England.",
   "filter": {
-    "format": "farming_grant_option"
+    "format": "farming_grant"
   },
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c",
@@ -15,7 +15,7 @@
   "show_summaries": true,
   "signup_content_id": "2cd12e92-3b68-4cb1-bafe-fde6a7939afb",
   "signup_copy": "You'll get an email each time a grant is updated or a new grant is published.",
-  "subscription_list_title_prefix": "Farming grant options",
+  "subscription_list_title_prefix": "Funding for land or farms",
   "summary": "<p>Find out about grants and funding for farmers and land managers in England. We will add more grants and funding as we develop this tool.</p><div class=\"application-notice info-notice\"><p>You can search for actions you can get paid for as part of the Sustainable Farming Incentive (SFI). The tool does not confirm your eligibility. <a href=\"https://www.gov.uk/government/collections/sustainable-farming-incentive-guidance\">Read the SFI guidance to check if you're eligible and how you can apply.</a></p></div><p>Search by keyword, action name or code if you know it. Use the filters to search by land types or areas of interest.</p>",
 
   "document_noun": "result",

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -741,9 +741,9 @@ FactoryBot.define do
     end
   end
 
-  factory :farming_grant_option, parent: :document do
+  factory :farming_grant, parent: :document do
     base_path { "/find-funding-for-land-or-farms/example-document" }
-    document_type { "farming_grant_option" }
+    document_type { "farming_grant" }
 
     transient do
       default_metadata do

--- a/spec/models/farming_grant_spec.rb
+++ b/spec/models/farming_grant_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 require "models/valid_against_schema"
 
-RSpec.describe FarmingGrantOption do
-  let(:payload) { FactoryBot.create(:farming_grant_option) }
+RSpec.describe FarmingGrant do
+  let(:payload) { FactoryBot.create(:farming_grant) }
   include_examples "it saves payloads that are valid against the 'specialist_document' schema"
-  subject(:farming_grant_option) { described_class.from_publishing_api(payload) }
+  subject(:farming_grant) { described_class.from_publishing_api(payload) }
 
   it "is not exportable" do
     expect(described_class).not_to be_exportable
@@ -12,12 +12,12 @@ RSpec.describe FarmingGrantOption do
 
   describe "validations" do
     it "is valid from the payload" do
-      expect(farming_grant_option).to be_valid
+      expect(farming_grant).to be_valid
     end
 
     it "is invalid if the payment types field is missing" do
-      farming_grant_option.payment_types = nil
-      expect(farming_grant_option).not_to be_valid
+      farming_grant.payment_types = nil
+      expect(farming_grant).not_to be_valid
     end
   end
 end


### PR DESCRIPTION
The users wanted the title changed, which introduces a bit of inconsistency with the way other document models and associated files are named in specialist publisher, so we are updating the name of the finder across publishing-api, search and publisher.

[trello card](https://trello.com/c/e0KYS9mQ/2584-farming-grant-options-breadcrumb-not-showing-not-able-to-save-documents)
