### PR TITLE
Move logic from admin controller to finder schema model

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -20,27 +20,12 @@ class AdminController < ApplicationController
       related: [],
     )
 
-    @params[:organisations].reject!(&:empty?)
-    @params[:related].reject!(&:empty?)
-
     @proposed_schema = FinderSchema.new
-    @proposed_schema.assign_attributes(@current_format.finder_schema.attributes.merge(@params.except(:email_alerts).to_unsafe_h))
-
-    @proposed_schema.signup_content_id = if @params[:email_alerts] == "no"
-                                           nil
-                                         else
-                                           @proposed_schema.signup_content_id || SecureRandom.uuid
-                                         end
-
-    if @proposed_schema.signup_copy.present?
-      @proposed_schema.signup_copy = "You'll get an email each time a #{@params[:document_noun]} is updated or a new #{@params[:document_noun]} is published."
-    end
+    @proposed_schema.assign_attributes(@current_format.finder_schema.attributes.merge(@params.to_unsafe_h))
 
     if params[:include_related] != "true"
       @proposed_schema.related = nil
     end
-
-    @proposed_schema.show_summaries = params[:show_summaries] == "true"
 
     render :confirm_metadata
   end

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -14,14 +14,15 @@ class FinderSchema
     new.from_json(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
   end
 
-  attr_writer :editing_organisations, :facets, :organisations, :show_summaries, :taxons
+  attribute :show_summaries, :boolean, default: false
+  attr_writer :editing_organisations, :facets, :taxons
+  attr_reader :document_noun, :related
   attr_accessor :base_path,
                 :beta,
                 :beta_message,
                 :content_id,
                 :default_order,
                 :description,
-                :document_noun,
                 :document_title,
                 :email_filter_by,
                 :email_filter_facets,
@@ -32,7 +33,6 @@ class FinderSchema
                 :open_filter_on_load,
                 :parent,
                 :phase,
-                :related,
                 :signup_content_id,
                 :signup_copy,
                 :signup_link,
@@ -41,6 +41,13 @@ class FinderSchema
                 :summary,
                 :target_stack,
                 :topics
+
+  def document_noun=(noun)
+    @document_noun = noun
+    if @signup_copy.present?
+      @signup_copy = "You'll get an email each time a #{noun} is updated or a new #{noun} is published."
+    end
+  end
 
   def format
     @filter["format"]
@@ -54,16 +61,28 @@ class FinderSchema
     @organisations || []
   end
 
+  def organisations=(value)
+    @organisations = value.reject(&:empty?)
+  end
+
   def editing_organisations
     @editing_organisations || []
+  end
+
+  def related=(value)
+    @related = value.nil? ? nil : value.reject(&:empty?)
   end
 
   def facets
     @facets.map { |facet| facet["key"].to_sym }
   end
 
-  def show_summaries
-    @show_summaries || false
+  def email_alerts=(value)
+    @signup_content_id = if value == "no"
+                           nil
+                         else
+                           @signup_content_id || SecureRandom.uuid
+                         end
   end
 
   def options_for(facet_name)

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe FinderSchema do
     end
   end
 
+  describe "#document_noun=" do
+    it "updates the signup copy based on the new document noun" do
+      noun = "specialist document"
+      expected_copy = "You'll get an email each time a #{noun} is updated or a new #{noun} is published."
+      schema = FinderSchema.new
+      schema.signup_copy = "existing copy"
+      schema.document_noun = noun
+      expect(schema.signup_copy).to eq(expected_copy)
+    end
+
+    it "does not update the signup copy if the copy is not already set" do
+      schema = FinderSchema.new
+      schema.document_noun = "specialist document"
+      expect(schema.signup_copy).to be_nil
+    end
+  end
+
+  describe "#show_summaries=" do
+    it "casts 'true' to true" do
+      schema = FinderSchema.new
+      schema.show_summaries = "true"
+      expect(schema.show_summaries).to eq(true)
+    end
+  end
+
   describe "#organisations" do
     it "returns empty array if not present" do
       expect(FinderSchema.new(mandatory_properties).organisations).to eq([])
@@ -70,6 +95,15 @@ RSpec.describe FinderSchema do
     end
   end
 
+  describe "#organisations=" do
+    it "ignores empty organisations" do
+      schema = FinderSchema.new
+      schema.organisations = %w[abc123 def456]
+      schema.organisations = ["", "def456"]
+      expect(schema.organisations).to eq(%w[def456])
+    end
+  end
+
   describe "#editing_organisations" do
     it "returns empty array if not present" do
       expect(FinderSchema.new(mandatory_properties).editing_organisations).to eq([])
@@ -78,6 +112,15 @@ RSpec.describe FinderSchema do
     it "returns the editing_organisations if present" do
       properties = mandatory_properties.merge({ "editing_organisations" => %w[def456] })
       expect(FinderSchema.new(properties).editing_organisations).to eq(%w[def456])
+    end
+  end
+
+  describe "#related=" do
+    it "ignores empty related link items" do
+      schema = FinderSchema.new
+      schema.related = %w[abc123 def456]
+      schema.related = ["", "def456"]
+      expect(schema.related).to eq(%w[def456])
     end
   end
 
@@ -107,6 +150,28 @@ RSpec.describe FinderSchema do
         ],
       })
       expect(FinderSchema.new(properties).facets).to eq(%i[research_document_type something_else])
+    end
+  end
+
+  describe "#email_alerts=" do
+    it "sets the signup_content_id to nil if email_alerts is 'no'" do
+      schema = FinderSchema.new
+      schema.email_alerts = "no"
+      expect(schema.signup_content_id).to be_nil
+    end
+
+    it "sets the signup_content_id to a the existing ID if email_alerts is not 'no' and there is an existing signup content ID" do
+      schema = FinderSchema.new
+      schema.signup_content_id = "existing-id"
+      schema.email_alerts = "yes"
+      expect(schema.signup_content_id).to eq("existing-id")
+    end
+
+    it "sets the signup_content_id to a new UUID if email_alerts is not 'no' and there is not an existing signup content ID" do
+      schema = FinderSchema.new
+      allow(SecureRandom).to receive(:uuid).and_return("new-id")
+      schema.email_alerts = "yes"
+      expect(schema.signup_content_id).to eq("new-id")
     end
   end
 


### PR DESCRIPTION
This refactor should give us a more expressive domain model we can use in future to compose new features. It also gives us some test coverage a bit lower down the testing pyramid.
