### PR TITLE
Remove unused GovukAdminTemplate /style-guide route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,6 @@ Rails.application.routes.draw do
   post "/preview", to: "govspeak#preview"
   get "/error", to: "passthrough#error"
 
-  mount GovukAdminTemplate::Engine, at: "/style-guide"
-
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]
 
   resources :documents, path: "/:document_type_slug", param: :content_id_and_locale, except: :destroy do


### PR DESCRIPTION
Attempting to access the route raises the following error:
> Pundit::AuthorizationNotPerformedError in
> GovukAdminTemplate::StyleGuideController#index

Sentry error: https://govuk.sentry.io/issues/5682336154/?environment=integration&project=202253&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=15m&stream_index=0

The route was added in 2015 with little context:
https://github.com/alphagov/specialist-publisher/commit/2c4f4f0d63d95c2c4490c66e75871816bb101143

There are no tests for it and presumably it has been broken for a long time. Given it's no longer used, let's remove it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
