### PR TITLE
Add new facet values to cma cases

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -161,6 +161,10 @@
           "value": "defence"
         },
         {
+          "label": "Digital markets",
+          "value": "digital-markets"
+        },
+        {
           "label": "Distribution and service industries",
           "value": "distribution-and-service-industries"
         },
@@ -300,6 +304,14 @@
         {
           "label": "Criminal cartels - verdict",
           "value": "criminal-cartels-verdict"
+        },
+        {
+          "label": "Firm not designated",
+          "value": "firm-not-designated"
+        },
+        {
+          "label": "SMS designation",
+          "value": "sms-designation"
         },
         {
           "label": "Markets - phase 1 no enforcement action",


### PR DESCRIPTION
- Add ‘digital markets’ as a market sector on CMA case pages
- Add ‘SMS designation’ and ‘Firm not designated’ to case outcomes

> ![Screenshot 2025-01-20 at 10 42 26](https://github.com/user-attachments/assets/20b478c0-1f17-409c-8fb0-769fad140ada)


> ![Screenshot 2025-01-20 at 10 42 37](https://github.com/user-attachments/assets/de904d21-9495-4f97-a92f-af8365fdffe6)


Note: Some of the facet values in the `outcome_type` are not in alphabetical order - just added the new values wherever. 

Tested in integration. As per the documentation, there should have been [changes](https://github.com/alphagov/search-api/pull/3124) made to Search API, but they are not required anymore due to  work done in https://github.com/alphagov/finder-frontend/pull/3627 - all looking good in integration. 

[Trello](https://trello.com/c/2ILbcjuO/3333-re-gds-support-services-re-urgent-cma-case-type-changes-govt-agency-general-issue)

