### PR TITLE
WIP: pull Specialist Finder content items from Publishing API

### DIFF
--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -8,8 +8,8 @@ class FinderSchema
 
   attr_reader :base_path, :organisations, :format, :content_id, :editing_organisations
 
-  def initialize(schema_type)
-    @schema = load_schema_for(schema_type)
+  def initialize(schema_type: nil)
+    @schema = load_local_schema(schema_type)
     @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
     @editing_organisations = schema.fetch("editing_organisations", [])
@@ -48,7 +48,7 @@ private
 
   attr_reader :schema
 
-  def load_schema_for(type)
+  def load_local_schema(type)
     JSON.parse(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
   end
 

--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -8,58 +8,56 @@ class FinderSchema
 
   attr_reader :base_path, :organisations, :format, :content_id, :editing_organisations
 
-  def initialize(schema_type: nil)
-    @schema = load_local_schema(schema_type)
+  def initialize(content_id: nil)
+    @schema = load_remote_schema(content_id)
     @base_path = schema.fetch("base_path")
     @organisations = schema.fetch("organisations", [])
     @editing_organisations = schema.fetch("editing_organisations", [])
-    @format = schema.fetch("filter", {}).fetch("format")
+    @format = schema.fetch("details", {}).fetch("filter", {}).fetch("format")
     @content_id = schema.fetch("content_id")
   end
 
   def facets
-    schema.fetch("facets", []).map do |facet|
+    schema.fetch("details", []).fetch("facets", []).map do |facet|
       facet.fetch("key").to_sym
     end
   end
 
-  def options_for(facet_name)
-    allowed_values_as_option_tuples(allowed_values_for(facet_name))
+  def options_for(facet_name_as_symbol)
+    facet = schema&.fetch("details")&.fetch("facets")&.find { |facet_record| facet_name_as_symbol == facet_record["key"].to_sym }
+    allowed_values = facet.dig("allowed_values") || []
+    allowed_values_as_option_tuples(allowed_values)
   end
 
   def humanized_facet_value(facet_key, value)
-    type = facet_data_for(facet_key).fetch("type", nil)
-    if type == "text" && allowed_values_for(facet_key).empty?
+    facet = facet_data(facet_key)
+    allowed_values = facet.dig("allowed_values") || []
+    type = facet.fetch("type")
+    if type == "text" && allowed_values.empty?
       value
     elsif %w[hidden text].include?(type)
       Array(value).map do |v|
-        value_label_mapping_for(facet_key, v).fetch("label") { value }
+        value_label_mapping_for(allowed_values, v).fetch("label") { value }
       end
     else
-      value_label_mapping_for(facet_key, value).fetch("label") { value }
+      value_label_mapping_for(allowed_values, value).fetch("label") { value }
     end
   end
 
   def humanized_facet_name(key)
-    facet_data_for(key).fetch("name") { key.to_s.humanize }
+    facet_data(key)&.fetch("name") || key.to_s.humanize
   end
 
 private
 
   attr_reader :schema
 
-  def load_local_schema(type)
-    JSON.parse(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
+  def load_remote_schema(content_id)
+    DocumentFinder.find(Finder, content_id, "en")
   end
 
-  def facet_data_for(facet_name)
-    schema.fetch("facets", []).find do |facet_record|
-      facet_record.fetch("key") == facet_name.to_s
-    end || {}
-  end
-
-  def allowed_values_for(facet_name)
-    facet_data_for(facet_name).fetch("allowed_values", [])
+  def facet_data(key)
+    schema&.fetch("details")&.fetch("facets")&.find { |facet_record| key == facet_record["key"] }
   end
 
   def allowed_values_as_option_tuples(allowed_values)
@@ -71,8 +69,8 @@ private
     end
   end
 
-  def value_label_mapping_for(facet_key, value)
-    allowed_values_for(facet_key).find do |allowed_value|
+  def value_label_mapping_for(allowed_values, value)
+    allowed_values.find do |allowed_value|
       allowed_value.fetch("value") == value.to_s
     end || {}
   end

--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -25,6 +25,10 @@ class AaibReport < Document
     [AIR_ACCIDENTS_AND_SERIOUS_INCIDENTS_TAXON_ID]
   end
 
+  def self.content_id_for_finder
+    "b7574bba-969f-4c49-855a-ae1586258ff6"
+  end
+
   def self.title
     "AAIB Report"
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -332,7 +332,7 @@ class Document
   end
 
   def self.finder_schema
-    @finder_schema ||= FinderSchema.new(schema_type: document_type.pluralize)
+    @finder_schema ||= FinderSchema.new(content_id: new.class.content_id_for_finder)
   end
 
   def links

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -332,7 +332,7 @@ class Document
   end
 
   def self.finder_schema
-    @finder_schema ||= FinderSchema.new(document_type.pluralize)
+    @finder_schema ||= FinderSchema.new(schema_type: document_type.pluralize)
   end
 
   def links

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -1,0 +1,5 @@
+class Finder
+  def self.from_publishing_api(payload)
+    payload
+  end
+end

--- a/app/services/document_finder.rb
+++ b/app/services/document_finder.rb
@@ -1,4 +1,5 @@
 require "services"
+require_relative "../models/finder"
 
 # Find a document of a certain type by content_id. Returns a `Document` object.
 class DocumentFinder

--- a/lib/documents/schemas/aaib_reports-vs-publishing_api.txt
+++ b/lib/documents/schemas/aaib_reports-vs-publishing_api.txt
@@ -1,0 +1,83 @@
+{
+  "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6", # foo.to_h["content_id"]
+  "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"], # MISSING
+
+  "base_path": "/aaib-reports", # foo.to_h["base_path"]
+  "format_name": "Air Accidents Investigation Branch report", # foo.to_h["details"]["format_name"]
+  "name": "Air Accidents Investigation Branch reports", # foo.to_h["title"]
+  "description": "Find reports of AAIB investigations into air accidents and incidents", # foo.to_h["description"]
+  "phase": "live", # foo.to_h["phase"]
+  "filter": { # foo.to_h["details"]["filter"]
+    "format": "aaib_report"
+  },
+  "show_summaries": true, foo.to_h["details"]["show_summaries"]
+  "document_noun": "report", # foo.to_h["details"]["document_noun"]
+  "facets": [ # foo.to_h["details"]["facets"]
+    {
+      "key": "aircraft_category",
+      "name": "Category",
+      "type": "text",
+      "preposition": "in category",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
+        {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
+        {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
+        {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
+        {"label": "Spaceflight", "value": "spaceflight"},
+        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"},
+        {"label": "Unmanned Aircraft Systems (UAS)", "value": "unmanned-aircraft-systems"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "text",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "allowed_values": [
+        {"label": "Annual safety report", "value": "annual-safety-report"},
+        {"label": "Bulletin - Correspondence investigation", "value": "correspondence-investigation"},
+        {"label": "Bulletin - Field investigation", "value": "field-investigation"},
+        {"label": "Bulletin - Pre-1997 uncategorised monthly report", "value": "pre-1997-monthly-report"},
+        {"label": "Foreign report", "value": "foreign-report"},
+        {"label": "Formal report", "value": "formal-report"},
+        {"label": "Spaceflight", "value": "spaceflight"},
+        {"label": "Special bulletin", "value": "special-bulletin"},
+        {"label": "Safety study", "value": "safety-study"}
+      ]
+    },
+    {
+      "key": "date_of_occurrence",
+      "name": "Date of occurrence",
+      "short_name": "Occurred",
+      "type": "date",
+      "preposition": "occurred",
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "aircraft_type",
+      "name": "Aircraft type",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "location",
+      "name": "Location",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    },
+    {
+      "key": "registration",
+      "name": "Registration",
+      "type": "text",
+      "display_as_result_metadata": false,
+      "filterable": false
+    }
+  ]
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -155,7 +155,7 @@ FactoryBot.define do
       if document_type
         result = result.merge(
           links: {
-            finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
+            finder: [FinderSchema.new(content_id: "abc123").content_id],
           },
         )
       end
@@ -516,7 +516,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
+          finder: [FinderSchema.new(content_id: "abc123").content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -545,7 +545,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
+          finder: [FinderSchema.new(content_id: "abc123").content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -658,7 +658,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
+          finder: [FinderSchema.new(content_id: "abc123").content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -155,7 +155,7 @@ FactoryBot.define do
       if document_type
         result = result.merge(
           links: {
-            finder: [FinderSchema.new(document_type.pluralize).content_id],
+            finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
           },
         )
       end
@@ -516,7 +516,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -545,7 +545,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -658,7 +658,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(document_type.pluralize).content_id],
+          finder: [FinderSchema.new(schema_type: document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },

--- a/spec/fixtures/publishing_api/get_finder_payload.json
+++ b/spec/fixtures/publishing_api/get_finder_payload.json
@@ -1,0 +1,1048 @@
+{
+  "auth_bypass_ids": [],
+  "base_path": "/research-for-development-outputs",
+  "content_store": "live",
+  "description": "Find outputs from Research for Development projects",
+  "details": {
+    "facets": [
+      {
+        "key": "country",
+        "name": "Country",
+        "type": "text",
+        "filterable": true,
+        "preposition": "covering",
+        "allowed_values": [
+          {
+            "label": "Afghanistan",
+            "value": "AF"
+          },
+          {
+            "label": "Albania",
+            "value": "AL"
+          },
+          {
+            "label": "Algeria",
+            "value": "DZ"
+          },
+          {
+            "label": "Andorra",
+            "value": "AD"
+          },
+          {
+            "label": "Angola",
+            "value": "AO"
+          },
+          {
+            "label": "Antigua and Barbuda",
+            "value": "AG"
+          },
+          {
+            "label": "Argentina",
+            "value": "AR"
+          },
+          {
+            "label": "Armenia",
+            "value": "AM"
+          },
+          {
+            "label": "Australia",
+            "value": "AU"
+          },
+          {
+            "label": "Austria",
+            "value": "AT"
+          },
+          {
+            "label": "Azerbaijan",
+            "value": "AZ"
+          },
+          {
+            "label": "Bahamas, The",
+            "value": "BS"
+          },
+          {
+            "label": "Bahrain",
+            "value": "BH"
+          },
+          {
+            "label": "Bangladesh",
+            "value": "BD"
+          },
+          {
+            "label": "Barbados",
+            "value": "BB"
+          },
+          {
+            "label": "Belarus",
+            "value": "BY"
+          },
+          {
+            "label": "Belgium",
+            "value": "BE"
+          },
+          {
+            "label": "Belize",
+            "value": "BZ"
+          },
+          {
+            "label": "Benin",
+            "value": "BJ"
+          },
+          {
+            "label": "Bhutan",
+            "value": "BT"
+          },
+          {
+            "label": "Bolivia",
+            "value": "BO"
+          },
+          {
+            "label": "Bosnia and Herzegovina",
+            "value": "BA"
+          },
+          {
+            "label": "Botswana",
+            "value": "BW"
+          },
+          {
+            "label": "Brazil",
+            "value": "BR"
+          },
+          {
+            "label": "Brunei",
+            "value": "BN"
+          },
+          {
+            "label": "Bulgaria",
+            "value": "BG"
+          },
+          {
+            "label": "Burkina Faso",
+            "value": "BF"
+          },
+          {
+            "label": "Burma",
+            "value": "MM"
+          },
+          {
+            "label": "Burundi",
+            "value": "BI"
+          },
+          {
+            "label": "Cambodia",
+            "value": "KH"
+          },
+          {
+            "label": "Cameroon",
+            "value": "CM"
+          },
+          {
+            "label": "Canada",
+            "value": "CA"
+          },
+          {
+            "label": "Cape Verde",
+            "value": "CV"
+          },
+          {
+            "label": "Central African Republic",
+            "value": "CF"
+          },
+          {
+            "label": "Chad",
+            "value": "TD"
+          },
+          {
+            "label": "Chile",
+            "value": "CL"
+          },
+          {
+            "label": "China",
+            "value": "CN"
+          },
+          {
+            "label": "Colombia",
+            "value": "CO"
+          },
+          {
+            "label": "Comoros",
+            "value": "KM"
+          },
+          {
+            "label": "Congo",
+            "value": "CG"
+          },
+          {
+            "label": "Congo (Democratic Republic)",
+            "value": "CD"
+          },
+          {
+            "label": "Cook Islands",
+            "value": "CK"
+          },
+          {
+            "label": "Costa Rica",
+            "value": "CR"
+          },
+          {
+            "label": "Croatia",
+            "value": "HR"
+          },
+          {
+            "label": "Cuba",
+            "value": "CU"
+          },
+          {
+            "label": "Cyprus",
+            "value": "CY"
+          },
+          {
+            "label": "Czech Republic",
+            "value": "CZ"
+          },
+          {
+            "label": "Denmark",
+            "value": "DK"
+          },
+          {
+            "label": "Djibouti",
+            "value": "DJ"
+          },
+          {
+            "label": "Dominica",
+            "value": "DM"
+          },
+          {
+            "label": "Dominican Republic",
+            "value": "DO"
+          },
+          {
+            "label": "East Timor",
+            "value": "TL"
+          },
+          {
+            "label": "Ecuador",
+            "value": "EC"
+          },
+          {
+            "label": "Egypt",
+            "value": "EG"
+          },
+          {
+            "label": "El Salvador",
+            "value": "SV"
+          },
+          {
+            "label": "Equatorial Guinea",
+            "value": "GQ"
+          },
+          {
+            "label": "Eritrea",
+            "value": "ER"
+          },
+          {
+            "label": "Estonia",
+            "value": "EE"
+          },
+          {
+            "label": "Ethiopia",
+            "value": "ET"
+          },
+          {
+            "label": "Federated States of Micronesia",
+            "value": "FS"
+          },
+          {
+            "label": "Fiji",
+            "value": "FJ"
+          },
+          {
+            "label": "Finland",
+            "value": "FI"
+          },
+          {
+            "label": "France",
+            "value": "FR"
+          },
+          {
+            "label": "Gabon",
+            "value": "GA"
+          },
+          {
+            "label": "Gambia, The",
+            "value": "GM"
+          },
+          {
+            "label": "Georgia",
+            "value": "GE"
+          },
+          {
+            "label": "Germany",
+            "value": "DE"
+          },
+          {
+            "label": "Ghana",
+            "value": "GH"
+          },
+          {
+            "label": "Greece",
+            "value": "GR"
+          },
+          {
+            "label": "Grenada",
+            "value": "GD"
+          },
+          {
+            "label": "Guatemala",
+            "value": "GT"
+          },
+          {
+            "label": "Guinea",
+            "value": "GN"
+          },
+          {
+            "label": "Guinea-Bissau",
+            "value": "GW"
+          },
+          {
+            "label": "Guyana",
+            "value": "GY"
+          },
+          {
+            "label": "Haiti",
+            "value": "HT"
+          },
+          {
+            "label": "Honduras",
+            "value": "HN"
+          },
+          {
+            "label": "Hungary",
+            "value": "HU"
+          },
+          {
+            "label": "Iceland",
+            "value": "IS"
+          },
+          {
+            "label": "India",
+            "value": "IN"
+          },
+          {
+            "label": "Indonesia",
+            "value": "ID"
+          },
+          {
+            "label": "Iran",
+            "value": "IR"
+          },
+          {
+            "label": "Iraq",
+            "value": "IQ"
+          },
+          {
+            "label": "Ireland",
+            "value": "IE"
+          },
+          {
+            "label": "Israel",
+            "value": "IL"
+          },
+          {
+            "label": "Italy",
+            "value": "IT"
+          },
+          {
+            "label": "Ivory Coast",
+            "value": "CI"
+          },
+          {
+            "label": "Jamaica",
+            "value": "JM"
+          },
+          {
+            "label": "Japan",
+            "value": "JP"
+          },
+          {
+            "label": "Jordan",
+            "value": "JO"
+          },
+          {
+            "label": "Kazakhstan",
+            "value": "KZ"
+          },
+          {
+            "label": "Kenya",
+            "value": "KE"
+          },
+          {
+            "label": "Kiribati",
+            "value": "KI"
+          },
+          {
+            "label": "Kosovo",
+            "value": "XK"
+          },
+          {
+            "label": "Kuwait",
+            "value": "KW"
+          },
+          {
+            "label": "Kyrgyzstan",
+            "value": "KG"
+          },
+          {
+            "label": "Laos",
+            "value": "LA"
+          },
+          {
+            "label": "Latvia",
+            "value": "LV"
+          },
+          {
+            "label": "Lebanon",
+            "value": "LB"
+          },
+          {
+            "label": "Lesotho",
+            "value": "LS"
+          },
+          {
+            "label": "Liberia",
+            "value": "LR"
+          },
+          {
+            "label": "Libya",
+            "value": "LY"
+          },
+          {
+            "label": "Liechtenstein",
+            "value": "LI"
+          },
+          {
+            "label": "Lithuania",
+            "value": "LT"
+          },
+          {
+            "label": "Luxembourg",
+            "value": "LU"
+          },
+          {
+            "label": "North Macedonia",
+            "value": "MK"
+          },
+          {
+            "label": "Madagascar",
+            "value": "MG"
+          },
+          {
+            "label": "Malawi",
+            "value": "MW"
+          },
+          {
+            "label": "Malaysia",
+            "value": "MY"
+          },
+          {
+            "label": "Maldives",
+            "value": "MV"
+          },
+          {
+            "label": "Mali",
+            "value": "ML"
+          },
+          {
+            "label": "Malta",
+            "value": "MT"
+          },
+          {
+            "label": "Marshall Islands",
+            "value": "MH"
+          },
+          {
+            "label": "Mauritania",
+            "value": "MR"
+          },
+          {
+            "label": "Mauritius",
+            "value": "MU"
+          },
+          {
+            "label": "Mexico",
+            "value": "MX"
+          },
+          {
+            "label": "Moldova",
+            "value": "MD"
+          },
+          {
+            "label": "Monaco",
+            "value": "MC"
+          },
+          {
+            "label": "Mongolia",
+            "value": "MN"
+          },
+          {
+            "label": "Montenegro",
+            "value": "ME"
+          },
+          {
+            "label": "Morocco",
+            "value": "MA"
+          },
+          {
+            "label": "Mozambique",
+            "value": "MZ"
+          },
+          {
+            "label": "Namibia",
+            "value": "NA"
+          },
+          {
+            "label": "Nauru",
+            "value": "NR"
+          },
+          {
+            "label": "Nepal",
+            "value": "NP"
+          },
+          {
+            "label": "Netherlands",
+            "value": "NL"
+          },
+          {
+            "label": "New Zealand",
+            "value": "NZ"
+          },
+          {
+            "label": "Nicaragua",
+            "value": "NI"
+          },
+          {
+            "label": "Niger",
+            "value": "NE"
+          },
+          {
+            "label": "Nigeria",
+            "value": "NG"
+          },
+          {
+            "label": "North Korea",
+            "value": "KP"
+          },
+          {
+            "label": "Norway",
+            "value": "NO"
+          },
+          {
+            "label": "Oman",
+            "value": "OM"
+          },
+          {
+            "label": "Pakistan",
+            "value": "PK"
+          },
+          {
+            "label": "Palau",
+            "value": "PW"
+          },
+          {
+            "label": "Panama",
+            "value": "PA"
+          },
+          {
+            "label": "Papua New Guinea",
+            "value": "PG"
+          },
+          {
+            "label": "Paraguay",
+            "value": "PY"
+          },
+          {
+            "label": "Peru",
+            "value": "PE"
+          },
+          {
+            "label": "Philippines",
+            "value": "PH"
+          },
+          {
+            "label": "Poland",
+            "value": "PL"
+          },
+          {
+            "label": "Portugal",
+            "value": "PT"
+          },
+          {
+            "label": "Qatar",
+            "value": "QA"
+          },
+          {
+            "label": "Romania",
+            "value": "RO"
+          },
+          {
+            "label": "Russia",
+            "value": "RU"
+          },
+          {
+            "label": "Rwanda",
+            "value": "RW"
+          },
+          {
+            "label": "Samoa",
+            "value": "WS"
+          },
+          {
+            "label": "San Marino",
+            "value": "SM"
+          },
+          {
+            "label": "Sao Tome and Principe",
+            "value": "ST"
+          },
+          {
+            "label": "Saudi Arabia",
+            "value": "SA"
+          },
+          {
+            "label": "Senegal",
+            "value": "SN"
+          },
+          {
+            "label": "Serbia",
+            "value": "RS"
+          },
+          {
+            "label": "Seychelles",
+            "value": "SC"
+          },
+          {
+            "label": "Sierra Leone",
+            "value": "SL"
+          },
+          {
+            "label": "Singapore",
+            "value": "SG"
+          },
+          {
+            "label": "Slovakia",
+            "value": "SK"
+          },
+          {
+            "label": "Slovenia",
+            "value": "SI"
+          },
+          {
+            "label": "Solomon Islands",
+            "value": "SB"
+          },
+          {
+            "label": "Somalia",
+            "value": "SO"
+          },
+          {
+            "label": "South Africa",
+            "value": "ZA"
+          },
+          {
+            "label": "South Korea",
+            "value": "KR"
+          },
+          {
+            "label": "South Sudan",
+            "value": "SS"
+          },
+          {
+            "label": "Spain",
+            "value": "ES"
+          },
+          {
+            "label": "Sri Lanka",
+            "value": "LK"
+          },
+          {
+            "label": "St Kitts and Nevis",
+            "value": "KN"
+          },
+          {
+            "label": "St Lucia",
+            "value": "LC"
+          },
+          {
+            "label": "St Vincent",
+            "value": "VC"
+          },
+          {
+            "label": "Sudan",
+            "value": "SD"
+          },
+          {
+            "label": "Suriname",
+            "value": "SR"
+          },
+          {
+            "label": "Swaziland",
+            "value": "SZ"
+          },
+          {
+            "label": "Sweden",
+            "value": "SE"
+          },
+          {
+            "label": "Switzerland",
+            "value": "CH"
+          },
+          {
+            "label": "Syria",
+            "value": "SY"
+          },
+          {
+            "label": "Tajikistan",
+            "value": "TJ"
+          },
+          {
+            "label": "Tanzania",
+            "value": "TZ"
+          },
+          {
+            "label": "Thailand",
+            "value": "TH"
+          },
+          {
+            "label": "Togo",
+            "value": "TG"
+          },
+          {
+            "label": "Tonga",
+            "value": "TO"
+          },
+          {
+            "label": "Trinidad and Tobago",
+            "value": "TT"
+          },
+          {
+            "label": "Tunisia",
+            "value": "TN"
+          },
+          {
+            "label": "Turkey",
+            "value": "TR"
+          },
+          {
+            "label": "Turkmenistan",
+            "value": "TM"
+          },
+          {
+            "label": "Tuvalu",
+            "value": "TV"
+          },
+          {
+            "label": "Uganda",
+            "value": "UG"
+          },
+          {
+            "label": "Ukraine",
+            "value": "UA"
+          },
+          {
+            "label": "United Arab Emirates",
+            "value": "AE"
+          },
+          {
+            "label": "United Kingdom",
+            "value": "GB"
+          },
+          {
+            "label": "United States",
+            "value": "US"
+          },
+          {
+            "label": "Uruguay",
+            "value": "UY"
+          },
+          {
+            "label": "Uzbekistan",
+            "value": "UZ"
+          },
+          {
+            "label": "Vanuatu",
+            "value": "VU"
+          },
+          {
+            "label": "Vatican City",
+            "value": "VA"
+          },
+          {
+            "label": "Venezuela",
+            "value": "VE"
+          },
+          {
+            "label": "Vietnam",
+            "value": "VN"
+          },
+          {
+            "label": "Yemen",
+            "value": "YE"
+          },
+          {
+            "label": "Zambia",
+            "value": "ZM"
+          },
+          {
+            "label": "Zimbabwe",
+            "value": "ZW"
+          }
+        ],
+        "display_as_result_metadata": true
+      },
+      {
+        "key": "research_document_type",
+        "name": "Document Type",
+        "type": "text",
+        "filterable": true,
+        "short_name": "Document Type",
+        "preposition": "of type",
+        "allowed_values": [
+          {
+            "label": "Book",
+            "value": "book"
+          },
+          {
+            "label": "Book Chapter",
+            "value": "book_chapter"
+          },
+          {
+            "label": "Briefing",
+            "value": "briefing"
+          },
+          {
+            "label": "Case Study",
+            "value": "case_study"
+          },
+          {
+            "label": "Conference Paper",
+            "value": "conference_paper"
+          },
+          {
+            "label": "Country Report",
+            "value": "country_report"
+          },
+          {
+            "label": "Dataset",
+            "value": "dataset"
+          },
+          {
+            "label": "Discussion Paper",
+            "value": "discussion_paper"
+          },
+          {
+            "label": "Evaluation Report",
+            "value": "evaluation_report"
+          },
+          {
+            "label": "Journal Article",
+            "value": "journal_article"
+          },
+          {
+            "label": "Journal Issue",
+            "value": "journal_issue"
+          },
+          {
+            "label": "Lessons Learned",
+            "value": "lessons_learned"
+          },
+          {
+            "label": "Literature Review",
+            "value": "literature_review"
+          },
+          {
+            "label": "Manual",
+            "value": "manual"
+          },
+          {
+            "label": "Protocol",
+            "value": "protocol"
+          },
+          {
+            "label": "Research Paper",
+            "value": "research_paper"
+          },
+          {
+            "label": "Systematic Review",
+            "value": "systematic_review"
+          },
+          {
+            "label": "Technical Report",
+            "value": "technical_report"
+          },
+          {
+            "label": "Thematic Summary",
+            "value": "thematic_summary"
+          },
+          {
+            "label": "Tool kit",
+            "value": "tool_kit"
+          },
+          {
+            "label": "Training Materials",
+            "value": "training_materials"
+          },
+          {
+            "label": "Working Paper",
+            "value": "working_paper"
+          }
+        ],
+        "display_as_result_metadata": true
+      },
+      {
+        "key": "theme",
+        "name": "Theme",
+        "type": "text",
+        "filterable": true,
+        "short_name": "Theme",
+        "preposition": "about",
+        "allowed_values": [
+          {
+            "label": "Agriculture",
+            "value": "agriculture"
+          },
+          {
+            "label": "Climate and Environment",
+            "value": "climate_and_environment"
+          },
+          {
+            "label": "Economic Growth",
+            "value": "economic_growth"
+          },
+          {
+            "label": "Education",
+            "value": "education"
+          },
+          {
+            "label": "Food and Nutrition",
+            "value": "food_and_nutrition"
+          },
+          {
+            "label": "Governance and Conflict",
+            "value": "governance_and_conflict"
+          },
+          {
+            "label": "Health",
+            "value": "health"
+          },
+          {
+            "label": "Humanitarian Disasters and Emergencies",
+            "value": "humanitarian_disasters_and_emergencies"
+          },
+          {
+            "label": "Infrastructure",
+            "value": "infrastructure"
+          },
+          {
+            "label": "Research Communication and Uptake",
+            "value": "research_communication_and_uptake"
+          },
+          {
+            "label": "Social Change",
+            "value": "social_change"
+          },
+          {
+            "label": "Water and Sanitation",
+            "value": "water_and_sanitation"
+          }
+        ],
+        "display_as_result_metadata": true
+      },
+      {
+        "key": "first_published_at",
+        "name": "First published",
+        "type": "date",
+        "filterable": true,
+        "short_name": "First published",
+        "display_as_result_metadata": true
+      },
+      {
+        "key": "authors",
+        "name": "Authors",
+        "type": "text",
+        "filterable": false,
+        "short_name": "Authors",
+        "display_as_result_metadata": true
+      }
+    ],
+    "filter": {
+      "format": "research_for_development_output"
+    },
+    "summary": "\\u003cp\\u003eResearch outputs published before 2 September 2020 were published by the Department for International Development (DFID)\\u003c/p\\u003e",
+    "format_name": "Research for Development Output",
+    "document_noun": "output",
+    "show_summaries": false,
+    "default_documents_per_page": 50
+  },
+  "document_type": "finder",
+  "first_published_at": "2020-09-01T08:22:02Z",
+  "last_edited_at": "2024-06-07T13:47:51Z",
+  "phase": "live",
+  "public_updated_at": "2024-06-07T13:12:06Z",
+  "published_at": "2024-06-07T13:47:51Z",
+  "publishing_app": "specialist-publisher",
+  "publishing_api_first_published_at": "2020-09-01T08:22:02Z",
+  "publishing_api_last_edited_at": "2024-06-07T13:47:51Z",
+  "redirects": [],
+  "rendering_app": "finder-frontend",
+  "routes": [
+    {
+      "path": "/research-for-development-outputs",
+      "type": "exact"
+    },
+    {
+      "path": "/research-for-development-outputs.json",
+      "type": "exact"
+    },
+    {
+      "path": "/research-for-development-outputs.atom",
+      "type": "exact"
+    }
+  ],
+  "schema_name": "finder",
+  "title": "Research for Development Outputs",
+  "user_facing_version": 25,
+  "update_type": "minor",
+  "publication_state": "published",
+  "content_id": "853596e7-8ae3-42bd-838b-25ca3076e35f",
+  "locale": "en",
+  "lock_version": 25,
+  "updated_at": "2024-06-07T13:47:51Z",
+  "state_history": {
+    "1": "superseded",
+    "2": "superseded",
+    "3": "superseded",
+    "4": "superseded",
+    "5": "superseded",
+    "6": "superseded",
+    "7": "superseded",
+    "8": "superseded",
+    "9": "superseded",
+    "10": "superseded",
+    "11": "superseded",
+    "12": "superseded",
+    "13": "superseded",
+    "14": "superseded",
+    "15": "superseded",
+    "16": "superseded",
+    "17": "superseded",
+    "18": "superseded",
+    "19": "superseded",
+    "20": "superseded",
+    "21": "superseded",
+    "22": "superseded",
+    "23": "superseded",
+    "24": "superseded",
+    "25": "published"
+  },
+  "links": {}
+}

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -7,8 +7,57 @@ RSpec.describe FinderSchema do
     end
   end
 
-  context "the `schema_type` keyword arg is passed" do
-    let(:schema) { FinderSchema.new(schema_type: "research_for_development_outputs") }
+  context "the `content_id` keyword arg is passed" do
+    let(:content_id) { "853596e7-8ae3-42bd-838b-25ca3076e35f" }
+    let(:schema) { FinderSchema.new(content_id:) }
+
+    before do
+      payload = JSON.parse(File.read(Rails.root.join("spec/fixtures/publishing_api/get_finder_payload.json")))
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/#{content_id}?locale=en")
+        .to_return(status: 200, body: payload.to_json)
+    end
+
+    describe "base_path" do
+      it "returns the base path" do
+        expect(schema.base_path).to eq("/research-for-development-outputs")
+      end
+    end
+
+    describe "organisations" do
+      it "returns the organisations" do
+        expect(schema.organisations).to eq([])
+      end
+    end
+
+    describe "editing_organisations" do
+      it "returns the editing_organisations" do
+        expect(schema.editing_organisations).to eq([])
+      end
+    end
+
+    describe "format" do
+      it "returns the format" do
+        expect(schema.format).to eq("research_for_development_output")
+      end
+    end
+
+    describe "content_id" do
+      it "returns the content_id" do
+        expect(schema.content_id).to eq(content_id)
+      end
+    end
+
+    describe "facets" do
+      it "returns the facets names as symbols" do
+        expect(schema.facets).to eq(%i[country research_document_type theme first_published_at authors])
+      end
+    end
+
+    describe "options_for" do
+      it "returns options for the given facet name" do
+        expect(schema.options_for(:country).first).to eq(%w[Afghanistan AF])
+      end
+    end
 
     describe "#humanized_facet_name" do
       it "returns the name defined in the schema for the supplied facet key" do
@@ -53,4 +102,51 @@ RSpec.describe FinderSchema do
       end
     end
   end
+
+  # context "the `schema_type` keyword arg is passed" do
+  #   let(:schema) { FinderSchema.new(schema_type: "research_for_development_outputs") }
+
+  #   describe "#humanized_facet_name" do
+  #     it "returns the name defined in the schema for the supplied facet key" do
+  #       expect(schema.humanized_facet_name("research_document_type")).to eq("Document Type")
+  #     end
+
+  #     it "returns the humanized version of the supplied facet key is not defined in the schema" do
+  #       expect(schema.humanized_facet_name("review_status")).to eq("Review status")
+  #     end
+  #   end
+
+  #   describe "#humanized_facet_value" do
+  #     context "a text facet" do
+  #       context "with allowed_values " do
+  #         context "looking up a single value" do
+  #           it "returns an array with only the looked-up value" do
+  #             expect(schema.humanized_facet_value("country", "AL")).to eql(%w[Albania])
+  #           end
+  #         end
+
+  #         context "looking up multiple values" do
+  #           it "returns an array with the looked-up values" do
+  #             expect(schema.humanized_facet_value("country", %w[AL AF])).to eql(%w[Albania Afghanistan])
+  #           end
+  #         end
+  #       end
+
+  #       context "with an empty set of allowed_values" do
+  #         it "returns the value itself" do
+  #           authors_value = ["Mr. Potato Head", "Mrs. Potato Head"]
+  #           expect(
+  #             schema.humanized_facet_value("authors", authors_value),
+  #           ).to eql(authors_value)
+  #         end
+  #       end
+  #     end
+
+  #     context "a date facet" do
+  #       it "just returns the value unmodified" do
+  #         expect(schema.humanized_facet_value("first_published_at", "2012-01-01")).to eql("2012-01-01")
+  #       end
+  #     end
+  #   end
+  # end
 end

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -7,47 +7,49 @@ RSpec.describe FinderSchema do
     end
   end
 
-  let(:schema) { FinderSchema.new("research_for_development_outputs") }
+  context "the `schema_type` keyword arg is passed" do
+    let(:schema) { FinderSchema.new(schema_type: "research_for_development_outputs") }
 
-  describe "#humanized_facet_name" do
-    it "returns the name defined in the schema for the supplied facet key" do
-      expect(schema.humanized_facet_name("research_document_type")).to eq("Document Type")
+    describe "#humanized_facet_name" do
+      it "returns the name defined in the schema for the supplied facet key" do
+        expect(schema.humanized_facet_name("research_document_type")).to eq("Document Type")
+      end
+
+      it "returns the humanized version of the supplied facet key is not defined in the schema" do
+        expect(schema.humanized_facet_name("review_status")).to eq("Review status")
+      end
     end
 
-    it "returns the humanized version of the supplied facet key is not defined in the schema" do
-      expect(schema.humanized_facet_name("review_status")).to eq("Review status")
-    end
-  end
+    describe "#humanized_facet_value" do
+      context "a text facet" do
+        context "with allowed_values " do
+          context "looking up a single value" do
+            it "returns an array with only the looked-up value" do
+              expect(schema.humanized_facet_value("country", "AL")).to eql(%w[Albania])
+            end
+          end
 
-  describe "#humanized_facet_value" do
-    context "a text facet" do
-      context "with allowed_values " do
-        context "looking up a single value" do
-          it "returns an array with only the looked-up value" do
-            expect(schema.humanized_facet_value("country", "AL")).to eql(%w[Albania])
+          context "looking up multiple values" do
+            it "returns an array with the looked-up values" do
+              expect(schema.humanized_facet_value("country", %w[AL AF])).to eql(%w[Albania Afghanistan])
+            end
           end
         end
 
-        context "looking up multiple values" do
-          it "returns an array with the looked-up values" do
-            expect(schema.humanized_facet_value("country", %w[AL AF])).to eql(%w[Albania Afghanistan])
+        context "with an empty set of allowed_values" do
+          it "returns the value itself" do
+            authors_value = ["Mr. Potato Head", "Mrs. Potato Head"]
+            expect(
+              schema.humanized_facet_value("authors", authors_value),
+            ).to eql(authors_value)
           end
         end
       end
 
-      context "with an empty set of allowed_values" do
-        it "returns the value itself" do
-          authors_value = ["Mr. Potato Head", "Mrs. Potato Head"]
-          expect(
-            schema.humanized_facet_value("authors", authors_value),
-          ).to eql(authors_value)
+      context "a date facet" do
+        it "just returns the value unmodified" do
+          expect(schema.humanized_facet_value("first_published_at", "2012-01-01")).to eql("2012-01-01")
         end
-      end
-    end
-
-    context "a date facet" do
-      it "just returns the value unmodified" do
-        expect(schema.humanized_facet_value("first_published_at", "2012-01-01")).to eql("2012-01-01")
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Document do
   let(:document) { MyDocumentType.from_publishing_api(payload) }
 
   before do
-    allow_any_instance_of(FinderSchema).to receive(:load_schema_for).with("my_document_types")
+    allow_any_instance_of(FinderSchema).to receive(:load_local_schema).with("my_document_types")
       .and_return(finder_schema)
   end
 

--- a/spec/services/republish_service_spec.rb
+++ b/spec/services/republish_service_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe RepublishService do
   end
 
   before do
+    stub_finder_payload
     stub_any_publishing_api_call
     stub_publishing_api_has_item(document)
+    stub_finder_payload
   end
 
   shared_examples "preserve timestamp" do |times: 1|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,12 @@ require "pundit/rspec"
 require "govuk_sidekiq/testing"
 Sidekiq::Testing.inline!
 
+def stub_finder_payload
+  payload = JSON.parse(File.read(Rails.root.join("spec/fixtures/publishing_api/get_finder_payload.json")))
+  stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/abc123?locale=en")
+    .to_return(status: 200, body: payload.to_json)
+end
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
 
@@ -48,6 +54,10 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
+  end
+
+  config.before do
+    stub_finder_payload
   end
 
   config.before(:each) do


### PR DESCRIPTION
WIP.

Appears to be working:

```
$ kconsole specialist-publisher
console$ DocumentFinder.find(Finder, "b7574bba-969f-4c49-855a-ae1586258ff6", "en")
=> 
{"auth_bypass_ids"=>[],
 "base_path"=>"/aaib-reports",
 "content_store"=>"live",
 "description"=>"Find reports of AAIB investigations into air accidents and incidents",
 "details"=>
  {"facets"=>
    [{"key"=>"aircraft_category",
      "name"=>"Category",
...
```

Once the tests are sorted, we can define a `content_id_for_finder` method on all existing finders, and delete all of the schema JSON files 🎉 (we then need to consider how to add a new specialist finder, and make changes).

Trello: https://trello.com/c/cevf50zS/2451-spike-specialist-finder-previews-kick-off-needed

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
