### PR TITLE
Add digital markets competition regime to topics - cma cases

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -24,7 +24,8 @@
     "competition/consumer-protection",
     "competition/markets",
     "competition/mergers",
-    "competition/regulatory-appeals-references"
+    "competition/regulatory-appeals-references",
+    "competition/regime"
   ],
   "subscription_list_title_prefix": "CMA cases",
   "email_filter_options": {


### PR DESCRIPTION
The taxon is currently being created - see [zendesk ticket](https://govuk.zendesk.com/agent/tickets/6012967). This is a draft PR to update once we know the exact taxon.


[Trello](https://trello.com/c/2ILbcjuO/3333-re-gds-support-services-re-urgent-cma-case-type-changes-govt-agency-general-issue)
