### PR TITLE
Add C4 context diagram for the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ bundle exec rake
 - [Creating and editing specialist document types](/docs/creating-editing-and-removing-specialist-document-types-and-finders.md)
 - [Updating existing organisation data](/docs/updating-existing-organisation-data.md)
 - [Historical info about migrating to use the Publishing API](/docs/phase-2-migration/README.md)
+- [C4 context diagram](docs/diagrams/c4-context.mmd)
 
 ## Licence
 

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -1,0 +1,31 @@
+C4Context
+    title System Context diagram for Specialist Finders
+
+    System_Ext(notify, "GOV.UK Notify", "Sends notifications to GOV.UK subscribers")
+    Person(user, "User", "A member of the public.")
+    Person(publisher, "Publisher", "A civil servant.")
+    System_Boundary(b0, "GOV.UK") {
+        System_Boundary(b1, "GOV.UK Web") {
+            System(finder_frontend, "Finder frontend", "Allows users to search and filter documents.")
+        }
+        System_Boundary(b2, "GOV.UK Publishing") {
+            System(search_api, "Search API", "An API for searching for documents.")
+            System(publishing_api, "Publishing API", "An API for publishing documents.")
+            System(content_store, "Content Store", "The store for denormalised GOV.UK content.")
+            System(specialist_publisher, "Specialist Publisher", "The tool for publishing specialist documents.")
+        }
+    }
+
+    BiRel(user, finder_frontend, "Uses")
+    BiRel(publisher, specialist_publisher, "Uses")
+    Rel(search_api, finder_frontend, "Fetches search results")
+    Rel(content_store, finder_frontend, "Fetches content")
+    Rel(publishing_api, search_api, "Indexes content")
+    Rel(publishing_api, content_store, "Stores content")
+    Rel(specialist_publisher, publishing_api, "Publishes content")
+    Rel(finder_frontend, notify, "Subscribes users to notifications")
+    Rel(publishing_api, notify, "Notifies on update")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+
+

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -7,6 +7,7 @@ C4Context
     System_Boundary(b0, "GOV.UK") {
         System_Boundary(b1, "GOV.UK Web") {
             System(finder_frontend, "Finder frontend", "Allows users to search and filter documents.")
+            System(government_frontend, "Government frontend", "Allow user to view documents published by the government.")
         }
         System_Boundary(b2, "GOV.UK Publishing") {
             System(search_api, "Search API", "An API for searching for documents.")
@@ -17,9 +18,11 @@ C4Context
     }
 
     BiRel(user, finder_frontend, "Uses")
+    BiRel(user, government_frontend, "Uses")
     BiRel(publisher, specialist_publisher, "Uses")
     Rel(search_api, finder_frontend, "Fetches search results")
-    Rel(content_store, finder_frontend, "Fetches content")
+    Rel(content_store, government_frontend, "Fetches document content")
+    Rel(content_store, finder_frontend, "Fetches finder content")
     Rel(publishing_api, search_api, "Indexes content")
     Rel(publishing_api, content_store, "Stores content")
     Rel(specialist_publisher, publishing_api, "Publishes content")

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -29,7 +29,7 @@ C4Context
     Rel(specialist_publisher, publishing_api, "Publishes content")
     Rel(finder_frontend, notify, "Subscribes users to notifications")
     Rel(publishing_api, notify, "Notifies on update")
-    Rel(developer, specialist_publisher, "Publishes finder")
+    Rel(developer, specialist_publisher, "Publishes finder and email signup")
     BiRel(publisher, specialist_publisher, "Uses")
 
     UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -3,24 +3,24 @@ C4Context
 
     System_Ext(notify, "GOV.UK Notify", "Sends notifications to GOV.UK subscribers")
     Person(user, "User", "A member of the public.")
-    Person(publisher, "Publisher", "A civil servant.")
     System_Boundary(b0, "GOV.UK") {
         System_Boundary(b1, "GOV.UK Web") {
             System(finder_frontend, "Finder frontend", "Allows users to search and filter documents.")
             System(government_frontend, "Government frontend", "Allow user to view documents published by the government.")
         }
         System_Boundary(b2, "GOV.UK Publishing") {
-            Person(developer, "Developer", "A Whitehall experience team member")
             System(search_api, "Search API", "An API for searching for documents.")
-            System(publishing_api, "Publishing API", "An API for publishing documents.")
             System(content_store, "Content Store", "The store for denormalised GOV.UK content.")
+            System(publishing_api, "Publishing API", "An API for publishing documents.")
             System(specialist_publisher, "Specialist Publisher", "The tool for publishing specialist documents.")
+            Person(developer, "Developer", "A Whitehall experience team member")
         }
     }
 
+    Person(publisher, "Publisher", "A civil servant.")
+
     BiRel(user, finder_frontend, "Uses")
     BiRel(user, government_frontend, "Uses")
-    BiRel(publisher, specialist_publisher, "Uses")
     Rel(search_api, finder_frontend, "Fetches search results")
     Rel(content_store, government_frontend, "Fetches document content")
     Rel(content_store, finder_frontend, "Fetches finder content")
@@ -30,7 +30,8 @@ C4Context
     Rel(finder_frontend, notify, "Subscribes users to notifications")
     Rel(publishing_api, notify, "Notifies on update")
     Rel(developer, specialist_publisher, "Publishes finder")
+    BiRel(publisher, specialist_publisher, "Uses")
 
-    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
 
 

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -1,28 +1,26 @@
 C4Context
     title System Context diagram for Specialist Finders
-
-    System_Ext(notify, "GOV.UK Notify", "Sends notifications to GOV.UK subscribers")
     Person(user, "User", "A member of the public.")
+    Person(publisher, "Publisher", "A civil servant.")
     System_Boundary(b0, "GOV.UK") {
         System_Boundary(b1, "GOV.UK Web") {
             System(finder_frontend, "Finder frontend", "Allows users to search and filter documents.")
+            System(email_alert_api, "Email alert API", "Manages email subscriptions")
             System(government_frontend, "Government frontend", "Allow user to view documents published by the government.")
         }
         System_Boundary(b2, "GOV.UK Publishing") {
             System(search_api, "Search API", "An API for searching for documents.")
             System(content_store, "Content Store", "The store for denormalised GOV.UK content.")
-            System(publishing_api, "Publishing API", "An API for publishing documents.")
             System(asset_manager, "Asset Manager", "Stores binary files")
+            System(publishing_api, "Publishing API", "An API for publishing documents.")
             System(specialist_publisher, "Specialist Publisher", "The tool for publishing specialist documents.")
             Person(developer, "Developer", "A Whitehall experience team member")
         }
-    }
 
-    Person(publisher, "Publisher", "A civil servant.")
+    }
 
     BiRel(user, finder_frontend, "Uses")
     BiRel(user, government_frontend, "Uses")
-    Rel(user, asset_manager, "Views attachments")
     Rel(search_api, finder_frontend, "Fetches search results")
     Rel(content_store, government_frontend, "Fetches document content")
     Rel(content_store, finder_frontend, "Fetches finder content")
@@ -30,11 +28,11 @@ C4Context
     Rel(publishing_api, content_store, "Stores content")
     Rel(specialist_publisher, publishing_api, "Publishes content")
     Rel(specialist_publisher, asset_manager, "Uploads attachments")
-    Rel(finder_frontend, notify, "Subscribes users to notifications")
-    Rel(publishing_api, notify, "Notifies on update")
+    Rel(finder_frontend, email_alert_api, "Subscribes users to notifications")
+    Rel(specialist_publisher, email_alert_api, "Notifies on update")
     Rel(developer, specialist_publisher, "Publishes finder and email signup")
     BiRel(publisher, specialist_publisher, "Uses")
 
-    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 
 

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -10,6 +10,7 @@ C4Context
             System(government_frontend, "Government frontend", "Allow user to view documents published by the government.")
         }
         System_Boundary(b2, "GOV.UK Publishing") {
+            Person(developer, "Developer", "A Whitehall experience team member")
             System(search_api, "Search API", "An API for searching for documents.")
             System(publishing_api, "Publishing API", "An API for publishing documents.")
             System(content_store, "Content Store", "The store for denormalised GOV.UK content.")
@@ -28,6 +29,7 @@ C4Context
     Rel(specialist_publisher, publishing_api, "Publishes content")
     Rel(finder_frontend, notify, "Subscribes users to notifications")
     Rel(publishing_api, notify, "Notifies on update")
+    Rel(developer, specialist_publisher, "Publishes finder")
 
     UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 

--- a/docs/diagrams/c4-context.mmd
+++ b/docs/diagrams/c4-context.mmd
@@ -12,6 +12,7 @@ C4Context
             System(search_api, "Search API", "An API for searching for documents.")
             System(content_store, "Content Store", "The store for denormalised GOV.UK content.")
             System(publishing_api, "Publishing API", "An API for publishing documents.")
+            System(asset_manager, "Asset Manager", "Stores binary files")
             System(specialist_publisher, "Specialist Publisher", "The tool for publishing specialist documents.")
             Person(developer, "Developer", "A Whitehall experience team member")
         }
@@ -21,12 +22,14 @@ C4Context
 
     BiRel(user, finder_frontend, "Uses")
     BiRel(user, government_frontend, "Uses")
+    Rel(user, asset_manager, "Views attachments")
     Rel(search_api, finder_frontend, "Fetches search results")
     Rel(content_store, government_frontend, "Fetches document content")
     Rel(content_store, finder_frontend, "Fetches finder content")
     Rel(publishing_api, search_api, "Indexes content")
     Rel(publishing_api, content_store, "Stores content")
     Rel(specialist_publisher, publishing_api, "Publishes content")
+    Rel(specialist_publisher, asset_manager, "Uploads attachments")
     Rel(finder_frontend, notify, "Subscribes users to notifications")
     Rel(publishing_api, notify, "Notifies on update")
     Rel(developer, specialist_publisher, "Publishes finder and email signup")


### PR DESCRIPTION
As we're looking at some technical improvements to Specialist Finders this quarter, I thought I would put together a diagram of the system as a whole. I think Specialist Publisher is probably the best place to keep this.

A couple of notes:

1. I can't do anything about the shonky layout, that doesn't seem to be a problem C4 diagram as code tools have solved yet unfortunately. Very annoying.
2. It's probably worth looking at the [link to the diagram in the branch](https://github.com/alphagov/specialist-publisher/blob/c4-context-diagram/docs/diagrams/c4-context.mmd) to review it, as the diff unfortunately doesn't show a preview of the actual diagram.
