### PR TITLE
Release farming grants finder

### DIFF
--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -1,5 +1,4 @@
 {
-  "pre_production": true,
   "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
   "base_path": "/find-funding-for-land-or-farms",
   "format_name": "Find funding for land or farms",


### PR DESCRIPTION
The finder is ready to be released.
Removing the `pre-production` field. Upon merging, we will then be able to publish the finder using the `publish_finder` rake task.

[trello](https://trello.com/c/cJDwKAx3/2393-release-defra-finder)