### PR TITLE
Add new facet to SFO finder

### DIFF
--- a/app/models/sfo_case.rb
+++ b/app/models/sfo_case.rb
@@ -1,8 +1,10 @@
 class SfoCase < Document
   validates :sfo_case_state, presence: true
+  validates :sfo_case_opened_date, presence: true, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     sfo_case_state
+    sfo_case_opened_date
   ].freeze
 
   attr_accessor(*FORMAT_SPECIFIC_FIELDS)

--- a/app/views/metadata_fields/_sfo_cases.html.erb
+++ b/app/views/metadata_fields/_sfo_cases.html.erb
@@ -1,3 +1,5 @@
+<%= render layout: "shared/date_fields", locals: { f: f, field: :sfo_case_opened_date, format: :sfo_case,  label: "Opened date" } do %>
+<% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :sfo_case_state, label: "Case state" } do %>
     <%= f.select :sfo_case_state, facet_options(f, :sfo_case_state), {}, { class: 'form-control' } %>
 <% end %>

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -34,6 +34,15 @@
           "value": "closed"
         }
       ]
+    },
+    {
+      "key": "sfo_case_opened_date",
+      "name": "Opened date",
+      "short_name": "Opened date",
+      "type": "date",
+      "preposition": "opened",
+      "display_as_result_metadata": false,
+      "filterable": true
     }
   ]
 }

--- a/spec/features/creating_a_sfo_case_spec.rb
+++ b/spec/features/creating_a_sfo_case_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Creating an sfo Case", type: :feature do
     fill_in "Summary", with: "This is the summary of an example sfo case"
     fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example life saving maritime appliance service station" * 2}"
     select "Closed", from: "Case state"
+    fill_in "Opened date", with: "2023-01-01"
 
     expect(page).to have_css("div.govspeak-help")
     expect(page).to have_content("To add an attachment, please save the draft first.")
@@ -57,6 +58,7 @@ RSpec.feature "Creating an sfo Case", type: :feature do
           ],
         "metadata" => {
           "sfo_case_state" => "closed",
+          "sfo_case_opened_date" => "2023-01-01",
         },
         "max_cache_time" => 10,
         "headers" => [
@@ -108,6 +110,7 @@ RSpec.feature "Creating an sfo Case", type: :feature do
     fill_in "Title", with: "Example sfo Case"
     fill_in "Summary", with: "This is the summary of an example sfo case"
     fill_in "Body", with: "<script>alert('hello')</script>"
+    fill_in "Opened date", with: "invalid_date"
 
     click_button "Save as draft"
 
@@ -118,5 +121,6 @@ RSpec.feature "Creating an sfo Case", type: :feature do
 
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Body cannot include invalid Govspeak")
+    expect(page).to have_content("Sfo case opened date is not a valid date")
   end
 end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -653,7 +653,8 @@ FactoryBot.define do
 
     transient do
       default_metadata do
-        { "sfo_case_state" => "open" }
+        { "sfo_case_state" => "open",
+          "sfo_case_opened_date" => "2015-10-10" }
       end
     end
   end

--- a/spec/models/sfo_case_spec.rb
+++ b/spec/models/sfo_case_spec.rb
@@ -15,8 +15,23 @@ RSpec.describe SfoCase do
       expect(sfo_case).to be_valid
     end
 
+    it "is valid if the opened date is a valid date" do
+      sfo_case.sfo_case_opened_date = "2023-01-01"
+      expect(sfo_case).to be_valid
+    end
+
     it "is invalid if the case state is missing" do
       sfo_case.sfo_case_state = nil
+      expect(sfo_case).not_to be_valid
+    end
+
+    it "is invalid if the opened date is missing" do
+      sfo_case.sfo_case_opened_date = nil
+      expect(sfo_case).not_to be_valid
+    end
+
+    it "is invalid if the opened date is not a valid date" do
+      sfo_case.sfo_case_opened_date = "invalid_date"
       expect(sfo_case).not_to be_valid
     end
   end


### PR DESCRIPTION
Adds an additional facet to the new to SFO Finder specialist finder. As per documentation found [here](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-editing-and-removing-specialist-document-types-and-finders.html#editing-a-specialist-document-type)

[First PR](https://github.com/alphagov/specialist-publisher/pull/2835)
[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5958029)