### PR TITLE
Two content changes to Life Saving Maritime Appliance Service Stations

### DIFF
--- a/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
+++ b/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
@@ -32,7 +32,8 @@
         {"label": "West Midlands", "value": "west-midlands"},
         {"label": "Yorkshire and The Humber", "value": "yorkshire-and-the-humber"},
         {"label": "Scotland", "value": "scotland"},
-        {"label": "Wales", "value": "wales"}
+        {"label": "Wales", "value": "wales"},
+        {"label": "Northern Ireland", "value": "northern-ireland"}
       ]
     },
     {
@@ -126,7 +127,7 @@
           "value": "eurovinil"
         },
         {
-          "label": "Fujikura MES",
+          "label": "Fujikura",
           "value": "fujikura-mes"
         },
         {


### PR DESCRIPTION
Add Northern Ireland to life saving maritime appliance service station region options.

And relabel one of the appliance manufacturers

Trello: https://trello.com/c/LilUa29H
