### PR TITLE
Remove `subscription_list_title_prefix` from Drug Safety Update schema.

### DIFF
--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -19,7 +19,6 @@
   "topics": [
     "medicines-medical-devices-blood/vigilance-safety-alerts"
   ],
-  "subscription_list_title_prefix": "Drug Safety Update",
   "document_noun": "update",
   "document_title": "Drug Safety Update",
   "facets": [


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Why
- Drug safety updates use a separate email delivery mechanism to other finders.
- Other email specific fields were removed in #1176, but this one was missed.
- This standardises email fields across schemas prior to https://trello.com/c/93Fs6zxD/3059-create-edit-finder-form-email-alerts