### PR TITLE
Derive field label from its 'name' property in the finder schema

### DIFF
--- a/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
+++ b/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_organisation, label: "Organisation" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_organisation } do %>
   <%= f.select :algorithmic_transparency_record_organisation,
                f.object.facet_options(:algorithmic_transparency_record_organisation),
                {
@@ -14,7 +14,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_organisation_type, label: "Organisation type" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_organisation_type } do %>
   <%= f.select :algorithmic_transparency_record_organisation_type,
                f.object.facet_options(:algorithmic_transparency_record_organisation_type),
                {},
@@ -28,7 +28,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_function, label: "Function" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_function } do %>
   <%= f.select :algorithmic_transparency_record_function,
                f.object.facet_options(:algorithmic_transparency_record_function),
                {},
@@ -42,7 +42,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_capability, label: "Capability" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_capability } do %>
   <%= f.select :algorithmic_transparency_record_capability,
                f.object.facet_options(:algorithmic_transparency_record_capability),
                {},
@@ -56,11 +56,11 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_task, label: "Task" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_task } do %>
   <%= f.text_field :algorithmic_transparency_record_task, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_phase, label: "Phase" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_phase } do %>
   <%= f.select :algorithmic_transparency_record_phase,
                f.object.facet_options(:algorithmic_transparency_record_phase),
                {
@@ -76,7 +76,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_region, label: "Region" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_region } do %>
   <%= f.select :algorithmic_transparency_record_region,
                f.object.facet_options(:algorithmic_transparency_record_region),
                {},
@@ -90,13 +90,13 @@
   %>
 <% end %>
 
-<%= render layout: "shared/date_fields", locals: { f: f, field: :algorithmic_transparency_record_date_published, format: :algorithmic_transparency_record, label: "Date published" } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :algorithmic_transparency_record_date_published, format: :algorithmic_transparency_record } do %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_atrs_version, label: "ATRS version" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_atrs_version } do %>
   <%= f.text_field :algorithmic_transparency_record_atrs_version, class: 'form-control' %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_other_tags, label: "Other tags" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :algorithmic_transparency_record_other_tags } do %>
   <%= f.text_field :algorithmic_transparency_record_other_tags, class: 'form-control' %>
 <% end %>

--- a/app/views/metadata_fields/_animal_disease_cases.html.erb
+++ b/app/views/metadata_fields/_animal_disease_cases.html.erb
@@ -1,7 +1,7 @@
-<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_opened_date, format: :animal_disease_case, label: "Case opened date" } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_opened_date, format: :animal_disease_case } do %>
 <% end %>
 
-<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_closed_date, format: :animal_disease_case, label: "Case closed date" } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :disease_case_closed_date, format: :animal_disease_case } do %>
 <% end %>
 
 <%= render layout: "shared/form_group", locals: { f: f, field: :disease_type } do %>
@@ -18,7 +18,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :zone_restriction, label: "Disease control zone restriction" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :zone_restriction } do %>
   <%= f.select :zone_restriction,
       f.object.facet_options(:zone_restriction),
       {

--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -46,7 +46,6 @@
 <% end %>
 <%= render layout: "shared/form_group", locals: {f: f, field: :tribunal_decision_reference_number} do %>
   <%= f.text_field :tribunal_decision_reference_number,
-                   label: "Reference number",
                    class: 'form-control'
   %>
 <% end %>

--- a/app/views/metadata_fields/_business_finance_support_schemes.html.erb
+++ b/app/views/metadata_fields/_business_finance_support_schemes.html.erb
@@ -1,10 +1,10 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :continuation_link } do %>
   <%= f.url_field :continuation_link, class: 'form-control' %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on, label: 'Will continue' } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :will_continue_on } do %>
   <%= f.text_field :will_continue_on, class: 'form-control' %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :types_of_support, label: 'Types of support offered' } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :types_of_support } do %>
   <%= f.select :types_of_support,
       facet_options(f, :types_of_support),
       {},

--- a/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
+++ b/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
@@ -28,9 +28,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :funding_amount } do %>
 <%= f.select :funding_amount,
     f.object.facet_options(:funding_amount),
-    {
-      label: 'Funding (per unit per year)'
-    },
+    {},
     {
       class: 'select2 form-control',
       multiple: true,

--- a/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
+++ b/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_category, label: "Category" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_category } do %>
   <%= f.select :digital_market_research_category,
       f.object.facet_options(:digital_market_research_category),
       {
@@ -13,7 +13,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_publisher, label: "Publisher" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_publisher } do %>
   <%= f.select :digital_market_research_publisher,
       f.object.facet_options(:digital_market_research_publisher),
       {},
@@ -27,7 +27,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_area, label: "Research area" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_area } do %>
   <%= f.select :digital_market_research_area,
       f.object.facet_options(:digital_market_research_area),
       {},
@@ -41,7 +41,7 @@
       }
   %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_topic, label: "Research topic" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :digital_market_research_topic } do %>
   <%= f.select :digital_market_research_topic,
       f.object.facet_options(:digital_market_research_topic),
       {},
@@ -58,6 +58,5 @@
 <%= render "shared/date_fields",
   f: f,
   field: :digital_market_research_publish_date,
-  format: :drcf_digital_markets_research,
-  label: "Research publish date"
+  format: :drcf_digital_markets_research
 %>

--- a/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_categories } do %>
   <%= f.select :tribunal_decision_categories,
       f.object.facet_options(:tribunal_decision_categories),
-      { label: "Category" },
+      {},
       {
         class: 'select2',
         multiple: true,
@@ -15,7 +15,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_sub_categories } do %>
   <%= f.select :tribunal_decision_sub_categories,
       f.object.facet_options(:tribunal_decision_sub_categories),
-      { label: "Sub-category" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -29,7 +29,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_landmark } do %>
   <%= f.select :tribunal_decision_landmark,
       f.object.facet_options(:tribunal_decision_landmark),
-      { label: "Landmark" },
+      {},
       { class: 'form-control' }
   %>
 <% end %>

--- a/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
@@ -1,14 +1,14 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_country } do %>
   <%= f.select :tribunal_decision_country,
       f.object.facet_options(:tribunal_decision_country),
-      { label: "Country" },
+      {},
       { class: 'form-control' }
   %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_categories } do %>
   <%= f.select :tribunal_decision_categories,
       f.object.facet_options(:tribunal_decision_categories),
-      { label: "Jurisdiction code" },
+      { label: "Category" },
       {
         class: 'select2 form-control',
         multiple: true,

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -38,7 +38,7 @@
   %>
 <% end %>
 
-<%= render "shared/form_group", f: f, field: :primary_publishing_organisation, label: "Publishing organisation" do %>
+<%= render "shared/form_group", f: f, field: :primary_publishing_organisation do %>
   <%= f.select :primary_publishing_organisation,
       organisations_options,
       { selected: selected_organisation_or_current(@document.primary_publishing_organisation) },
@@ -52,7 +52,7 @@
   %>
 <% end %>
 
-<%= render "shared/form_group", f: f, field: :organisations, label: "Other associated organisations" do %>
+<%= render "shared/form_group", f: f, field: :organisations do %>
   <%= f.select :organisations,
       organisations_options,
       {},

--- a/app/views/metadata_fields/_licences.html.erb
+++ b/app/views/metadata_fields/_licences.html.erb
@@ -2,7 +2,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_industry, label: "Industry" } do %>
   <%= f.select :licence_transaction_industry,
       f.object.facet_options(:licence_transaction_industry),
-      { label: "Industry" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -14,7 +14,7 @@
 <% end %>
 
 <%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_location, label: "Location" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :licence_transaction_location } do %>
   <%= f.select :licence_transaction_location,
       f.object.facet_options(:licence_transaction_location),
       { label: "Location" },

--- a/app/views/metadata_fields/_marine_notices.html.erb
+++ b/app/views/metadata_fields/_marine_notices.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :marine_notice_type } do %>
   <%= f.select :marine_notice_type,
       f.object.facet_options(:marine_notice_type),
-      { label: "Notice type", include_blank: 'Select type' },
+      { include_blank: 'Select type' },
       { class: 'form-control' }
   %>
 <% end %>
@@ -9,7 +9,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :marine_notice_vessel_type } do %>
   <%= f.select :marine_notice_vessel_type,
       f.object.facet_options(:marine_notice_vessel_type),
-      { label: "Vessel type", include_blank: 'Select vessel type' },
+      { include_blank: 'Select vessel type' },
       {
         class: 'select2 form-control',
         multiple: true,
@@ -23,7 +23,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :marine_notice_topic } do %>
   <%= f.select :marine_notice_topic,
       f.object.facet_options(:marine_notice_topic),
-      { label: "Topic", include_blank: 'Select topic' },
+      { include_blank: 'Select topic' },
       {
         class: 'select2 form-control',
         multiple: true,

--- a/app/views/metadata_fields/_product_safety_alerts_reports_recalls.html.erb
+++ b/app/views/metadata_fields/_product_safety_alerts_reports_recalls.html.erb
@@ -1,14 +1,14 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :product_alert_type, label: "Alert type" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_alert_type do %>
   <%= f.select :product_alert_type, facet_options(f, :product_alert_type), {}, { class: "form-control" } %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :product_risk_level, label: "Risk level" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_risk_level } do %>
   <%= f.select :product_risk_level, facet_options(f, :product_risk_level), {}, { class: "form-control" } %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :product_category, label: "Product category" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_category } do %>
   <%= f.select :product_category, facet_options(f, :product_category), {}, { class: "form-control" } %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :product_measure_type, label: "Measure type" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :product_measure_type } do %>
   <%= f.select :product_measure_type, facet_options(f, :product_measure_type), {}, { class: "form-control", multiple: true } %>
 <% end %>
-<%= render layout: "shared/date_fields", locals: { f: f, field: :product_recall_alert_date, format: :product_safety_alert_report_recall, label: "Recall/alert date" } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :product_recall_alert_date, format: :product_safety_alert_report_recall } do %>
 <% end %>

--- a/app/views/metadata_fields/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields/_protected_food_drink_names.html.erb
@@ -5,7 +5,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :register } do %>
   <%= f.select :register,
       f.object.facet_options(:register),
-      { label: "Register", include_blank: 'Select register' },
+      { include_blank: 'Select register' },
       { class: 'form-control' }
   %>
 <% end %>
@@ -13,16 +13,16 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :status } do %>
   <%= f.select :status,
       f.object.facet_options(:status),
-      { label: "Status", include_blank: 'Select status' },
+      { include_blank: 'Select status' },
       { class: 'form-control' }
   %>
 <% end %>
 
 <%# You can select multiple class or categories so this has multi-select option %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :class_category } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :class_category, label: "Class category" } do %>
   <%= f.select :class_category,
       f.object.facet_options(:class_category),
-      { label: "Class or category of product" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -36,7 +36,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :protection_type } do %>
   <%= f.select :protection_type,
       f.object.facet_options(:protection_type),
-      { label: "Protection type", include_blank: 'Select protection type' },
+      { include_blank: 'Select protection type' },
       { class: 'form-control' }
   %>
 <% end %>
@@ -45,7 +45,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :country_of_origin } do %>
   <%= f.select :country_of_origin,
       f.object.facet_options(:country_of_origin),
-      { label: "Country of origin" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -60,7 +60,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :traditional_term_grapevine_product_category } do %>
   <%= f.select :traditional_term_grapevine_product_category,
       f.object.facet_options(:traditional_term_grapevine_product_category),
-      { label: "Traditional term grapevine product category" },
+      {},
       {
         class: 'select2 form-control',
         multiple: true,
@@ -74,7 +74,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :traditional_term_type } do %>
   <%= f.select :traditional_term_type,
       f.object.facet_options(:traditional_term_type),
-      { label: "Traditional term type", include_blank: 'Select term type' },
+      { include_blank: 'Select term type' },
       { class: 'form-control' }
   %>
 <% end %>
@@ -82,7 +82,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :traditional_term_language } do %>
   <%= f.select :traditional_term_language,
       f.object.facet_options(:traditional_term_language),
-      { label: "Traditional term language", include_blank: 'Select language' },
+      { include_blank: 'Select language' },
       { class: 'form-control' }
   %>
 <% end %>
@@ -90,7 +90,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :reason_for_protection } do %>
   <%= f.select :reason_for_protection,
       f.object.facet_options(:reason_for_protection),
-      { label: "Reason for protection", include_blank: 'Select reason for protection' },
+      { include_blank: 'Select reason for protection' },
       { class: 'form-control' }
   %>
 <% end %>

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'shared/form_group', locals: { f: f, field: :research_document_type, label: 'Document type' } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :research_document_type } do %>
   <%=
     f.select :research_document_type, facet_options(f, :research_document_type),
       { include_blank: true },
@@ -6,11 +6,11 @@
   %>
 <% end %>
 
-<%= render layout: 'shared/form_group', locals: { f: f, field: :authors, label: 'Authors' } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :authors } do %>
   <%= f.text_field :author_tags, class: 'form-control free-form-list', data: { placeholder: 'Add authors' } %>
 <% end %>
 
-<%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: 'Countries' } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: "Countries" } do %>
   <%=
     f.select :country, facet_options(f, :country),
       { include_blank: true },
@@ -18,7 +18,7 @@
   %>
 <% end %>
 
-<%= render layout: 'shared/form_group', locals: { f: f, field: :theme, label: 'Themes' } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :theme } do %>
   <%=
     f.select :theme, facet_options(f, :theme),
              { include_blank: false },
@@ -27,7 +27,7 @@
 <% end %>
 <%= render layout: "shared/date_fields", locals: { f: f, field: :first_published_at, format: :research_for_development_output } do %>
 <% end %>
-<%= render layout: 'shared/form_group', locals: { f: f, field: :review_status, label: 'Review status' } do %>
+<%= render layout: 'shared/form_group', locals: { f: f, field: :review_status } do %>
   <%= f.select :review_status, review_status_options,
     {},
     { class: 'form-control' } %>

--- a/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
@@ -1,14 +1,14 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_category } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_category, label: "Tribunal decision category" } do %>
   <%= f.select :tribunal_decision_category,
       f.object.facet_options(:tribunal_decision_category),
-      { label: "Category", include_blank: 'Select category' },
+      { include_blank: 'Select category' },
       { class: 'form-control' }
   %>
 <% end %>
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_sub_category } do %>
   <%= f.select :tribunal_decision_sub_category,
       f.object.facet_options(:tribunal_decision_sub_category),
-      { label: "Sub-category", include_blank: true },
+      { include_blank: true },
       { class: 'select2 form-control', data: { placeholder: 'Select sub-category' } }
   %>
 <% end %>

--- a/app/views/metadata_fields/_sfo_cases.html.erb
+++ b/app/views/metadata_fields/_sfo_cases.html.erb
@@ -1,5 +1,5 @@
-<%= render layout: "shared/date_fields", locals: { f: f, field: :sfo_case_date_announced, format: :sfo_case,  label: "Date announced" } do %>
+<%= render layout: "shared/date_fields", locals: { f: f, field: :sfo_case_date_announced, format: :sfo_case } do %>
 <% end %>
-<%= render layout: "shared/form_group", locals: { f: f, field: :sfo_case_state, label: "Case state" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :sfo_case_state } do %>
     <%= f.select :sfo_case_state, facet_options(f, :sfo_case_state), {}, { class: 'form-control' } %>
 <% end %>

--- a/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: "shared/form_group", locals: { f: f, field: :tribunal_decision_category } do %>
   <%= f.select :tribunal_decision_category,
       f.object.facet_options(:tribunal_decision_category),
-      { label: "Category" },
+      {},
       { class: 'form-control' }
   %>
 <% end %>

--- a/app/views/metadata_fields/_veterans_support_organisations.html.erb
+++ b/app/views/metadata_fields/_veterans_support_organisations.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_health_and_social_care, label: "Health and Social Care" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_health_and_social_care } do %>
   <%= f.select :veterans_support_organisation_health_and_social_care,
       facet_options(f, :veterans_support_organisation_health_and_social_care),
       {},
@@ -13,7 +13,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_finance, label: "Finance" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_finance } do %>
   <%= f.select :veterans_support_organisation_finance,
       facet_options(f, :veterans_support_organisation_finance),
       {},
@@ -28,7 +28,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_legal_and_justice, label: "Legal and justice" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_legal_and_justice } do %>
   <%= f.select :veterans_support_organisation_legal_and_justice,
       facet_options(f, :veterans_support_organisation_legal_and_justice),
       {},
@@ -43,7 +43,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_employment_education_and_training, label: "Employment, education and training" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_employment_education_and_training } do %>
   <%= f.select :veterans_support_organisation_employment_education_and_training,
       facet_options(f, :veterans_support_organisation_employment_education_and_training),
       {},
@@ -58,7 +58,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_housing, label: "Housing" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_housing } do %>
   <%= f.select :veterans_support_organisation_housing,
       facet_options(f, :veterans_support_organisation_housing),
       {},
@@ -73,7 +73,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_families_and_children, label: "Families and children" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_families_and_children } do %>
   <%= f.select :veterans_support_organisation_families_and_children,
       facet_options(f, :veterans_support_organisation_families_and_children),
       {},
@@ -88,7 +88,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_community_and_social, label: "Community and social" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_community_and_social } do %>
   <%= f.select :veterans_support_organisation_community_and_social,
       facet_options(f, :veterans_support_organisation_community_and_social),
       {},
@@ -103,7 +103,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_england, label: "England" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_england } do %>
   <%= f.select :veterans_support_organisation_region_england,
       facet_options(f, :veterans_support_organisation_region_england),
       {},
@@ -118,7 +118,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_northern_ireland, label: "Northern Ireland" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_northern_ireland } do %>
   <%= f.select :veterans_support_organisation_region_northern_ireland,
       facet_options(f, :veterans_support_organisation_region_northern_ireland),
       {},
@@ -133,7 +133,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_scotland, label: "Scotland" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_scotland } do %>
   <%= f.select :veterans_support_organisation_region_scotland,
       facet_options(f, :veterans_support_organisation_region_scotland),
       {},
@@ -148,7 +148,7 @@
   %>
 <% end %>
 
-<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_wales, label: "Wales" } do %>
+<%= render layout: "shared/form_group", locals: { f: f, field: :veterans_support_organisation_region_wales } do %>
   <%= f.select :veterans_support_organisation_region_wales,
       facet_options(f, :veterans_support_organisation_region_wales),
       {},

--- a/app/views/shared/_date_fields.html.erb
+++ b/app/views/shared/_date_fields.html.erb
@@ -1,4 +1,4 @@
-<% label ||= field.to_s.humanize %>
+<% label ||= f.object.finder_schema.humanized_facet_name(field) %>
 
 <div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
   <%= f.label field, for: "#{format}_#{field}_year" do %>

--- a/app/views/shared/_form_group.html.erb
+++ b/app/views/shared/_form_group.html.erb
@@ -1,4 +1,4 @@
-<% label ||= field.to_s.humanize %>
+<% label ||= f.object.finder_schema.humanized_facet_name(field) %>
 
 <div class="form-group <%= 'elements-error' if field_has_errors(@document, field) %>">
   <%= f.label field do %>

--- a/spec/features/creating_a_drcf_digital_markets_research_spec.rb
+++ b/spec/features/creating_a_drcf_digital_markets_research_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Creating a DRCF digital markets research", type: :feature do
     fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(2i)", with: "02"
     fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(3i)", with: "02"
     select "Ad hoc research", from: "Category"
-    select "Gambling Commission", from: "Publisher"
+    select "Gambling Commission", from: "Original publisher"
     select "Media and entertainment", from: "Research area"
     select "Future connectivity", from: "Research topic"
 
@@ -115,7 +115,7 @@ RSpec.feature "Creating a DRCF digital markets research", type: :feature do
     fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(2i)", with: "02"
     fill_in "[drcf_digital_markets_research]digital_market_research_publish_date(3i)", with: "31"
     select "Ad hoc research", from: "Category"
-    select "Gambling Commission", from: "Publisher"
+    select "Gambling Commission", from: "Original publisher"
     select "Media and entertainment", from: "Research area"
     select "Future connectivity", from: "Research topic"
 

--- a/spec/features/creating_a_research_for_development_output_spec.rb
+++ b/spec/features/creating_a_research_for_development_output_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Creating a Research for Development Output", type: :feature do
     fill_in "[research_for_development_output]first_published_at(1i)", with: "2013"
     fill_in "[research_for_development_output]first_published_at(2i)", with: "01"
     fill_in "[research_for_development_output]first_published_at(3i)", with: "01"
-    select "Book Chapter", from: "Document type"
+    select "Book Chapter", from: "Document Type"
     select "Infrastructure", from: "Themes"
     select "Peer reviewed", from: "Review status"
 


### PR DESCRIPTION
Whilst developing a finder recently, I was surprised that my 'name' wasn't having any effect on what was showing in the admin UI. I believe until now, the 'name' is only used in finder-frontend itself.

The label was derived from the key instead of the name, but this often wasn't suitable, meaning we had a lot of `label:` overrides (as keys had to be namespaced, but labels can afford to use more generic language).

I've tweaked the templates to derive the label from the 'name' instead, which is already a curated human-readable name for the thing - so we no longer need to try to guess from the key. We still have the freedom to use explicit label overrides where needed (indeed, I've left several untouched in the _licences.html.erb file, as the name was quite different to what was configured in that view).

Trello: https://trello.com/c/5RZhjdWe/3211-specialist-finder-for-the-data-ethics-guidance

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
