### PR TITLE
Improvements to fields in the request changes form

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -30,11 +30,9 @@ class AdminController < ApplicationController
       @proposed_schema.delete("related")
     end
 
-    if params["show_summaries"] == "true"
-      @proposed_schema["show_summaries"] = true
-    else
-      @proposed_schema.delete("show_summaries")
-    end
+    @proposed_schema["show_summaries"] = params[:show_summaries] == "true"
+
+    @proposed_schema.reject! { |_, value| value.blank? }
 
     render :confirm_metadata
   end

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -26,7 +26,7 @@
     } if !(defined? previous_schema) || schema["base_path"] != previous_schema["base_path"]),
     ({
       key: "Organisations the finder should be attached to",
-      value: schema["organisations"].map { |content_id| organisation_name(content_id)  }.compact.join(",")
+      value: (schema["organisations"] || []).map { |content_id| organisation_name(content_id)  }.compact.join(",")
     } if !(defined? previous_schema) || schema["organisations"] != previous_schema["organisations"]),
     ({
       key: "Short description (For search engines)",
@@ -46,7 +46,7 @@
     } if !(defined? previous_schema) || schema["show_summaries"] != previous_schema["show_summaries"]),
     ({
       key: "The document noun (How the documents on the finder are referred to)",
-      value: schema["document_noun"].humanize
+      value: (schema["document_noun"] || "").humanize
     } if !(defined? previous_schema) || schema["document_noun"] != previous_schema["document_noun"]),
   ].compact,
   summary_card_actions:,

--- a/app/views/admin/edit_metadata.html.erb
+++ b/app/views/admin/edit_metadata.html.erb
@@ -77,7 +77,7 @@
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: "Summary of the finder (Longer description shown below title)",
+          text: "Summary of the finder (Longer description shown below title) (optional)",
           heading_size: "s",
         },
         hint: "Example: Find notifiable exotic animal disease cases and control zone declarations for England. There are cases of bird flu (avian influenza) in England. Check if you are in a disease control zone on the map. Find an export health certificate - GOV.UK",

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -49,6 +49,35 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page).to have_selector(".gem-c-success-alert__message", text: "Your changes have been submitted and Zendesk ticket created.")
   end
 
+  scenario "deleting all fields" do
+    visit "admin/cma-cases"
+    click_link "Request changes"
+
+    fill_in "name", with: ""
+    fill_in "base_path", with: ""
+    fill_in "description", with: ""
+    fill_in "summary", with: ""
+    fill_in "Link 1", with: ""
+    fill_in "Link 2", with: ""
+    fill_in "Link 3", with: ""
+    fill_in "document_noun", with: ""
+
+    click_button "Submit changes"
+
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+    expect(page).to have_selector("dt", text: "")
+
+    click_button "Submit changes"
+
+    expect(page).to have_selector(".gem-c-success-alert__message", text: "Your changes have been submitted and Zendesk ticket created.")
+  end
+
   scenario "fields are not shown on the confirmation page if not changed" do
     visit "admin/metadata/cma-cases"
     click_button "Submit changes"

--- a/spec/features/editing_the_farming_grant_finder_spec.rb
+++ b/spec/features/editing_the_farming_grant_finder_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.feature "Editing the Farming grant finder", type: :feature do
+  let(:organisations) do
+    [
+      { "content_id" => "de4e9dc6-cca4-43af-a594-682023b84d6c", "title" => "Department for Environment, Food & Rural Affairs" },
+      { "content_id" => "e8fae147-6232-4163-a3f1-1c15b755a8a4", "title" => "Rural Payments Agency" },
+    ]
+  end
+
+  before do
+    log_in_as_editor(:farming_grant_editor)
+    stub_publishing_api_has_content([], hash_including(document_type: FarmingGrant.document_type))
+    stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+  end
+
+  scenario "fields are not shown on the confirmation page if not changed" do
+    visit "admin/metadata/farming-grants"
+    click_button "Submit changes"
+    expect(page).not_to have_selector("dt")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -83,6 +83,11 @@ FactoryBot.define do
     organisation_content_id { "de4e9dc6-cca4-43af-a594-682023b84d6c" }
   end
 
+  factory :farming_grant_editor, parent: :editor do
+    organisation_slug { "department-for-environment-food-rural-affairs" }
+    organisation_content_id { "de4e9dc6-cca4-43af-a594-682023b84d6c" }
+  end
+
   # Writer factories:
   factory :writer, aliases: [:cma_writer], parent: :editor do
     organisation_slug { "competition-and-markets-authority" }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Improve handling of empty/deleted finder fields
  - Delete all fields from the proposed schema that are blank this is to match the existing schemas.
  - Ensure they are correctly rendered on the confirmation and summary pages and add tests.
- Mark finder summary as optional

https://trello.com/c/YdGWsy0I/3035-integrate-the-specialist-finder-edit-forms-with-support-api