### PR TITLE
Add rake task to report on licences

### DIFF
--- a/lib/tasks/licence_reports.rake
+++ b/lib/tasks/licence_reports.rake
@@ -1,0 +1,25 @@
+require "csv"
+
+namespace :licence_reports do
+  desc "CSV report on licences"
+  task all: :environment do
+    include OrganisationsHelper
+
+    csv_string = CSV.generate do |csv|
+      csv << %w[title link_to_competent_authority licence_identifier location publishing_organisation other_associated_organisations publication_state last_updated_at]
+
+      LicenceTransaction.find_each do |doc|
+        csv << [doc.title,
+                doc.licence_transaction_continuation_link,
+                doc.licence_transaction_licence_identifier,
+                doc.licence_transaction_location.join(" / "),
+                organisation_name(doc.primary_publishing_organisation),
+                doc.organisations.map { |org| organisation_name(org) }.join(" / "),
+                doc.publication_state,
+                doc.public_updated_at]
+      end
+    end
+
+    puts(csv_string)
+  end
+end

--- a/spec/lib/tasks/licence_reports_spec.rb
+++ b/spec/lib/tasks/licence_reports_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "licence_reports", type: :task do
+  describe "licence_reports:all" do
+    let(:task) { Rake::Task["licence_reports:all"] }
+    before(:each) { task.reenable }
+
+    let(:licence_transaction) do
+      lt = FactoryBot.create(:licence_transaction)
+      lt["details"]["metadata"]["licence_transaction_location"] = %w[england wales]
+      lt
+    end
+    let(:content_id) { licence_transaction["content_id"] }
+    let(:organisations) do
+      [
+        { "content_id" => "6de6b795-9d30-4bd8-a257-ab9a6879e1ea", "title" => "PPO Org" },
+        { "content_id" => "d31d9806-2644-4023-be70-5376cae84a06", "title" => "Other Org" },
+      ]
+    end
+
+    before do
+      stub_publishing_api_has_content([licence_transaction], hash_including(document_type: LicenceTransaction.document_type))
+      stub_publishing_api_has_item(licence_transaction)
+      stub_publishing_api_has_content(organisations, hash_including(document_type: Organisation.document_type))
+    end
+
+    it "reports on licences" do
+      expect { task.invoke }.to output(
+        "title,link_to_competent_authority,licence_identifier,location,publishing_organisation,other_associated_organisations,publication_state,last_updated_at\n" \
+        "Example document,https://www.gov.uk,,england / wales,Other Org,PPO Org,draft,2015-11-16T11:53:30+00:00\n",
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
- DBT occasionally want to know the status of licences so they can chase departments to keep them up to date. Add a simple rake task to report on licences.

https://trello.com/c/A2lujzP0/387-report-on-licences-for-dbt

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


