### PR TITLE
Add `publish_pre_production_finders` rake task for republishing pre-production finders only

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_directory ../javascripts .js
 //= link_tree ../builds
+//= link application.css

--- a/app/lib/finder_loader.rb
+++ b/app/lib/finder_loader.rb
@@ -1,13 +1,14 @@
 require "multi_json"
 
 class FinderLoader
-  def finders
-    files.map do |json_schema|
+  def finders(pre_production_only: false)
+    data_objects = files.map do |json_schema|
       {
         file: MultiJson.load(File.read(json_schema)),
         timestamp: File.mtime(json_schema),
       }
     end
+    pre_production_only ? data_objects.select { |obj| obj[:file]["pre_production"] == true } : data_objects
   end
 
   def finder(name)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,6 +12,19 @@ namespace :publishing_api do
     end
   end
 
+  desc "Publish pre-production finders only, to the Publishing API"
+  task publish_pre_production_finders: :environment do
+    raise "Not allowed to publish pre-production finders in this environment" unless Rails.application.config.publish_pre_production_finders
+
+    finder_loader = FinderLoader.new
+
+    begin
+      PublishingApiFinderPublisher.new(finder_loader.finders(pre_production_only: true)).call
+    rescue GdsApi::HTTPServerError => e
+      puts "Error publishing finder: #{e.inspect}"
+    end
+  end
+
   desc "Publish a single Finder to the Publishing API"
   task :publish_finder, [:name] => :environment do |_, args|
     begin

--- a/spec/lib/finder_loader_spec.rb
+++ b/spec/lib/finder_loader_spec.rb
@@ -7,40 +7,45 @@ RSpec.describe FinderLoader do
     expect(File).to receive(:mtime).with("lib/documents/schemas/format-1.json")
                       .and_return("yesterday")
   end
-  it "returns matching finder data objects" do
-    expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
-      lib/documents/schemas/format-1.json
-      lib/documents/schemas/format-2.json
-    ])
-    expect(File).to receive(:read).with("lib/documents/schemas/format-2.json")
-      .and_return('{"name":"format-2"}')
-    expect(File).to receive(:mtime).with("lib/documents/schemas/format-2.json")
-      .and_return("today")
 
-    loader = FinderLoader.new
-    expect(loader.finders).to match_array([
-      {
-        file: { "name" => "format-1" },
-        timestamp: "yesterday",
-      },
-      {
+  describe "#finders" do
+    it "returns matching finder data objects" do
+      expect(Dir).to receive(:glob).with("lib/documents/schemas/*.json").and_return(%w[
+        lib/documents/schemas/format-1.json
+        lib/documents/schemas/format-2.json
+      ])
+      expect(File).to receive(:read).with("lib/documents/schemas/format-2.json")
+        .and_return('{"name":"format-2"}')
+      expect(File).to receive(:mtime).with("lib/documents/schemas/format-2.json")
+        .and_return("today")
 
-        file: { "name" => "format-2" },
-        timestamp: "today",
-      },
-    ])
+      loader = FinderLoader.new
+      expect(loader.finders).to match_array([
+        {
+          file: { "name" => "format-1" },
+          timestamp: "yesterday",
+        },
+        {
+
+          file: { "name" => "format-2" },
+          timestamp: "today",
+        },
+      ])
+    end
   end
 
-  it "returns one matching finder data object" do
-    expect(File).to receive(:exist?).with("lib/documents/schemas/format-1.json")
-                      .and_return(true)
+  describe "#finder" do
+    it "returns one matching finder data object" do
+      expect(File).to receive(:exist?).with("lib/documents/schemas/format-1.json")
+                        .and_return(true)
 
-    loader = FinderLoader.new
-    expect(loader.finder("format-1")).to match_array([
-      {
-        file: { "name" => "format-1" },
-        timestamp: "yesterday",
-      },
-    ])
+      loader = FinderLoader.new
+      expect(loader.finder("format-1")).to match_array([
+        {
+          file: { "name" => "format-1" },
+          timestamp: "yesterday",
+        },
+      ])
+    end
   end
 end


### PR DESCRIPTION
See commits for details.

Trello: https://trello.com/c/yPEWns6H/2738-make-daily-finder-cronjob-only-republish-pre-production-finders

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
