### PR TITLE
Add new values to stage facet in service standard reports schema

### DIFF
--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -48,11 +48,14 @@
       "allowed_values": [
         {"label": "Alpha", "value": "alpha"},
         {"label": "Alpha reassessment", "value": "alpha-reassessment"},
+        {"label": "Alpha amber evidence review", "value": "alpha-amber-evidence-review"},
         {"label": "Beta", "value": "beta"},
         {"label": "Beta reassessment", "value": "beta-reassessment"},
+        {"label": "Beta amber evidence review", "value": "beta-amber-evidence-review"},
         {"label": "Live", "value": "live"},
         {"label": "Live reassessment", "value": "live-reassessment"},
-        {"label": "Live review", "value": "live-review"}
+        {"label": "Live review", "value": "live-review"},
+        {"label": "Live amber evidence review", "value": "live-amber-evidence-review"}
       ]
     }
   ]


### PR DESCRIPTION
CDDO would like to update the [Service Standards Reports](https://www.gov.uk/service-standard-reports) finder.

All they’ve asked for so far is to add one more drop-down option.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5905154

[Trello ticket](https://trello.com/c/sImB9Gm7/2810-update-service-standards-reports-finder)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
