### PR TITLE
Integrate the finder edit forms with support api

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/secondary-navigation';
 @import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/skip-link';
+@import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-card';
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,6 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/checkboxes';
-@import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/hint';

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -13,6 +13,7 @@ class AdminController < ApplicationController
       :base_path,
       :description,
       :summary,
+      :show_summaries,
       :document_noun,
       organisations: [],
       related: [],
@@ -29,7 +30,7 @@ class AdminController < ApplicationController
       @proposed_schema.delete("related")
     end
 
-    if @proposed_schema["show_summaries"] == "true"
+    if params["show_summaries"] == "true"
       @proposed_schema["show_summaries"] = true
     else
       @proposed_schema.delete("show_summaries")

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -38,6 +38,11 @@ class AdminController < ApplicationController
     render :confirm_metadata
   end
 
+  def zendesk
+    GdsApi.support_api.raise_support_ticket(support_payload)
+    redirect_to "/admin/#{current_format.admin_slug}", notice: "Your changes have been submitted and Zendesk ticket created."
+  end
+
 private
 
   def check_authorisation
@@ -47,5 +52,18 @@ private
       flash[:danger] = "That format doesn't exist. If you feel you've reached this in error, please contact your main GDS contact."
       redirect_to root_path
     end
+  end
+
+  def support_payload
+    {
+      subject: "Specialist Finder Edit Request: #{current_format.title.pluralize}",
+      tags: %w[specialist_finder_edit_request],
+      priority: "normal",
+      description: "```\r\n#{params[:proposed_schema]}\r\n```",
+      requester: {
+        name: current_user.name,
+        email: current_user.email,
+      },
+    }
   end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -18,6 +18,7 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :summary?, :can_request_edits_to_finder?
   alias_method :edit_metadata?, :can_request_edits_to_finder?
   alias_method :confirm_metadata?, :can_request_edits_to_finder?
+  alias_method :zendesk?, :can_request_edits_to_finder?
 
   def publish?
     document_type_editor? || gds_editor? || departmental_editor?

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -33,14 +33,6 @@
       previous_schema: @current_format.finder_schema.schema,
     } %>
 
-    <%= render "govuk_publishing_components/components/details", {
-      title: "Proposed JSON",
-    } do %>
-      <% capture do %>
-        <pre><%= JSON.pretty_generate(@proposed_schema) %></pre>
-      <% end %>
-    <% end %>
-
     <p class="govuk-body govuk-body govuk-!-margin-top-7">
       By submitting you are confirming that these changes are required to the specialist finder.
     </p>

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -38,10 +38,12 @@
     </p>
 
     <div class="govuk-button-group govuk-!-margin-top-7">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Submit changes",
-        href: "/admin/#{current_format.admin_slug}"
-      } %>
+      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
+        <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(@proposed_schema) %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Submit changes"
+        } %>
+      <% end %>
 
       <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
     </div>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -42,6 +42,11 @@
     <%= yield(:breadcrumbs) %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank? %>" id="main-content" role="main">
+
+      <%= render "govuk_publishing_components/components/success_alert", {
+        message: flash[:notice]
+      } if flash[:notice] %>
+
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get "/admin/:document_type_slug", to: "admin#summary"
   get "/admin/metadata/:document_type_slug", to: "admin#edit_metadata"
   post "/admin/metadata/:document_type_slug", to: "admin#confirm_metadata"
+  post "/admin/zendesk/:document_type_slug", to: "admin#zendesk"
 
   resources :documents, path: "/:document_type_slug", param: :content_id_and_locale, except: :destroy do
     collection do

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,11 +1,19 @@
 require "spec_helper"
+require "gds_api/test_helpers/support_api"
 
 RSpec.describe AdminController, type: :controller do
+  include GdsApi::TestHelpers::SupportApi
+
   render_views
+
+  let(:user) { FactoryBot.create(:gds_editor) }
+
+  before do
+    log_in_as user
+  end
 
   describe "GET summary" do
     it "responds successfully" do
-      log_in_as_gds_editor
       stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
       get :summary, params: { document_type_slug: "asylum-support-decisions" }
       expect(response.status).to eq(200)
@@ -14,7 +22,6 @@ RSpec.describe AdminController, type: :controller do
 
   describe "GET edit metadata" do
     it "responds successfully" do
-      log_in_as_gds_editor
       stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
       get :edit_metadata, params: { document_type_slug: "asylum-support-decisions" }
       expect(response.status).to eq(200)
@@ -23,10 +30,24 @@ RSpec.describe AdminController, type: :controller do
 
   describe "POST edit metadata" do
     it "responds successfully" do
-      log_in_as_gds_editor
       stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
       post :edit_metadata, params: { document_type_slug: "asylum-support-decisions" }
       expect(response.status).to eq(200)
+    end
+  end
+
+  describe "POST zendesk" do
+    it "responds successfully, calling support api" do
+      stub_post = stub_support_api_valid_raise_support_ticket(hash_including({
+        subject: "Specialist Finder Edit Request: CMA Cases",
+        tags: %w[specialist_finder_edit_request],
+        priority: "normal",
+        requester: { name: user.name, email: user.email },
+      }))
+
+      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.schema }
+
+      assert_requested(stub_post)
     end
   end
 end

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
+require "gds_api/test_helpers/support_api"
 
 RSpec.feature "Editing the CMA case finder", type: :feature do
+  include GdsApi::TestHelpers::SupportApi
+
   let(:organisations) do
     [
       { "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea", "title" => "Competition and Markets Authority" },
@@ -11,6 +14,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     log_in_as_editor(:cma_editor)
     stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
     stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+    stub_any_support_api_call
   end
 
   scenario "changing all fields" do
@@ -39,6 +43,10 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page).to have_selector("dt", text: "Changed link 2")
     expect(page).to have_selector("dt", text: "Changed link 3")
     expect(page).to have_selector("dt", text: "Changed document noun")
+
+    click_button "Submit changes"
+
+    expect(page).to have_selector(".gem-c-success-alert__message", text: "Your changes have been submitted and Zendesk ticket created.")
   end
 
   scenario "fields are not shown on the confirmation page if not changed" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Update the confirm_metadata page to post the proposed schema to a new zendesk endpoint to open a ticket using the support API.
- Use the `success_alert` component to display `flash[notice]`s.
- Revert "Temporarily include the proposed JSON for metadata"

## Screenshot
![specialist-publisher dev gov uk_admin_cma-cases(iPad Pro) (1)](https://github.com/user-attachments/assets/27ffc931-20ee-48e3-8363-63bd3e2779bc)

Trello Ticket:
https://trello.com/c/YdGWsy0I/3035-integrate-the-specialist-finder-edit-forms-with-support-api
