### PR TITLE
Point users to GOV.UK docker documentation for running specialist finders locally

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,53 +1,8 @@
 # Local Development
 
-It is possible to test changes to specialist finders end-to-end using the govuk docker stack. This is useful to avoid having to reindex all of the content on integration to test changes. Here's how to do it:
+## Testing finders end-to-end locally
 
-1. Start the specialist publisher and finder frontend services. They will spin up all necessary dependencies.
-
-```bash
-govuk-docker up specialist-publisher-app -d
-govuk-docker up finder-frontend -d
-```
-
-2. Create the search indices
-
-```bash
-govuk-docker exec search-api-app env SEARCH_INDEX=all bundle exec rake search:create_all_indices
-```
-
-3. Create the RabbitMQ exchange for Publishing API to send messages to
-
-```bash
-govuk-docker exec publishing-api-app bundle exec rake setup_exchange
-```
-
-4. Create the Search API message queues
-
-```bash
-govuk-docker exec search-api-app bundle exec rake message_queue:create_queues
-```
-
-5. Publish the routes for the Search API endpoints
-
-```bash
-govuk-docker exec search-api-app bundle exec rake publishing_api:publish_special_routes
-```
-
-6. Publish your finder, for example
-
-```bash
-govuk-docker exec specialist-publisher-app bundle exec rails publishing_api:publish_finder\[ai_assurance_portfolio_techniques\] 
-```
-
-7. Run the Search API queue consumer. You need to keep this process running to index published documents.
-
-```bash
-govuk-docker exec search-api-worker bundle exec rake message_queue:insert_data_into_govuk
-```
-
-When you publish a specialist document, it should be updated in the search results.
-
-Note that elasticsearch data is not persisted when you stop the docker container at present.
+See the [GOV.UK Docker documentation](https://docs.publishing.service.gov.uk/repos/govuk-docker/how-tos/finder-setup.html).
 
 ## Search API configuration changes
 


### PR DESCRIPTION
Documentation is difficult enough to keep up to date without having duplicate copies around!