### PR TITLE
Full support for "email alert" configuration on the edit metadata form

### DIFF
--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -11,23 +11,12 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
     ].compact.join.html_safe
   end
 
-  # We are handling changes to email facet filters offline at present.
   def render_filtered_content_condition_inputs
     [
       render_hidden_signup_content_id_input("filtered_content_signup_id"),
       render_email_topic_list_title_prefix("filtered_content_list_title_prefix"),
       render_hidden_email_filter_options("filtered_content_email_filter_options"),
-      render("govuk_publishing_components/components/checkboxes", {
-        name: "email_filter_by",
-        heading: "Selected filter: #{@email_alert.filter&.humanize}",
-        no_hint_text: true,
-        items: [
-          {
-            label: "Make changes to this filter criteria (The development team will reach out to you to discuss the requirements to allow users to sign up by specific filter criteria)",
-            value: "CHANGE_REQUESTED",
-          },
-        ],
-      }),
+      render_email_filter_by_select("email_filter_by"),
     ].compact.join.html_safe
   end
 
@@ -68,6 +57,22 @@ private
       type: "hidden",
       name: input_name,
       value: @email_alert.email_filter_options.to_json,
+    })
+  end
+
+  def render_email_filter_by_select(input_name)
+    render("govuk_publishing_components/components/select", {
+      id: input_name,
+      name: input_name,
+      label: "Email filter",
+      hint: "'all_selected_facets' subscribes users to whatever facets they chose on the search page (there is no option to edit their choices on the email signup page). For any other option, users can edit their choices on the email signup page, and any facets chosen on the search page are prefilled.",
+      options: (@email_alert.email_filter_by_candidates || []).map do |facet|
+        {
+          text: facet,
+          value: facet,
+          selected: @email_alert.filter == facet,
+        }
+      end,
     })
   end
 end

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -7,6 +7,7 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
     [
       render_hidden_signup_content_id_input("all_content_signup_id"),
       render_email_topic_list_title_prefix("all_content_list_title_prefix"),
+      render_hidden_email_filter_options("all_content_email_filter_options"),
     ].compact.join.html_safe
   end
 
@@ -15,6 +16,7 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
     [
       render_hidden_signup_content_id_input("filtered_content_signup_id"),
       render_email_topic_list_title_prefix("filtered_content_list_title_prefix"),
+      render_hidden_email_filter_options("filtered_content_email_filter_options"),
       render("govuk_publishing_components/components/checkboxes", {
         name: "email_filter_by",
         heading: "Selected filter: #{@email_alert.filter&.humanize}",
@@ -58,6 +60,14 @@ private
       type: "hidden",
       name: input_name,
       value: @email_alert.content_id || SecureRandom.uuid,
+    })
+  end
+
+  def render_hidden_email_filter_options(input_name)
+    render("govuk_publishing_components/components/input", {
+      type: "hidden",
+      name: input_name,
+      value: @email_alert.email_filter_options.to_json,
     })
   end
 end

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -43,11 +43,6 @@ class EmailAlertFieldsetComponent < ViewComponent::Base
 private
 
   def render_email_topic_list_title_prefix(input_name)
-    # Do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
-    # values in such cases. We are going to revisit this later, but for now we only allow users to override this setting
-    # for finders with a single string value. Trello card for future work: https://trello.com/c/Qe8wOpaw
-    return if @email_alert.list_title_prefix.is_a?(Hash)
-
     render("govuk_publishing_components/components/input", {
       label: {
         text: "Email subscription topic",

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -86,8 +86,10 @@ private
       :email_alert_type,
       :all_content_signup_id,
       :all_content_list_title_prefix,
+      :all_content_email_filter_options,
       :filtered_content_signup_id,
       :filtered_content_list_title_prefix,
+      :filtered_content_email_filter_options,
       :email_filter_by,
       :signup_link,
     )

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -1,7 +1,7 @@
 class EmailAlert
   include ActiveModel::Model
 
-  attr_accessor :type, :list_title_prefix, :link, :content_id, :email_filter_options
+  attr_accessor :type, :list_title_prefix, :link, :content_id, :email_filter_options, :email_filter_by_candidates
 
   def to_finder_schema_attributes
     {
@@ -24,6 +24,7 @@ class EmailAlert
       email_alert.list_title_prefix = schema.subscription_list_title_prefix
       email_alert.email_filter_options = schema.email_filter_options
       email_alert.link = schema.signup_link
+      email_alert.email_filter_by_candidates = %w[all_selected_facets] + schema.facets.map { |facet| facet["key"] }
       email_alert
     end
 

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -1,17 +1,19 @@
 class EmailAlert
   include ActiveModel::Model
 
-  attr_accessor :type, :list_title_prefix, :link, :content_id, :filter
+  attr_accessor :type, :list_title_prefix, :link, :content_id, :email_filter_options
 
   def to_finder_schema_attributes
     {
       signup_content_id: content_id.presence,
       subscription_list_title_prefix: list_title_prefix,
-      email_filter_options: {
-        email_filter_by: filter,
-      },
+      email_filter_options:,
       signup_link: link.presence,
     }
+  end
+
+  def filter
+    email_filter_options&.fetch("email_filter_by", nil)
   end
 
   class << self
@@ -20,7 +22,7 @@ class EmailAlert
       email_alert.type = email_alert_type(schema)
       email_alert.content_id = schema.signup_content_id
       email_alert.list_title_prefix = schema.subscription_list_title_prefix
-      email_alert.filter = schema.email_filter_options&.fetch("email_filter_by", nil)
+      email_alert.email_filter_options = schema.email_filter_options
       email_alert.link = schema.signup_link
       email_alert
     end
@@ -58,7 +60,9 @@ class EmailAlert
       {
         content_id: params["filtered_content_signup_id"],
         list_title_prefix: params["filtered_content_list_title_prefix"],
-        filter: params["email_filter_by"],
+        email_filter_options: {
+          "email_filter_by" => params["email_filter_by"],
+        },
       }
     end
 

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -7,7 +7,9 @@ class EmailAlert
     {
       signup_content_id: content_id.presence,
       subscription_list_title_prefix: list_title_prefix,
-      email_filter_by: filter,
+      email_filter_options: {
+        email_filter_by: filter,
+      },
       signup_link: link.presence,
     }
   end
@@ -18,7 +20,7 @@ class EmailAlert
       email_alert.type = email_alert_type(schema)
       email_alert.content_id = schema.signup_content_id
       email_alert.list_title_prefix = schema.subscription_list_title_prefix
-      email_alert.filter = schema.email_filter_by
+      email_alert.filter = schema.email_filter_options&.fetch("email_filter_by", nil)
       email_alert.link = schema.signup_link
       email_alert
     end
@@ -33,7 +35,7 @@ class EmailAlert
   private
 
     def email_alert_type(schema)
-      return :filtered_content if schema.signup_content_id.present? && schema.email_filter_by.present?
+      return :filtered_content if schema.signup_content_id.present? && schema.email_filter_options.present?
       return :external if schema.signup_link.present?
       return :all_content if schema.signup_content_id.present?
 

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -5,10 +5,10 @@ class EmailAlert
 
   def to_finder_schema_attributes
     {
-      signup_content_id: content_id,
+      signup_content_id: content_id.presence,
       subscription_list_title_prefix: list_title_prefix,
       email_filter_by: filter,
-      signup_link: link,
+      signup_link: link.presence,
     }
   end
 

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -53,17 +53,33 @@ class EmailAlert
     end
 
     def all_content_params(params)
-      { content_id: params["all_content_signup_id"], list_title_prefix: params["all_content_list_title_prefix"] }
+      {
+        content_id: params["all_content_signup_id"],
+        list_title_prefix: params["all_content_list_title_prefix"],
+        email_filter_options: email_filter_options_for_all_content(params),
+      }
     end
 
     def filtered_content_params(params)
       {
         content_id: params["filtered_content_signup_id"],
         list_title_prefix: params["filtered_content_list_title_prefix"],
-        email_filter_options: {
-          "email_filter_by" => params["email_filter_by"],
-        },
+        email_filter_options: email_filter_options_for_filtered_content(params),
       }
+    end
+
+    def email_filter_options_for_all_content(params)
+      return if params["all_content_email_filter_options"].nil?
+
+      email_filter_options = JSON.parse(params["all_content_email_filter_options"])
+      email_filter_options.delete("email_filter_by")
+      email_filter_options.delete("pre_checked_email_alert_checkboxes")
+      email_filter_options
+    end
+
+    def email_filter_options_for_filtered_content(params)
+      email_filter_options = JSON.parse(params["filtered_content_email_filter_options"] || "{}")
+      email_filter_options.merge("email_filter_by" => params["email_filter_by"])
     end
 
     def external_params(params)

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -28,7 +28,6 @@ class FinderSchema
   attribute :document_noun
   attribute :document_title
   attribute :editing_organisations, default: []
-  attribute :email_filter_by
   attribute :email_filter_options
   attribute :facets, default: []
   attribute :filter

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -29,7 +29,6 @@ class FinderSchema
   attribute :document_title
   attribute :editing_organisations, default: []
   attribute :email_filter_by
-  attribute :email_filter_facets, default: []
   attribute :email_filter_options
   attribute :facets, default: []
   attribute :filter

--- a/app/views/admin/_diff.html.erb
+++ b/app/views/admin/_diff.html.erb
@@ -1,0 +1,15 @@
+<details>
+  <summary>View diff</summary>
+  <%=
+    Diffy::Diff.new(
+      JSON.pretty_generate(old_schema.as_json).to_s,
+      JSON.pretty_generate(new_schema.as_json).to_s,
+      allow_empty_diff: false,
+    ).to_s(:html).html_safe
+  %>
+</details>
+
+<details>
+  <summary>View generated schema</summary>
+  <pre><code><%= JSON.pretty_generate(new_schema.as_json) %></code></pre>
+</details>

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -12,6 +12,21 @@
     No
   <% end %>
 <% end %>
+<%
+  email_alerts_value = capture do
+    email_alerts_are_configured = schema.signup_content_id || schema.signup_link
+    email_alerts_were_configured = defined?(previous_schema) && (previous_schema.signup_content_id || previous_schema.signup_link)
+%>
+  <% if email_alerts_are_configured && !email_alerts_were_configured %>
+    Yes
+  <% elsif !email_alerts_are_configured && email_alerts_were_configured %>
+    No
+  <% elsif email_alerts_are_configured %>
+    <% if (schema.signup_link != previous_schema.signup_link) || (schema.email_filter_options != previous_schema.email_filter_options) %>
+      Updated configuration
+    <% end %>
+  <% end %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/summary_card", {
   id: "metadata_summary_card",
@@ -51,8 +66,8 @@
     } if !(defined? previous_schema) || schema.document_noun != previous_schema.document_noun),
     ({
       key: "Would you like to set up email alerts for the finder?",
-      value: schema.signup_content_id.present? ? "Yes" : "No"
-    } if !(defined? previous_schema) || (schema.signup_content_id.present? != previous_schema.signup_content_id.present?))
+      value: email_alerts_value,
+    } if email_alerts_value.present?)
   ].compact,
   summary_card_actions:,
   margin_top: 6,

--- a/app/views/admin/confirm_facets.html.erb
+++ b/app/views/admin/confirm_facets.html.erb
@@ -33,21 +33,7 @@
       previous_schema: @current_format.finder_schema,
     } %>
 
-    <details>
-      <summary>View diff</summary>
-      <%=
-        Diffy::Diff.new(
-          JSON.pretty_generate(@current_format.finder_schema.as_json).to_s,
-          JSON.pretty_generate(@proposed_schema.as_json).to_s,
-          allow_empty_diff: false,
-        ).to_s(:html).html_safe
-      %>
-    </details>
-
-    <details>
-      <summary>View generated schema</summary>
-      <pre><code><%= JSON.pretty_generate(@proposed_schema.as_json) %></code></pre>
-    </details>
+    <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
 
     <p class="govuk-body govuk-body govuk-!-margin-top-7">
       By submitting you are confirming that these changes are required to the specialist finder.

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -33,6 +33,8 @@
       previous_schema: @current_format.finder_schema,
     } %>
 
+    <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
+
     <p class="govuk-body govuk-body govuk-!-margin-top-7">
       By submitting you are confirming that these changes are required to the specialist finder.
     </p>

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     email_alert = EmailAlert.new
     email_alert.type = :filtered_content
     email_alert.content_id = "123"
-    email_alert.filter = "some_facet"
+    email_alert.email_filter_options = { "email_filter_by" => "some_facet" }
     render_inline(described_class.new(email_alert:))
 
     expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
@@ -72,7 +72,7 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
   it "sets the value of the radio button to 'filtered_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
     email_alert = EmailAlert.new
     email_alert.type = :filtered_content
-    email_alert.filter = "some_facet"
+    email_alert.email_filter_options = { "email_filter_by" => "some_facet" }
     allow(SecureRandom).to receive(:uuid).and_return("new-id")
     render_inline(described_class.new(email_alert:))
 

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     email_alert.type = :filtered_content
     email_alert.content_id = "123"
     email_alert.email_filter_options = { "email_filter_by" => "some_facet" }
+    email_alert.email_filter_by_candidates = %w[some_other_facet some_facet some_other_facet_again]
     render_inline(described_class.new(email_alert:))
 
     expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
-    expect(page).to have_text("Selected filter: Some facet")
+    expect(page).to have_select("Email filter", selected: "some_facet")
     expect(page).to have_field("filtered_content_signup_id", with: email_alert.content_id, type: "hidden")
-    expect(page).to have_unchecked_field("email_filter_by", with: "CHANGE_REQUESTED")
   end
 
   it "sets the value of the radio button to 'filtered_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     email_alert = EmailAlert.new
     email_alert.type = :all_content
     email_alert.content_id = "123"
+    email_alert.email_filter_options = { "email_filter_by" => "some_facet", "foo" => "bar" }
     render_inline(described_class.new(email_alert:))
 
     expect(page).to have_checked_field("email_alert_type", with: "all_content")
     expect(page).to have_field("all_content_signup_id", with: "123", type: "hidden")
+    expect(page).to have_field("all_content_email_filter_options", with: email_alert.email_filter_options.to_json, type: "hidden")
   end
 
   it "sets the value of the radio button to 'all_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
@@ -72,12 +74,13 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
   it "sets the value of the radio button to 'filtered_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
     email_alert = EmailAlert.new
     email_alert.type = :filtered_content
-    email_alert.email_filter_options = { "email_filter_by" => "some_facet" }
+    email_alert.email_filter_options = { "email_filter_by" => "some_facet", "foo" => "bar" }
     allow(SecureRandom).to receive(:uuid).and_return("new-id")
     render_inline(described_class.new(email_alert:))
 
     expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
     expect(page).to have_field("filtered_content_signup_id", with: "new-id", type: "hidden")
+    expect(page).to have_field("filtered_content_email_filter_options", with: email_alert.email_filter_options.to_json, type: "hidden")
   end
 
   it "renders the email subscription topic if the filtered_content value is checked" do

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -46,18 +46,6 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     expect(page).to have_field("all_content_list_title_prefix", with: email_alert.list_title_prefix)
   end
 
-  # We do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
-  # values in such cases. We are going to revisit this later. Trello card for future work: https://trello.com/c/Qe8wOpaw
-  it "does not render the email subscription topic if the all_content value is checked but the current topic value is a hash" do
-    email_alert = EmailAlert.new
-    email_alert.type = :all_content
-    email_alert.list_title_prefix = {}
-    render_inline(described_class.new(email_alert:))
-
-    expect(page).not_to have_text("Email subscription topic")
-    expect(page).not_to have_field("all_content_list_title_prefix", with: email_alert.list_title_prefix)
-  end
-
   it "sets the value of the radio button to 'external' if email alerts are enabled using an external system" do
     email_alert = EmailAlert.new
     email_alert.type = :external
@@ -100,17 +88,5 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
 
     expect(page).to have_text("Email subscription topic")
     expect(page).to have_field("filtered_content_list_title_prefix", with: email_alert.list_title_prefix)
-  end
-
-  # We do not render the title prefix input if the value is a hash because we don't want to override the existing the existing
-  # values in such cases. We are going to revisit this later. Trello card for future work: https://trello.com/c/Qe8wOpaw
-  it "does not render the email subscription topic if the filtered_content value is checked but the current topic value is a hash" do
-    email_alert = EmailAlert.new
-    email_alert.type = :filtered_content
-    email_alert.list_title_prefix = {}
-    render_inline(described_class.new(email_alert:))
-
-    expect(page).not_to have_text("Email subscription topic")
-    expect(page).not_to have_field("filtered_content_list_title_prefix", with: email_alert.list_title_prefix)
   end
 end

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
   let(:organisations) do
     [
       { "content_id" => "957eb4ec-089b-4f71-ba2a-dc69ac8919ea", "title" => "Competition and Markets Authority" },
+      { "content_id" => "abc123", "title" => "Some other org" },
     ]
   end
 
@@ -28,6 +29,8 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
 
     fill_in "name", with: "Changed title"
     fill_in "base_path", with: "Changed slug"
+    select = page.find("select#organisations")
+    select.select "Some other org"
     fill_in "description", with: "Changed description"
     fill_in "summary", with: "Changed summary"
     fill_in "Link 1", with: "Changed link 1"
@@ -38,15 +41,14 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
 
     click_button "Submit changes"
 
-    expect(page).to have_selector("dt", text: "Changed title")
-    expect(page).to have_selector("dt", text: "Changed slug")
-    expect(page).to have_selector("dt", text: "Changed description")
-    expect(page).to have_selector("dt", text: "Changed summary")
-    expect(page).to have_selector("dt", text: "Changed link 1")
-    expect(page).to have_selector("dt", text: "Changed link 2")
-    expect(page).to have_selector("dt", text: "Changed link 3")
-    expect(page).to have_selector("dt", text: "Changed document noun")
-    expect(page).to have_selector("dt", text: "No")
+    expect(page.find(".govuk-summary-list__row", text: "Title of the finder")).to have_selector("dt", text: "Changed title")
+    expect(page.find(".govuk-summary-list__row", text: "Slug or URL")).to have_selector("dt", text: "Changed slug")
+    expect(page.find(".govuk-summary-list__row", text: "Organisations the finder should be attached to")).to have_selector("dt", text: "Competition and Markets Authority,Some other org")
+    expect(page.find(".govuk-summary-list__row", text: "Short description (For search engines)")).to have_selector("dt", text: "Changed description")
+    expect(page.find(".govuk-summary-list__row", text: "Summary of the finder (Longer description shown below title)")).to have_selector("dt", text: "Changed summary")
+    expect(page.find(".govuk-summary-list__row", text: "Any related links on GOV.UK?")).to have_selector("dt", text: "Yes\nLink 1: Changed link 1\nLink 2: Changed link 2\nLink 3: Changed link 3")
+    expect(page.find(".govuk-summary-list__row", text: "The document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: "Changed document noun")
+    expect(page.find(".govuk-summary-list__row", text: "Would you like to set up email alerts for the finder?")).to have_selector("dt", text: "No")
 
     click_button "Submit changes"
 
@@ -61,6 +63,9 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
 
     fill_in "name", with: ""
     fill_in "base_path", with: ""
+    select = page.find("select#organisations")
+    select.unselect "Competition and Markets Authority"
+    select.unselect "Some other org"
     fill_in "description", with: ""
     fill_in "summary", with: ""
     fill_in "Link 1", with: ""
@@ -70,14 +75,13 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
 
     click_button "Submit changes"
 
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
-    expect(page).to have_selector("dt", text: "")
+    expect(page.find(".govuk-summary-list__row", text: "Title of the finder")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Slug or URL")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Organisations the finder should be attached to")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Short description (For search engines)")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Summary of the finder (Longer description shown below title)")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Any related links on GOV.UK?")).to have_selector("dt", text: "Yes")
+    expect(page.find(".govuk-summary-list__row", text: "The document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: /^$/)
 
     click_button "Submit changes"
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe "EmailAlert" do
     it "builds an email alert for a finder schema with alerts configured for a filtered set of the content" do
       schema = FinderSchema.new
       schema.signup_content_id = "123"
-      schema.email_filter_by = "some_facet"
+      schema.email_filter_options = { "email_filter_by" => "some_facet" }
       schema.subscription_list_title_prefix = "Finder email subscription"
       email_alert = EmailAlert.from_finder_schema(schema)
       expect(email_alert.type).to eq(:filtered_content)
       expect(email_alert.content_id).to eq(schema.signup_content_id)
       expect(email_alert.list_title_prefix).to eq(schema.subscription_list_title_prefix)
-      expect(email_alert.filter).to eq(schema.email_filter_by)
+      expect(email_alert.filter).to eq("some_facet")
     end
 
     it "builds an email alert for a finder schema with alerts configured to use an external system" do
@@ -95,7 +95,9 @@ RSpec.describe "EmailAlert" do
       expect(email_alert.to_finder_schema_attributes).to eq({
         signup_content_id: "123",
         subscription_list_title_prefix: "Finder email subscription",
-        email_filter_by: "some_facet",
+        email_filter_options: {
+          email_filter_by: "some_facet",
+        },
         signup_link: "https://example.com",
       })
     end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -99,5 +99,13 @@ RSpec.describe "EmailAlert" do
         signup_link: "https://example.com",
       })
     end
+
+    it "converts falsey values to nil" do
+      email_alert = EmailAlert.new
+      email_alert.content_id = ""
+      email_alert.link = ""
+      expect(email_alert.to_finder_schema_attributes[:signup_content_id]).to eq(nil)
+      expect(email_alert.to_finder_schema_attributes[:signup_link]).to eq(nil)
+    end
   end
 end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe "EmailAlert" do
       email_alert = EmailAlert.from_finder_schema(schema)
       expect(email_alert.type).to eq(:no)
     end
+
+    it "builds a list of possible values for email_filter_by" do
+      schema = FinderSchema.new
+      schema.facets = [
+        { "key" => "foo" },
+        { "key" => "bar" },
+      ]
+      email_alert = EmailAlert.from_finder_schema(schema)
+      expect(email_alert.email_filter_by_candidates).to eq(%w[
+        all_selected_facets
+        foo
+        bar
+      ])
+    end
   end
 
   describe "#from_finder_admin_form_params" do

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe "EmailAlert" do
       email_alert = EmailAlert.new
       email_alert.content_id = "123"
       email_alert.list_title_prefix = "Finder email subscription"
-      email_alert.filter = "some_facet"
+      email_alert.email_filter_options = { "email_filter_by" => "some_facet" }
       email_alert.link = "https://example.com"
       expect(email_alert.to_finder_schema_attributes).to eq({
         signup_content_id: "123",
         subscription_list_title_prefix: "Finder email subscription",
         email_filter_options: {
-          email_filter_by: "some_facet",
+          "email_filter_by" => "some_facet",
         },
         signup_link: "https://example.com",
       })

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -40,48 +40,261 @@ RSpec.describe "EmailAlert" do
   end
 
   describe "#from_finder_admin_form_params" do
-    it "builds an email alert for a finder schema with alerts configured for all content" do
-      params = {
-        "email_alert_type" => "all_content",
-        "all_content_signup_id" => "123",
-        "all_content_list_title_prefix" => "Finder email subscription",
-      }
-      email_alert = EmailAlert.from_finder_admin_form_params(params)
-      expect(email_alert.type).to eq(:all_content)
-      expect(email_alert.content_id).to eq(params["all_content_signup_id"])
-      expect(email_alert.list_title_prefix).to eq(params["all_content_list_title_prefix"])
+    context "building an email alert for a finder schema with alerts configured for all content" do
+      let(:email_alert_type) { "all_content" }
+
+      it "sets type as all_content" do
+        params = {
+          "email_alert_type" => email_alert_type,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.type).to eq(:all_content)
+      end
+
+      it "uses the all_content prefixed parameters" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_signup_id" => "123",
+          "all_content_list_title_prefix" => "Finder email subscription",
+          "filtered_content_signup_id" => "456",
+          "filtered_content_list_title_prefix" => "Something else",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.content_id).to eq(params["all_content_signup_id"])
+        expect(email_alert.list_title_prefix).to eq(params["all_content_list_title_prefix"])
+      end
+
+      it "deletes any existing `email_filter_options.email_filter_by` option" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_email_filter_options" => {
+            email_filter_by: "some_facet",
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({})
+      end
+
+      it "deletes any existing `email_filter_options.pre_checked_email_alert_checkboxes` option" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_email_filter_options" => {
+            pre_checked_email_alert_checkboxes: %w[foo bar baz],
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({})
+      end
+
+      it "deletes any existing `signup_link` property" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "signup_link" => "https://example.com",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.link).to eq(nil)
+      end
+
+      it "retains any existing `email_filter_options.downcase_email_alert_topic_names` option" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_email_filter_options" => {
+            downcase_email_alert_topic_names: true,
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({ "downcase_email_alert_topic_names" => true })
+      end
+
+      it "retains any existing `email_filter_options.email_alert_topic_name_overrides` option" do
+        email_alert_topic_name_overrides = {
+          "some_facet" => [
+            {
+              "facet_option_key" => "baz-baz",
+              "topic_name_override" => "something ENTIRELY different",
+            },
+          ],
+        }
+
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_email_filter_options" => {
+            email_alert_topic_name_overrides:,
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({ "email_alert_topic_name_overrides" => email_alert_topic_name_overrides })
+      end
     end
 
-    it "builds an email alert for a finder schema with alerts configured for a filtered set of the content" do
-      params = {
-        "email_alert_type" => "filtered_content",
-        "filtered_content_signup_id" => "123",
-        "email_filter_by" => "some_facet",
-        "filtered_content_list_title_prefix" => "Finder email subscription",
-      }
-      email_alert = EmailAlert.from_finder_admin_form_params(params)
-      expect(email_alert.type).to eq(:filtered_content)
-      expect(email_alert.content_id).to eq(params["filtered_content_signup_id"])
-      expect(email_alert.list_title_prefix).to eq(params["filtered_content_list_title_prefix"])
-      expect(email_alert.filter).to eq(params["email_filter_by"])
+    context "building an email alert for a finder schema with alerts configured for a filtered set of content" do
+      let(:email_alert_type) { "filtered_content" }
+
+      it "sets type as filtered_content" do
+        params = {
+          "email_alert_type" => email_alert_type,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.type).to eq(:filtered_content)
+      end
+
+      it "deletes any existing `signup_link` property" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "signup_link" => "https://example.com",
+          "email_filter_by" => "some_facet",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.link).to eq(nil)
+      end
+
+      it "populates email_filter_options with the email_filter_by param" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
+        })
+      end
+
+      it "uses the filtered_content prefixed parameters" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_signup_id" => "123",
+          "all_content_list_title_prefix" => "Finder email subscription",
+          "filtered_content_signup_id" => "456",
+          "filtered_content_list_title_prefix" => "Something else",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.content_id).to eq(params["filtered_content_signup_id"])
+        expect(email_alert.list_title_prefix).to eq(params["filtered_content_list_title_prefix"])
+      end
+
+      it "retains any existing `email_filter_options.pre_checked_email_alert_checkboxes` option" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+          "filtered_content_email_filter_options" => {
+            pre_checked_email_alert_checkboxes: %w[foo bar baz],
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
+          "pre_checked_email_alert_checkboxes" => %w[foo bar baz],
+        })
+      end
+
+      it "retains any existing `email_filter_options.downcase_email_alert_topic_names` option" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+          "filtered_content_email_filter_options" => {
+            downcase_email_alert_topic_names: true,
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
+          "downcase_email_alert_topic_names" => true,
+        })
+      end
+
+      it "retains any existing `email_filter_options.email_alert_topic_name_overrides` option" do
+        email_alert_topic_name_overrides = {
+          "some_facet" => [
+            {
+              "facet_option_key" => "baz-baz",
+              "topic_name_override" => "something ENTIRELY different",
+            },
+          ],
+        }
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+          "filtered_content_email_filter_options" => {
+            email_alert_topic_name_overrides:,
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
+          "email_alert_topic_name_overrides" => email_alert_topic_name_overrides,
+        })
+      end
     end
 
-    it "builds an email alert for a finder schema with alerts configured to use an external system" do
-      params = {
-        "email_alert_type" => "external",
-        "signup_link" => "https://example.com",
-      }
-      email_alert = EmailAlert.from_finder_admin_form_params(params)
-      expect(email_alert.type).to eq(:external)
-      expect(email_alert.link).to eq(params["signup_link"])
+    context "building an email alert for a finder schema with alerts configured to use an external system" do
+      let(:email_alert_type) { "external" }
+
+      it "populates signup_link" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "signup_link" => "https://example.com",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.type).to eq(:external)
+        expect(email_alert.link).to eq(params["signup_link"])
+      end
+
+      it "drops all other email-related properties" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "signup_link" => "https://example.com",
+          "email_filter_by" => "some_facet",
+          "all_content_signup_id" => "123",
+          "all_content_list_title_prefix" => "Finder email subscription",
+          "filtered_content_signup_id" => "456",
+          "filtered_content_list_title_prefix" => "Something else",
+          "all_content_email_filter_options" => {
+            "foo" => "bar",
+          }.to_json,
+          "filtered_content_email_filter_options" => {
+            "foo" => "bar",
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq(nil)
+        expect(email_alert.content_id).to eq(nil)
+        expect(email_alert.list_title_prefix).to eq(nil)
+      end
     end
 
-    it "builds an email alert for a finder schema without alerts configured" do
-      params = {
-        "email_alert_type" => "no",
-      }
-      email_alert = EmailAlert.from_finder_admin_form_params(params)
-      expect(email_alert.type).to eq(:no)
+    context "building an email alert for a finder schema without alerts configured" do
+      let(:email_alert_type) { "no" }
+
+      it "builds an email alert for a finder schema without alerts configured" do
+        params = {
+          "email_alert_type" => email_alert_type,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.type).to eq(:no)
+      end
+
+      it "drops all other email-related properties" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "signup_link" => "https://example.com",
+          "email_filter_by" => "some_facet",
+          "all_content_signup_id" => "123",
+          "all_content_list_title_prefix" => "Finder email subscription",
+          "filtered_content_signup_id" => "456",
+          "filtered_content_list_title_prefix" => "Something else",
+          "all_content_email_filter_options" => {
+            "foo" => "bar",
+          }.to_json,
+          "filtered_content_email_filter_options" => {
+            "foo" => "bar",
+          }.to_json,
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq(nil)
+        expect(email_alert.content_id).to eq(nil)
+        expect(email_alert.list_title_prefix).to eq(nil)
+        expect(email_alert.link).to eq(nil)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds full support for editing "email alert" configuration on finders, insofar as publishers can request:

1. Subscribe to all selected facets by default
2. Subscribe to one particular facet
3. Subscribe via an external service
4. Do not allow subscriptions

Note that the 'hidden' properties inside `email_filter_options` (configuring the 'topic name' associated with each facet option, and also configuring which should be pre-checked, which is only used by one finder) is not configurable. It is, however, preserved, so the publisher can make tweaks to email alert configuration and not break things. (It is also automatically removed if the publisher turns off email alert subscriptions altogether). This should mean existing/legacy subscriber lists are unaffected by these changes, even in cases where they're configured slightly off-standard.

NB, it took a fair bit of investigation to figure out what each property does, in order to simplify the behaviour in the form. I've documented this in our [Specialist Publisher proposed improvements](https://docs.google.com/document/d/1hZD3eJjX3qWL6ntWV_aUq0U43m5LIEblwAeIRoUY7x0/edit?tab=t.0#heading=h.2f6xql52kyeg) doc.

Trello: https://trello.com/c/l9XfLavV/3212-email-alerts-on-edit-finder-form

## Screenshots

| Form | Results page | Expanded |
|---|---|---|
|![1 form](https://github.com/user-attachments/assets/bfbc234a-194b-47b1-abaf-392a78ccdb19)|![2 results](https://github.com/user-attachments/assets/95a31b90-7ed2-46d1-a6c2-de8bed69b621)|![3 expanded](https://github.com/user-attachments/assets/ca51b47c-4e28-4cf0-af17-5176a78213fc)|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
