### PR TITLE
Remove unused finder schema facet properties

### DIFF
--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -50,13 +50,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_category_name",
-      "name": "Category name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_sub_categories",
       "name": "Sub-category",
       "type": "text",
@@ -141,13 +134,6 @@
           "value": "section-95-other"
         }
       ]
-    },
-    {
-      "key": "tribunal_decision_sub_category_name",
-      "name": "Sub-category name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
     },
     {
       "key": "tribunal_decision_judges",
@@ -268,13 +254,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_judges_name",
-      "name": "Judges name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "type": "text",
@@ -290,13 +269,6 @@
           "value": "not-landmark"
         }
       ]
-    },
-    {
-      "key": "tribunal_decision_landmark_name",
-      "name": "Landmark name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
     },
     {
       "key": "tribunal_decision_reference_number",

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -218,13 +218,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_categories_name",
-      "name": "Category name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_sub_categories",
       "name": "Sub-category",
       "type": "text",
@@ -1023,13 +1016,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_sub_categories_name",
-      "name": "Sub-category name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "type": "text",
@@ -1045,13 +1031,6 @@
           "value": "not-landmark"
         }
       ]
-    },
-    {
-      "key": "tribunal_decision_landmark_name",
-      "name": "Landmark name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
     },
     {
       "key": "tribunal_decision_decision_date",

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -380,13 +380,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_country_name",
-      "name": "Country name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_categories",
       "name": "Jurisdiction code",
       "type": "text",
@@ -611,13 +604,6 @@
           "value": "written-statements"
         }
       ]
-    },
-    {
-      "key": "tribunal_decision_categories_name",
-      "name": "Jurisdiction code name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
     },
     {
       "key": "tribunal_decision_decision_date",

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -361,14 +361,6 @@
       "filterable": false
     },
     {
-      "key": "first_published_at",
-      "name": "Date",
-      "short_name": "Date",
-      "type": "date",
-      "display_as_result_metadata": false,
-      "filterable": false
-    },
-    {
       "key": "date_of_start",
       "name": "Date of start",
       "type": "date",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -114,13 +114,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_category_name",
-      "name": "Category name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_decision_date",
       "name": "Release date",
       "short_name": "Released",

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -289,13 +289,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_categories_name",
-      "name": "Categories name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_sub_categories",
       "name": "Sub-categories",
       "type": "text",
@@ -2250,13 +2243,6 @@
       ]
     },
     {
-      "key": "tribunal_decision_sub_categories_name",
-      "name": "Sub-categories name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
       "key": "tribunal_decision_judges",
       "name": "Judges",
       "type": "text",
@@ -2721,13 +2707,6 @@
           "value": "wright-s"
         }
       ]
-    },
-    {
-      "key": "tribunal_decision_judges_name",
-      "name": "Judges name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
     },
     {
       "key": "tribunal_decision_decision_date",


### PR DESCRIPTION
I noticed that there were several facet fields defined in the
tribunal related finders, which aren't actually displayed in
the publishing UI, nor are they referenced in Publishing API.
(Presumably they were superseded by something else but never
removed).

I did this by cross-referencing every facet specified in the
finder schema with a corresponding property on
https://github.com/alphagov/publishing-api/blob/main/content_schemas/formats/shared/definitions/_specialist_document.jsonnet

Trello: https://trello.com/c/KijYVpyo/3290-dry-up-specialist-publisher-views

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
