### PR TITLE
Only update schema `signup_copy` if already set

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -24,7 +24,9 @@ class AdminController < ApplicationController
 
     @proposed_schema = @current_format.finder_schema.schema.merge(@params.to_unsafe_h)
 
-    @proposed_schema["signup_copy"] = "You'll get an email each time a #{@params[:document_noun]} is updated or a new #{@params[:document_noun]} is published."
+    if @proposed_schema["signup_copy"]
+      @proposed_schema["signup_copy"] = "You'll get an email each time a #{@params[:document_noun]} is updated or a new #{@params[:document_noun]} is published."
+    end
 
     if params[:include_related] != "true"
       @proposed_schema.delete("related")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Adding it to finders that otherwise do not have email fields is confusing.
https://trello.com/c/2tIw1Sdd/3131-dont-add-signupcopy-to-finder-schemas-where-its-not-already-defined