### PR TITLE
Add `yarn install` to `Dockerfile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,7 @@ docs
 features
 log
 node_modules
-package.json
 script
 spec
 test
 tmp
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV GOVUK_NOTIFY_API_KEY=unused
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY package.json yarn.lock ./
+RUN yarn install --production
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Following #2816 a `yarn install` install is required to build the application.

Without this line in the `Dockerfile` the [build step in deployment was failing](https://github.com/alphagov/specialist-publisher/actions/runs/11571811805/job/32210489450).

[Trello ticket](https://trello.com/c/IGg2kTG5/3015-create-edit-finder-form-basic-details).
