### PR TITLE
Show summaries in RAIB reports

### DIFF
--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -9,6 +9,7 @@
   },
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "show_summaries": true,
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],
   "subscription_list_title_prefix": {
     "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",


### PR DESCRIPTION
- this appears to just have been missed when the code was updated for RAIB/MAIB/AAIB reports.

https://govuk.zendesk.com/agent/tickets/5841871

Probably existing RAIB reports will have to be republished.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
