### PR TITLE
Add preview link for draft finders

### DIFF
--- a/app/lib/finder_schema.rb
+++ b/app/lib/finder_schema.rb
@@ -10,11 +10,12 @@ class FinderSchema
     JSON.parse(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
   end
 
-  attr_reader :schema, :base_path, :organisations, :editing_organisations, :taxons, :format, :content_id, :document_title
+  attr_reader :schema, :base_path, :target_stack, :organisations, :editing_organisations, :taxons, :format, :content_id, :document_title
 
   def initialize(schema)
     @schema = schema
     @base_path = schema.fetch("base_path")
+    @target_stack = schema.fetch("target_stack")
     @organisations = schema.fetch("organisations", [])
     @editing_organisations = schema.fetch("editing_organisations", [])
     @taxons = schema.fetch("taxons", [])

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -308,6 +308,10 @@ class Document
     URI.join(Plek.website_root, finder_schema.base_path).to_s
   end
 
+  def self.draft_url
+    URI.join(Plek.external_url_for("draft-origin"), finder_schema.base_path).to_s
+  end
+
   def content_id_and_locale
     "#{content_id}:#{locale}"
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -110,6 +110,10 @@ class Document
     self.class.document_type
   end
 
+  def self.target_stack
+    finder_schema.target_stack
+  end
+
   def self.document_type
     to_s.underscore
   end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -9,7 +9,11 @@
 <div class="row">
   <div class="col-md-12 text-right">
     <p>
-      <%= link_to "View on website (opens in new tab)", current_format.live_url, target: "_blank" %>
+      <% if current_format.target_stack == "draft" %>
+        <%= link_to "Preview draft (opens in new tab)", current_format.draft_url, target: "_blank" %>
+      <% elsif current_format.target_stack == "live" %>
+        <%= link_to "View on website (opens in new tab)", current_format.live_url, target: "_blank" %>
+      <% end %>
     </p>
   </div>
 </div>

--- a/spec/features/searching_and_filtering_cma_cases_spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_spec.rb
@@ -25,12 +25,22 @@ RSpec.feature "Searching and filtering", type: :feature do
     log_in_as_editor(:cma_editor)
   end
 
-  scenario "visiting the index has a preview link" do
+  scenario "visiting the index of a live finder has a link to 'view on website'" do
     stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
 
     visit "/cma-cases"
 
     expect(page).to have_link("View on website (opens in new tab)", href: "http://www.dev.gov.uk/cma-cases")
+  end
+
+  scenario "visiting the index of a draft finder has a link to 'preview draft'" do
+    stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
+
+    allow(CmaCase).to receive(:target_stack).and_return("draft")
+
+    visit "/cma-cases"
+
+    expect(page).to have_link("Preview draft (opens in new tab)", href: "http://draft-origin.dev.gov.uk/cma-cases")
   end
 
   context "visiting the index with results" do

--- a/spec/lib/finder_schema_spec.rb
+++ b/spec/lib/finder_schema_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe FinderSchema do
   let(:mandatory_properties) do
     {
       "base_path" => "stubbed",
+      "target_stack" => "live",
       "content_id" => "stubbed",
       "document_title" => "stubbed",
       "filter" => {
@@ -36,6 +37,12 @@ RSpec.describe FinderSchema do
     it "returns the base path" do
       properties = mandatory_properties.merge({ "base_path" => "/research-for-development-outputs" })
       expect(FinderSchema.new(properties).base_path).to eq("/research-for-development-outputs")
+    end
+  end
+
+  describe "#target_stack" do
+    it "returns the stack the finder has been deployed to" do
+      expect(FinderSchema.new(mandatory_properties).target_stack).to eq("live")
     end
   end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Document do
   let(:finder_schema) do
     {
       base_path: "/my-document-types",
+      target_stack: "live",
       filter: {
         format: "my_format",
       },
@@ -815,6 +816,13 @@ RSpec.describe Document do
         document = MyDocumentType.new
         allow(document.finder_schema).to receive(:taxons).and_return(%w[foo])
         expect(document.taxons).to eq(%w[foo])
+      end
+    end
+
+    describe "#target_stack" do
+      it "delegates to the FinderSchema" do
+        allow(MyDocumentType.finder_schema).to receive(:target_stack).and_return("draft")
+        expect(MyDocumentType.target_stack).to eq("draft")
       end
     end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Document do
     expect(MyDocumentType.live_url).to eq("http://www.dev.gov.uk/foo")
   end
 
+  it "has a link to the draft URL of the finder" do
+    schema = double("some schema", base_path: "/foo")
+    allow(MyDocumentType).to receive(:finder_schema).and_return(schema)
+    expect(MyDocumentType.draft_url).to eq("http://draft-origin.dev.gov.uk/foo")
+  end
+
   describe "parsing date params" do
     it "sets a date string from rails date select style params" do
       doc = MyDocumentType.new("field1(1i)": "2016", "field1(2i)": "09", "field1(3i)": "07")


### PR DESCRIPTION
This PR conditionally shows either a "View on website" link (if the finder is live) or a "Preview draft" link (if the finder is still under development).

> ![Screenshot 2024-10-02 at 16 05 07](https://github.com/user-attachments/assets/563224dd-d947-4cb5-9e7d-eae0f504f7c6)

Note that we would ideally have liked to introduce a third state, showing both "View on website" _and_ "Preview draft" (for finders which are live but have some edits on them that need previewing), but this is not possible with our current binary use of `target_stack`. We can add it later if needed - see [backlog item](https://trello.com/c/syhocFz5/367-spike-feasibility-preview-for-changes-to-existing-published-finder-with-published-documents-publishedwithdraft).

Trello: https://trello.com/c/q397lsTa/2817-add-preview-links-to-specialist-publisher

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
