### PR TITLE
Fix link for "Finder setup"

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -22,7 +22,7 @@
   <div class="sidebar col-md-3">
     <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'action-link' %>
     <hr>
-    <%= link_to "Finder setup", new_document_path(current_format.admin_slug), class: 'action-link' %>
+    <%= link_to "Finder setup", administrate_finder_path(current_format.admin_slug), class: 'action-link' %>
 
     <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "add-vertical-margins well") do %>
       <% if current_format.has_organisations? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]
 
-  get "/admin/:document_type_slug", to: "admin#summary"
+  get "/admin/:document_type_slug", to: "admin#summary", as: :administrate_finder
   get "/admin/facets/:document_type_slug", to: "admin#edit_facets"
   post "/admin/facets/:document_type_slug", to: "admin#confirm_facets"
   get "/admin/metadata/:document_type_slug", to: "admin#edit_metadata"


### PR DESCRIPTION
🤦‍ I'd used the wrong link in #2952!

Trello: https://trello.com/c/JoK7tUbQ/3036-release-the-edit-finder-forms-feature-%F0%9F%9A%80

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
