### PR TITLE
Introduce form object for handling email alert finder schema values

### DIFF
--- a/app/components/email_alert_fieldset_component.html.erb
+++ b/app/components/email_alert_fieldset_component.html.erb
@@ -7,30 +7,30 @@
     heading: "Would you like to set up email alerts for the finder?",
     heading_size: "s",
     hint: "Email alerts should only be added if you've tested a user need for these",
-    name: "email_alerts",
+    name: "email_alert_type",
     items: [
       {
         value: "all_content",
         text: "Yes. Allow users to sign up to email alerts for everything published on the finder.",
-        checked: @schema.signup_content_id,
+        checked: @email_alert.type == :all_content,
         conditional: render_all_content_condition_inputs
       },
       {
         value: "filtered_content",
         text: "Yes. Allow users to sign up by specific filter criteria",
-        checked: @schema.email_filter_by,
+        checked: @email_alert.type == :filtered_content,
         conditional: render_filtered_content_condition_inputs
       },
       {
         value: "external",
         text: "Yes. Allow users to sign up for updates using a signup link.",
-        checked: @schema.signup_link,
+        checked: @email_alert.type == :external,
         conditional: render_external_condition_inputs
       },
       {
         value: "no",
         text: "No",
-        checked: !@schema.signup_content_id
+        checked: @email_alert.type == :no
       }
     ]
   } %>

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -1,27 +1,27 @@
 class EmailAlertFieldsetComponent < ViewComponent::Base
-  def initialize(schema:)
-    @schema = schema
+  def initialize(email_alert:)
+    @email_alert = email_alert
   end
 
   def render_all_content_condition_inputs
     signup_content_id_input = render("govuk_publishing_components/components/input", {
       type: "hidden",
-      name: "signup_content_id",
-      value: @schema.signup_content_id || SecureRandom.uuid,
+      name: "all_content_signup_id",
+      value: @email_alert.content_id || SecureRandom.uuid,
     })
 
     # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
     # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
     # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
-    if @schema.subscription_list_title_prefix.is_a?(Hash)
+    if @email_alert.list_title_prefix.is_a?(Hash)
       signup_content_id_input
     else
       render("govuk_publishing_components/components/input", {
         label: {
           text: "Email subscription topic",
         },
-        name: "subscription_list_title_prefix",
-        value: @schema.subscription_list_title_prefix,
+        name: "all_content_list_title_prefix",
+        value: @email_alert.list_title_prefix,
       }) + signup_content_id_input
     end
   end
@@ -30,12 +30,12 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
   def render_filtered_content_condition_inputs
     render("govuk_publishing_components/components/input", {
       type: "hidden",
-      name: "signup_content_id",
-      value: @schema.signup_content_id || SecureRandom.uuid,
+      name: "filtered_content_signup_id",
+      value: @email_alert.content_id || SecureRandom.uuid,
     }) +
       render("govuk_publishing_components/components/checkboxes", {
         name: "email_filter_by",
-        heading: "Selected filter: #{@schema.email_filter_by&.humanize}",
+        heading: "Selected filter: #{@email_alert.filter&.humanize}",
         items: [
           {
             label: "Make changes to this filter criteria (The development team will reach out to you to discuss the requirements to allow users to sign up by specific filter criteria)",
@@ -52,7 +52,7 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
       },
       hint: "A link to an email signup page",
       name: "signup_link",
-      value: @schema.signup_link,
+      value: @email_alert.link,
     })
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,10 +15,12 @@ class AdminController < ApplicationController
       :summary,
       :show_summaries,
       :document_noun,
-      *email_alert_params,
       organisations: [],
       related: [],
     )
+
+    email_alert = EmailAlert.from_finder_admin_form_params(email_alert_params)
+    @params.merge!(email_alert.to_finder_schema_attributes)
 
     @proposed_schema = FinderSchema.new(@current_format.finder_schema.attributes)
     @proposed_schema.update(@params.to_unsafe_h)
@@ -63,12 +65,14 @@ private
   end
 
   def email_alert_params
-    permitted_email_alert_params = {
-      "all_content" => %i[signup_content_id subscription_list_title_prefix],
-      "filtered_content" => %i[signup_content_id email_filter_by],
-      "external" => %i[signup_link],
-      "no" => [],
-    }
-    permitted_email_alert_params[params[:email_alerts]]
+    params.permit(
+      :email_alert_type,
+      :all_content_signup_id,
+      :all_content_list_title_prefix,
+      :filtered_content_signup_id,
+      :filtered_content_list_title_prefix,
+      :email_filter_by,
+      :signup_link,
+    )
   end
 end

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -1,0 +1,67 @@
+class EmailAlert
+  include ActiveModel::Model
+
+  attr_accessor :type, :list_title_prefix, :link, :content_id, :filter
+
+  def to_finder_schema_attributes
+    {
+      signup_content_id: content_id,
+      subscription_list_title_prefix: list_title_prefix,
+      email_filter_by: filter,
+      signup_link: link,
+    }
+  end
+
+  class << self
+    def from_finder_schema(schema)
+      email_alert = new
+      email_alert.type = email_alert_type(schema)
+      email_alert.content_id = schema.signup_content_id
+      email_alert.list_title_prefix = schema.subscription_list_title_prefix
+      email_alert.filter = schema.email_filter_by
+      email_alert.link = schema.signup_link
+      email_alert
+    end
+
+    def from_finder_admin_form_params(params)
+      email_alert = new
+      email_alert.type = params["email_alert_type"].to_sym
+      email_alert.assign_attributes(email_alert_params_by_type(params, email_alert.type))
+      email_alert
+    end
+
+  private
+
+    def email_alert_type(schema)
+      return :filtered_content if schema.signup_content_id.present? && schema.email_filter_by.present?
+      return :external if schema.signup_link.present?
+      return :all_content if schema.signup_content_id.present?
+
+      :no
+    end
+
+    def email_alert_params_by_type(params, type)
+      {
+        all_content: all_content_params(params),
+        filtered_content: filtered_content_params(params),
+        external: external_params(params),
+      }[type] || {}
+    end
+
+    def all_content_params(params)
+      { content_id: params["all_content_signup_id"], list_title_prefix: params["all_content_list_title_prefix"] }
+    end
+
+    def filtered_content_params(params)
+      {
+        content_id: params["filtered_content_signup_id"],
+        list_title_prefix: params["filtered_content_list_title_prefix"],
+        filter: params["email_filter_by"],
+      }
+    end
+
+    def external_params(params)
+      { link: params["signup_link"] }
+    end
+  end
+end

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -6,7 +6,6 @@ class FinderSchema
 
   define_model_callbacks :update
 
-  before_update :reset_email_alerts
   after_update :override_signup_copy, :remove_empty_related_links, :remove_empty_organisations
 
   # Pluralized names of all document types
@@ -63,16 +62,6 @@ class FinderSchema
 
   def format
     filter["format"]
-  end
-
-  def reset_email_alerts
-    assign_attributes(
-      signup_content_id: nil,
-      subscription_list_title_prefix: nil,
-      signup_link: nil,
-      email_filter_by: nil,
-      email_filter_facets: nil,
-    )
   end
 
   def override_signup_copy

--- a/app/views/admin/edit_metadata.html.erb
+++ b/app/views/admin/edit_metadata.html.erb
@@ -146,7 +146,7 @@
         hint: "For example ‘scheme’. On Finance and support for your business there’s 151 schemes, which updates when you start selecting filter options"
       } %>
 
-      <%= render EmailAlertFieldsetComponent.new(schema: current_format.finder_schema) %>
+      <%= render EmailAlertFieldsetComponent.new(email_alert: EmailAlert.from_finder_schema(current_format.finder_schema)) %>
 
       <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -2,84 +2,93 @@ require "rails_helper"
 
 RSpec.describe EmailAlertFieldsetComponent, type: :component do
   it "renders an email alerts fieldset containing two radio buttons with expected values" do
-    schema = FinderSchema.new
-    render_inline(described_class.new(schema:))
+    email_alert = EmailAlert.new
+    render_inline(described_class.new(email_alert:))
     expect(page).to have_text("Email Alerts")
-    expect(page).to have_field("email_alerts")
+    expect(page).to have_field("email_alert_type")
   end
 
-  it "sets the value of the radio button to 'no' if the schema does not have a signup_content_id" do
-    schema = FinderSchema.new
-    render_inline(described_class.new(schema:))
+  it "sets the value of the radio button to 'no' if the email alert is not enabled" do
+    email_alert = EmailAlert.new
+    email_alert.type = :no
+    render_inline(described_class.new(email_alert:))
 
-    expect(page).to have_checked_field("email_alerts", with: "no")
+    expect(page).to have_checked_field("email_alert_type", with: "no")
   end
 
-  it "sets the value of the radio button to 'no' if the schema does not have a signup_content_id" do
-    schema = FinderSchema.new
-    render_inline(described_class.new(schema:))
+  it "sets the value of the radio button to 'all_content' if the email alert is enabled for all content" do
+    email_alert = EmailAlert.new
+    email_alert.type = :all_content
+    email_alert.content_id = "123"
+    render_inline(described_class.new(email_alert:))
 
-    expect(page).to have_checked_field("email_alerts", with: "no")
+    expect(page).to have_checked_field("email_alert_type", with: "all_content")
+    expect(page).to have_field("all_content_signup_id", with: "123", type: "hidden")
   end
 
-  it "sets the value of the radio button to 'all_content' if the schema has a signup content id" do
-    schema = FinderSchema.new
-    schema.signup_content_id = "123"
-    render_inline(described_class.new(schema:))
-
-    expect(page).to have_checked_field("email_alerts", with: "all_content")
-    expect(page).to have_field("signup_content_id", with: "123", type: "hidden")
-  end
-
-  it "sets the value of the radio button to 'all_content' and renders a hidden input with a generated content id if the schema is missing a signup content id" do
-    schema = FinderSchema.new
+  it "sets the value of the radio button to 'all_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
+    email_alert = EmailAlert.new
+    email_alert.type = :all_content
     allow(SecureRandom).to receive(:uuid).and_return("new-id")
-    render_inline(described_class.new(schema:))
+    render_inline(described_class.new(email_alert:))
 
-    expect(page).to have_checked_field("email_alerts", with: "no")
-    expect(page).to have_field("signup_content_id", with: "new-id", type: "hidden")
+    expect(page).to have_checked_field("email_alert_type", with: "all_content")
+    expect(page).to have_field("all_content_signup_id", with: "new-id", type: "hidden")
   end
 
   it "renders the email subscription topic if the all_content value is checked" do
-    schema = FinderSchema.new
-    schema.signup_content_id = "123"
-    schema.subscription_list_title_prefix = "Finder email subscription"
-    render_inline(described_class.new(schema:))
+    email_alert = EmailAlert.new
+    email_alert.type = :all_content
+    email_alert.list_title_prefix = "Finder email subscription"
+    render_inline(described_class.new(email_alert:))
 
     expect(page).to have_text("Email subscription topic")
-    expect(page).to have_field("subscription_list_title_prefix", with: schema.subscription_list_title_prefix)
+    expect(page).to have_field("all_content_list_title_prefix", with: email_alert.list_title_prefix)
   end
 
   # We do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
   # values in such cases. We are going to revisit this later. Trello card for future work: https://trello.com/c/Qe8wOpaw
-  it "does not render the email subscription topic if the all_content value is checked but the current schema value is a hash" do
-    schema = FinderSchema.new
-    schema.signup_content_id = "123"
-    schema.subscription_list_title_prefix = {}
-    render_inline(described_class.new(schema:))
+  it "does not render the email subscription topic if the all_content value is checked but the current topic value is a hash" do
+    email_alert = EmailAlert.new
+    email_alert.type = :all_content
+    email_alert.list_title_prefix = {}
+    render_inline(described_class.new(email_alert:))
 
     expect(page).not_to have_text("Email subscription topic")
-    expect(page).not_to have_field("subscription_list_title_prefix", with: schema.subscription_list_title_prefix)
+    expect(page).not_to have_field("all_content_list_title_prefix", with: email_alert.list_title_prefix)
   end
 
-  it "sets the value of the radio button to 'external' if the schema has a signup link" do
-    schema = FinderSchema.new
-    schema.signup_link = "https://example.com"
-    render_inline(described_class.new(schema:))
+  it "sets the value of the radio button to 'external' if email alerts are enabled using an external system" do
+    email_alert = EmailAlert.new
+    email_alert.type = :external
+    email_alert.link = "https://example.com"
+    render_inline(described_class.new(email_alert:))
 
-    expect(page).to have_checked_field("email_alerts", with: "external")
-    expect(page).to have_field("signup_link", with: schema.signup_link)
+    expect(page).to have_checked_field("email_alert_type", with: "external")
+    expect(page).to have_field("signup_link", with: email_alert.link)
   end
 
-  it "sets the value of the radio button to 'filtered_content' if the schema has an email filter attribute" do
-    schema = FinderSchema.new
-    schema.signup_content_id = "123"
-    schema.email_filter_by = "some_facet"
-    render_inline(described_class.new(schema:))
+  it "sets the value of the radio button to 'filtered_content' if email alerts are enabled for a filtered subset of the content" do
+    email_alert = EmailAlert.new
+    email_alert.type = :filtered_content
+    email_alert.content_id = "123"
+    email_alert.filter = "some_facet"
+    render_inline(described_class.new(email_alert:))
 
-    expect(page).to have_checked_field("email_alerts", with: "filtered_content")
+    expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
     expect(page).to have_text("Selected filter: Some facet")
-    expect(page).to have_field("signup_content_id", with: schema.signup_content_id, type: "hidden")
+    expect(page).to have_field("filtered_content_signup_id", with: email_alert.content_id, type: "hidden")
     expect(page).to have_unchecked_field("email_filter_by", with: "CHANGE_REQUESTED")
+  end
+
+  it "sets the value of the radio button to 'filtered_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
+    email_alert = EmailAlert.new
+    email_alert.type = :filtered_content
+    email_alert.filter = "some_facet"
+    allow(SecureRandom).to receive(:uuid).and_return("new-id")
+    render_inline(described_class.new(email_alert:))
+
+    expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
+    expect(page).to have_field("filtered_content_signup_id", with: "new-id", type: "hidden")
   end
 end

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     fill_in "Link 2", with: "Changed link 2"
     fill_in "Link 3", with: "Changed link 3"
     fill_in "document_noun", with: "Changed document noun"
-    choose "email_alerts", option: "no"
+    choose "email_alert_type", option: "no"
 
     click_button "Submit changes"
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+
+RSpec.describe "EmailAlert" do
+  describe "#from_finder_schema" do
+    it "builds an email alert for a finder schema with alerts configured for all content" do
+      schema = FinderSchema.new
+      schema.signup_content_id = "123"
+      schema.subscription_list_title_prefix = "Finder email subscription"
+      email_alert = EmailAlert.from_finder_schema(schema)
+      expect(email_alert.type).to eq(:all_content)
+      expect(email_alert.content_id).to eq(schema.signup_content_id)
+      expect(email_alert.list_title_prefix).to eq(schema.subscription_list_title_prefix)
+    end
+
+    it "builds an email alert for a finder schema with alerts configured for a filtered set of the content" do
+      schema = FinderSchema.new
+      schema.signup_content_id = "123"
+      schema.email_filter_by = "some_facet"
+      schema.subscription_list_title_prefix = "Finder email subscription"
+      email_alert = EmailAlert.from_finder_schema(schema)
+      expect(email_alert.type).to eq(:filtered_content)
+      expect(email_alert.content_id).to eq(schema.signup_content_id)
+      expect(email_alert.list_title_prefix).to eq(schema.subscription_list_title_prefix)
+      expect(email_alert.filter).to eq(schema.email_filter_by)
+    end
+
+    it "builds an email alert for a finder schema with alerts configured to use an external system" do
+      schema = FinderSchema.new
+      schema.signup_link = "https://example.com"
+      email_alert = EmailAlert.from_finder_schema(schema)
+      expect(email_alert.type).to eq(:external)
+      expect(email_alert.link).to eq(schema.signup_link)
+    end
+
+    it "builds an email alert for a finder schema without alerts configured" do
+      schema = FinderSchema.new
+      email_alert = EmailAlert.from_finder_schema(schema)
+      expect(email_alert.type).to eq(:no)
+    end
+  end
+
+  describe "#from_finder_admin_form_params" do
+    it "builds an email alert for a finder schema with alerts configured for all content" do
+      params = {
+        "email_alert_type" => "all_content",
+        "all_content_signup_id" => "123",
+        "all_content_list_title_prefix" => "Finder email subscription",
+      }
+      email_alert = EmailAlert.from_finder_admin_form_params(params)
+      expect(email_alert.type).to eq(:all_content)
+      expect(email_alert.content_id).to eq(params["all_content_signup_id"])
+      expect(email_alert.list_title_prefix).to eq(params["all_content_list_title_prefix"])
+    end
+
+    it "builds an email alert for a finder schema with alerts configured for a filtered set of the content" do
+      params = {
+        "email_alert_type" => "filtered_content",
+        "filtered_content_signup_id" => "123",
+        "email_filter_by" => "some_facet",
+        "filtered_content_list_title_prefix" => "Finder email subscription",
+      }
+      email_alert = EmailAlert.from_finder_admin_form_params(params)
+      expect(email_alert.type).to eq(:filtered_content)
+      expect(email_alert.content_id).to eq(params["filtered_content_signup_id"])
+      expect(email_alert.list_title_prefix).to eq(params["filtered_content_list_title_prefix"])
+      expect(email_alert.filter).to eq(params["email_filter_by"])
+    end
+
+    it "builds an email alert for a finder schema with alerts configured to use an external system" do
+      params = {
+        "email_alert_type" => "external",
+        "signup_link" => "https://example.com",
+      }
+      email_alert = EmailAlert.from_finder_admin_form_params(params)
+      expect(email_alert.type).to eq(:external)
+      expect(email_alert.link).to eq(params["signup_link"])
+    end
+
+    it "builds an email alert for a finder schema without alerts configured" do
+      params = {
+        "email_alert_type" => "no",
+      }
+      email_alert = EmailAlert.from_finder_admin_form_params(params)
+      expect(email_alert.type).to eq(:no)
+    end
+  end
+
+  describe "#to_finder_schema_attributes" do
+    it "transforms the attributes of the email alert to a hash of finder schema attributes" do
+      email_alert = EmailAlert.new
+      email_alert.content_id = "123"
+      email_alert.list_title_prefix = "Finder email subscription"
+      email_alert.filter = "some_facet"
+      email_alert.link = "https://example.com"
+      expect(email_alert.to_finder_schema_attributes).to eq({
+        signup_content_id: "123",
+        subscription_list_title_prefix: "Finder email subscription",
+        email_filter_by: "some_facet",
+        signup_link: "https://example.com",
+      })
+    end
+  end
+end

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -64,25 +64,6 @@ RSpec.describe FinderSchema do
     end
   end
 
-  describe "#reset_email_alerts" do
-    it "resets email alert fields when update is called" do
-      schema = FinderSchema.new
-      schema.assign_attributes(
-        signup_content_id: "123",
-        subscription_list_title_prefix: "456",
-        signup_link: "789",
-        email_filter_by: "foo",
-        email_filter_facets: "bar",
-      )
-      schema.update({})
-      expect(schema.signup_content_id).to be_nil
-      expect(schema.subscription_list_title_prefix).to be_nil
-      expect(schema.signup_link).to be_nil
-      expect(schema.email_filter_by).to be_nil
-      expect(schema.email_filter_facets).to be_nil
-    end
-  end
-
   describe "#override_signup_copy" do
     it "overrides the signup copy based on the document noun on update if the schema has signup copy" do
       schema = FinderSchema.new


### PR DESCRIPTION
We need the subscription title list prefix attribute to be provided for both the filtered content email signup and the all content email signup.

However, having duplicate fields in the HTML form, even when one was hidden via the radio button Publishing component conditional behaviour, would result in both input values being submitted.

I have therefore reluctantly chosen to introduce an extra layer of indirection to manage this, as the input form fields will need to have prefixed names. The email alert class handles mapping the form parameter values to the finder schema keys.

The before update callback on the finder schema which reset the email alert attributes is now redundant, so that has been removed.

The input for the subscription title list prefix will be added in the next PR.

Trello: https://trello.com/c/l9XfLavV
