### PR TITLE
Remove focus sector facet from AI assurance techniques finder

### DIFF
--- a/app/models/ai_assurance_portfolio_technique.rb
+++ b/app/models/ai_assurance_portfolio_technique.rb
@@ -6,7 +6,6 @@ class AiAssurancePortfolioTechnique < Document
     key_function
     ai_assurance_technique
     assurance_technique_approach
-    focus_sector
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
+++ b/app/views/metadata_fields/_portfolio_of_assurance_techniques.html.erb
@@ -87,19 +87,3 @@
       }
   %>
 <% end %>
-
-<%= render layout: "shared/form_group", locals: { f: f, field: :focus_sector } do %>
-  <%= f.select :focus_sector,
-               facet_options(f, :focus_sector),
-               {},
-               {
-                 class: 'select2 form-control',
-                 multiple: true,
-                 data:
-                   {
-                     placeholder: 'Select a focus sector'
-                   }
-               }
-  %>
-<% end %>
-

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -303,20 +303,6 @@
           "value": "educational"
         }
       ]
-    },
-    {
-      "key": "focus_sector",
-      "name": "Focus Sector",
-      "type": "text",
-      "preposition": "Focus Sector",
-      "display_as_result_metadata": true,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "label": "Financial Services",
-          "value": "financial-services"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Trello: https://trello.com/c/Gevbmi5F/2828-remove-focus-sector-filter-from-ai-assurance-techniques-finder
