### PR TITLE
Add new SFO finder

### DIFF
--- a/app/models/sfo_case.rb
+++ b/app/models/sfo_case.rb
@@ -1,0 +1,13 @@
+class SfoCase < Document
+  validates :sfo_case_state, presence: true
+
+  FORMAT_SPECIFIC_FIELDS = %i[
+    sfo_case_state
+  ].freeze
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+end

--- a/app/views/metadata_fields/_sfo_cases.html.erb
+++ b/app/views/metadata_fields/_sfo_cases.html.erb
@@ -1,0 +1,3 @@
+<%= render layout: "shared/form_group", locals: { f: f, field: :sfo_case_state, label: "Case state" } do %>
+    <%= f.select :sfo_case_state, facet_options(f, :sfo_case_state), {}, { class: 'form-control' } %>
+<% end %>

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -1,0 +1,39 @@
+{
+  "target_stack": "draft",
+  "content_id": "b8b8fb77-c5e9-41d6-b133-44ecd1958e28",
+  "base_path": "/sfo-cases",
+  "format_name": "Find an SFO case",
+  "name": "Find an SFO case",
+  "description": "Find fraud, bribery and corruption cases investigated by the SFO.",
+  "summary": "<p>This case finder includes all ongoing Serious Fraud Office (SFO) prosecutions and investigations that are in the public domain. This does not include intelligence referrals, covert investigations or proceeds of crime cases.</p><p>For updates on the SFO’s proceeds of crime recovery, see <a href=#>this page</a>.</p>",
+  "filter": {
+    "format": "sfo_case"
+  },
+  "related": [],
+  "show_summaries": true,
+  "organisations": [
+    "ebae4517-422f-44dd-9f87-13304c9815cb"
+  ],
+  "document_noun": "case",
+  "document_title": "SFO Case",
+  "facets": [
+    {
+      "key": "sfo_case_state",
+      "name": "Case state",
+      "type": "text",
+      "preposition": "with case state",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "allowed_values": [
+        {
+          "label": "Open",
+          "value": "open"
+        },
+        {
+          "label": "Closed",
+          "value": "closed"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/features/creating_a_sfo_case_spec.rb
+++ b/spec/features/creating_a_sfo_case_spec.rb
@@ -1,0 +1,122 @@
+require "spec_helper"
+
+RSpec.feature "Creating an sfo Case", type: :feature do
+  let(:sfo_case) { FactoryBot.create(:sfo_case) }
+  let(:content_id) { sfo_case["content_id"] }
+  let(:save_button_disable_with_message) { page.find_button("Save as draft")["data-disable-with"] }
+
+  before do
+    log_in_as_editor(:sfo_case_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([sfo_case], hash_including(document_type: SfoCase.document_type))
+    stub_publishing_api_has_item(sfo_case)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "visiting the new document page" do
+    visit "/sfo-cases"
+    click_link "Add another SFO Case"
+
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/sfo-cases/new")
+  end
+
+  scenario "with valid data" do
+    visit "/sfo-cases/new"
+
+    fill_in "Title", with: "Example sfo Case"
+    fill_in "Summary", with: "This is the summary of an example sfo case"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example life saving maritime appliance service station" * 2}"
+    select "Closed", from: "Case state"
+
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+    expect(save_button_disable_with_message).to eq("Saving...")
+
+    click_button "Save as draft"
+
+    expected_sent_payload = {
+      "base_path" => "/sfo-cases/example-sfo-case",
+      "title" => "Example sfo Case",
+      "description" => "This is the summary of an example sfo case",
+      "document_type" => "sfo_case",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "government-frontend",
+      "locale" => "en",
+      "phase": "live",
+      "details" => {
+        "body" =>
+          [
+            {
+              "content_type" => "text/govspeak",
+              "content" => "## Header\r\n\r\nThis is the long body of an example life saving maritime appliance service station\r\n\r\nThis is the long body of an example life saving maritime appliance service station",
+            },
+          ],
+        "metadata" => {
+          "sfo_case_state" => "closed",
+        },
+        "max_cache_time" => 10,
+        "headers" => [
+          { "text" => "Header", "level" => 2, "id" => "header" },
+        ],
+        "temporary_update_type" => false,
+      },
+      "routes" => [
+        {
+          "path" => "/sfo-cases/example-sfo-case",
+          "type" => "exact",
+        },
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" =>
+        {
+          "finder" => %w[b8b8fb77-c5e9-41d6-b133-44ecd1958e28],
+        },
+    }
+
+    assert_publishing_api_put_content(content_id, expected_sent_payload)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example sfo Case")
+    expect(page).to have_content("Bulk published false")
+  end
+
+  scenario "with no data" do
+    visit "/sfo-cases/new"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css(".elements-error-summary")
+    expect(page).to have_css(".form-group.elements-error")
+    expect(page).to have_css(".elements-error-message")
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+  end
+
+  scenario "with invalid data" do
+    visit "/sfo-cases/new"
+
+    fill_in "Title", with: "Example sfo Case"
+    fill_in "Summary", with: "This is the summary of an example sfo case"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css(".elements-error-summary")
+    expect(page).to have_css(".elements-error-message")
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -24,6 +24,11 @@ FactoryBot.define do
     organisation_content_id { "e338f02d-82a3-4c6c-8a36-df3050869d97" }
   end
 
+  factory :sfo_case_editor, parent: :user do
+    organisation_slug { "serious-fraud-office" }
+    organisation_content_id { "ebae4517-422f-44dd-9f87-13304c9815cb" }
+  end
+
   factory :statutory_instrument_editor, parent: :user do
     permissions { %w[signin statutory_instrument_editor] }
   end
@@ -633,6 +638,17 @@ FactoryBot.define do
           "tribunal_decision_decision_date" => "2018-01-17",
           "hidden_indexable_content" => "some hidden content",
         }
+      end
+    end
+  end
+
+  factory :sfo_case, parent: :document do
+    base_path { "/sfo-cases/example-document" }
+    document_type { "sfo_case" }
+
+    transient do
+      default_metadata do
+        { "sfo_case_state" => "open" }
       end
     end
   end

--- a/spec/models/sfo_case_spec.rb
+++ b/spec/models/sfo_case_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe SfoCase do
+  let(:payload) { FactoryBot.create(:sfo_case) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+  subject(:sfo_case) { described_class.from_publishing_api(payload) }
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+
+  describe "validations" do
+    it "is valid from the payload" do
+      expect(sfo_case).to be_valid
+    end
+
+    it "is invalid if the case state is missing" do
+      sfo_case.sfo_case_state = nil
+      expect(sfo_case).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This finder uses the new "preview flow". Here are some screenshots showing how it works. 


Preview link showing on the index page:
![Screenshot 2024-11-01 at 16 23 38](https://github.com/user-attachments/assets/6e01e825-e2ee-4807-9ac3-b7b9ecde3d88)

On a published document, we cannot see the links to the finder:
![Screenshot 2024-11-01 at 16 23 54](https://github.com/user-attachments/assets/3fb2d279-4a31-436a-9a45-4f259a732519)


On a draft document, we can see the links to the finder:
<img width="833" alt="Screenshot 2024-11-01 at 18 09 58" src="https://github.com/user-attachments/assets/139183a0-ff17-4c70-802a-3c3cd864dbcd">


Finder filtering works (if we publish documents)
![Screenshot 2024-11-01 at 16 24 47](https://github.com/user-attachments/assets/6ce8e729-7254-4a75-b35e-ce1b1204615f)


We did deploy `search-api` and run the `update_schema`, so we're updating the documentation to include these steps. 
In order to prevent users from publishing documents while in preview mode, which would then require us to run a reindex if changes are requested, we could start off with less signon permissions that we can then upgrade once we go live. Added that into the documentation. See [PR here](https://github.com/alphagov/specialist-publisher/pull/2836).

The mixture of draft/live links and what is available in the finder might be confusing to user, we'll discuss that with the wider team (but current behaviour is intentional, given the current technical possibilities).

[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)