### PR TITLE
Remove pluralization of email subscription topic prefixes

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -21,10 +21,7 @@
   ],
   "show_summaries": true,
   "signup_content_id": "99f5bacb-d1ef-4b93-87ef-bae129fed396",
-  "subscription_list_title_prefix": {
-    "singular": "Algorithmic transparency records with the following function: ",
-    "plural": "Algorithmic transparency records with the following functions: "
-  },
+  "subscription_list_title_prefix": "Algorithmic transparency records with the following function(s): ",
   "email_filter_options": {
     "email_filter_by": "algorithmic_transparency_record_function"
   },

--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -21,7 +21,7 @@
   ],
   "show_summaries": true,
   "signup_content_id": "99f5bacb-d1ef-4b93-87ef-bae129fed396",
-  "subscription_list_title_prefix": "Algorithmic transparency records with the following function(s): ",
+  "subscription_list_title_prefix": "Algorithmic transparency records",
   "email_filter_options": {
     "email_filter_by": "algorithmic_transparency_record_function"
   },

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -26,10 +26,7 @@
     "competition/mergers",
     "competition/regulatory-appeals-references"
   ],
-  "subscription_list_title_prefix": {
-    "singular": "CMA cases with the following case type: ",
-    "plural": "CMA cases with the following case types: "
-  },
+  "subscription_list_title_prefix": "CMA cases with the following case type(s): ",
   "email_filter_options": {
     "email_filter_by": "case_type",
     "downcase_email_alert_topic_names": true,

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -26,7 +26,7 @@
     "competition/mergers",
     "competition/regulatory-appeals-references"
   ],
-  "subscription_list_title_prefix": "CMA cases with the following case type(s): ",
+  "subscription_list_title_prefix": "CMA cases",
   "email_filter_options": {
     "email_filter_by": "case_type",
     "downcase_email_alert_topic_names": true,

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -21,7 +21,7 @@
   "taxons": [
     "2894668d-0c21-491a-9069-a271e67f6025"
   ],
-  "subscription_list_title_prefix": "European Structural and Investment Fund with the following location(s): ",
+  "subscription_list_title_prefix": "European Structural and Investment Fund",
   "email_filter_options": {
     "email_filter_by": "location",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -21,10 +21,7 @@
   "taxons": [
     "2894668d-0c21-491a-9069-a271e67f6025"
   ],
-  "subscription_list_title_prefix": {
-    "singular": "European Structural and Investment Fund with the following location: ",
-    "plural": "European Structural and Investment Funds with the following locations: "
-  },
+  "subscription_list_title_prefix": "European Structural and Investment Fund with the following location(s): ",
   "email_filter_options": {
     "email_filter_by": "location",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -16,7 +16,7 @@
   "taxons": [
     "7a5e878e-2b0f-4c3f-9079-586590a1a194"
   ],
-  "subscription_list_title_prefix": "Marine Accident Investigation Branch (MAIB) reports with the following vessel type(s): ",
+  "subscription_list_title_prefix": "Marine Accident Investigation Branch (MAIB) reports",
   "email_filter_options": {
     "email_filter_by": "vessel_type",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -16,10 +16,7 @@
   "taxons": [
     "7a5e878e-2b0f-4c3f-9079-586590a1a194"
   ],
-  "subscription_list_title_prefix": {
-    "singular": "Marine Accident Investigation Branch (MAIB) reports with the following vessel type: ",
-    "plural": "Marine Accident Investigation Branch (MAIB) reports with the following vessel types: "
-  },
+  "subscription_list_title_prefix": "Marine Accident Investigation Branch (MAIB) reports with the following vessel type(s): ",
   "email_filter_options": {
     "email_filter_by": "vessel_type",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -16,10 +16,7 @@
   "taxons": [
     "c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7"
   ],
-  "subscription_list_title_prefix": {
-    "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
-    "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: "
-  },
+  "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports with the following railway type(s): ",
   "email_filter_options": {
     "email_filter_by": "railway_type",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -16,7 +16,7 @@
   "taxons": [
     "c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7"
   ],
-  "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports with the following railway type(s): ",
+  "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports",
   "email_filter_options": {
     "email_filter_by": "railway_type",
     "downcase_email_alert_topic_names": true

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -22,10 +22,7 @@
     "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ],
   "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
-  "subscription_list_title_prefix": {
-    "singular": "Upper Tribunal (Tax and Chancery Chamber) decisions with the following category: ",
-    "plural": "Upper Tribunal (Tax and Chancery Chamber) decisions with the following categories: "
-  },
+  "subscription_list_title_prefix": "Upper Tribunal (Tax and Chancery Chamber) decisions",
   "email_filter_options": {
     "email_filter_by": "tribunal_decision_category",
     "downcase_email_alert_topic_names": true

--- a/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_signup_content_item_presenter_spec.rb
@@ -23,18 +23,7 @@ RSpec.describe FinderSignupContentItemPresenter do
         presented_data = finder_signup_content_presenter.to_json
         next unless presented_data[:details][:subscription_list_title_prefix]
 
-        name = if presented_data[:details][:subscription_list_title_prefix][:plural]
-                 # If the list name has singular and plural forms, test the plural
-                 # form with every possible topic name appended to make the longest
-                 # possible name
-                 (presented_data[:details][:subscription_list_title_prefix][:plural] +
-                   presented_data[:details][:email_filter_facets][0][:facet_choices].collect { |topic| topic[:topic_name] }.to_sentence)
-                   .humanize
-               else
-                 # If the list name only has one form, then topic names are not
-                 # appended; just check the name itself isn't too long
-                 presented_data[:details][:subscription_list_title_prefix]
-               end
+        name = presented_data[:details][:subscription_list_title_prefix]
 
         expect(name.length).to be <= 1000
       end


### PR DESCRIPTION
Trello: https://trello.com/c/l9XfLavV/3212-email-alerts-on-edit-finder-form

Support for a hash value for `subscription_list_title_prefix` has been around for ages (at least [9 years](b2e3d30#diff-793b8db55b8b5c75a5bf7007ed820f5038b1e7f6160a7f43a12477372fc3c3ceR16)) but it is only used by a handful of finders.

A [whole bunch of logic](https://github.com/alphagov/finder-frontend/blob/484396b660715811500af3e3b226ecf0dd69c675/app/lib/email_alert_title_builder.rb#L19-L47) has to be maintained in finder-frontend to support plurality. Until now, we haven't felt the pain of it in Specialist Publisher, but we're now building a form whereby publishers can request edits to the configuration of their finder. That means we either need to add support for pluralised subscription topics in the form itself, or skip over any existing hash values, or, as we're doing in this commit, omit the hash values altogether. This commit argues that the feature is poorly utilised, not very valuable, and is actively blocking development of the "request edits to email alerts" form.

Only 6 finders made use of the feature, and for five of these, we were able to trivially replace references to "...the following {nouns|noun}" to "...the following noun(s)". There is one finder that had "category" vs "categories", which is harder to substitute, but [taking inspiration from other finders](https://github.com/alphagov/specialist-publisher/blob/b638d1326b570988d63aaec9de2bd6c2c877ea22/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json#L17) we can simply follow the form "{Finder name} {document noun}", with no need to overcomplicate things by trying to form a partial sentence.

With this commit, we can delete the corresponding code from finder-frontend.

NB, I wasn't sure what would happen to existing subscriber lists if we were to go and change the subscriber list title (but keeping all other params the same) - is a new one created, and if so, is that even a problem? So I tried it out. Rails console on Integration (Email Alert API), getting a subscriber list:

``` email-alert-api(prod)> SubscriberList.find_by(slug: "upper-tribunal-tax-and-chancery-chamber-decisions-with-the-following-category-charity") => id: 8330, title: "Upper Tribunal (Tax and Chancery Chamber) decision...", created_at: "2017-04-04 11:25:58.190324000 +0100", updated_at: "2019-09-16 13:26:39.390801000 +0100", document_type: "", tags: {"format"=>{"any"=>["tax_tribunal_decision"]}, "tribunal_decision_category"=>{"any"=>["charity"]}}, links: {}, email_document_supertype: "", government_document_supertype: "", signon_user_uid: nil, slug: "upper-tribunal-tax-and-chancery-chamber-decisions-...", url: nil, tags_digest: "56ebfeb705da5037ebe24ed1617068a34810753649c60eb80b...", links_digest: nil, content_id: nil, description: nil, last_audited_at: nil, last_alerted_at: "2024-11-12 08:45:04.474051000 +0000"> ```

I then tried calling `find_or_create_subscriber_list` with the same links, but a new title:

``` finder-frontend(prod)> GdsApi.email_alert_api.find_or_create_subscriber_list({ "title" => "Upper Tribunal NEW", "tags" => { "format"=>{"any"=>["tax_tribunal_decision"]}, "tribunal_decision_category"=>{"any"=>["charity"]} } }) ```

We can see that `title` got updated on the existing subscriber list:

``` email-alert-api(prod)> existing.reload => id: 8330, title: "Upper Tribunal NEW", created_at: "2017-04-04 11:25:58.190324000 +0100", updated_at: "2025-01-14 10:45:26.063566000 +0000", document_type: "", tags: {"format"=>{"any"=>["tax_tribunal_decision"]}, "tribunal_decision_category"=>{"any"=>["charity"]}}, links: {}, ... ```

Therefore we can safely conclude that tweaking the subscriber list title generation logic won't have a detrimental effect on data fragmentation. But just to be sure, the team in charge of Email Alert API will monitor the effects of this change, in https://trello.com/c/5HrbIlhQ/287-confirm-status-of-email-lists-affected-by-pluralisation-simplification

## Next steps

- Remove the corresponding code from Finder Frontend: https://github.com/alphagov/finder-frontend/pull/3626
- Remove the hash option from the schema in Publishing API: TODO

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
