### PR TITLE
Remove related links ATR

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -16,8 +16,6 @@
     "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
   ],
   "related": [
-    "12b8c1ed-46c8-4943-a2c0-5dadc768fdb0",
-    "4e5f4a62-ec3d-49ec-a73c-ab2429babf12",
     "9be2896c-2c32-4108-a465-e37ba16f6dd1"
   ],
   "show_summaries": true,


### PR DESCRIPTION
Remove the sidebar links to the “Algorithmic Transparency Recording Standard” and “Guidance for organisations using the Algorithmic Transparency Recording Standard” (current top and bottom link).

[Zendesk](https://govuk.zendesk.com/agent/tickets/5919565)
[Trello](https://trello.com/c/frX7PHrO/2829-remove-links-from-algorithmic-transparency-record-finder)