### PR TITLE
Fix placeholder text

### DIFF
--- a/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
+++ b/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
@@ -8,7 +8,7 @@
                  class: 'select2 form-control',
                  multiple: false,
                  data: {
-                   placeholder: 'Select organisation type'
+                   placeholder: 'Select organisation'
                  }
                }
   %>


### PR DESCRIPTION
Happened to spot this refers to Organisation Type, presumably copied from the field below it. This field is about the Organisation itself.

![Screenshot 2024-12-05 at 18 15 02](https://github.com/user-attachments/assets/166674da-314e-46e2-854b-ed5b9bbc3a59)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
