### PR TITLE
Rake task to allow bulk publishing that disables email sending

### DIFF
--- a/app/lib/publisher.rb
+++ b/app/lib/publisher.rb
@@ -1,13 +1,13 @@
 require "services"
 
 class Publisher
-  def self.publish_all(types: nil)
-    new(types).publish_all
+  def self.publish_all(types: nil, disable_email_alert: false)
+    new(types).publish_all(disable_email_alert)
   end
 
-  def publish_all
+  def publish_all(disable_email_alert)
     types.each do |document_type|
-      publish_document_type(document_type)
+      publish_document_type(document_type, disable_email_alert)
     end
   end
 
@@ -19,11 +19,12 @@ private
     @types = types.presence || document_types
   end
 
-  def publish_document_type(document_type)
+  def publish_document_type(document_type, disable_email_alert)
     content_id_and_locale_pairs_for_document_type(
       document_type,
     ).each do |content_id, locale|
       document = Document.find(content_id, locale)
+      document.disable_email_alert = true if disable_email_alert
 
       unless Services.with_timeout(30) { document.publish }
         Rails.logger.warn "Cannot publish document: #{content_id}:#{locale}"

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,6 +30,7 @@ class Document
     :first_published_at,
     :previous_version,
     :warnings,
+    :disable_email_alert,
   )
 
   def temporary_update_type
@@ -59,6 +60,7 @@ class Document
     bulk_published
     temporary_update_type
     warnings
+    disable_email_alert
   ].freeze
 
   def self.policy_class
@@ -307,7 +309,11 @@ class Document
   end
 
   def send_email_on_publish?
-    update_type == "major"
+    if disable_email_alert.present? && ![true, false].include?(disable_email_alert)
+      raise "Invalid disable email alert flag. Please use booleans only."
+    end
+
+    update_type == "major" && !disable_email_alert
   end
 
   # This is set to nil for all non-urgent emails.

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -4,12 +4,22 @@ require "services"
 
 namespace :publish do
   desc "Publishes all documents of given types in a draft publication state.\n" \
-    "Usage: `rake publish:all[protected_food_drink_name,esi_fund]`"
+    "Usage: `rake publish:all[protected_food_drink_name esi_fund]`"
   task :all, [:document_types] => :environment do |_, args|
     types = args.document_types.presence&.split(" ")&.compact
 
-    raise ArgumentError, "No type given." if types.empty?
+    raise ArgumentError, "No type given." if types.blank?
 
     Publisher.publish_all(types:)
+  end
+
+  desc "Publishes all documents of given types in a draft publication state, but does not send any email alerts.\n" \
+         "Usage: `rake publish:all_silent[protected_food_drink_name,esi_fund]`"
+  task :all_silent, [:document_types] => :environment do |_, args|
+    types = args.document_types.presence&.split(" ")&.compact
+
+    raise ArgumentError, "No type given." if types.blank?
+
+    Publisher.publish_all(types:, disable_email_alert: true)
   end
 end

--- a/spec/lib/tasks/publish_spec.rb
+++ b/spec/lib/tasks/publish_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "publish rake tasks", type: :task do
+  describe "publish:all" do
+    let(:task) { Rake::Task["publish:all"] }
+    before(:each) { task.reenable }
+
+    it "errors if no document type is given" do
+      expect { task.invoke("") }.to raise_error("No type given.")
+    end
+
+    it "calls publisher with the input document types" do
+      expect(Publisher).to receive(:publish_all).with({ types: %w[abc def] })
+      task.invoke("abc def")
+    end
+  end
+
+  describe "publish:all_silent" do
+    let(:task) { Rake::Task["publish:all_silent"] }
+    before(:each) { task.reenable }
+
+    it "errors if no document type is given" do
+      expect { task.invoke("") }.to raise_error("No type given.")
+    end
+
+    it "calls publisher with the input document types" do
+      expect(Publisher).to receive(:publish_all).with({ types: %w[abc def], disable_email_alert: true })
+      task.invoke("abc def")
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -833,4 +833,41 @@ RSpec.describe Document do
       expect(AaibReport.title).to eq("AAIB Report")
     end
   end
+
+  describe "#send_email_on_publish?" do
+    it "should send email if document is major update and no disable_email_alert override exists" do
+      doc = MyDocumentType.new(update_type: "major")
+      expect(doc.send_email_on_publish?).to be true
+    end
+
+    it "should send email if document is major update and disable_email_alert override is false" do
+      doc = MyDocumentType.new(update_type: "major")
+      doc.disable_email_alert = false
+      expect(doc.send_email_on_publish?).to be true
+    end
+
+    it "should raise an error if document is major update and disable_email_alert override is a random string" do
+      doc = MyDocumentType.new(update_type: "major")
+      doc.disable_email_alert = "invalid"
+      expect { doc.send_email_on_publish? }.to raise_error("Invalid disable email alert flag. Please use booleans only.")
+    end
+
+    it "should stop send email if document is major update and disable_email_alert override is true" do
+      doc = MyDocumentType.new(update_type: "major")
+      doc.disable_email_alert = true
+      expect(doc.send_email_on_publish?).to be false
+    end
+
+    it "should stop send email if document is minor update and disable_email_alert override is true" do
+      doc = MyDocumentType.new(update_type: "minor")
+      doc.disable_email_alert = true
+      expect(doc.send_email_on_publish?).to be false
+    end
+
+    it "should stop send email if document is minor update even if disable_email_alert override is false" do
+      doc = MyDocumentType.new(update_type: "minor")
+      doc.disable_email_alert = false
+      expect(doc.send_email_on_publish?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Introduced a flag on the document model - this flag is used to override whether or not emails should be sent for a document upon publishing. 

We use this flag in the bulk publishing rake task so we can silence alerts when publishing in large amounts.

In the future could potentially it could be used within a self-serve UI so users can decide themselves whether or not to alert with an email during publishing. However this UI solution needs to consider the fact that the flag is not yet persisted within Publishing API, and documents are persisted within Publishing API, not Specialist Publisher.

https://trello.com/c/BRwLszUk/2841-investigate-email-alerts-for-ova-finder


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
