### PR TITLE
Remove pre-production flag

### DIFF
--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -1,5 +1,4 @@
 {
-  "pre_production": true,
   "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
   "base_path": "/find-funding-for-land-or-farms",
   "format_name": "Find funding for land or farms",


### PR DESCRIPTION
Removing the `pre-production` field. Upon merging, we will then be able to publish the finder using the `publish_finder` rake task. 
We want to do this in staging to get some confidence that the finder is working as expected, since integration is playing up.

We will not be publishing the finder in prod, and we will revert this change upon testing.

[Trello card](https://trello.com/c/e0KYS9mQ/2584-farming-grant-options-breadcrumb-not-showing-not-able-to-save-documents)


