### PR TITLE
Reenable pre-production flag for farming grants

### DIFF
--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -1,4 +1,5 @@
 {
+  "pre_production": true,
   "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
   "base_path": "/find-funding-for-land-or-farms",
   "format_name": "Find funding for land or farms",


### PR DESCRIPTION
We temporarily removed the pre-production flag to test in staging.

[Trello card](https://trello.com/c/e0KYS9mQ/2584-farming-grant-options-breadcrumb-not-showing-not-able-to-save-documents)
