### PR TITLE
Email alerts configuration form - part 1

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,6 +15,7 @@ class AdminController < ApplicationController
       :summary,
       :show_summaries,
       :document_noun,
+      :email_alerts,
       organisations: [],
       related: [],
     )
@@ -22,7 +23,13 @@ class AdminController < ApplicationController
     @params[:organisations].reject!(&:empty?)
     @params[:related].reject!(&:empty?)
 
-    @proposed_schema = @current_format.finder_schema.schema.merge(@params.to_unsafe_h)
+    @proposed_schema = @current_format.finder_schema.schema.merge(@params.except(:email_alerts).to_unsafe_h)
+
+    if @params[:email_alerts] == "no"
+      @proposed_schema.delete("signup_content_id")
+    else
+      @proposed_schema["signup_content_id"] = @proposed_schema.fetch("signup_content_id", SecureRandom.uuid)
+    end
 
     if @proposed_schema["signup_copy"]
       @proposed_schema["signup_copy"] = "You'll get an email each time a #{@params[:document_noun]} is updated or a new #{@params[:document_noun]} is published."

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -345,7 +345,7 @@ class Document
   end
 
   def self.finder_schema
-    @finder_schema ||= FinderSchema.new(FinderSchema.load_schema_for(document_type.pluralize))
+    @finder_schema ||= FinderSchema.load_from_schema(document_type.pluralize)
   end
 
   def links

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -3,9 +3,9 @@
 %>
 
 <% related_links_value = capture do %>
-  <% if schema["related"] %>
+  <% if schema.related %>
     Yes
-    <% schema["related"].each_with_index do |content_id, index| %>
+    <% schema.related.each_with_index do |content_id, index| %>
       <p>Link <%= index + 1 %>: <%= content_id %></p>
     <% end %>
   <% else %>
@@ -18,40 +18,40 @@
   rows: [
     ({
       key: "Title of the finder",
-      value: schema["name"]
-    } if !(defined? previous_schema) || schema["name"] != previous_schema["name"]),
+      value: schema.name
+    } if !(defined? previous_schema) || schema.name != previous_schema.name),
     ({
       key: "Slug or URL",
-      value: schema["base_path"]
-    } if !(defined? previous_schema) || schema["base_path"] != previous_schema["base_path"]),
+      value: schema.base_path
+    } if !(defined? previous_schema) || schema.base_path != previous_schema.base_path),
     ({
       key: "Organisations the finder should be attached to",
-      value: (schema["organisations"] || []).map { |content_id| organisation_name(content_id)  }.compact.join(",")
-    } if !(defined? previous_schema) || schema["organisations"] != previous_schema["organisations"]),
+      value: (schema.organisations || []).map { |content_id| organisation_name(content_id)  }.compact.join(",")
+    } if !(defined? previous_schema) || schema.organisations != previous_schema.organisations),
     ({
       key: "Short description (For search engines)",
-      value: schema["description"]
-    } if !(defined? previous_schema) || schema["description"] != previous_schema["description"]),
+      value: schema.description
+    } if !(defined? previous_schema) || schema.description != previous_schema.description),
     ({
       key: "Summary of the finder (Longer description shown below title)",
-      value: sanitize("<div class='govspeak'>#{schema["summary"]}</div>")
-    } if !(defined? previous_schema) || schema["summary"] != previous_schema["summary"]),
+      value: sanitize("<div class='govspeak'>#{schema.summary}</div>")
+    } if !(defined? previous_schema) || schema.summary != previous_schema.summary),
     ({
       key: "Any related links on GOV.UK?",
       value: related_links_value,
-    } if !(defined? previous_schema) || schema["related"] != previous_schema["related"]),
+    } if !(defined? previous_schema) || schema.related != previous_schema.related),
     ({
       key: "Should summary of each content show under the title in the finder list page?",
-      value: schema["show_summaries"] ? "Yes" : "No"
-    } if !(defined? previous_schema) || schema["show_summaries"] != previous_schema["show_summaries"]),
+      value: schema.show_summaries ? "Yes" : "No"
+    } if !(defined? previous_schema) || schema.show_summaries != previous_schema.show_summaries),
     ({
       key: "The document noun (How the documents on the finder are referred to)",
-      value: (schema["document_noun"] || "").humanize
-    } if !(defined? previous_schema) || schema["document_noun"] != previous_schema["document_noun"]),
+      value: (schema.document_noun || "").humanize
+    } if !(defined? previous_schema) || schema.document_noun != previous_schema.document_noun),
     ({
       key: "Would you like to set up email alerts for the finder?",
-      value: schema.key?("signup_content_id") ? "Yes" : "No"
-    } if !(defined? previous_schema) || (schema.key?("signup_content_id") != previous_schema.key?("signup_content_id")))
+      value: schema.signup_content_id.present? ? "Yes" : "No"
+    } if !(defined? previous_schema) || (schema.signup_content_id.present? != previous_schema.signup_content_id.present?))
   ].compact,
   summary_card_actions:,
   margin_top: 6,

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -48,6 +48,10 @@
       key: "The document noun (How the documents on the finder are referred to)",
       value: (schema["document_noun"] || "").humanize
     } if !(defined? previous_schema) || schema["document_noun"] != previous_schema["document_noun"]),
+    ({
+      key: "Would you like to set up email alerts for the finder?",
+      value: schema.key?("signup_content_id") ? "Yes" : "No"
+    } if !(defined? previous_schema) || (schema.key?("signup_content_id") != previous_schema.key?("signup_content_id")))
   ].compact,
   summary_card_actions:,
   margin_top: 6,

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -30,7 +30,7 @@
   <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-top-8">
     <%= render "metadata_summary_card", {
       schema: @proposed_schema,
-      previous_schema: @current_format.finder_schema.schema,
+      previous_schema: @current_format.finder_schema,
     } %>
 
     <p class="govuk-body govuk-body govuk-!-margin-top-7">

--- a/app/views/admin/edit_metadata.html.erb
+++ b/app/views/admin/edit_metadata.html.erb
@@ -36,7 +36,7 @@
           heading_size: "s",
         },
         name: "name",
-        value: current_format.finder_schema.schema["name"],
+        value: current_format.finder_schema.name,
         hint: "Example: Find animal disease cases and control zones"
       } %>
 
@@ -46,7 +46,7 @@
           heading_size: "s",
         },
         name: "base_path",
-        value: current_format.finder_schema.schema["base_path"],
+        value: current_format.finder_schema.base_path,
         hint: "Example: /animal-disease-cases-england"
       } %>
 
@@ -59,7 +59,7 @@
         name: "organisations[]",
         select: {
           multiple: true,
-          selected: current_format.finder_schema.schema["organisations"],
+          selected: current_format.finder_schema.organisations,
           options: [""] + organisations_options,
         },
       } %>
@@ -72,7 +72,7 @@
         hint: "Example: Find notifiable exotic animal disease cases and control zone declarations for England.",
         name: "description",
         rows: 5,
-        value: current_format.finder_schema.schema["description"],
+        value: current_format.finder_schema.description,
       } %>
 
       <%= render "govuk_publishing_components/components/textarea", {
@@ -83,7 +83,7 @@
         hint: "Example: Find notifiable exotic animal disease cases and control zone declarations for England. There are cases of bird flu (avian influenza) in England. Check if you are in a disease control zone on the map. Find an export health certificate - GOV.UK",
         name: "summary",
         rows: 8,
-        value: current_format.finder_schema.schema["summary"],
+        value: current_format.finder_schema.summary,
       } %>
 
       <%
@@ -94,7 +94,7 @@
             },
             name: "related[]",
             rows: 8,
-            value: (current_format.finder_schema.schema["related"]||[])[index] ,
+            value: (current_format.finder_schema.related||[])[index] ,
           }
         })
       %>
@@ -110,7 +110,7 @@
           {
             label: "Yes",
             value: true,
-            checked: current_format.finder_schema.schema["related"],
+            checked: current_format.finder_schema.related,
             conditional: related_links
           }
         ]
@@ -126,12 +126,12 @@
           {
             value: "true",
             text: "Yes",
-            checked: current_format.finder_schema.schema["show_summaries"]
+            checked: current_format.finder_schema.show_summaries
           },
           {
             value: "false",
             text: "No",
-            checked: !current_format.finder_schema.schema["show_summaries"]
+            checked: !current_format.finder_schema.show_summaries
           }
         ]
       } %>
@@ -142,7 +142,7 @@
           heading_size: "s",
         },
         name: "document_noun",
-        value: current_format.finder_schema.schema["document_noun"],
+        value: current_format.finder_schema.document_noun,
         hint: "For example ‘scheme’. On Finance and support for your business there’s 151 schemes, which updates when you start selecting filter options"
       } %>
 
@@ -160,12 +160,12 @@
             {
               value: "all_content",
               text: "Yes. Allow users to sign up to the entire finder (all content)",
-              checked: current_format.finder_schema.schema["signup_content_id"]
+              checked: current_format.finder_schema.signup_content_id
             },
             {
               value: "no",
               text: "No",
-              checked: !current_format.finder_schema.schema["signup_content_id"]
+              checked: !current_format.finder_schema.signup_content_id
             }
           ]
         } %>

--- a/app/views/admin/edit_metadata.html.erb
+++ b/app/views/admin/edit_metadata.html.erb
@@ -146,6 +146,31 @@
         hint: "For example ‘scheme’. On Finance and support for your business there’s 151 schemes, which updates when you start selecting filter options"
       } %>
 
+      <%= render "govuk_publishing_components/components/fieldset", {
+        legend_text: "Email Alerts",
+        heading_level: 2,
+        heading_size: "m",
+      } do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: "Would you like to set up email alerts for the finder?",
+          heading_size: "s",
+          hint: "Email alerts should only be added if you've tested a user need for these",
+          name: "email_alerts",
+          items: [
+            {
+              value: "all_content",
+              text: "Yes. Allow users to sign up to the entire finder (all content)",
+              checked: current_format.finder_schema.schema["signup_content_id"]
+            },
+            {
+              value: "no",
+              text: "No",
+              checked: !current_format.finder_schema.schema["signup_content_id"]
+            }
+          ]
+        } %>
+      <% end %>
+
       <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit changes",

--- a/app/views/admin/summary.erb
+++ b/app/views/admin/summary.erb
@@ -59,7 +59,7 @@
     </p>
 
     <%= render "metadata_summary_card", {
-      schema: current_format.finder_schema.schema,
+      schema: current_format.finder_schema,
       summary_card_actions: [
         {
           label: "Request changes",

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AdminController, type: :controller do
         description: /^Developer - raise a PR replacing this schema with the schema below: https:\/\/github\.com\/alphagov\/specialist-publisher\/edit\/main\/lib\/documents\/schemas\/cma_cases\.json\r\n---\r\n```\r\n{/,
       }))
 
-      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.schema }
+      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.to_json }
 
       assert_requested(stub_post)
     end

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     fill_in "Link 2", with: "Changed link 2"
     fill_in "Link 3", with: "Changed link 3"
     fill_in "document_noun", with: "Changed document noun"
+    choose "email_alerts", option: "no"
 
     click_button "Submit changes"
 
@@ -43,6 +44,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page).to have_selector("dt", text: "Changed link 2")
     expect(page).to have_selector("dt", text: "Changed link 3")
     expect(page).to have_selector("dt", text: "Changed document noun")
+    expect(page).to have_selector("dt", text: "No")
 
     click_button "Submit changes"
 

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -165,7 +165,7 @@ FactoryBot.define do
       if document_type
         result = result.merge(
           links: {
-            finder: [FinderSchema.new(FinderSchema.load_schema_for(document_type.pluralize)).content_id],
+            finder: [FinderSchema.load_from_schema(document_type.pluralize).content_id],
           },
         )
       end
@@ -526,7 +526,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(FinderSchema.load_schema_for(document_type.pluralize)).content_id],
+          finder: [FinderSchema.load_from_schema(document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -555,7 +555,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(FinderSchema.load_schema_for(document_type.pluralize)).content_id],
+          finder: [FinderSchema.load_from_schema(document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },
@@ -680,7 +680,7 @@ FactoryBot.define do
     initialize_with do
       attributes.merge(
         links: {
-          finder: [FinderSchema.new(FinderSchema.load_schema_for(document_type.pluralize)).content_id],
+          finder: [FinderSchema.load_from_schema(document_type.pluralize).content_id],
           organisations: [organisation_content_id, primary_publishing_org_content_id],
           primary_publishing_organisation: [primary_publishing_org_content_id],
         },

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Document do
     end
 
     it "sends a correct document" do
-      allow(FinderSchema).to receive(:load_schema_for).with("my_document_types")
+      allow(FinderSchema).to receive(:load_from_schema).with("my_document_types")
         .and_return(finder_schema)
 
       expect(subject.save).to be true
@@ -128,14 +128,16 @@ RSpec.describe Document do
   end
 
   let(:finder_schema) do
-    {
+    schema = FinderSchema.new
+    schema.assign_attributes({
       base_path: "/my-document-types",
       target_stack: "live",
       filter: {
-        format: "my_format",
+        "format" => "my_format",
       },
       content_id: @finder_content_id,
-    }.deep_stringify_keys
+    })
+    schema
   end
 
   let(:payload_attributes) do
@@ -167,7 +169,7 @@ RSpec.describe Document do
 
   context "with stubbed FinderSchema" do
     before do
-      allow(FinderSchema).to receive(:load_schema_for).with("my_document_types")
+      allow(FinderSchema).to receive(:load_from_schema).with("my_document_types")
         .and_return(finder_schema)
     end
 

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -13,23 +13,15 @@ RSpec.describe FinderSchema do
     }
   end
 
-  describe ".schema" do
-    it "returns the schema hash" do
-      expect(FinderSchema.new(mandatory_properties).schema).to eq(mandatory_properties)
-    end
-  end
-
   describe ".schema_names" do
     it "returns schema names" do
       expect(FinderSchema.schema_names).to include("aaib_reports")
     end
   end
 
-  describe ".load_schema_for" do
+  describe ".load_from_schema" do
     it "loads the given schema" do
-      json = JSON.parse(File.read(Rails.root.join("lib/documents/schemas/aaib_reports.json")))
-
-      expect(FinderSchema.load_schema_for("aaib_reports")).to eq(json)
+      expect(FinderSchema.load_from_schema("aaib_reports")).to be_a(FinderSchema)
     end
   end
 


### PR DESCRIPTION
This includes just a simple yes/no question for email signup opt-in. I will add the more complex functionality for external signup links and email facets in a separate PR.

This PR introduces a finder schema model, based on the existing finder schema object that merely decorated a hash object. Given the amount of changes, I decided not to do any further refactoring in this PR in order to keep it reviewable. Future PRs will move more logic from the admin controller on to the finder schema model. I think we will also want a finder facet model, as much of the logic around facets on the existing finder schema class is poorly factored.

## Screenshot

<img width="811" alt="Screenshot 2024-11-27 at 14 46 02" src="https://github.com/user-attachments/assets/e8e390e0-ab54-4a7c-ab3f-0f3ef538fac7">

