### PR TITLE
Correct spelling of remuneration on employment tribunal decision filter

### DIFF
--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -223,8 +223,8 @@
           "prechecked": false
         },
         {
-          "radio_button_name": "Renumeration",
-          "topic_name": "renumeration",
+          "radio_button_name": "Remuneration",
+          "topic_name": "remuneration",
           "key": "renumeration",
           "prechecked": false
         },
@@ -520,7 +520,7 @@
           "value": "religion-or-belief-discrimination"
         },
         {
-          "label": "Renumeration",
+          "label": "Remuneration",
           "value": "renumeration"
         },
         {


### PR DESCRIPTION
Note that we only change the label because there is already data in Search API associated with the old (incorrect) value 😢 

Trello: https://trello.com/c/p8T47NcL