### PR TITLE
Add Sint Maarten

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -1090,6 +1090,12 @@
           "prechecked": false
         },
         {
+          "key": "sint-maarten",
+          "radio_button_name": "Sint Maarten",
+          "topic_name": "Sint Maarten",
+          "prechecked": false
+        },
+        {
           "key": "slovakia",
           "radio_button_name": "Slovakia",
           "topic_name": "Slovakia",
@@ -2137,6 +2143,10 @@
         {
           "label": "Singapore",
           "value": "singapore"
+        },
+        {
+          "label": "Sint Maarten",
+          "value": "sint-maarten"
         },
         {
           "label": "Slovakia",


### PR DESCRIPTION
From the [Zendesk](https://govuk.zendesk.com/agent/tickets/6000442) ticket - "We require the addition of "Sint Maarten" to the list of destination countries available to select in the Export Health Certificates section of Specialist Publisher. We have a certificate that needs to be published, but we cannot create a page for it whilst the country does not exist in the system."

[Trello](https://trello.com/c/UuMKP5Si/3289-addition-of-country-to-export-health-certificates-metadata-govt-agency-general-issue)
