### PR TITLE
Email alerts configuration form

### DIFF
--- a/app/components/email_alert_fieldset_component.html.erb
+++ b/app/components/email_alert_fieldset_component.html.erb
@@ -3,7 +3,7 @@
   heading_level: 2,
   heading_size: "m",
 } do %>
-  <%= render "govuk_publishing_components/components/radio", {
+  <% render "govuk_publishing_components/components/radio", {
     heading: "Would you like to set up email alerts for the finder?",
     heading_size: "s",
     hint: "Email alerts should only be added if you've tested a user need for these",

--- a/app/components/email_alert_fieldset_component.html.erb
+++ b/app/components/email_alert_fieldset_component.html.erb
@@ -11,8 +11,21 @@
     items: [
       {
         value: "all_content",
-        text: "Yes. Allow users to sign up to the entire finder (all content)",
-        checked: @schema.signup_content_id
+        text: "Yes. Allow users to sign up to email alerts for everything published on the finder.",
+        checked: @schema.signup_content_id,
+        conditional: render_all_content_condition_inputs
+      },
+      {
+        value: "filtered_content",
+        text: "Yes. Allow users to sign up by specific filter criteria",
+        checked: @schema.email_filter_by,
+        conditional: render_filtered_content_condition_inputs
+      },
+      {
+        value: "external",
+        text: "Yes. Allow users to sign up for updates using a signup link.",
+        checked: @schema.signup_link,
+        conditional: render_external_condition_inputs
       },
       {
         value: "no",

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -2,4 +2,57 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
   def initialize(schema:)
     @schema = schema
   end
+
+  def render_all_content_condition_inputs
+    signup_content_id_input = render("govuk_publishing_components/components/input", {
+      type: "hidden",
+      name: "signup_content_id",
+      value: @schema.signup_content_id || SecureRandom.uuid,
+    })
+
+    # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
+    # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
+    # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
+    if @schema.subscription_list_title_prefix.is_a?(Hash)
+      signup_content_id_input
+    else
+      render("govuk_publishing_components/components/input", {
+        label: {
+          text: "Email subscription topic",
+        },
+        name: "subscription_list_title_prefix",
+        value: @schema.subscription_list_title_prefix,
+      }) + signup_content_id_input
+    end
+  end
+
+  # We are handling changes to email facet filters offline at present.
+  def render_filtered_content_condition_inputs
+    render("govuk_publishing_components/components/input", {
+      type: "hidden",
+      name: "signup_content_id",
+      value: @schema.signup_content_id || SecureRandom.uuid,
+    }) +
+      render("govuk_publishing_components/components/checkboxes", {
+        name: "email_filter_by",
+        heading: "Selected filter: #{@schema.email_filter_by&.humanize}",
+        items: [
+          {
+            label: "Make changes to this filter criteria (The development team will reach out to you to discuss the requirements to allow users to sign up by specific filter criteria)",
+            value: "CHANGE_REQUESTED",
+          },
+        ],
+      })
+  end
+
+  def render_external_condition_inputs
+    render("govuk_publishing_components/components/input", {
+      label: {
+        text: "Signup link",
+      },
+      hint: "A link to an email signup page",
+      name: "signup_link",
+      value: @schema.signup_link,
+    })
+  end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,13 +15,13 @@ class AdminController < ApplicationController
       :summary,
       :show_summaries,
       :document_noun,
-      :email_alerts,
+      *email_alert_params,
       organisations: [],
       related: [],
     )
 
-    @proposed_schema = FinderSchema.new
-    @proposed_schema.assign_attributes(@current_format.finder_schema.attributes.merge(@params.to_unsafe_h))
+    @proposed_schema = FinderSchema.new(@current_format.finder_schema.attributes)
+    @proposed_schema.update(@params.to_unsafe_h)
 
     if params[:include_related] != "true"
       @proposed_schema.related = nil
@@ -60,5 +60,15 @@ private
         email: current_user.email,
       },
     }
+  end
+
+  def email_alert_params
+    permitted_email_alert_params = {
+      "all_content" => %i[signup_content_id subscription_list_title_prefix],
+      "filtered_content" => %i[signup_content_id email_filter_by],
+      "external" => %i[signup_link],
+      "no" => [],
+    }
+    permitted_email_alert_params[params[:email_alerts]]
   end
 end

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -7,7 +7,7 @@ class FinderSchema
   define_model_callbacks :update
 
   before_update :reset_email_alerts
-  after_update :override_signup_copy
+  after_update :override_signup_copy, :remove_empty_related_links, :remove_empty_organisations
 
   # Pluralized names of all document types
   def self.schema_names
@@ -20,33 +20,36 @@ class FinderSchema
     new.from_json(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
   end
 
+  attribute :base_path
+  attribute :beta
+  attribute :beta_message
+  attribute :content_id
+  attribute :default_order
+  attribute :description
+  attribute :document_noun
+  attribute :document_title
+  attribute :editing_organisations, default: []
+  attribute :email_filter_by
+  attribute :email_filter_facets, default: []
+  attribute :facets, default: []
+  attribute :filter
+  attribute :format_name
+  attribute :label_text
+  attribute :name
+  attribute :organisations, default: []
+  attribute :open_filter_on_load
+  attribute :parent
+  attribute :phase
+  attribute :related
   attribute :show_summaries, :boolean, default: false
-  attr_writer :editing_organisations, :facets, :taxons
-  attr_reader :related
-  attr_accessor :base_path,
-                :beta,
-                :beta_message,
-                :content_id,
-                :default_order,
-                :description,
-                :document_noun,
-                :document_title,
-                :email_filter_by,
-                :email_filter_facets,
-                :filter,
-                :format_name,
-                :label_text,
-                :name,
-                :open_filter_on_load,
-                :parent,
-                :phase,
-                :signup_content_id,
-                :signup_copy,
-                :signup_link,
-                :subscription_list_title_prefix,
-                :summary,
-                :target_stack,
-                :topics
+  attribute :signup_content_id
+  attribute :signup_copy
+  attribute :signup_link
+  attribute :subscription_list_title_prefix
+  attribute :summary, default: ""
+  attribute :target_stack
+  attribute :taxons, default: []
+  attribute :topics, default: []
 
   def update(attributes)
     run_callbacks :update do
@@ -54,46 +57,36 @@ class FinderSchema
     end
   end
 
+  def as_json(options = nil)
+    super.compact.reject { |_k, v| v.blank? }
+  end
+
   def format
-    @filter["format"]
-  end
-
-  def taxons
-    @taxons || []
-  end
-
-  def organisations
-    @organisations || []
-  end
-
-  def organisations=(value)
-    @organisations = value.reject(&:empty?)
-  end
-
-  def editing_organisations
-    @editing_organisations || []
-  end
-
-  def related=(value)
-    @related = value.nil? ? nil : value.reject(&:empty?)
-  end
-
-  def facets
-    @facets.map { |facet| facet["key"].to_sym }
+    filter["format"]
   end
 
   def reset_email_alerts
-    @signup_content_id = nil
-    @subscription_list_title_prefix = nil
-    @signup_link = nil
-    @email_filter_by = nil
-    @email_filter_facets = nil
+    assign_attributes(
+      signup_content_id: nil,
+      subscription_list_title_prefix: nil,
+      signup_link: nil,
+      email_filter_by: nil,
+      email_filter_facets: nil,
+    )
   end
 
   def override_signup_copy
-    if @signup_copy.present?
-      @signup_copy = "You'll get an email each time a #{document_noun} is updated or a new #{document_noun} is published."
+    if signup_copy.present?
+      _assign_attribute(:signup_copy, "You'll get an email each time a #{document_noun} is updated or a new #{document_noun} is published.")
     end
+  end
+
+  def remove_empty_organisations
+    organisations.reject!(&:blank?)
+  end
+
+  def remove_empty_related_links
+    related&.reject!(&:blank?)
   end
 
   def options_for(facet_name)
@@ -120,7 +113,7 @@ class FinderSchema
 private
 
   def facet_data_for(facet_name)
-    (@facets || []).find do |facet_record|
+    facets.find do |facet_record|
       facet_record.fetch("key") == facet_name.to_s
     end || {}
   end

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -39,7 +39,7 @@
 
     <div class="govuk-button-group govuk-!-margin-top-7">
       <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
-        <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(@proposed_schema) %>
+        <%= hidden_field_tag :proposed_schema, @proposed_schema.to_json %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit changes"
         } %>

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -15,11 +15,71 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     expect(page).to have_checked_field("email_alerts", with: "no")
   end
 
+  it "sets the value of the radio button to 'no' if the schema does not have a signup_content_id" do
+    schema = FinderSchema.new
+    render_inline(described_class.new(schema:))
+
+    expect(page).to have_checked_field("email_alerts", with: "no")
+  end
+
   it "sets the value of the radio button to 'all_content' if the schema has a signup content id" do
     schema = FinderSchema.new
     schema.signup_content_id = "123"
     render_inline(described_class.new(schema:))
 
     expect(page).to have_checked_field("email_alerts", with: "all_content")
+    expect(page).to have_field("signup_content_id", with: "123", type: "hidden")
+  end
+
+  it "sets the value of the radio button to 'all_content' and renders a hidden input with a generated content id if the schema is missing a signup content id" do
+    schema = FinderSchema.new
+    allow(SecureRandom).to receive(:uuid).and_return("new-id")
+    render_inline(described_class.new(schema:))
+
+    expect(page).to have_checked_field("email_alerts", with: "no")
+    expect(page).to have_field("signup_content_id", with: "new-id", type: "hidden")
+  end
+
+  it "renders the email subscription topic if the all_content value is checked" do
+    schema = FinderSchema.new
+    schema.signup_content_id = "123"
+    schema.subscription_list_title_prefix = "Finder email subscription"
+    render_inline(described_class.new(schema:))
+
+    expect(page).to have_text("Email subscription topic")
+    expect(page).to have_field("subscription_list_title_prefix", with: schema.subscription_list_title_prefix)
+  end
+
+  # We do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
+  # values in such cases. We are going to revisit this later. Trello card for future work: https://trello.com/c/Qe8wOpaw
+  it "does not render the email subscription topic if the all_content value is checked but the current schema value is a hash" do
+    schema = FinderSchema.new
+    schema.signup_content_id = "123"
+    schema.subscription_list_title_prefix = {}
+    render_inline(described_class.new(schema:))
+
+    expect(page).not_to have_text("Email subscription topic")
+    expect(page).not_to have_field("subscription_list_title_prefix", with: schema.subscription_list_title_prefix)
+  end
+
+  it "sets the value of the radio button to 'external' if the schema has a signup link" do
+    schema = FinderSchema.new
+    schema.signup_link = "https://example.com"
+    render_inline(described_class.new(schema:))
+
+    expect(page).to have_checked_field("email_alerts", with: "external")
+    expect(page).to have_field("signup_link", with: schema.signup_link)
+  end
+
+  it "sets the value of the radio button to 'filtered_content' if the schema has an email filter attribute" do
+    schema = FinderSchema.new
+    schema.signup_content_id = "123"
+    schema.email_filter_by = "some_facet"
+    render_inline(described_class.new(schema:))
+
+    expect(page).to have_checked_field("email_alerts", with: "filtered_content")
+    expect(page).to have_text("Selected filter: Some facet")
+    expect(page).to have_field("signup_content_id", with: schema.signup_content_id, type: "hidden")
+    expect(page).to have_unchecked_field("email_filter_by", with: "CHANGE_REQUESTED")
   end
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AdminController, type: :controller do
         description: /^Developer - raise a PR replacing this schema with the schema below: https:\/\/github\.com\/alphagov\/specialist-publisher\/edit\/main\/lib\/documents\/schemas\/cma_cases\.json\r\n---\r\n```\r\n{/,
       }))
 
-      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.to_json }
+      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.as_json }
 
       assert_requested(stub_post)
     end

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -59,23 +59,6 @@ RSpec.describe FinderSchema do
     end
   end
 
-  describe "#document_noun=" do
-    it "updates the signup copy based on the new document noun" do
-      noun = "specialist document"
-      expected_copy = "You'll get an email each time a #{noun} is updated or a new #{noun} is published."
-      schema = FinderSchema.new
-      schema.signup_copy = "existing copy"
-      schema.document_noun = noun
-      expect(schema.signup_copy).to eq(expected_copy)
-    end
-
-    it "does not update the signup copy if the copy is not already set" do
-      schema = FinderSchema.new
-      schema.document_noun = "specialist document"
-      expect(schema.signup_copy).to be_nil
-    end
-  end
-
   describe "#show_summaries=" do
     it "casts 'true' to true" do
       schema = FinderSchema.new
@@ -124,6 +107,40 @@ RSpec.describe FinderSchema do
     end
   end
 
+  describe "#reset_email_alerts" do
+    it "resets email alert fields when update is called" do
+      schema = FinderSchema.new
+      schema.assign_attributes(
+        signup_content_id: "123",
+        subscription_list_title_prefix: "456",
+        signup_link: "789",
+        email_filter_by: "foo",
+        email_filter_facets: "bar",
+      )
+      schema.update({})
+      expect(schema.signup_content_id).to be_nil
+      expect(schema.subscription_list_title_prefix).to be_nil
+      expect(schema.signup_link).to be_nil
+      expect(schema.email_filter_by).to be_nil
+      expect(schema.email_filter_facets).to be_nil
+    end
+  end
+
+  describe "#override_signup_copy" do
+    it "overrides the signup copy based on the document noun on update if the schema has signup copy" do
+      schema = FinderSchema.new
+      schema.signup_copy = "You'll get an email each time a document is updated or a new document is published."
+      schema.update({ document_noun: "publication" })
+      expect(schema.signup_copy).to eq("You'll get an email each time a publication is updated or a new publication is published.")
+    end
+
+    it "does not override the signup copy if the schema does not have signup copy already" do
+      schema = FinderSchema.new
+      schema.update({ document_noun: "publication" })
+      expect(schema.signup_copy).to be_nil
+    end
+  end
+
   describe "#taxons" do
     it "returns empty array if not present" do
       expect(FinderSchema.new(mandatory_properties).taxons).to eq([])
@@ -150,28 +167,6 @@ RSpec.describe FinderSchema do
         ],
       })
       expect(FinderSchema.new(properties).facets).to eq(%i[research_document_type something_else])
-    end
-  end
-
-  describe "#email_alerts=" do
-    it "sets the signup_content_id to nil if email_alerts is 'no'" do
-      schema = FinderSchema.new
-      schema.email_alerts = "no"
-      expect(schema.signup_content_id).to be_nil
-    end
-
-    it "sets the signup_content_id to a the existing ID if email_alerts is not 'no' and there is an existing signup content ID" do
-      schema = FinderSchema.new
-      schema.signup_content_id = "existing-id"
-      schema.email_alerts = "yes"
-      expect(schema.signup_content_id).to eq("existing-id")
-    end
-
-    it "sets the signup_content_id to a new UUID if email_alerts is not 'no' and there is not an existing signup content ID" do
-      schema = FinderSchema.new
-      allow(SecureRandom).to receive(:uuid).and_return("new-id")
-      schema.email_alerts = "yes"
-      expect(schema.signup_content_id).to eq("new-id")
     end
   end
 

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -25,16 +25,17 @@ RSpec.describe FinderSchema do
     end
   end
 
-  describe "#base_path" do
-    it "returns the base path" do
-      properties = mandatory_properties.merge({ "base_path" => "/research-for-development-outputs" })
-      expect(FinderSchema.new(properties).base_path).to eq("/research-for-development-outputs")
+  describe "#as_json" do
+    it "excludes nil values" do
+      schema = FinderSchema.new(mandatory_properties)
+      schema.signup_link = nil
+      expect(schema.as_json.key?(:signup_link)).to be_falsey
     end
-  end
 
-  describe "#target_stack" do
-    it "returns the stack the finder has been deployed to" do
-      expect(FinderSchema.new(mandatory_properties).target_stack).to eq("live")
+    it "excludes blank values" do
+      schema = FinderSchema.new(mandatory_properties)
+      schema.summary = ""
+      expect(schema.as_json.key?(:summary)).to be_falsey
     end
   end
 
@@ -45,64 +46,20 @@ RSpec.describe FinderSchema do
     end
   end
 
-  describe "#content_id" do
-    it "returns the content_id" do
-      properties = mandatory_properties.merge({ "content_id" => "853596e7-8ae3-42bd-838b-25ca3076e35f" })
-      expect(FinderSchema.new(properties).content_id).to eq("853596e7-8ae3-42bd-838b-25ca3076e35f")
-    end
-  end
-
-  describe "#document_title" do
-    it "returns the document title" do
-      properties = mandatory_properties.merge({ "document_title" => "foo" })
-      expect(FinderSchema.new(properties).document_title).to eq("foo")
-    end
-  end
-
-  describe "#show_summaries=" do
-    it "casts 'true' to true" do
-      schema = FinderSchema.new
-      schema.show_summaries = "true"
-      expect(schema.show_summaries).to eq(true)
-    end
-  end
-
-  describe "#organisations" do
-    it "returns empty array if not present" do
-      expect(FinderSchema.new(mandatory_properties).organisations).to eq([])
-    end
-
-    it "returns the organisations if present" do
-      properties = mandatory_properties.merge({ "organisations" => %w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26] })
-      expect(FinderSchema.new(properties).organisations).to eq(%w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26])
-    end
-  end
-
-  describe "#organisations=" do
-    it "ignores empty organisations" do
+  describe "#remove_empty_organisations" do
+    it "removes empty organisations on update" do
       schema = FinderSchema.new
       schema.organisations = %w[abc123 def456]
-      schema.organisations = ["", "def456"]
+      schema.update(organisations: ["", "def456"])
       expect(schema.organisations).to eq(%w[def456])
     end
   end
 
-  describe "#editing_organisations" do
-    it "returns empty array if not present" do
-      expect(FinderSchema.new(mandatory_properties).editing_organisations).to eq([])
-    end
-
-    it "returns the editing_organisations if present" do
-      properties = mandatory_properties.merge({ "editing_organisations" => %w[def456] })
-      expect(FinderSchema.new(properties).editing_organisations).to eq(%w[def456])
-    end
-  end
-
-  describe "#related=" do
-    it "ignores empty related link items" do
+  describe "#remove_empty_related_links" do
+    it "removes empty related link items on update" do
       schema = FinderSchema.new
       schema.related = %w[abc123 def456]
-      schema.related = ["", "def456"]
+      schema.update(related: ["", "def456"])
       expect(schema.related).to eq(%w[def456])
     end
   end
@@ -138,35 +95,6 @@ RSpec.describe FinderSchema do
       schema = FinderSchema.new
       schema.update({ document_noun: "publication" })
       expect(schema.signup_copy).to be_nil
-    end
-  end
-
-  describe "#taxons" do
-    it "returns empty array if not present" do
-      expect(FinderSchema.new(mandatory_properties).taxons).to eq([])
-    end
-
-    it "returns the taxons if present" do
-      properties = mandatory_properties.merge({ "taxons" => %w[951ece54-c6df-4fbc-aa18-1bc629815fe2] })
-      expect(FinderSchema.new(properties).taxons).to eq(%w[951ece54-c6df-4fbc-aa18-1bc629815fe2])
-    end
-  end
-
-  describe "#facets" do
-    it "returns the facet keys" do
-      properties = mandatory_properties.merge({
-        "facets" => [
-          {
-            "key" => "research_document_type",
-            "name" => "Document Type",
-          },
-          {
-            "key" => "something_else",
-            "name" => "Foo",
-          },
-        ],
-      })
-      expect(FinderSchema.new(properties).facets).to eq(%i[research_document_type something_else])
     end
   end
 


### PR DESCRIPTION
I'm not especially happy with how this has turned out, felt like I spent a lot of time fighting with Active Model to get the behaviour right. Sort of wonder if we should have just stuck with a plain Hash object to represent the finder schemas, but I've already spent far too long on this to start again now.

There's still a bit of work outstanding to make sure that external email signups are handled correctly by the metadata summary card but I want to make that a separate PR as I intend to refactor the summary card to a ViewComponent, as we will need more logic than I care to put in an erb template.

Worth reading the commit messages, they hopefully explain some of the more odd-looking code.

Trello: https://trello.com/c/l9XfLavV