### PR TITLE
Remove signup title schema attribute

### DIFF
--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -36,7 +36,6 @@ class FinderSchema
                 :signup_content_id,
                 :signup_copy,
                 :signup_link,
-                :signup_title,
                 :subscription_list_title_prefix,
                 :summary,
                 :target_stack,

--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -34,7 +34,7 @@ private
   end
 
   def title
-    schema.fetch("signup_title", schema.fetch("name"))
+    schema.fetch("name")
   end
 
   def base_path

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -9,7 +9,6 @@
     "format": "medical_safety_alert"
   },
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
-  "signup_title": "Alerts, recalls and safety information: drugs and medical devices",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "show_summaries": true,
   "organisations": [


### PR DESCRIPTION
The signup title schema attribute was only being used for one finder. If a signup title is not provided, the title of the finder is used instead. For the finder in question, the finder title value was the same as the signup title value provided.

We are therefore removing the signup title schema attribute so that we do not have to support it within the finder configuration editing form that we are building.
