### PR TITLE
Point developer to the schema that needs updating

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -58,7 +58,10 @@ private
       subject: "Specialist Finder Edit Request: #{current_format.title.pluralize}",
       tags: %w[specialist_finder_edit_request],
       priority: "normal",
-      description: "```\r\n#{params[:proposed_schema]}\r\n```",
+      description: "Developer - raise a PR replacing this schema with the schema below: " \
+        "https://github.com/alphagov/specialist-publisher/edit/main/lib/documents/schemas/#{current_format.document_type.pluralize}.json" \
+        "\r\n---\r\n" \
+        "```\r\n#{params[:proposed_schema]}\r\n```",
       requester: {
         name: current_user.name,
         email: current_user.email,

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe AdminController, type: :controller do
         tags: %w[specialist_finder_edit_request],
         priority: "normal",
         requester: { name: user.name, email: user.email },
+        description: /^Developer - raise a PR replacing this schema with the schema below: https:\/\/github\.com\/alphagov\/specialist-publisher\/edit\/main\/lib\/documents\/schemas\/cma_cases\.json\r\n---\r\n```\r\n{/,
       }))
 
       post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.schema }


### PR DESCRIPTION
The Zendesk integration currently just outputs the schema contents that need copying and pasting. But the developer still needs to track down the file in specialist-publisher, which is an unnecessarily manual step - let's give them the link directly to the file edit screen, ready to copy and paste the schema.

Trello: https://trello.com/c/YdGWsy0I/3035-integrate-the-specialist-finder-edit-forms-with-support-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
