### PR TITLE
Add subscription list prefix to filtered content email alerts fieldset component

### DIFF
--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -4,35 +4,19 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
   end
 
   def render_all_content_condition_inputs
-    signup_content_id_input = render("govuk_publishing_components/components/input", {
-      type: "hidden",
-      name: "all_content_signup_id",
-      value: @email_alert.content_id || SecureRandom.uuid,
-    })
+    hidden_signup_content_id_input = hidden_signup_content_id_input("all_content_signup_id")
 
     # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
     # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
     # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
-    if @email_alert.list_title_prefix.is_a?(Hash)
-      signup_content_id_input
-    else
-      render("govuk_publishing_components/components/input", {
-        label: {
-          text: "Email subscription topic",
-        },
-        name: "all_content_list_title_prefix",
-        value: @email_alert.list_title_prefix,
-      }) + signup_content_id_input
-    end
+    return hidden_signup_content_id_input if @email_alert.list_title_prefix.is_a?(Hash)
+
+    email_topic_list_title_prefix("all_content_list_title_prefix") + hidden_signup_content_id_input
   end
 
   # We are handling changes to email facet filters offline at present.
   def render_filtered_content_condition_inputs
-    render("govuk_publishing_components/components/input", {
-      type: "hidden",
-      name: "filtered_content_signup_id",
-      value: @email_alert.content_id || SecureRandom.uuid,
-    }) +
+    hidden_signup_content_id_input("filtered_content_signup_id") +
       render("govuk_publishing_components/components/checkboxes", {
         name: "email_filter_by",
         heading: "Selected filter: #{@email_alert.filter&.humanize}",
@@ -53,6 +37,26 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
       hint: "A link to an email signup page",
       name: "signup_link",
       value: @email_alert.link,
+    })
+  end
+
+private
+
+  def email_topic_list_title_prefix(input_name)
+    render("govuk_publishing_components/components/input", {
+      label: {
+        text: "Email subscription topic",
+      },
+      name: input_name,
+      value: @email_alert.list_title_prefix,
+    })
+  end
+
+  def hidden_signup_content_id_input(input_name)
+    render("govuk_publishing_components/components/input", {
+      type: "hidden",
+      name: input_name,
+      value: @email_alert.content_id || SecureRandom.uuid,
     })
   end
 end

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -18,6 +18,7 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
       render("govuk_publishing_components/components/checkboxes", {
         name: "email_filter_by",
         heading: "Selected filter: #{@email_alert.filter&.humanize}",
+        no_hint_text: true,
         items: [
           {
             label: "Make changes to this filter criteria (The development team will reach out to you to discuss the requirements to allow users to sign up by specific filter criteria)",
@@ -53,6 +54,7 @@ private
       },
       name: input_name,
       value: @email_alert.list_title_prefix,
+      hint: "This reminds subscribers of the topic of the finder when they are sent emails or they are managing their subscriptions. Example: 'Funding for land or farms'",
     })
   end
 

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -4,19 +4,17 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
   end
 
   def render_all_content_condition_inputs
-    hidden_signup_content_id_input = hidden_signup_content_id_input("all_content_signup_id")
-
-    # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
-    # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
-    # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
-    return hidden_signup_content_id_input if @email_alert.list_title_prefix.is_a?(Hash)
-
-    email_topic_list_title_prefix("all_content_list_title_prefix") + hidden_signup_content_id_input
+    [
+      render_hidden_signup_content_id_input("all_content_signup_id"),
+      render_email_topic_list_title_prefix("all_content_list_title_prefix"),
+    ].compact.join.html_safe
   end
 
   # We are handling changes to email facet filters offline at present.
   def render_filtered_content_condition_inputs
-    hidden_signup_content_id_input("filtered_content_signup_id") +
+    [
+      render_hidden_signup_content_id_input("filtered_content_signup_id"),
+      render_email_topic_list_title_prefix("filtered_content_list_title_prefix"),
       render("govuk_publishing_components/components/checkboxes", {
         name: "email_filter_by",
         heading: "Selected filter: #{@email_alert.filter&.humanize}",
@@ -26,7 +24,8 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
             value: "CHANGE_REQUESTED",
           },
         ],
-      })
+      }),
+    ].compact.join.html_safe
   end
 
   def render_external_condition_inputs
@@ -42,7 +41,12 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
 
 private
 
-  def email_topic_list_title_prefix(input_name)
+  def render_email_topic_list_title_prefix(input_name)
+    # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
+    # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
+    # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
+    return if @email_alert.list_title_prefix.is_a?(Hash)
+
     render("govuk_publishing_components/components/input", {
       label: {
         text: "Email subscription topic",
@@ -52,7 +56,7 @@ private
     })
   end
 
-  def hidden_signup_content_id_input(input_name)
+  def render_hidden_signup_content_id_input(input_name)
     render("govuk_publishing_components/components/input", {
       type: "hidden",
       name: input_name,

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -91,4 +91,26 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
     expect(page).to have_field("filtered_content_signup_id", with: "new-id", type: "hidden")
   end
+
+  it "renders the email subscription topic if the filtered_content value is checked" do
+    email_alert = EmailAlert.new
+    email_alert.type = :filtered_content
+    email_alert.list_title_prefix = "Finder email subscription"
+    render_inline(described_class.new(email_alert:))
+
+    expect(page).to have_text("Email subscription topic")
+    expect(page).to have_field("filtered_content_list_title_prefix", with: email_alert.list_title_prefix)
+  end
+
+  # We do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
+  # values in such cases. We are going to revisit this later. Trello card for future work: https://trello.com/c/Qe8wOpaw
+  it "does not render the email subscription topic if the filtered_content value is checked but the current topic value is a hash" do
+    email_alert = EmailAlert.new
+    email_alert.type = :filtered_content
+    email_alert.list_title_prefix = {}
+    render_inline(described_class.new(email_alert:))
+
+    expect(page).not_to have_text("Email subscription topic")
+    expect(page).not_to have_field("filtered_content_list_title_prefix", with: email_alert.list_title_prefix)
+  end
 end


### PR DESCRIPTION
Add email subscription topic list prefix to filtered content option as well as all content option. Changed the hint texts to also reflect desired design. 

The 4 options for when there is no existing subscription list prefix set: 
<img width="888" alt="Screenshot 2024-12-13 at 14 14 09" src="https://github.com/user-attachments/assets/b6b54256-d294-44f4-b86f-595d8c3b4bbe" />
<img width="873" alt="Screenshot 2024-12-13 at 14 14 14" src="https://github.com/user-attachments/assets/72330981-a512-4ce1-b6e3-4ba10a64ea8a" />
<img width="834" alt="Screenshot 2024-12-13 at 14 14 20" src="https://github.com/user-attachments/assets/79b48ca3-2c1e-4293-8c91-6578954d2d16" />
<img width="808" alt="Screenshot 2024-12-13 at 14 14 25" src="https://github.com/user-attachments/assets/df3cc9b8-dfd7-4f7e-baba-9b81ffd2a360" />

For when the topic list prefix is existing but is a hash: 
<img width="790" alt="Screenshot 2024-12-13 at 14 14 42" src="https://github.com/user-attachments/assets/c1ae7b23-421e-46c7-82a8-e4000a283947" />
<img width="806" alt="Screenshot 2024-12-13 at 14 14 50" src="https://github.com/user-attachments/assets/594850d9-f39e-475c-8c09-a61cea5bdf7d" />

https://trello.com/c/l9XfLavV/3212-email-alerts-on-edit-finder-form

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
