### PR TITLE
Hotfixes/tweaks for the new "request edits" forms

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/checkboxes';
+@import 'govuk_publishing_components/components/error-alert';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/hint';

--- a/app/components/email_alert_fieldset_component.rb
+++ b/app/components/email_alert_fieldset_component.rb
@@ -56,7 +56,7 @@ private
     render("govuk_publishing_components/components/input", {
       type: "hidden",
       name: input_name,
-      value: @email_alert.email_filter_options.to_json,
+      value: (@email_alert.email_filter_options.nil? ? "" : @email_alert.email_filter_options.to_json),
     })
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -52,6 +52,9 @@ class AdminController < ApplicationController
   def zendesk
     GdsApi.support_api.raise_support_ticket(support_payload)
     redirect_to "/admin/#{current_format.admin_slug}", notice: "Your changes have been submitted and Zendesk ticket created."
+  rescue GdsApi::HTTPErrorResponse
+    flash[:danger] = "There was an error submitting your request. Please try again."
+    redirect_back(fallback_location: root_path)
   end
 
 private

--- a/app/models/email_alert.rb
+++ b/app/models/email_alert.rb
@@ -70,7 +70,7 @@ class EmailAlert
     end
 
     def email_filter_options_for_all_content(params)
-      return if params["all_content_email_filter_options"].nil?
+      return if params["all_content_email_filter_options"].nil? || params["all_content_email_filter_options"].blank?
 
       email_filter_options = JSON.parse(params["all_content_email_filter_options"])
       email_filter_options.delete("email_filter_by")
@@ -79,7 +79,8 @@ class EmailAlert
     end
 
     def email_filter_options_for_filtered_content(params)
-      email_filter_options = JSON.parse(params["filtered_content_email_filter_options"] || "{}")
+      options = params["filtered_content_email_filter_options"].presence || "{}"
+      email_filter_options = JSON.parse(options)
       email_filter_options.merge("email_filter_by" => params["email_filter_by"])
     end
 

--- a/app/views/admin/_confirmation_page.html.erb
+++ b/app/views/admin/_confirmation_page.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title, "Edit #{current_format.title} finder" %>
+<% content_for :title, "Check your changes before submitting" %>
+<% content_for :context, "#{current_format.title} finder" %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-body govuk-!-margin-top-8">
+    <%= render summary_card_template, {
+      schema: @proposed_schema,
+      previous_schema: @current_format.finder_schema,
+    } %>
+
+    <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
+
+    <p class="govuk-body govuk-body govuk-!-margin-top-7">
+      By submitting you are confirming that these changes are required to the specialist finder.
+    </p>
+
+    <div class="govuk-button-group govuk-!-margin-top-7">
+      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
+        <%= hidden_field_tag :proposed_schema, @proposed_schema.to_json %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Submit changes"
+        } %>
+      <% end %>
+
+      <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/_confirmation_page.html.erb
+++ b/app/views/admin/_confirmation_page.html.erb
@@ -18,7 +18,7 @@
 
     <div class="govuk-button-group govuk-!-margin-top-7">
       <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
-        <%= hidden_field_tag :proposed_schema, @proposed_schema.to_json %>
+        <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(JSON.parse(@proposed_schema.to_json)) %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit changes"
         } %>

--- a/app/views/admin/confirm_facets.html.erb
+++ b/app/views/admin/confirm_facets.html.erb
@@ -21,33 +21,7 @@
     ]
   } %>
 <% end %>
-<% content_for :page_title, "Edit #{current_format.title} finder" %>
-<% content_for :title, "Check your changes before submitting" %>
-<% content_for :context, "#{current_format.title} finder" %>
 
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-body govuk-!-margin-top-8">
-    <%= render "facets_summary_card", {
-      schema: @proposed_schema,
-      previous_schema: @current_format.finder_schema,
-    } %>
-
-    <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
-
-    <p class="govuk-body govuk-body govuk-!-margin-top-7">
-      By submitting you are confirming that these changes are required to the specialist finder.
-    </p>
-
-    <div class="govuk-button-group govuk-!-margin-top-7">
-      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
-        <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(@proposed_schema) %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Submit changes"
-        } %>
-      <% end %>
-
-      <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
-  </div>
-</div>
+<%= render "confirmation_page", {
+  summary_card_template: "facets_summary_card",
+} %>

--- a/app/views/admin/confirm_metadata.html.erb
+++ b/app/views/admin/confirm_metadata.html.erb
@@ -21,33 +21,7 @@
     ]
   } %>
 <% end %>
-<% content_for :page_title, "Edit #{current_format.title} finder" %>
-<% content_for :title, "Check your changes before submitting" %>
-<% content_for :context, "#{current_format.title} finder" %>
 
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-top-8">
-    <%= render "metadata_summary_card", {
-      schema: @proposed_schema,
-      previous_schema: @current_format.finder_schema,
-    } %>
-
-    <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
-
-    <p class="govuk-body govuk-body govuk-!-margin-top-7">
-      By submitting you are confirming that these changes are required to the specialist finder.
-    </p>
-
-    <div class="govuk-button-group govuk-!-margin-top-7">
-      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
-        <%= hidden_field_tag :proposed_schema, @proposed_schema.to_json %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Submit changes"
-        } %>
-      <% end %>
-
-      <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
-  </div>
-</div>
+<%= render "confirmation_page", {
+  summary_card_template: "metadata_summary_card",
+} %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -46,6 +46,9 @@
       <%= render "govuk_publishing_components/components/success_alert", {
         message: flash[:notice]
       } if flash[:notice] %>
+      <%= render "govuk_publishing_components/components/error_alert", {
+        message: flash[:danger]
+      } if flash[:danger] %>
 
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">

--- a/spec/components/email_alert_fieldset_component_spec.rb
+++ b/spec/components/email_alert_fieldset_component_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     expect(page).to have_field("all_content_email_filter_options", with: email_alert.email_filter_options.to_json, type: "hidden")
   end
 
+  it "defaults to empty value if no pre-existing `email_filter_options`" do
+    email_alert = EmailAlert.new
+    email_alert.type = :all_content
+    render_inline(described_class.new(email_alert:))
+
+    expect(page).to have_field("all_content_email_filter_options", with: "", type: "hidden")
+  end
+
   it "sets the value of the radio button to 'all_content' and renders a hidden input with a generated content id if the alert is missing a signup content id" do
     email_alert = EmailAlert.new
     email_alert.type = :all_content
@@ -81,6 +89,14 @@ RSpec.describe EmailAlertFieldsetComponent, type: :component do
     expect(page).to have_checked_field("email_alert_type", with: "filtered_content")
     expect(page).to have_field("filtered_content_signup_id", with: "new-id", type: "hidden")
     expect(page).to have_field("filtered_content_email_filter_options", with: email_alert.email_filter_options.to_json, type: "hidden")
+  end
+
+  it "defaults to empty value if no pre-existing `email_filter_options`" do
+    email_alert = EmailAlert.new
+    email_alert.type = :filtered_content
+    render_inline(described_class.new(email_alert:))
+
+    expect(page).to have_field("filtered_content_email_filter_options", with: "", type: "hidden")
   end
 
   it "renders the email subscription topic if the filtered_content value is checked" do

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -81,5 +81,15 @@ RSpec.describe AdminController, type: :controller do
       assert_requested(stub_post)
       expect(captured_body).to eq(expected_payload)
     end
+
+    it "informs user if there was a failure creating the Zendesk ticket" do
+      stub_post = stub_support_api_invalid_raise_support_ticket(anything)
+
+      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: CmaCase.finder_schema.to_json }
+
+      assert_requested(stub_post)
+      expect(response.status).to eq(302)
+      expect(flash[:danger]).to eq("There was an error submitting your request. Please try again.")
+    end
   end
 end

--- a/spec/features/editing_the_cma_case_filters_and_options_spec.rb
+++ b/spec/features/editing_the_cma_case_filters_and_options_spec.rb
@@ -64,4 +64,11 @@ RSpec.feature "Editing the CMA case finder filters and options", type: :feature 
     click_button "Submit changes"
     expect(page).to have_selector(".gem-c-success-alert__message", text: "Your changes have been submitted and Zendesk ticket created.")
   end
+
+  scenario "the generated schema is outputted to a hidden input ready for form submission" do
+    visit "admin/facets/cma-cases"
+    click_button "Submit changes"
+    hidden_input = find("[name=proposed_schema]", visible: false)
+    expect(hidden_input.value).to eq(JSON.pretty_generate(JSON.parse(CmaCase.finder_schema.to_json)))
+  end
 end

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -94,6 +94,13 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page).not_to have_selector("dt")
   end
 
+  scenario "the generated schema is outputted to a hidden input ready for form submission" do
+    visit "admin/metadata/cma-cases"
+    click_button "Submit changes"
+    hidden_input = find("[name=proposed_schema]", visible: false)
+    expect(hidden_input.value).to eq(JSON.pretty_generate(JSON.parse(CmaCase.finder_schema.to_json)))
+  end
+
   scenario "unchecking 'Any related links on GOV.UK?' removes related links" do
     visit "admin/metadata/cma-cases"
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe "EmailAlert" do
         expect(email_alert.email_filter_options).to eq({})
       end
 
+      it "converts a blank `email_filter_options` parameter into nil" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "all_content_email_filter_options" => "",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq(nil)
+      end
+
       it "deletes any existing `email_filter_options.pre_checked_email_alert_checkboxes` option" do
         params = {
           "email_alert_type" => email_alert_type,
@@ -198,6 +207,29 @@ RSpec.describe "EmailAlert" do
         expect(email_alert.email_filter_options).to eq({
           "email_filter_by" => "some_facet",
           "pre_checked_email_alert_checkboxes" => %w[foo bar baz],
+        })
+      end
+
+      it "copes with a blank `filtered_content_email_filter_options` value" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+          "filtered_content_email_filter_options" => "",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
+        })
+      end
+
+      it "copes with no `filtered_content_email_filter_options` value" do
+        params = {
+          "email_alert_type" => email_alert_type,
+          "email_filter_by" => "some_facet",
+        }
+        email_alert = EmailAlert.from_finder_admin_form_params(params)
+        expect(email_alert.email_filter_options).to eq({
+          "email_filter_by" => "some_facet",
         })
       end
 


### PR DESCRIPTION
Trello: https://trello.com/c/JoK7tUbQ/3036-release-the-edit-finder-forms-feature-%F0%9F%9A%80

Successfully tested in the creation of one Zendesk ticket per form:
- https://govuk.zendesk.com/agent/tickets/6016878
- https://govuk.zendesk.com/agent/tickets/6016879

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
