### PR TITLE
Add "View on website" link to specialist finder index pages.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -298,6 +298,10 @@ class Document
     title.parameterize.pluralize
   end
 
+  def self.live_url
+    URI.join(Plek.website_root, finder_schema.base_path).to_s
+  end
+
   def content_id_and_locale
     "#{content_id}:#{locale}"
   end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -7,6 +7,14 @@
 <h1 class="page-header"><%= current_format.title.pluralize %></h1>
 
 <div class="row">
+  <div class="col-md-12 text-right">
+    <p>
+      <%= link_to "View on website (opens in new tab)", current_format.live_url, target: "_blank" %>
+    </p>
+  </div>
+</div>
+
+<div class="row">
   <div class="sidebar col-md-3">
     <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'action-link' %>
     <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "add-vertical-margins well") do %>

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -25,6 +25,14 @@ RSpec.feature "Searching and filtering", type: :feature do
     log_in_as_editor(:cma_editor)
   end
 
+  scenario "visiting the index has a preview link" do
+    stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
+
+    visit "/cma-cases"
+
+    expect(page).to have_link("View on website (opens in new tab)", href: "http://www.dev.gov.uk/cma-cases")
+  end
+
   context "visiting the index with results" do
     before do
       stub_publishing_api_has_content(cma_cases, hash_including(document_type: CmaCase.document_type))

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe Document do
     expect(MyDocumentType.document_type).to eq("my_document_type")
   end
 
+  it "has a link to the live URL of the finder" do
+    schema = double("some schema", base_path: "/foo")
+    allow(MyDocumentType).to receive(:finder_schema).and_return(schema)
+    expect(MyDocumentType.live_url).to eq("http://www.dev.gov.uk/foo")
+  end
+
   describe "parsing date params" do
     it "sets a date string from rails date select style params" do
       doc = MyDocumentType.new("field1(1i)": "2016", "field1(2i)": "09", "field1(3i)": "07")


### PR DESCRIPTION
Trello: https://trello.com/c/q397lsTa/2817-add-preview-links-to-specialist-publisher

See commits for details. Screenshot:

![screenshot of AAIB report index page](https://github.com/user-attachments/assets/f64ef2b0-1ee2-4fc7-ae92-72f94e78da50)

CAVEATS: assumes all finders are live. Adding finder previews will complicate things (see https://trello.com/c/JrkAwfDU/2786-dynamically-update-stacks-based-on-state-of-specialist-finder#comment-66e1a6db04669f5e44e09a3c).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
