### PR TITLE
Create 'edit finder' form "filters and options"

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/add-another
 //= require govuk_publishing_components/components/copy-to-clipboard
 
 //= require components/autocomplete

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@ $govuk-page-width: 1140px;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/add-another';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/checkboxes';

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,6 +5,8 @@ class AdminController < ApplicationController
 
   def summary; end
 
+  def edit_facets; end
+
   def edit_metadata; end
 
   def confirm_metadata

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,6 +7,10 @@ class AdminController < ApplicationController
 
   def edit_facets; end
 
+  def confirm_metadata
+    render :confirm_facets
+  end
+
   def edit_metadata; end
 
   def confirm_metadata

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -17,6 +17,7 @@ class DocumentPolicy < ApplicationPolicy
   end
   alias_method :summary?, :can_request_edits_to_finder?
   alias_method :edit_facets?, :can_request_edits_to_finder?
+  alias_method :confirm_facets?, :can_request_edits_to_finder?
   alias_method :edit_metadata?, :can_request_edits_to_finder?
   alias_method :confirm_metadata?, :can_request_edits_to_finder?
   alias_method :zendesk?, :can_request_edits_to_finder?

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -16,6 +16,7 @@ class DocumentPolicy < ApplicationPolicy
     publish?
   end
   alias_method :summary?, :can_request_edits_to_finder?
+  alias_method :edit_facets?, :can_request_edits_to_finder?
   alias_method :edit_metadata?, :can_request_edits_to_finder?
   alias_method :confirm_metadata?, :can_request_edits_to_finder?
   alias_method :zendesk?, :can_request_edits_to_finder?

--- a/app/views/admin/_facet_fields.html.erb
+++ b/app/views/admin/_facet_fields.html.erb
@@ -1,0 +1,117 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Filter",
+    heading_size: "s",
+  },
+  name: "facet[#{index}][name]",
+  value: facet["name"],
+  hint: "Example: Disease control zone type"
+} %>
+
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Filter short name (optional)",
+    heading_size: "s",
+  },
+  name: "facet[#{index}][short_name]",
+  value: facet["short_name"],
+  hint: "Example: Control zone type"
+} %>
+
+<%= render "govuk_publishing_components/components/select", {
+  name: "facet[#{index}][type]",
+  id: "facet[#{index}][type]",
+  label: "Type",
+  heading_size: "s",
+  options: [
+      {
+        text: "Text",
+        value: "text",
+        selected: facet["type"] == "text",
+      },
+      {
+        text: "Date",
+        value: "date",
+        selected: facet["type"] == "date",
+      }
+    ]
+} %>
+
+<%= render "govuk_publishing_components/components/textarea", {
+  label: {
+    text: "Filter options",
+    heading_size: "s",
+  },
+  hint: sanitize("Separate options with commas<br>Example: Option 1, Option 2"),
+  name: "TODO",
+  rows: 5,
+  value: "TODO",
+} %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Can users use this filter when searching for content items?",
+  heading_size: "s",
+  name: "facet[#{index}][filterable]",
+  inline: true,
+  items: [
+    {
+      value: "true",
+      text: "Yes",
+      checked: facet["filterable"]
+    },
+    {
+      value: "false",
+      text: "No",
+      checked: !facet["filterable"]
+    }
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Show as information under content item?",
+  heading_size: "s",
+  hint: "Example: Air Accidents Investigation Branch reports displays ‘Aircraft category: Commercial - fixed wing’ under relevant content items",
+  name: "facet[#{index}][display_as_result_metadata]",
+  inline: true,
+  items: [
+    {
+      value: "true",
+      text: "Yes",
+      checked: facet["display_as_result_metadata"]
+    },
+    {
+      value: "false",
+      text: "No",
+      checked: !facet["display_as_result_metadata"]
+    }
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Do publishers need to select an option for this filter when they add new content items?",
+  heading_size: "s",
+  name: "facet[#{index}][TODO]",
+  inline: true,
+  items: [
+    {
+      value: "true",
+      text: "Yes",
+      checked: facet["TODO"]
+    },
+    {
+      value: "false",
+      text: "No",
+      checked: !facet["TODO"]
+    }
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Preposition (to be displayed when filter option is selected)",
+    heading_size: "s",
+  },
+  name: "facet[#{index}][preposition]",
+  value: facet["preposition"],
+  hint: "Example: In Find funding for land or farms,  selecting an option in the filter ‘Area of interest’ displays the preposition ‘With’ before the selected option"
+} %>

--- a/app/views/admin/_facets_summary_card.html.erb
+++ b/app/views/admin/_facets_summary_card.html.erb
@@ -1,0 +1,10 @@
+<%
+  summary_card_actions ||= []
+%>
+
+<%= render "govuk_publishing_components/components/summary_card", {
+  title: "Filters and options",
+  rows: schema["facets"].map { |facet| { key: facet["name"] , value: facet["allowed_values"] ? facet["allowed_values"].first(3).map{ |value| value["label"] }.join(", ") + (facet["allowed_values"].length > 3 ? "…" : "") : facet["type"].humanize }},
+  summary_card_actions:,
+  margin_top: 6,
+} %>

--- a/app/views/admin/confirm_facets.html.erb
+++ b/app/views/admin/confirm_facets.html.erb
@@ -1,0 +1,50 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: root_path
+      },
+      {
+        title: "#{current_format.title} finder",
+        url: "/admin/#{current_format.admin_slug}"
+      },
+      {
+        title: "Request change",
+        url: "/admin/facets/#{current_format.admin_slug}"
+      },
+      {
+        title: "Check changes",
+        url: request.original_url
+      }
+    ]
+  } %>
+<% end %>
+<% content_for :page_title, "Edit #{current_format.title} finder" %>
+<% content_for :title, "Check your changes before submitting" %>
+<% content_for :context, "#{current_format.title} finder" %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-top-8">
+    <%= render "facets_summary_card", {
+      schema: @current_format.finder_schema.schema,
+    } %>
+
+    <p class="govuk-body govuk-body govuk-!-margin-top-7">
+      By submitting you are confirming that these changes are required to the specialist finder.
+    </p>
+
+    <div class="govuk-button-group govuk-!-margin-top-7">
+      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
+        <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(@proposed_schema) %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Submit changes"
+        } %>
+      <% end %>
+
+      <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/edit_facets.html.erb
+++ b/app/views/admin/edit_facets.html.erb
@@ -1,0 +1,53 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: root_path
+      },
+      {
+        title: "#{current_format.title} finder",
+        url: "/admin/#{current_format.admin_slug}"
+      },
+      {
+        title: "Request change",
+        url: request.original_url
+      }
+    ]
+  } %>
+<% end %>
+<% content_for :page_title, "Edit #{current_format.title} finder" %>
+<% content_for :title, "Request change: Filters and options" %>
+<% content_for :context, "#{current_format.title} finder" %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag do %>
+      <p class="govuk-body govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+        Filters and its options are to help users find desired content on a specialist finder. These are selected by you for each specialist content item created in the Specialist Publisher. These are shown in the blue box on the documents and elsewhere.
+      </p>
+
+      <%= render "govuk_publishing_components/components/add_another", {
+        fieldset_legend: "Filter",
+        add_button_text: "Add another filter",
+        items: current_format.finder_schema.schema["facets"].each_with_index.map do  |facet, index|
+          {
+            fields: render(partial: "facet_fields", locals: { facet:, index: }),
+            destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "facet[#{index}][_destroy]", items: [{label: "Delete", value: "1" }]})
+          }
+        end,
+        empty: "",
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Submit changes",
+        } %>
+
+        <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/summary.erb
+++ b/app/views/admin/summary.erb
@@ -67,5 +67,15 @@
         },
       ],
     } %>
+
+    <%= render "facets_summary_card", {
+      schema: current_format.finder_schema.schema,
+      summary_card_actions: [
+        {
+          label: "Request changes",
+          href: "/admin/facets/#{current_format.admin_slug}"
+        },
+      ],
+    } %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get "/admin/:document_type_slug", to: "admin#summary"
   get "/admin/facets/:document_type_slug", to: "admin#edit_facets"
+  post "/admin/facets/:document_type_slug", to: "admin#confirm_facets"
   get "/admin/metadata/:document_type_slug", to: "admin#edit_metadata"
   post "/admin/metadata/:document_type_slug", to: "admin#confirm_metadata"
   post "/admin/zendesk/:document_type_slug", to: "admin#zendesk"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]
 
   get "/admin/:document_type_slug", to: "admin#summary"
+  get "/admin/facets/:document_type_slug", to: "admin#edit_facets"
   get "/admin/metadata/:document_type_slug", to: "admin#edit_metadata"
   post "/admin/metadata/:document_type_slug", to: "admin#confirm_metadata"
   post "/admin/zendesk/:document_type_slug", to: "admin#zendesk"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Add summary card for facets, displaying them on the admin page
- Introduce route and form to modify the facets for a finder
- Introduce page to confirm changes to the facets of a finder
- https://trello.com/c/KNf2zNFI/3037-create-edit-finder-form-filters-and-options

## Screenshot

![specialist-publisher dev gov uk_admin_cma-cases(iPad Pro)](https://github.com/user-attachments/assets/b7d5568f-0487-40f8-bc01-a8e2386756e9)
