### PR TITLE
Add "Finder setup" link to finder pages

### DIFF
--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -12,7 +12,6 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :destroy?, :index?
 
   def can_request_edits_to_finder?
-    # TODO: figure out who should be allowed to do what RE administrating finders
     publish?
   end
   alias_method :summary?, :can_request_edits_to_finder?

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -21,6 +21,9 @@
 <div class="row">
   <div class="sidebar col-md-3">
     <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'action-link' %>
+    <hr>
+    <%= link_to "Finder setup", new_document_path(current_format.admin_slug), class: 'action-link' %>
+
     <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "add-vertical-margins well") do %>
       <% if current_format.has_organisations? %>
         <%= label_tag "organisation", "Organisation" %>


### PR DESCRIPTION
This is a temporary step until we migrate this page to the design system (#2951).

| Before | After |
|--------|-------|
|![1  before](https://github.com/user-attachments/assets/a0470cbb-da4a-48f8-b912-eb8d92c18029)|![2  after](https://github.com/user-attachments/assets/064ae4e6-4702-491c-96ef-cd8a2d14b266)|

Linking to the new admin forms is the final step in releasing the forms for general use by publishers 🎉

Trello: https://trello.com/c/JoK7tUbQ/3036-release-the-edit-finder-forms-feature-%F0%9F%9A%80

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
