### PR TITLE
Sort JSON properties alphabetically

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -14,15 +14,15 @@ class Facet
 
   def to_finder_schema_attributes
     {
-      key:,
-      name:,
-      short_name:,
-      type:,
-      preposition:,
+      allowed_values:,
       display_as_result_metadata:,
       filterable:,
-      allowed_values:,
+      key:,
+      name:,
+      preposition:,
       specialist_publisher_properties:,
+      short_name:,
+      type:,
     }.compact
   end
 

--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -1,31 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "base_path": "/aaib-reports",
-  "format_name": "Air Accidents Investigation Branch report",
-  "name": "Air Accidents Investigation Branch reports",
+  "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "description": "Find reports of AAIB investigations into air accidents and incidents",
-  "phase": "live",
-  "filter": {
-    "format": "aaib_report"
-  },
-  "show_summaries": true,
-  "organisations": [
-    "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
-  ],
-  "taxons": [
-    "951ece54-c6df-4fbc-aa18-1bc629815fe2"
-  ],
   "document_noun": "report",
   "document_title": "AAIB Report",
   "facets": [
     {
-      "key": "aircraft_category",
-      "name": "Category",
-      "type": "text",
-      "preposition": "in category",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Commercial - fixed wing",
@@ -56,17 +36,17 @@
           "value": "unmanned-aircraft-systems"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "report_type",
-      "name": "Report type",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "aircraft_category",
+      "name": "Category",
+      "preposition": "in category",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Annual safety report",
@@ -105,39 +85,59 @@
           "value": "safety-study"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "report_type",
+      "name": "Report type",
+      "preposition": "of type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
-      "short_name": "Occurred",
-      "type": "date",
       "preposition": "occurred",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Occurred",
+      "type": "date"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "aircraft_type",
       "name": "Aircraft type",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "location",
       "name": "Location",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "registration",
       "name": "Registration",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "aaib_report"
+  },
+  "format_name": "Air Accidents Investigation Branch report",
+  "name": "Air Accidents Investigation Branch reports",
+  "organisations": [
+    "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
+  ],
+  "phase": "live",
+  "show_summaries": true,
+  "target_stack": "live",
+  "taxons": [
+    "951ece54-c6df-4fbc-aa18-1bc629815fe2"
   ]
 }

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -1,33 +1,14 @@
 {
-  "target_stack": "live",
-  "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
   "base_path": "/ai-assurance-techniques",
-  "format_name": "Find out about artificial intelligence (AI) assurance techniques",
-  "name": "Find out about artificial intelligence (AI) assurance techniques",
+  "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
   "description": "Find out what AI assurance is and what AI assurance techniques you can use in your organisation.",
-  "summary": "Find out what AI assurance is and what effective AI assurance techniques you can use in your organisation. You can also read examples of AI assurance in practice across a variety of sectors.",
-  "filter": {
-    "format": "ai_assurance_portfolio_technique"
-  },
-  "organisations": [
-    "c352c234-8083-47ec-8a4b-0edd45c31263"
-  ],
+  "document_noun": "case study",
+  "document_title": "Portfolio of Assurance Techniques",
   "editing_organisations": [
     "c352c234-8083-47ec-8a4b-0edd45c31263"
   ],
-  "related": [
-    "4519b26b-6312-4855-bc45-828123bd8a2f"
-  ],
-  "document_noun": "case study",
-  "document_title": "Portfolio of Assurance Techniques",
   "facets": [
     {
-      "key": "use_case",
-      "name": "Use case",
-      "type": "text",
-      "preposition": "Use case",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Big data analytics",
@@ -66,17 +47,17 @@
           "value": "robotics-and-autonomous-vehicles-systems"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "sector",
-      "name": "Sector",
-      "type": "text",
-      "preposition": "sector",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "use_case",
+      "name": "Use case",
+      "preposition": "Use case",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Agriculture, Forestry and Fishing (SIC Code Section A)",
@@ -151,17 +132,17 @@
           "value": "other-services"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "principle",
-      "name": "Principle",
-      "type": "text",
-      "preposition": "Principle",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "sector",
+      "name": "Sector",
+      "preposition": "sector",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Safety, security and robustness",
@@ -184,17 +165,17 @@
           "value": "contestability-and-redress"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "key_function",
-      "name": "Key function",
-      "type": "text",
-      "preposition": "function",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "principle",
+      "name": "Principle",
+      "preposition": "Principle",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "R&D",
@@ -237,17 +218,17 @@
           "value": "strategy-and-corporate-finance"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "ai_assurance_technique",
-      "name": "AI Assurance Technique",
-      "type": "text",
-      "preposition": "AI Assurance Technique",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "key_function",
+      "name": "Key function",
+      "preposition": "function",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Data assurance",
@@ -294,17 +275,17 @@
           "value": "assurance-warranty"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "assurance_technique_approach",
-      "name": "Assurance Technique Approach",
-      "type": "text",
-      "preposition": "Assurance Technique Approach",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "ai_assurance_technique",
+      "name": "AI Assurance Technique",
+      "preposition": "AI Assurance Technique",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Technical",
@@ -319,9 +300,28 @@
           "value": "educational"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "assurance_technique_approach",
+      "name": "Assurance Technique Approach",
+      "preposition": "Assurance Technique Approach",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "ai_assurance_portfolio_technique"
+  },
+  "format_name": "Find out about artificial intelligence (AI) assurance techniques",
+  "name": "Find out about artificial intelligence (AI) assurance techniques",
+  "organisations": [
+    "c352c234-8083-47ec-8a4b-0edd45c31263"
+  ],
+  "related": [
+    "4519b26b-6312-4855-bc45-828123bd8a2f"
+  ],
+  "summary": "Find out what AI assurance is and what effective AI assurance techniques you can use in your organisation. You can also read examples of AI assurance in practice across a variety of sectors.",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -1,42 +1,17 @@
 {
-  "target_stack": "live",
-  "content_id": "dc6dc59b-af0b-4849-a3f1-aa7b96635fac",
   "base_path": "/algorithmic-transparency-records",
-  "format_name": "Find out how algorithmic tools are used in public organisations",
-  "name": "Find out how algorithmic tools are used in public organisations",
+  "content_id": "dc6dc59b-af0b-4849-a3f1-aa7b96635fac",
   "description": "Find out how and why public sector organisations use AI and algorithmic tools for decision making.",
-  "filter": {
-    "format": "algorithmic_transparency_record"
-  },
+  "document_noun": "record",
+  "document_title": "Algorithmic transparency record",
   "editing_organisations": [
     "c352c234-8083-47ec-8a4b-0edd45c31263"
   ],
-  "organisations": [
-    "c352c234-8083-47ec-8a4b-0edd45c31263",
-    "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
-    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
-  ],
-  "related": [
-    "9be2896c-2c32-4108-a465-e37ba16f6dd1"
-  ],
-  "show_summaries": true,
-  "signup_content_id": "99f5bacb-d1ef-4b93-87ef-bae129fed396",
-  "subscription_list_title_prefix": "Algorithmic transparency records",
   "email_filter_options": {
     "email_filter_by": "algorithmic_transparency_record_function"
   },
-  "summary": "<p>Find algorithmic transparency records from UK public sector organisations with information on algorithmic tools used in decision making. These are completed in accordance with the Algorithmic Transparency Recording Standard.</p><p>Let us know what you think of this service: [<a href=\"https://forms.office.com/e/XNn3GBqzhY\">feedback form</a>]</p>",
-  "document_noun": "record",
-  "document_title": "Algorithmic transparency record",
   "facets": [
     {
-      "key": "algorithmic_transparency_record_organisation",
-      "name": "Organisation",
-      "short_name": "Organisation",
-      "type": "text",
-      "preposition": "Organisation",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Bristol City Council",
@@ -167,18 +142,18 @@
           "value": "west-midlands-police"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "algorithmic_transparency_record_organisation_type",
-      "name": "Organisation type",
-      "short_name": "Organisation type",
-      "type": "text",
-      "preposition": "Organisation type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "algorithmic_transparency_record_organisation",
+      "name": "Organisation",
+      "preposition": "Organisation",
+      "short_name": "Organisation",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Ministerial department",
@@ -209,18 +184,18 @@
           "value": "public-corporation"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "algorithmic_transparency_record_function",
-      "name": "Function",
-      "short_name": "Function",
-      "type": "text",
-      "preposition": "Function",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "algorithmic_transparency_record_organisation_type",
+      "name": "Organisation type",
+      "preposition": "Organisation type",
+      "short_name": "Organisation type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "General public services",
@@ -267,18 +242,18 @@
           "value": "regulation"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "algorithmic_transparency_record_function",
+      "name": "Function",
+      "preposition": "Function",
+      "short_name": "Function",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "algorithmic_transparency_record_capability",
-      "name": "Capability",
-      "short_name": "Capability",
-      "type": "text",
-      "preposition": "Capability",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Computer vision",
@@ -325,27 +300,27 @@
           "value": "other"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "algorithmic_transparency_record_capability",
+      "name": "Capability",
+      "preposition": "Capability",
+      "short_name": "Capability",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "algorithmic_transparency_record_task",
       "name": "Task",
-      "short_name": "Task",
-      "type": "text",
       "preposition": "Task",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "short_name": "Task",
+      "type": "text"
     },
     {
-      "key": "algorithmic_transparency_record_phase",
-      "name": "Phase",
-      "short_name": "Phase",
-      "type": "text",
-      "preposition": "Phase",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Pre-deployment",
@@ -364,18 +339,18 @@
           "value": "retired"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "algorithmic_transparency_record_region",
-      "name": "Region",
-      "short_name": "Region",
-      "type": "text",
-      "preposition": "Region",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "algorithmic_transparency_record_phase",
+      "name": "Phase",
+      "preposition": "Phase",
+      "short_name": "Phase",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "UK",
@@ -434,36 +409,61 @@
           "value": "south-west"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "algorithmic_transparency_record_region",
+      "name": "Region",
+      "preposition": "Region",
+      "short_name": "Region",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "algorithmic_transparency_record_date_published",
       "name": "Date published",
-      "short_name": "Date published",
-      "type": "date",
       "preposition": "Date published",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Date published",
+      "type": "date"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "algorithmic_transparency_record_atrs_version",
       "name": "ATRS version",
-      "short_name": "ATRS version",
-      "type": "text",
       "preposition": "ATRS version",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "short_name": "ATRS version",
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "algorithmic_transparency_record_other_tags",
       "name": "Other tags",
-      "short_name": "Other tags",
-      "type": "text",
       "preposition": "Other tags",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "short_name": "Other tags",
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "algorithmic_transparency_record"
+  },
+  "format_name": "Find out how algorithmic tools are used in public organisations",
+  "name": "Find out how algorithmic tools are used in public organisations",
+  "organisations": [
+    "c352c234-8083-47ec-8a4b-0edd45c31263",
+    "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
+  ],
+  "related": [
+    "9be2896c-2c32-4108-a465-e37ba16f6dd1"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "99f5bacb-d1ef-4b93-87ef-bae129fed396",
+  "subscription_list_title_prefix": "Algorithmic transparency records",
+  "summary": "<p>Find algorithmic transparency records from UK public sector organisations with information on algorithmic tools used in decision making. These are completed in accordance with the Algorithmic Transparency Recording Standard.</p><p>Let us know what you think of this service: [<a href=\"https://forms.office.com/e/XNn3GBqzhY\">feedback form</a>]</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -1,39 +1,14 @@
 {
-  "target_stack": "live",
-  "content_id": "48ef3920-b877-47af-8356-44f345c22a47",
   "base_path": "/animal-disease-cases-england",
-  "format_name": "Notifiable animal disease cases and control zone",
-  "name": "Notifiable animal disease cases and control zones",
+  "content_id": "48ef3920-b877-47af-8356-44f345c22a47",
   "description": "Find notifiable exotic animal disease cases and control zone declarations for England.",
-  "filter": {
-    "format": "animal_disease_case"
-  },
+  "document_noun": "case",
+  "document_title": "Animal disease case",
   "editing_organisations": [
     "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
   ],
-  "organisations": [
-    "de4e9dc6-cca4-43af-a594-682023b84d6c",
-    "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
-  ],
-  "related": [
-    "5f664bc2-7631-11e4-a3cb-005056011aef",
-    "af8eee5a-632a-4b8e-bb59-8fc5204892bc",
-    "5fa8f693-7631-11e4-a3cb-005056011aef"
-  ],
-  "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
-  "subscription_list_title_prefix": "Notifiable animal disease cases and control zones",
-  "summary": "<p>Find notifiable exotic animal disease cases and control zone declarations for England.</p><p>Read our <a href=\"https://www.gov.uk/government/collections/notifiable-diseases-in-animals\">guidance on notifiable diseases in animals</a>.</p>",
-  "document_noun": "case",
-  "document_title": "Animal disease case",
   "facets": [
     {
-      "key": "disease_type",
-      "name": "Disease Type",
-      "short_name": "type",
-      "type": "text",
-      "preposition": "of disease type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "African horse sickness",
@@ -72,18 +47,18 @@
           "value": "swine-vesicular-disease"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "zone_restriction",
-      "name": "Disease control zone restrictions",
-      "short_name": "Control zone restriction",
-      "type": "text",
-      "preposition": "with control zone restriction",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "disease_type",
+      "name": "Disease Type",
+      "preposition": "of disease type",
+      "short_name": "type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "In force",
@@ -94,18 +69,18 @@
           "value": "no-longer-in-force"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "zone_type",
-      "name": "Disease control zone type",
-      "short_name": "Control zone type",
-      "type": "text",
-      "preposition": "with control zone type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "zone_restriction",
+      "name": "Disease control zone restrictions",
+      "preposition": "with control zone restriction",
+      "short_name": "Control zone restriction",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Protection zone",
@@ -164,36 +139,61 @@
           "value": "none"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "zone_type",
+      "name": "Disease control zone type",
+      "preposition": "with control zone type",
+      "short_name": "Control zone type",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "virus_strain",
       "name": "Virus strain",
-      "short_name": "Virus strain",
-      "type": "text",
       "preposition": "of strain type",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "short_name": "Virus strain",
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "disease_case_opened_date",
       "name": "Case opened date",
-      "short_name": "Opened",
-      "type": "date",
       "preposition": "opened",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Opened",
+      "type": "date"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "disease_case_closed_date",
       "name": "Case closed date",
-      "short_name": "Closed",
-      "type": "date",
       "preposition": "closed",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Closed",
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "animal_disease_case"
+  },
+  "format_name": "Notifiable animal disease cases and control zone",
+  "name": "Notifiable animal disease cases and control zones",
+  "organisations": [
+    "de4e9dc6-cca4-43af-a594-682023b84d6c",
+    "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
+  ],
+  "related": [
+    "5f664bc2-7631-11e4-a3cb-005056011aef",
+    "af8eee5a-632a-4b8e-bb59-8fc5204892bc",
+    "5fa8f693-7631-11e4-a3cb-005056011aef"
+  ],
+  "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
+  "subscription_list_title_prefix": "Notifiable animal disease cases and control zones",
+  "summary": "<p>Find notifiable exotic animal disease cases and control zone declarations for England.</p><p>Read our <a href=\"https://www.gov.uk/government/collections/notifiable-diseases-in-animals\">guidance on notifiable diseases in animals</a>.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -1,38 +1,14 @@
 {
-  "target_stack": "live",
-  "content_id": "581b4bba-e58f-4d07-8e0a-03c8c00165cc",
   "base_path": "/asylum-support-tribunal-decisions",
-  "format_name": "Asylum support tribunal decision",
-  "name": "Asylum support tribunal decisions",
+  "content_id": "581b4bba-e58f-4d07-8e0a-03c8c00165cc",
   "description": "Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).",
-  "phase": "beta",
-  "filter": {
-    "format": "asylum_support_decision"
-  },
-  "show_summaries": true,
+  "document_noun": "decision",
+  "document_title": "Asylum Support Decisions",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "7141e343-e7bb-483b-920a-c6a5cf8f758c"
-  ],
-  "taxons": [
-    "e1d2032c-6a59-4a1a-919c-dc149847dffb"
-  ],
-  "signup_content_id": "307ea825-594c-4d88-85c9-0809fdc9c79e",
-  "subscription_list_title_prefix": "First-tier Tribunal (Asylum Support) decisions",
-  "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
-  "document_noun": "decision",
-  "document_title": "Asylum Support Decisions",
   "facets": [
     {
-      "key": "tribunal_decision_categories",
-      "name": "Category",
-      "type": "text",
-      "preposition": "categorised as",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Section 4(1) (support for persons who are neither an asylum seeker nor a failed asylum seeker)",
@@ -47,17 +23,17 @@
           "value": "section-95-support-for-asylum-seekers"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_sub_categories",
-      "name": "Sub-category",
-      "type": "text",
-      "preposition": "sub-categorised as",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_categories",
+      "name": "Category",
+      "preposition": "categorised as",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Section 4(1) - bail",
@@ -136,17 +112,17 @@
           "value": "section-95-other"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_judges",
-      "name": "Judges",
-      "type": "text",
-      "preposition": "by judge",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-category",
+      "preposition": "sub-categorised as",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Bashir, S",
@@ -257,16 +233,17 @@
           "value": "wyman-j"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_landmark",
-      "name": "Landmark",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_judges",
+      "name": "Judges",
+      "preposition": "by judge",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Landmark",
@@ -277,35 +254,58 @@
           "value": "not-landmark"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_landmark",
+      "name": "Landmark",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "tribunal_decision_reference_number",
       "name": "Reference number",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
-      "short_name": "Decided",
-      "type": "date",
       "preposition": "decided",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Decided",
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "asylum_support_decision"
+  },
+  "format_name": "Asylum support tribunal decision",
+  "name": "Asylum support tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "7141e343-e7bb-483b-920a-c6a5cf8f758c"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "307ea825-594c-4d88-85c9-0809fdc9c79e",
+  "subscription_list_title_prefix": "First-tier Tribunal (Asylum Support) decisions",
+  "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
+  "target_stack": "live",
+  "taxons": [
+    "e1d2032c-6a59-4a1a-919c-dc149847dffb"
   ]
 }

--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -1,37 +1,12 @@
 {
-  "target_stack": "live",
-  "content_id": "12fecc5b-c02a-405e-b96e-7aa32ceaf504",
   "base_path": "/business-finance-support",
-  "format_name": "Business finance support scheme",
-  "name": "Finance and support for your business",
+  "content_id": "12fecc5b-c02a-405e-b96e-7aa32ceaf504",
+  "default_order": "title",
   "description": "Find government-backed support and finance for business",
-  "filter": {
-    "format": "business_finance_support_scheme"
-  },
-  "show_summaries": true,
-  "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",
-  "organisations": [
-    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
-  ],
-  "taxons": [
-    "ccfc50f5-e193-4dac-9d78-50b3a8bb24c5"
-  ],
-  "related": [
-    "3d582854-ffc7-4d41-9266-ee87b9e6d230",
-    "89edffd2-3046-40bd-810c-cc1a13c05b6a"
-  ],
-  "subscription_list_title_prefix": "Business finance support schemes",
   "document_noun": "scheme",
   "document_title": "Business Finance Support Scheme",
-  "default_order": "title",
   "facets": [
     {
-      "key": "types_of_support",
-      "name": "Type of support",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Finance",
@@ -58,17 +33,17 @@
           "value": "recognition-award"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "business_stages",
-      "name": "Business stage",
-      "type": "text",
-      "preposition": "for businesses which are",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "types_of_support",
+      "name": "Type of support",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Not yet trading",
@@ -83,17 +58,17 @@
           "value": "established"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "industries",
-      "name": "Industry",
-      "type": "text",
-      "preposition": "for businesses in",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "business_stages",
+      "name": "Business stage",
+      "preposition": "for businesses which are",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Agriculture and food",
@@ -164,17 +139,17 @@
           "value": "wholesale-and-retail"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "business_sizes",
-      "name": "Number of employees",
-      "type": "text",
-      "preposition": "for businesses with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "industries",
+      "name": "Industry",
+      "preposition": "for businesses in",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "0 to 9 employees",
@@ -193,17 +168,17 @@
           "value": "over-500"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "regions",
-      "name": "Region",
-      "type": "text",
-      "preposition": "for businesses in",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "business_sizes",
+      "name": "Number of employees",
+      "preposition": "for businesses with",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "East Midlands",
@@ -254,9 +229,34 @@
           "value": "yorkshire-and-the-humber"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "regions",
+      "name": "Region",
+      "preposition": "for businesses in",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "business_finance_support_scheme"
+  },
+  "format_name": "Business finance support scheme",
+  "name": "Finance and support for your business",
+  "organisations": [
+    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+  ],
+  "related": [
+    "3d582854-ffc7-4d41-9266-ee87b9e6d230",
+    "89edffd2-3046-40bd-810c-cc1a13c05b6a"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",
+  "subscription_list_title_prefix": "Business finance support schemes",
+  "target_stack": "live",
+  "taxons": [
+    "ccfc50f5-e193-4dac-9d78-50b3a8bb24c5"
   ]
 }

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -1,34 +1,10 @@
 {
-  "target_stack": "live",
-  "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "base_path": "/cma-cases",
-  "format_name": "Competition and Markets Authority case",
-  "name": "Competition and Markets Authority cases and projects",
+  "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "description": "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)",
-  "summary": "<p>This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU).<p>",
-  "filter": {
-    "format": "cma_case"
-  },
-  "related": [
-    "46708567-70a6-4f20-8257-6c222b3d8cb3"
-  ],
-  "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
-  "organisations": [
-    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-  ],
-  "taxons": [
-    "8db04387-9076-4287-ab46-6a6695b593d7"
-  ],
-  "topics": [
-    "competition/competition-act-cartels",
-    "competition/consumer-protection",
-    "competition/markets",
-    "competition/mergers",
-    "competition/regulatory-appeals-references"
-  ],
-  "subscription_list_title_prefix": "CMA cases",
+  "document_noun": "case",
+  "document_title": "CMA Case",
   "email_filter_options": {
-    "email_filter_by": "case_type",
     "downcase_email_alert_topic_names": true,
     "email_alert_topic_name_overrides": {
       "case_type": [
@@ -37,18 +13,11 @@
           "topic_name_override": "CA98 and civil cartels"
         }
       ]
-    }
+    },
+    "email_filter_by": "case_type"
   },
-  "document_noun": "case",
-  "document_title": "CMA Case",
   "facets": [
     {
-      "key": "case_type",
-      "name": "Case type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "CA98 and civil cartels",
@@ -99,17 +68,17 @@
           "value": "sau-referral"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "case_state",
-      "name": "Case state",
-      "type": "text",
-      "preposition": "which are",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "case_type",
+      "name": "Case type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Open",
@@ -120,17 +89,17 @@
           "value": "closed"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "market_sector",
-      "name": "Market sector",
-      "type": "text",
-      "preposition": "about",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "case_state",
+      "name": "Case state",
+      "preposition": "which are",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Aerospace",
@@ -257,17 +226,17 @@
           "value": "utilities"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "outcome_type",
-      "name": "Outcome",
-      "type": "text",
-      "preposition": "with outcome",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "market_sector",
+      "name": "Market sector",
+      "preposition": "about",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "CA98 - no grounds for action",
@@ -394,26 +363,57 @@
           "value": "regulatory-references-and-appeals-final-determination"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "outcome_type",
+      "name": "Outcome",
+      "preposition": "with outcome",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "opened_date",
       "name": "Opened",
       "short_name": "Opened",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "closed_date",
       "name": "Closed",
-      "short_name": "Closed",
-      "type": "date",
       "preposition": "closed",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Closed",
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "cma_case"
+  },
+  "format_name": "Competition and Markets Authority case",
+  "name": "Competition and Markets Authority cases and projects",
+  "organisations": [
+    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+  ],
+  "related": [
+    "46708567-70a6-4f20-8257-6c222b3d8cb3"
+  ],
+  "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+  "subscription_list_title_prefix": "CMA cases",
+  "summary": "<p>This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU).<p>",
+  "target_stack": "live",
+  "taxons": [
+    "8db04387-9076-4287-ab46-6a6695b593d7"
+  ],
+  "topics": [
+    "competition/competition-act-cartels",
+    "competition/consumer-protection",
+    "competition/markets",
+    "competition/mergers",
+    "competition/regulatory-appeals-references"
   ]
 }

--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -1,38 +1,15 @@
 {
-  "target_stack": "live",
-  "content_id": "0eb7b150-879a-4c44-becc-718e23a77e2c",
   "base_path": "/countryside-stewardship-grants",
-  "name": "Countryside Stewardship grant finder",
-  "format_name": "Countryside Stewardship grant",
-  "description": "Find information about Countryside Stewardship options, capital items and supplements",
   "beta": true,
-  "filter": {
-    "format": "countryside_stewardship_grant"
-  },
+  "content_id": "0eb7b150-879a-4c44-becc-718e23a77e2c",
+  "description": "Find information about Countryside Stewardship options, capital items and supplements",
+  "document_noun": "grant",
+  "document_title": "Countryside Stewardship Grant",
   "editing_organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c"
   ],
-  "organisations": [
-    "e8fae147-6232-4163-a3f1-1c15b755a8a4",
-    "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
-  ],
-  "taxons": [
-    "9129d716-365b-44ba-9856-383423fe1e41"
-  ],
-  "related": [
-    "5e91c0bf-187d-4fa0-a6ef-992736d5644c"
-  ],
-  "summary": "<p>Search for options, supplements and capital items to include in your Countryside Stewardship application. Find out about <a href=\"/guidance/countryside-stewardship-get-funding-to-protect-and-improve-the-land-you-manage\">each Countryside Stewardship scheme and check if you’re eligible before you apply for a grant</a>.</p>",
-  "document_noun": "grant",
-  "document_title": "Countryside Stewardship Grant",
   "facets": [
     {
-      "key": "grant_type",
-      "name": "Grant type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Option",
@@ -47,17 +24,17 @@
           "value": "supplement"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "land_use",
-      "name": "Land use",
-      "type": "text",
-      "preposition": "for",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "grant_type",
+      "name": "Grant type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Air quality",
@@ -132,17 +109,17 @@
           "value": "woodland"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tiers_or_standalone_items",
-      "name": "Tiers or standalone items",
-      "type": "text",
-      "preposition": "for",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "land_use",
+      "name": "Land use",
+      "preposition": "for",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Higher Tier",
@@ -173,17 +150,17 @@
           "value": "standalone-capital-items"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "funding_amount",
-      "name": "Funding (per unit per year)",
-      "type": "text",
-      "preposition": "of",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tiers_or_standalone_items",
+      "name": "Tiers or standalone items",
+      "preposition": "for",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Up to £100",
@@ -218,9 +195,32 @@
           "value": "more-than-50-actual-costs"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "funding_amount",
+      "name": "Funding (per unit per year)",
+      "preposition": "of",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "countryside_stewardship_grant"
+  },
+  "format_name": "Countryside Stewardship grant",
+  "name": "Countryside Stewardship grant finder",
+  "organisations": [
+    "e8fae147-6232-4163-a3f1-1c15b755a8a4",
+    "d3ce4ba7-bc75-46b4-89d9-38cb3240376d"
+  ],
+  "related": [
+    "5e91c0bf-187d-4fa0-a6ef-992736d5644c"
+  ],
+  "summary": "<p>Search for options, supplements and capital items to include in your Countryside Stewardship application. Find out about <a href=\"/guidance/countryside-stewardship-get-funding-to-protect-and-improve-the-land-you-manage\">each Countryside Stewardship scheme and check if you’re eligible before you apply for a grant</a>.</p>",
+  "target_stack": "live",
+  "taxons": [
+    "9129d716-365b-44ba-9856-383423fe1e41"
   ]
 }

--- a/lib/documents/schemas/data_ethics_guidance_documents.json
+++ b/lib/documents/schemas/data_ethics_guidance_documents.json
@@ -1,30 +1,11 @@
 {
-  "target_stack": "draft",
-  "content_id": "2437862c-56d6-49f9-a5a5-f2a9460cc3ee",
   "base_path": "/data-ethics-guidance",
-  "format_name": "Find data ethics guidance, standards and frameworks",
-  "name": "Find data ethics guidance, standards and frameworks",
+  "content_id": "2437862c-56d6-49f9-a5a5-f2a9460cc3ee",
   "description": "This hub collates existing guidance for the responsible use and development of data and data-driven technologies, including artificial intelligence (AI), developed by and for government and public sector bodies.",
-  "summary": "<p>Find guidance for the responsible use and development of data and data technologies, including artificial intelligence (AI), developed by and for government and public sector bodies.</p><p>If you have suggestions for guidance, email <a href=\"mailto:data.ethics@digital.cabinet-office.gov.uk\">data.ethics@digital.cabinet-office.gov.uk</a>.</p>",
-  "filter": {
-    "format": "data_ethics_guidance_document"
-  },
-  "related": [],
-  "show_summaries": true,
-  "organisations": [
-    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
-  ],
   "document_noun": "guidance document",
   "document_title": "Data ethics guidance document",
   "facets": [
     {
-      "key": "data_ethics_guidance_document_ethical_theme",
-      "name": "Ethical theme",
-      "type": "text",
-      "preposition": "Ethical theme",
-      "short_name": "Ethical theme",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Safety, Security and Robustness",
@@ -55,18 +36,18 @@
           "value": "societal-wellbeing"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "data_ethics_guidance_document_organisation_alias",
-      "name": "Organisation",
-      "short_name": "Organisation",
-      "type": "text",
-      "preposition": "Organisation",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "data_ethics_guidance_document_ethical_theme",
+      "name": "Ethical theme",
+      "preposition": "Ethical theme",
+      "short_name": "Ethical theme",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "AI Safety Institute",
@@ -189,18 +170,18 @@
           "value": "uk-statistics-authority"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "data_ethics_guidance_document_project_phase",
-      "name": "Project phase",
-      "short_name": "Project phase",
-      "type": "text",
-      "preposition": "Project phase",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "data_ethics_guidance_document_organisation_alias",
+      "name": "Organisation",
+      "preposition": "Organisation",
+      "short_name": "Organisation",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Across Lifecycle",
@@ -227,18 +208,18 @@
           "value": "monitoring-review"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "data_ethics_guidance_document_technology_area",
-      "name": "Technology area",
-      "short_name": "Technology area",
-      "type": "text",
-      "preposition": "Technology area",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "data_ethics_guidance_document_project_phase",
+      "name": "Project phase",
+      "preposition": "Project phase",
+      "short_name": "Project phase",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "AI",
@@ -269,9 +250,28 @@
           "value": "automated-decision-making"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "data_ethics_guidance_document_technology_area",
+      "name": "Technology area",
+      "preposition": "Technology area",
+      "short_name": "Technology area",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "data_ethics_guidance_document"
+  },
+  "format_name": "Find data ethics guidance, standards and frameworks",
+  "name": "Find data ethics guidance, standards and frameworks",
+  "organisations": [
+    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
+  ],
+  "related": [],
+  "show_summaries": true,
+  "summary": "<p>Find guidance for the responsible use and development of data and data technologies, including artificial intelligence (AI), developed by and for government and public sector bodies.</p><p>If you have suggestions for guidance, email <a href=\"mailto:data.ethics@digital.cabinet-office.gov.uk\">data.ethics@digital.cabinet-office.gov.uk</a>.</p>",
+  "target_stack": "draft"
 }

--- a/lib/documents/schemas/drcf_digital_markets_researches.json
+++ b/lib/documents/schemas/drcf_digital_markets_researches.json
@@ -1,28 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "380def5e-bed2-4501-967e-334767ac270d",
   "base_path": "/find-digital-market-research",
-  "format_name": "Digital Regulation Cooperation Forum digital markets research",
-  "name": "Digital Regulation Cooperation Forum digital markets research",
+  "content_id": "380def5e-bed2-4501-967e-334767ac270d",
   "description": "DRCF digital markets research finder",
-  "filter": {
-    "format": "drcf_digital_markets_research"
-  },
-  "organisations": [
-    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-  ],
-  "summary": "<p>Find research about digital markets and regulation carried out by public authorities, curated by the <a href=\"government/collections/the-digital-regulation-cooperation-forum\"> Digital Regulation Cooperation Forum (DRCF)</a></p>",
   "document_noun": "report",
   "document_title": "DRCF digital markets research",
   "facets": [
     {
-      "key": "digital_market_research_category",
-      "name": "Category",
-      "short_name": "Category",
-      "type": "text",
-      "preposition": "",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Ad hoc research",
@@ -33,18 +16,18 @@
           "value": "ongoing-research"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "digital_market_research_publisher",
-      "name": "Original publisher",
-      "short_name": "Publisher",
-      "type": "text",
-      "preposition": "",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "digital_market_research_category",
+      "name": "Category",
+      "preposition": "",
+      "short_name": "Category",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Advertising Standards Authority",
@@ -91,18 +74,18 @@
           "value": "ofcom"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "digital_market_research_area",
-      "name": "Research area",
-      "short_name": "Research area",
-      "type": "text",
-      "preposition": "",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "digital_market_research_publisher",
+      "name": "Original publisher",
+      "preposition": "",
+      "short_name": "Publisher",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Advertising and marketing",
@@ -129,18 +112,18 @@
           "value": "technology"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "digital_market_research_topic",
-      "name": "Research topic",
-      "short_name": "Research topic",
-      "type": "text",
-      "preposition": "",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "digital_market_research_area",
+      "name": "Research area",
+      "preposition": "",
+      "short_name": "Research area",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Adtech",
@@ -287,18 +270,35 @@
           "value": "tv-video-and-on-demand"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "digital_market_research_topic",
+      "name": "Research topic",
+      "preposition": "",
+      "short_name": "Research topic",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "digital_market_research_publish_date",
       "name": "Research publish date",
-      "short_name": "Research published",
-      "type": "date",
       "preposition": "research published",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Research published",
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "drcf_digital_markets_research"
+  },
+  "format_name": "Digital Regulation Cooperation Forum digital markets research",
+  "name": "Digital Regulation Cooperation Forum digital markets research",
+  "organisations": [
+    "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+  ],
+  "summary": "<p>Find research about digital markets and regulation carried out by public authorities, curated by the <a href=\"government/collections/the-digital-regulation-cooperation-forum\"> Digital Regulation Cooperation Forum (DRCF)</a></p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -1,38 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "base_path": "/drug-safety-update",
-  "format_name": "Drug Safety Update",
-  "name": "Drug Safety Update",
+  "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "description": "Find drug safety updates issued by MHRA",
-  "filter": {
-    "format": "drug_safety_update"
-  },
-  "show_summaries": true,
-  "signup_link": "https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044",
-  "organisations": [
-    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
-  ],
-  "taxons": [
-    "51bbdf23-292a-4b74-8a66-f7db6b93b163"
-  ],
-  "related": [
-    "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
-    "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
-  ],
-  "topics": [
-    "medicines-medical-devices-blood/vigilance-safety-alerts"
-  ],
   "document_noun": "update",
   "document_title": "Drug Safety Update",
   "facets": [
     {
-      "key": "therapeutic_area",
-      "name": "Therapeutic area",
-      "type": "text",
-      "preposition": "about",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Anaesthesia and intensive care",
@@ -139,18 +112,45 @@
           "value": "urology-nephrology"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "therapeutic_area",
+      "name": "Therapeutic area",
+      "preposition": "about",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "first_published_at",
       "name": "Published",
-      "short_name": "Published",
-      "type": "date",
       "preposition": "published",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Published",
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "drug_safety_update"
+  },
+  "format_name": "Drug Safety Update",
+  "name": "Drug Safety Update",
+  "organisations": [
+    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
+  ],
+  "related": [
+    "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
+    "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
+  ],
+  "show_summaries": true,
+  "signup_link": "https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044",
+  "target_stack": "live",
+  "taxons": [
+    "51bbdf23-292a-4b74-8a66-f7db6b93b163"
+  ],
+  "topics": [
+    "medicines-medical-devices-blood/vigilance-safety-alerts"
   ]
 }

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -1,38 +1,14 @@
 {
-  "target_stack": "live",
-  "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
   "base_path": "/employment-appeal-tribunal-decisions",
-  "format_name": "Employment appeal tribunal decision",
-  "name": "Employment appeal tribunal decisions",
+  "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
   "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
-  "phase": "beta",
-  "filter": {
-    "format": "employment_appeal_tribunal_decision"
-  },
-  "show_summaries": true,
+  "document_noun": "decision",
+  "document_title": "EAT Decision",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "caeb418c-d11c-4352-92e9-47b21289f696"
-  ],
-  "taxons": [
-    "357110bb-cbc5-4708-9711-1b26e6c63e86"
-  ],
-  "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",
-  "subscription_list_title_prefix": "Employment Appeal Tribunal decisions",
-  "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
-  "document_noun": "decision",
-  "document_title": "EAT Decision",
   "facets": [
     {
-      "key": "tribunal_decision_categories",
-      "name": "Category",
-      "type": "text",
-      "preposition": "categorised as",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Age Discrimination",
@@ -215,17 +191,17 @@
           "value": "working-time-regulations"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_sub_categories",
-      "name": "Sub-category",
-      "type": "text",
-      "preposition": "sub-categorised as",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_categories",
+      "name": "Category",
+      "preposition": "categorised as",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Contract of Employment - Apprenticeship",
@@ -1016,16 +992,17 @@
           "value": "working-time-regulations-worker"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-category",
+      "preposition": "sub-categorised as",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "tribunal_decision_landmark",
-      "name": "Landmark",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false,
       "allowed_values": [
         {
           "label": "Landmark",
@@ -1036,27 +1013,50 @@
           "value": "not-landmark"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "key": "tribunal_decision_landmark",
+      "name": "Landmark",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "employment_appeal_tribunal_decision"
+  },
+  "format_name": "Employment appeal tribunal decision",
+  "name": "Employment appeal tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "caeb418c-d11c-4352-92e9-47b21289f696"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",
+  "subscription_list_title_prefix": "Employment Appeal Tribunal decisions",
+  "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
+  "target_stack": "live",
+  "taxons": [
+    "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ]
 }

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -1,32 +1,13 @@
 {
-  "target_stack": "live",
-  "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
   "base_path": "/employment-tribunal-decisions",
-  "format_name": "Employment tribunal decision",
-  "name": "Employment tribunal decisions",
+  "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
   "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
-  "phase": "beta",
-  "filter": {
-    "format": "employment_tribunal_decision"
-  },
-  "show_summaries": true,
+  "document_noun": "decision",
+  "document_title": "ET Decision",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "8bb37087-a5a7-4493-8afe-900b36ebc927"
-  ],
-  "taxons": [
-    "357110bb-cbc5-4708-9711-1b26e6c63e86"
-  ],
-  "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
-  "subscription_list_title_prefix": "Employment tribunal decisions",
-  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>For enquiries about Employment Tribunal judgments in England and Wales prior to February 2017 contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a>. Please note that we are currently experiencing technical difficulties with the system used to search for judgments. Unfortunately, we are unable to confirm when this issue will be resolved and there may be a delay to you receiving the judgment you have requested.</p><p>If the decision was made before February 2017 in Scotland, contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/glasgow-tribunals-centre'>Glasgow Tribunals Centre</a>.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
-  "document_noun": "decision",
-  "document_title": "ET Decision",
   "email_filter_options": {
-    "email_filter_by": "tribunal_decision_categories",
     "downcase_email_alert_topic_names": true,
     "email_alert_topic_name_overrides": {
       "tribunal_decision_categories": [
@@ -39,16 +20,11 @@
           "topic_name_override": "renumeration"
         }
       ]
-    }
+    },
+    "email_filter_by": "tribunal_decision_categories"
   },
   "facets": [
     {
-      "key": "tribunal_decision_country",
-      "name": "Country",
-      "type": "text",
-      "preposition": "by country",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "England and Wales",
@@ -59,17 +35,17 @@
           "value": "scotland"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "tribunal_decision_categories",
-      "name": "Jurisdiction code",
-      "type": "text",
-      "preposition": "by jurisdiction",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_country",
+      "name": "Country",
+      "preposition": "by country",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Age Discrimination",
@@ -288,27 +264,51 @@
           "value": "written-statements"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_categories",
+      "name": "Jurisdiction code",
+      "preposition": "by jurisdiction",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "employment_tribunal_decision"
+  },
+  "format_name": "Employment tribunal decision",
+  "name": "Employment tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "8bb37087-a5a7-4493-8afe-900b36ebc927"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
+  "subscription_list_title_prefix": "Employment tribunal decisions",
+  "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland from February 2017 onwards.</p><p>For enquiries about Employment Tribunal judgments in England and Wales prior to February 2017 contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court'>Bury St Edmunds County Court</a>. Please note that we are currently experiencing technical difficulties with the system used to search for judgments. Unfortunately, we are unable to confirm when this issue will be resolved and there may be a delay to you receiving the judgment you have requested.</p><p>If the decision was made before February 2017 in Scotland, contact <a href='https://www.find-court-tribunal.service.gov.uk/courts/glasgow-tribunals-centre'>Glasgow Tribunals Centre</a>.</p><p>Decisions are not affected by GDPR rules and cannot be removed from GOV.UK.</p>",
+  "target_stack": "live",
+  "taxons": [
+    "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ]
 }

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -1,41 +1,17 @@
 {
-  "target_stack": "live",
-  "content_id": "78cedbfe-d3aa-41c3-b8c0-aeb5d9035d6a",
   "base_path": "/european-structural-investment-funds",
-  "format_name": "ESIF call for proposals",
-  "name": "European Structural and Investment Funds (ESIF)",
-  "description": "Find and apply to run projects backed by ESIF",
   "beta": true,
-  "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.finance-ni.gov.uk/articles/european-structural-and-investment-fund-programmes-northern-ireland\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
-  "filter": {
-    "format": "european_structural_investment_fund"
-  },
+  "content_id": "78cedbfe-d3aa-41c3-b8c0-aeb5d9035d6a",
   "default_order": "-closing_date",
-  "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",
-  "organisations": [
-    "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
-    "b548a09f-8b35-4104-89f4-f1a40bf3136d",
-    "de4e9dc6-cca4-43af-a594-682023b84d6c",
-    "e8fae147-6232-4163-a3f1-1c15b755a8a4"
-  ],
-  "taxons": [
-    "2894668d-0c21-491a-9069-a271e67f6025"
-  ],
-  "subscription_list_title_prefix": "European Structural and Investment Fund",
-  "email_filter_options": {
-    "email_filter_by": "location",
-    "downcase_email_alert_topic_names": true
-  },
+  "description": "Find and apply to run projects backed by ESIF",
   "document_noun": "call",
   "document_title": "ESI Fund",
+  "email_filter_options": {
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "location"
+  },
   "facets": [
     {
-      "key": "fund_state",
-      "name": "Fund state",
-      "type": "text",
-      "preposition": "which are",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Open",
@@ -46,17 +22,17 @@
           "value": "closed"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "fund_state",
+      "name": "Fund state",
+      "preposition": "which are",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "fund_type",
-      "name": "Type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Access to employment",
@@ -111,17 +87,17 @@
           "value": "tourism"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "fund_type",
+      "name": "Type",
+      "preposition": "of type",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "location",
-      "name": "Location",
-      "type": "text",
-      "preposition": "in",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "North East",
@@ -160,17 +136,17 @@
           "value": "london"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "location",
+      "name": "Location",
+      "preposition": "in",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "funding_source",
-      "name": "Funding source",
-      "type": "text",
-      "preposition": "from",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "European Social Fund",
@@ -185,16 +161,40 @@
           "value": "european-agricoltural-fund-for-rural"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "funding_source",
+      "name": "Funding source",
+      "preposition": "from",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "closing_date",
       "name": "Closing date",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "european_structural_investment_fund"
+  },
+  "format_name": "ESIF call for proposals",
+  "name": "European Structural and Investment Funds (ESIF)",
+  "organisations": [
+    "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+    "b548a09f-8b35-4104-89f4-f1a40bf3136d",
+    "de4e9dc6-cca4-43af-a594-682023b84d6c",
+    "e8fae147-6232-4163-a3f1-1c15b755a8a4"
+  ],
+  "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",
+  "subscription_list_title_prefix": "European Structural and Investment Fund",
+  "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.finance-ni.gov.uk/articles/european-structural-and-investment-fund-programmes-northern-ireland\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
+  "target_stack": "live",
+  "taxons": [
+    "2894668d-0c21-491a-9069-a271e67f6025"
   ]
 }

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -1,21 +1,10 @@
 {
-  "target_stack": "live",
-  "content_id": "a485fe3e-6e1e-4d37-a2cc-06177089d1ac",
   "base_path": "/export-health-certificates",
-  "format_name": "Export health certificate",
-  "name": "Find an export health certificate",
+  "content_id": "a485fe3e-6e1e-4d37-a2cc-06177089d1ac",
   "description": "Find export health certificates (EHCs) used for exporting live animals and products of animal origin",
-  "summary": "<p>Find the export health certificate (EHC) and supporting documents you need to export a live animal or animal product like food and germplasm. The latest versions of the certificates are always here.</p> <p>You must nominate an official vet or local authority inspector to sign the certificate. Find out more about <a href=\"https://www.gov.uk/guidance/get-an-export-health-certificate\">getting an export health certificate</a>.</p><p>If you cannot find the correct export health certificate, <a href=\"https://www.gov.uk/guidance/get-an-export-health-certificate#if-you-need-help\">contact the Animal and Plant Health Agency (APHA)</a>.</p>",
-  "filter": {
-    "format": "export_health_certificate"
-  },
-  "organisations": [
-    "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
-  ],
-  "signup_content_id": "9a5260d2-07e7-45dc-a24a-791b02e4a9da",
-  "subscription_list_title_prefix": "Export health certificates",
+  "document_noun": "export health certificate",
+  "document_title": "Export health certificate",
   "email_filter_options": {
-    "email_filter_by": "all_selected_facets",
     "all_selected_facets_except_for": [
       "certificate_status"
     ],
@@ -26,23 +15,11 @@
           "topic_name_override": "Eurasian Customs Union"
         }
       ]
-    }
+    },
+    "email_filter_by": "all_selected_facets"
   },
-  "topics": [
-    "keeping-farmed-animals/animal-welfare"
-  ],
-  "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
-  "document_noun": "export health certificate",
-  "document_title": "Export health certificate",
   "facets": [
     {
-      "key": "destination_country",
-      "name": "Destination country",
-      "short_name": "Destination",
-      "type": "text",
-      "preposition": "to",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Afghanistan",
@@ -941,18 +918,18 @@
           "value": "zimbabwe"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "commodity_type",
-      "name": "Commodity type",
-      "short_name": "Commodity",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "destination_country",
+      "name": "Destination country",
+      "preposition": "to",
+      "short_name": "Destination",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Animal products including food",
@@ -983,17 +960,18 @@
           "value": "pets"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "certificate_status",
-      "name": "Certificate status",
-      "type": "text",
-      "preposition": "with status",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "commodity_type",
+      "name": "Commodity type",
+      "preposition": "of type",
+      "short_name": "Commodity",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Active",
@@ -1004,9 +982,31 @@
           "value": "on-hold"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "certificate_status",
+      "name": "Certificate status",
+      "preposition": "with status",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "export_health_certificate"
+  },
+  "format_name": "Export health certificate",
+  "name": "Find an export health certificate",
+  "organisations": [
+    "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
+  ],
+  "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
+  "signup_content_id": "9a5260d2-07e7-45dc-a24a-791b02e4a9da",
+  "subscription_list_title_prefix": "Export health certificates",
+  "summary": "<p>Find the export health certificate (EHC) and supporting documents you need to export a live animal or animal product like food and germplasm. The latest versions of the certificates are always here.</p> <p>You must nominate an official vet or local authority inspector to sign the certificate. Find out more about <a href=\"https://www.gov.uk/guidance/get-an-export-health-certificate\">getting an export health certificate</a>.</p><p>If you cannot find the correct export health certificate, <a href=\"https://www.gov.uk/guidance/get-an-export-health-certificate#if-you-need-help\">contact the Animal and Plant Health Agency (APHA)</a>.</p>",
+  "target_stack": "live",
+  "topics": [
+    "keeping-farmed-animals/animal-welfare"
   ]
 }

--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -1,33 +1,12 @@
 {
-  "target_stack": "live",
-  "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
   "base_path": "/find-funding-for-land-or-farms",
-  "format_name": "Find funding for land or farms",
-  "name": "Find funding for land or farms",
-  "description": "Find out about grants and funding for farmers and land managers in England.",
-  "phase": "beta",
   "beta_message": "This is a new tool – your <a href=\"https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=/find-funding-for-land-or-farms\">feedback</a> will help us to improve it.",
-  "filter": {
-    "format": "farming_grant"
-  },
-  "organisations": [
-    "de4e9dc6-cca4-43af-a594-682023b84d6c",
-    "e8fae147-6232-4163-a3f1-1c15b755a8a4"
-  ],
-  "show_summaries": true,
-  "signup_content_id": "2cd12e92-3b68-4cb1-bafe-fde6a7939afb",
-  "subscription_list_title_prefix": "Funding for land or farms",
-  "summary": "<p>Find out about grants and funding for farmers and land managers in England. We will add more grants and funding as we develop this tool.</p><div class=\"application-notice info-notice\"><p>You can search for actions you can get paid for as part of the Sustainable Farming Incentive (SFI). The tool does not confirm your eligibility. <a href=\"https://www.gov.uk/government/collections/sustainable-farming-incentive-guidance\">Read the SFI guidance to check if you're eligible and how you can apply.</a></p></div><p>Search by keyword, action name or code if you know it. Use the filters to search by land types or areas of interest.</p>",
+  "content_id": "23ad50d7-916c-456b-b3de-4b27739d5be1",
+  "description": "Find out about grants and funding for farmers and land managers in England.",
   "document_noun": "result",
   "document_title": "Farming Grant",
   "facets": [
     {
-      "key": "land_types",
-      "name": "Land types",
-      "type": "text",
-      "preposition": "for",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Arable",
@@ -70,17 +49,17 @@
           "value": "woodland"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "areas_of_interest",
-      "name": "Areas of interest",
-      "type": "text",
-      "preposition": "with",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "land_types",
+      "name": "Land types",
+      "preposition": "for",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Agroforestry",
@@ -183,17 +162,17 @@
           "value": "water-quality"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "payment_types",
-      "name": "Payment types",
-      "type": "text",
-      "preposition": "payment type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "areas_of_interest",
+      "name": "Areas of interest",
+      "preposition": "with",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Capital",
@@ -204,9 +183,30 @@
           "value": "revenue"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "payment_types",
+      "name": "Payment types",
+      "preposition": "payment type",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "farming_grant"
+  },
+  "format_name": "Find funding for land or farms",
+  "name": "Find funding for land or farms",
+  "organisations": [
+    "de4e9dc6-cca4-43af-a594-682023b84d6c",
+    "e8fae147-6232-4163-a3f1-1c15b755a8a4"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "2cd12e92-3b68-4cb1-bafe-fde6a7939afb",
+  "subscription_list_title_prefix": "Funding for land or farms",
+  "summary": "<p>Find out about grants and funding for farmers and land managers in England. We will add more grants and funding as we develop this tool.</p><div class=\"application-notice info-notice\"><p>You can search for actions you can get paid for as part of the Sustainable Farming Incentive (SFI). The tool does not confirm your eligibility. <a href=\"https://www.gov.uk/government/collections/sustainable-farming-incentive-guidance\">Read the SFI guidance to check if you're eligible and how you can apply.</a></p></div><p>Search by keyword, action name or code if you know it. Use the filters to search by land types or areas of interest.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -1,32 +1,15 @@
 {
-  "target_stack": "live",
-  "content_id": "a37f6a22-af8a-465a-89df-de5a5b40b6d0",
   "base_path": "/flood-and-coastal-erosion-risk-management-research-reports",
-  "format_name": "Flood and Coastal Erosion Risk Management (FCERM) research report",
-  "name": "Flood and Coastal Erosion Risk Management (FCERM) research reports",
+  "content_id": "a37f6a22-af8a-465a-89df-de5a5b40b6d0",
   "description": "Find Flood and Coastal Erosion Risk Management (FCERM) research reports",
-  "filter": {
-    "format": "flood_and_coastal_erosion_risk_management_research_report"
-  },
-  "organisations": [
-    "6fc7e0f4-1322-4469-af66-abec10c26883"
-  ],
   "document_noun": "research report",
   "document_title": "Flood and Coastal Erosion Risk Management Research Report",
-  "signup_content_id": "0b3468bb-ccbe-4c97-9d94-870ae02e977d",
-  "subscription_list_title_prefix": "Flood and Coastal Erosion Risk Management research reports",
   "email_filter_options": {
-    "email_filter_by": "flood_and_coastal_erosion_category",
-    "downcase_email_alert_topic_names": true
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "flood_and_coastal_erosion_category"
   },
   "facets": [
     {
-      "key": "flood_and_coastal_erosion_category",
-      "name": "Category",
-      "type": "text",
-      "preposition": "with category",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Environmental management and sustainability",
@@ -53,17 +36,17 @@
           "value": "whole-life-asset-management"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "topics",
-      "name": "Topics",
-      "type": "text",
-      "preposition": "with topics",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "flood_and_coastal_erosion_category",
+      "name": "Category",
+      "preposition": "with category",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Adaptation",
@@ -294,17 +277,17 @@
           "value": "whole-life-costs"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "project_status",
-      "name": "Project status",
-      "type": "text",
-      "preposition": "with project status",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "topics",
+      "name": "Topics",
+      "preposition": "with topics",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Completed",
@@ -315,30 +298,47 @@
           "value": "ongoing"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "project_status",
+      "name": "Project status",
+      "preposition": "with project status",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "project_code",
       "name": "Project code",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "date_of_start",
       "name": "Date of start",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "date"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "date_of_completion",
       "name": "Date of completion",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "flood_and_coastal_erosion_risk_management_research_report"
+  },
+  "format_name": "Flood and Coastal Erosion Risk Management (FCERM) research report",
+  "name": "Flood and Coastal Erosion Risk Management (FCERM) research reports",
+  "organisations": [
+    "6fc7e0f4-1322-4469-af66-abec10c26883"
+  ],
+  "signup_content_id": "0b3468bb-ccbe-4c97-9d94-870ae02e977d",
+  "subscription_list_title_prefix": "Flood and Coastal Erosion Risk Management research reports",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -1,33 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "base_path": "/international-development-funding",
-  "format_name": "International development funding",
-  "name": "International development funding",
+  "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "description": "Find and apply for funds to run international development projects",
-  "summary": "<p>The funding finder tool is to help potential applicants to view, sort and filter UK Official Development Assistance (ODA) funding opportunities, across all UK government departments.</p><p>Each funding call will include a high level overview and information on how to apply.</p>",
-  "filter": {
-    "format": "international_development_fund"
-  },
-  "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
-  "show_summaries": true,
-  "organisations": [
-    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
-  ],
-  "taxons": [
-    "9fb30a53-70fb-4f1c-878b-0064b202d1ba"
-  ],
-  "subscription_list_title_prefix": "International development funds",
   "document_noun": "fund",
   "document_title": "International Development Fund",
   "facets": [
     {
-      "key": "fund_state",
-      "name": "Funds",
-      "type": "text",
-      "preposition": "which are",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Open",
@@ -38,818 +16,818 @@
           "value": "closed"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "location",
-      "name": "Countries",
-      "type": "text",
-      "preposition": "for",
       "display_as_result_metadata": true,
       "filterable": true,
-      "allowed_values": [
-        {
-          "value": "afghanistan",
-          "label": "Afghanistan"
-        },
-        {
-          "value": "albania",
-          "label": "Albania"
-        },
-        {
-          "value": "algeria",
-          "label": "Algeria"
-        },
-        {
-          "value": "andorra",
-          "label": "Andorra"
-        },
-        {
-          "value": "angola",
-          "label": "Angola"
-        },
-        {
-          "value": "antigua-and-barbuda",
-          "label": "Antigua and Barbuda"
-        },
-        {
-          "value": "argentina",
-          "label": "Argentina"
-        },
-        {
-          "value": "armenia",
-          "label": "Armenia"
-        },
-        {
-          "value": "australia",
-          "label": "Australia"
-        },
-        {
-          "value": "austria",
-          "label": "Austria"
-        },
-        {
-          "value": "azerbaijan",
-          "label": "Azerbaijan"
-        },
-        {
-          "value": "bahamas",
-          "label": "Bahamas, The"
-        },
-        {
-          "value": "bahrain",
-          "label": "Bahrain"
-        },
-        {
-          "value": "bangladesh",
-          "label": "Bangladesh"
-        },
-        {
-          "value": "barbados",
-          "label": "Barbados"
-        },
-        {
-          "value": "belarus",
-          "label": "Belarus"
-        },
-        {
-          "value": "belgium",
-          "label": "Belgium"
-        },
-        {
-          "value": "belize",
-          "label": "Belize"
-        },
-        {
-          "value": "benin",
-          "label": "Benin"
-        },
-        {
-          "value": "bhutan",
-          "label": "Bhutan"
-        },
-        {
-          "value": "bolivia",
-          "label": "Bolivia"
-        },
-        {
-          "value": "bosnia-and-herzegovina",
-          "label": "Bosnia and Herzegovina"
-        },
-        {
-          "value": "botswana",
-          "label": "Botswana"
-        },
-        {
-          "value": "brazil",
-          "label": "Brazil"
-        },
-        {
-          "value": "brunei",
-          "label": "Brunei"
-        },
-        {
-          "value": "bulgaria",
-          "label": "Bulgaria"
-        },
-        {
-          "value": "burkina-faso",
-          "label": "Burkina Faso"
-        },
-        {
-          "value": "burundi",
-          "label": "Burundi"
-        },
-        {
-          "value": "cambodia",
-          "label": "Cambodia"
-        },
-        {
-          "value": "cameroon",
-          "label": "Cameroon"
-        },
-        {
-          "value": "canada",
-          "label": "Canada"
-        },
-        {
-          "value": "cape-verde",
-          "label": "Cape Verde"
-        },
-        {
-          "value": "central-african-republic",
-          "label": "Central African Republic"
-        },
-        {
-          "value": "chad",
-          "label": "Chad"
-        },
-        {
-          "value": "chile",
-          "label": "Chile"
-        },
-        {
-          "value": "china",
-          "label": "China"
-        },
-        {
-          "value": "colombia",
-          "label": "Colombia"
-        },
-        {
-          "value": "comoros",
-          "label": "Comoros"
-        },
-        {
-          "value": "congo",
-          "label": "Congo"
-        },
-        {
-          "value": "democratic-republic-of-congo",
-          "label": "Congo (Democratic Republic)"
-        },
-        {
-          "value": "cook-islands",
-          "label": "Cook Islands"
-        },
-        {
-          "value": "costa-rica",
-          "label": "Costa Rica"
-        },
-        {
-          "value": "croatia",
-          "label": "Croatia"
-        },
-        {
-          "value": "cuba",
-          "label": "Cuba"
-        },
-        {
-          "value": "cyprus",
-          "label": "Cyprus"
-        },
-        {
-          "value": "czech-republic",
-          "label": "Czech Republic"
-        },
-        {
-          "value": "denmark",
-          "label": "Denmark"
-        },
-        {
-          "value": "djibouti",
-          "label": "Djibouti"
-        },
-        {
-          "value": "dominica",
-          "label": "Dominica"
-        },
-        {
-          "value": "dominican-republic",
-          "label": "Dominican Republic"
-        },
-        {
-          "value": "east-timor",
-          "label": "East Timor"
-        },
-        {
-          "value": "ecuador",
-          "label": "Ecuador"
-        },
-        {
-          "value": "egypt",
-          "label": "Egypt"
-        },
-        {
-          "value": "el-salvador",
-          "label": "El Salvador"
-        },
-        {
-          "value": "equatorial-guinea",
-          "label": "Equatorial Guinea"
-        },
-        {
-          "value": "eritrea",
-          "label": "Eritrea"
-        },
-        {
-          "value": "estonia",
-          "label": "Estonia"
-        },
-        {
-          "value": "ethiopia",
-          "label": "Ethiopia"
-        },
-        {
-          "value": "federated-states-of-micronesia",
-          "label": "Federated States of Micronesia"
-        },
-        {
-          "value": "fiji",
-          "label": "Fiji"
-        },
-        {
-          "value": "finland",
-          "label": "Finland"
-        },
-        {
-          "value": "france",
-          "label": "France"
-        },
-        {
-          "value": "gabon",
-          "label": "Gabon"
-        },
-        {
-          "value": "gambia",
-          "label": "Gambia, The"
-        },
-        {
-          "value": "georgia",
-          "label": "Georgia"
-        },
-        {
-          "value": "germany",
-          "label": "Germany"
-        },
-        {
-          "value": "ghana",
-          "label": "Ghana"
-        },
-        {
-          "value": "greece",
-          "label": "Greece"
-        },
-        {
-          "value": "grenada",
-          "label": "Grenada"
-        },
-        {
-          "value": "guatemala",
-          "label": "Guatemala"
-        },
-        {
-          "value": "guinea",
-          "label": "Guinea"
-        },
-        {
-          "value": "guinea-bissau",
-          "label": "Guinea-Bissau"
-        },
-        {
-          "value": "guyana",
-          "label": "Guyana"
-        },
-        {
-          "value": "haiti",
-          "label": "Haiti"
-        },
-        {
-          "value": "honduras",
-          "label": "Honduras"
-        },
-        {
-          "value": "hungary",
-          "label": "Hungary"
-        },
-        {
-          "value": "iceland",
-          "label": "Iceland"
-        },
-        {
-          "value": "india",
-          "label": "India"
-        },
-        {
-          "value": "indonesia",
-          "label": "Indonesia"
-        },
-        {
-          "value": "iran",
-          "label": "Iran"
-        },
-        {
-          "value": "iraq",
-          "label": "Iraq"
-        },
-        {
-          "value": "ireland",
-          "label": "Ireland"
-        },
-        {
-          "value": "israel",
-          "label": "Israel"
-        },
-        {
-          "value": "italy",
-          "label": "Italy"
-        },
-        {
-          "value": "cote-d-ivoire",
-          "label": "Ivory Coast"
-        },
-        {
-          "value": "jamaica",
-          "label": "Jamaica"
-        },
-        {
-          "value": "japan",
-          "label": "Japan"
-        },
-        {
-          "value": "jordan",
-          "label": "Jordan"
-        },
-        {
-          "value": "kazakhstan",
-          "label": "Kazakhstan"
-        },
-        {
-          "value": "kenya",
-          "label": "Kenya"
-        },
-        {
-          "value": "kiribati",
-          "label": "Kiribati"
-        },
-        {
-          "value": "kosovo",
-          "label": "Kosovo"
-        },
-        {
-          "value": "kuwait",
-          "label": "Kuwait"
-        },
-        {
-          "value": "kyrgyzstan",
-          "label": "Kyrgyzstan"
-        },
-        {
-          "value": "laos",
-          "label": "Laos"
-        },
-        {
-          "value": "latvia",
-          "label": "Latvia"
-        },
-        {
-          "value": "lebanon",
-          "label": "Lebanon"
-        },
-        {
-          "value": "lesotho",
-          "label": "Lesotho"
-        },
-        {
-          "value": "liberia",
-          "label": "Liberia"
-        },
-        {
-          "value": "libya",
-          "label": "Libya"
-        },
-        {
-          "value": "liechtenstein",
-          "label": "Liechtenstein"
-        },
-        {
-          "value": "lithuania",
-          "label": "Lithuania"
-        },
-        {
-          "value": "luxembourg",
-          "label": "Luxembourg"
-        },
-        {
-          "value": "madagascar",
-          "label": "Madagascar"
-        },
-        {
-          "value": "malawi",
-          "label": "Malawi"
-        },
-        {
-          "value": "malaysia",
-          "label": "Malaysia"
-        },
-        {
-          "value": "maldives",
-          "label": "Maldives"
-        },
-        {
-          "value": "mali",
-          "label": "Mali"
-        },
-        {
-          "value": "malta",
-          "label": "Malta"
-        },
-        {
-          "value": "marshall-islands",
-          "label": "Marshall Islands"
-        },
-        {
-          "value": "mauritania",
-          "label": "Mauritania"
-        },
-        {
-          "value": "mauritius",
-          "label": "Mauritius"
-        },
-        {
-          "value": "mexico",
-          "label": "Mexico"
-        },
-        {
-          "value": "moldova",
-          "label": "Moldova"
-        },
-        {
-          "value": "monaco",
-          "label": "Monaco"
-        },
-        {
-          "value": "mongolia",
-          "label": "Mongolia"
-        },
-        {
-          "value": "montenegro",
-          "label": "Montenegro"
-        },
-        {
-          "value": "morocco",
-          "label": "Morocco"
-        },
-        {
-          "value": "north-macedonia",
-          "label": "North Macedonia"
-        },
-        {
-          "value": "mozambique",
-          "label": "Mozambique"
-        },
-        {
-          "value": "myanmar",
-          "label": "Myanmar"
-        },
-        {
-          "value": "namibia",
-          "label": "Namibia"
-        },
-        {
-          "value": "nauru",
-          "label": "Nauru"
-        },
-        {
-          "value": "nepal",
-          "label": "Nepal"
-        },
-        {
-          "value": "netherlands",
-          "label": "Netherlands"
-        },
-        {
-          "value": "new-zealand",
-          "label": "New Zealand"
-        },
-        {
-          "value": "nicaragua",
-          "label": "Nicaragua"
-        },
-        {
-          "value": "niger",
-          "label": "Niger"
-        },
-        {
-          "value": "nigeria",
-          "label": "Nigeria"
-        },
-        {
-          "value": "north-korea",
-          "label": "North Korea"
-        },
-        {
-          "value": "norway",
-          "label": "Norway"
-        },
-        {
-          "value": "the-occupied-palestinian-territories",
-          "label": "Occupied Palestinian Territories, The"
-        },
-        {
-          "value": "oman",
-          "label": "Oman"
-        },
-        {
-          "value": "pakistan",
-          "label": "Pakistan"
-        },
-        {
-          "value": "palau",
-          "label": "Palau"
-        },
-        {
-          "value": "panama",
-          "label": "Panama"
-        },
-        {
-          "value": "papua-new-guinea",
-          "label": "Papua New Guinea"
-        },
-        {
-          "value": "paraguay",
-          "label": "Paraguay"
-        },
-        {
-          "value": "peru",
-          "label": "Peru"
-        },
-        {
-          "value": "philippines",
-          "label": "Philippines"
-        },
-        {
-          "value": "poland",
-          "label": "Poland"
-        },
-        {
-          "value": "portugal",
-          "label": "Portugal"
-        },
-        {
-          "value": "qatar",
-          "label": "Qatar"
-        },
-        {
-          "value": "romania",
-          "label": "Romania"
-        },
-        {
-          "value": "russia",
-          "label": "Russia"
-        },
-        {
-          "value": "rwanda",
-          "label": "Rwanda"
-        },
-        {
-          "value": "samoa",
-          "label": "Samoa"
-        },
-        {
-          "value": "san-marino",
-          "label": "San Marino"
-        },
-        {
-          "value": "sao-tome-and-principe",
-          "label": "Sao Tome and Principe"
-        },
-        {
-          "value": "saudi-arabia",
-          "label": "Saudi Arabia"
-        },
-        {
-          "value": "senegal",
-          "label": "Senegal"
-        },
-        {
-          "value": "serbia",
-          "label": "Serbia"
-        },
-        {
-          "value": "seychelles",
-          "label": "Seychelles"
-        },
-        {
-          "value": "sierra-leone",
-          "label": "Sierra Leone"
-        },
-        {
-          "value": "singapore",
-          "label": "Singapore"
-        },
-        {
-          "value": "slovakia",
-          "label": "Slovakia"
-        },
-        {
-          "value": "slovenia",
-          "label": "Slovenia"
-        },
-        {
-          "value": "solomon-islands",
-          "label": "Solomon Islands"
-        },
-        {
-          "value": "somalia",
-          "label": "Somalia"
-        },
-        {
-          "value": "south-africa",
-          "label": "South Africa"
-        },
-        {
-          "value": "south-korea",
-          "label": "South Korea"
-        },
-        {
-          "value": "south-sudan",
-          "label": "South Sudan"
-        },
-        {
-          "value": "spain",
-          "label": "Spain"
-        },
-        {
-          "value": "sri-lanka",
-          "label": "Sri Lanka"
-        },
-        {
-          "value": "st-kitts-and-nevis",
-          "label": "St Kitts and Nevis"
-        },
-        {
-          "value": "st-lucia",
-          "label": "St Lucia"
-        },
-        {
-          "value": "st-vincent",
-          "label": "St Vincent"
-        },
-        {
-          "value": "sudan",
-          "label": "Sudan"
-        },
-        {
-          "value": "suriname",
-          "label": "Suriname"
-        },
-        {
-          "value": "swaziland",
-          "label": "Swaziland"
-        },
-        {
-          "value": "sweden",
-          "label": "Sweden"
-        },
-        {
-          "value": "switzerland",
-          "label": "Switzerland"
-        },
-        {
-          "value": "syria",
-          "label": "Syria"
-        },
-        {
-          "value": "tajikistan",
-          "label": "Tajikistan"
-        },
-        {
-          "value": "tanzania",
-          "label": "Tanzania"
-        },
-        {
-          "value": "thailand",
-          "label": "Thailand"
-        },
-        {
-          "value": "togo",
-          "label": "Togo"
-        },
-        {
-          "value": "tonga",
-          "label": "Tonga"
-        },
-        {
-          "value": "trinidad-and-tobago",
-          "label": "Trinidad and Tobago"
-        },
-        {
-          "value": "tunisia",
-          "label": "Tunisia"
-        },
-        {
-          "value": "turkey",
-          "label": "Turkey"
-        },
-        {
-          "value": "turkmenistan",
-          "label": "Turkmenistan"
-        },
-        {
-          "value": "tuvalu",
-          "label": "Tuvalu"
-        },
-        {
-          "value": "uganda",
-          "label": "Uganda"
-        },
-        {
-          "value": "ukraine",
-          "label": "Ukraine"
-        },
-        {
-          "value": "united-arab-emirates",
-          "label": "United Arab Emirates"
-        },
-        {
-          "value": "united-kingdom",
-          "label": "United Kingdom"
-        },
-        {
-          "value": "united-states",
-          "label": "United States"
-        },
-        {
-          "value": "uruguay",
-          "label": "Uruguay"
-        },
-        {
-          "value": "uzbekistan",
-          "label": "Uzbekistan"
-        },
-        {
-          "value": "vanuatu",
-          "label": "Vanuatu"
-        },
-        {
-          "value": "vatican-city",
-          "label": "Vatican City"
-        },
-        {
-          "value": "venezuela",
-          "label": "Venezuela"
-        },
-        {
-          "value": "vietnam",
-          "label": "Vietnam"
-        },
-        {
-          "value": "yemen",
-          "label": "Yemen"
-        },
-        {
-          "value": "zambia",
-          "label": "Zambia"
-        },
-        {
-          "value": "zimbabwe",
-          "label": "Zimbabwe"
-        }
-      ],
+      "key": "fund_state",
+      "name": "Funds",
+      "preposition": "which are",
       "specialist_publisher_properties": {
-        "select": "multiple"
-      }
+        "select": "one"
+      },
+      "type": "text"
     },
     {
-      "key": "development_sector",
-      "name": "Sector",
-      "type": "text",
-      "preposition": "for",
-      "display_as_result_metadata": false,
+      "allowed_values": [
+        {
+          "label": "Afghanistan",
+          "value": "afghanistan"
+        },
+        {
+          "label": "Albania",
+          "value": "albania"
+        },
+        {
+          "label": "Algeria",
+          "value": "algeria"
+        },
+        {
+          "label": "Andorra",
+          "value": "andorra"
+        },
+        {
+          "label": "Angola",
+          "value": "angola"
+        },
+        {
+          "label": "Antigua and Barbuda",
+          "value": "antigua-and-barbuda"
+        },
+        {
+          "label": "Argentina",
+          "value": "argentina"
+        },
+        {
+          "label": "Armenia",
+          "value": "armenia"
+        },
+        {
+          "label": "Australia",
+          "value": "australia"
+        },
+        {
+          "label": "Austria",
+          "value": "austria"
+        },
+        {
+          "label": "Azerbaijan",
+          "value": "azerbaijan"
+        },
+        {
+          "label": "Bahamas, The",
+          "value": "bahamas"
+        },
+        {
+          "label": "Bahrain",
+          "value": "bahrain"
+        },
+        {
+          "label": "Bangladesh",
+          "value": "bangladesh"
+        },
+        {
+          "label": "Barbados",
+          "value": "barbados"
+        },
+        {
+          "label": "Belarus",
+          "value": "belarus"
+        },
+        {
+          "label": "Belgium",
+          "value": "belgium"
+        },
+        {
+          "label": "Belize",
+          "value": "belize"
+        },
+        {
+          "label": "Benin",
+          "value": "benin"
+        },
+        {
+          "label": "Bhutan",
+          "value": "bhutan"
+        },
+        {
+          "label": "Bolivia",
+          "value": "bolivia"
+        },
+        {
+          "label": "Bosnia and Herzegovina",
+          "value": "bosnia-and-herzegovina"
+        },
+        {
+          "label": "Botswana",
+          "value": "botswana"
+        },
+        {
+          "label": "Brazil",
+          "value": "brazil"
+        },
+        {
+          "label": "Brunei",
+          "value": "brunei"
+        },
+        {
+          "label": "Bulgaria",
+          "value": "bulgaria"
+        },
+        {
+          "label": "Burkina Faso",
+          "value": "burkina-faso"
+        },
+        {
+          "label": "Burundi",
+          "value": "burundi"
+        },
+        {
+          "label": "Cambodia",
+          "value": "cambodia"
+        },
+        {
+          "label": "Cameroon",
+          "value": "cameroon"
+        },
+        {
+          "label": "Canada",
+          "value": "canada"
+        },
+        {
+          "label": "Cape Verde",
+          "value": "cape-verde"
+        },
+        {
+          "label": "Central African Republic",
+          "value": "central-african-republic"
+        },
+        {
+          "label": "Chad",
+          "value": "chad"
+        },
+        {
+          "label": "Chile",
+          "value": "chile"
+        },
+        {
+          "label": "China",
+          "value": "china"
+        },
+        {
+          "label": "Colombia",
+          "value": "colombia"
+        },
+        {
+          "label": "Comoros",
+          "value": "comoros"
+        },
+        {
+          "label": "Congo",
+          "value": "congo"
+        },
+        {
+          "label": "Congo (Democratic Republic)",
+          "value": "democratic-republic-of-congo"
+        },
+        {
+          "label": "Cook Islands",
+          "value": "cook-islands"
+        },
+        {
+          "label": "Costa Rica",
+          "value": "costa-rica"
+        },
+        {
+          "label": "Croatia",
+          "value": "croatia"
+        },
+        {
+          "label": "Cuba",
+          "value": "cuba"
+        },
+        {
+          "label": "Cyprus",
+          "value": "cyprus"
+        },
+        {
+          "label": "Czech Republic",
+          "value": "czech-republic"
+        },
+        {
+          "label": "Denmark",
+          "value": "denmark"
+        },
+        {
+          "label": "Djibouti",
+          "value": "djibouti"
+        },
+        {
+          "label": "Dominica",
+          "value": "dominica"
+        },
+        {
+          "label": "Dominican Republic",
+          "value": "dominican-republic"
+        },
+        {
+          "label": "East Timor",
+          "value": "east-timor"
+        },
+        {
+          "label": "Ecuador",
+          "value": "ecuador"
+        },
+        {
+          "label": "Egypt",
+          "value": "egypt"
+        },
+        {
+          "label": "El Salvador",
+          "value": "el-salvador"
+        },
+        {
+          "label": "Equatorial Guinea",
+          "value": "equatorial-guinea"
+        },
+        {
+          "label": "Eritrea",
+          "value": "eritrea"
+        },
+        {
+          "label": "Estonia",
+          "value": "estonia"
+        },
+        {
+          "label": "Ethiopia",
+          "value": "ethiopia"
+        },
+        {
+          "label": "Federated States of Micronesia",
+          "value": "federated-states-of-micronesia"
+        },
+        {
+          "label": "Fiji",
+          "value": "fiji"
+        },
+        {
+          "label": "Finland",
+          "value": "finland"
+        },
+        {
+          "label": "France",
+          "value": "france"
+        },
+        {
+          "label": "Gabon",
+          "value": "gabon"
+        },
+        {
+          "label": "Gambia, The",
+          "value": "gambia"
+        },
+        {
+          "label": "Georgia",
+          "value": "georgia"
+        },
+        {
+          "label": "Germany",
+          "value": "germany"
+        },
+        {
+          "label": "Ghana",
+          "value": "ghana"
+        },
+        {
+          "label": "Greece",
+          "value": "greece"
+        },
+        {
+          "label": "Grenada",
+          "value": "grenada"
+        },
+        {
+          "label": "Guatemala",
+          "value": "guatemala"
+        },
+        {
+          "label": "Guinea",
+          "value": "guinea"
+        },
+        {
+          "label": "Guinea-Bissau",
+          "value": "guinea-bissau"
+        },
+        {
+          "label": "Guyana",
+          "value": "guyana"
+        },
+        {
+          "label": "Haiti",
+          "value": "haiti"
+        },
+        {
+          "label": "Honduras",
+          "value": "honduras"
+        },
+        {
+          "label": "Hungary",
+          "value": "hungary"
+        },
+        {
+          "label": "Iceland",
+          "value": "iceland"
+        },
+        {
+          "label": "India",
+          "value": "india"
+        },
+        {
+          "label": "Indonesia",
+          "value": "indonesia"
+        },
+        {
+          "label": "Iran",
+          "value": "iran"
+        },
+        {
+          "label": "Iraq",
+          "value": "iraq"
+        },
+        {
+          "label": "Ireland",
+          "value": "ireland"
+        },
+        {
+          "label": "Israel",
+          "value": "israel"
+        },
+        {
+          "label": "Italy",
+          "value": "italy"
+        },
+        {
+          "label": "Ivory Coast",
+          "value": "cote-d-ivoire"
+        },
+        {
+          "label": "Jamaica",
+          "value": "jamaica"
+        },
+        {
+          "label": "Japan",
+          "value": "japan"
+        },
+        {
+          "label": "Jordan",
+          "value": "jordan"
+        },
+        {
+          "label": "Kazakhstan",
+          "value": "kazakhstan"
+        },
+        {
+          "label": "Kenya",
+          "value": "kenya"
+        },
+        {
+          "label": "Kiribati",
+          "value": "kiribati"
+        },
+        {
+          "label": "Kosovo",
+          "value": "kosovo"
+        },
+        {
+          "label": "Kuwait",
+          "value": "kuwait"
+        },
+        {
+          "label": "Kyrgyzstan",
+          "value": "kyrgyzstan"
+        },
+        {
+          "label": "Laos",
+          "value": "laos"
+        },
+        {
+          "label": "Latvia",
+          "value": "latvia"
+        },
+        {
+          "label": "Lebanon",
+          "value": "lebanon"
+        },
+        {
+          "label": "Lesotho",
+          "value": "lesotho"
+        },
+        {
+          "label": "Liberia",
+          "value": "liberia"
+        },
+        {
+          "label": "Libya",
+          "value": "libya"
+        },
+        {
+          "label": "Liechtenstein",
+          "value": "liechtenstein"
+        },
+        {
+          "label": "Lithuania",
+          "value": "lithuania"
+        },
+        {
+          "label": "Luxembourg",
+          "value": "luxembourg"
+        },
+        {
+          "label": "Madagascar",
+          "value": "madagascar"
+        },
+        {
+          "label": "Malawi",
+          "value": "malawi"
+        },
+        {
+          "label": "Malaysia",
+          "value": "malaysia"
+        },
+        {
+          "label": "Maldives",
+          "value": "maldives"
+        },
+        {
+          "label": "Mali",
+          "value": "mali"
+        },
+        {
+          "label": "Malta",
+          "value": "malta"
+        },
+        {
+          "label": "Marshall Islands",
+          "value": "marshall-islands"
+        },
+        {
+          "label": "Mauritania",
+          "value": "mauritania"
+        },
+        {
+          "label": "Mauritius",
+          "value": "mauritius"
+        },
+        {
+          "label": "Mexico",
+          "value": "mexico"
+        },
+        {
+          "label": "Moldova",
+          "value": "moldova"
+        },
+        {
+          "label": "Monaco",
+          "value": "monaco"
+        },
+        {
+          "label": "Mongolia",
+          "value": "mongolia"
+        },
+        {
+          "label": "Montenegro",
+          "value": "montenegro"
+        },
+        {
+          "label": "Morocco",
+          "value": "morocco"
+        },
+        {
+          "label": "North Macedonia",
+          "value": "north-macedonia"
+        },
+        {
+          "label": "Mozambique",
+          "value": "mozambique"
+        },
+        {
+          "label": "Myanmar",
+          "value": "myanmar"
+        },
+        {
+          "label": "Namibia",
+          "value": "namibia"
+        },
+        {
+          "label": "Nauru",
+          "value": "nauru"
+        },
+        {
+          "label": "Nepal",
+          "value": "nepal"
+        },
+        {
+          "label": "Netherlands",
+          "value": "netherlands"
+        },
+        {
+          "label": "New Zealand",
+          "value": "new-zealand"
+        },
+        {
+          "label": "Nicaragua",
+          "value": "nicaragua"
+        },
+        {
+          "label": "Niger",
+          "value": "niger"
+        },
+        {
+          "label": "Nigeria",
+          "value": "nigeria"
+        },
+        {
+          "label": "North Korea",
+          "value": "north-korea"
+        },
+        {
+          "label": "Norway",
+          "value": "norway"
+        },
+        {
+          "label": "Occupied Palestinian Territories, The",
+          "value": "the-occupied-palestinian-territories"
+        },
+        {
+          "label": "Oman",
+          "value": "oman"
+        },
+        {
+          "label": "Pakistan",
+          "value": "pakistan"
+        },
+        {
+          "label": "Palau",
+          "value": "palau"
+        },
+        {
+          "label": "Panama",
+          "value": "panama"
+        },
+        {
+          "label": "Papua New Guinea",
+          "value": "papua-new-guinea"
+        },
+        {
+          "label": "Paraguay",
+          "value": "paraguay"
+        },
+        {
+          "label": "Peru",
+          "value": "peru"
+        },
+        {
+          "label": "Philippines",
+          "value": "philippines"
+        },
+        {
+          "label": "Poland",
+          "value": "poland"
+        },
+        {
+          "label": "Portugal",
+          "value": "portugal"
+        },
+        {
+          "label": "Qatar",
+          "value": "qatar"
+        },
+        {
+          "label": "Romania",
+          "value": "romania"
+        },
+        {
+          "label": "Russia",
+          "value": "russia"
+        },
+        {
+          "label": "Rwanda",
+          "value": "rwanda"
+        },
+        {
+          "label": "Samoa",
+          "value": "samoa"
+        },
+        {
+          "label": "San Marino",
+          "value": "san-marino"
+        },
+        {
+          "label": "Sao Tome and Principe",
+          "value": "sao-tome-and-principe"
+        },
+        {
+          "label": "Saudi Arabia",
+          "value": "saudi-arabia"
+        },
+        {
+          "label": "Senegal",
+          "value": "senegal"
+        },
+        {
+          "label": "Serbia",
+          "value": "serbia"
+        },
+        {
+          "label": "Seychelles",
+          "value": "seychelles"
+        },
+        {
+          "label": "Sierra Leone",
+          "value": "sierra-leone"
+        },
+        {
+          "label": "Singapore",
+          "value": "singapore"
+        },
+        {
+          "label": "Slovakia",
+          "value": "slovakia"
+        },
+        {
+          "label": "Slovenia",
+          "value": "slovenia"
+        },
+        {
+          "label": "Solomon Islands",
+          "value": "solomon-islands"
+        },
+        {
+          "label": "Somalia",
+          "value": "somalia"
+        },
+        {
+          "label": "South Africa",
+          "value": "south-africa"
+        },
+        {
+          "label": "South Korea",
+          "value": "south-korea"
+        },
+        {
+          "label": "South Sudan",
+          "value": "south-sudan"
+        },
+        {
+          "label": "Spain",
+          "value": "spain"
+        },
+        {
+          "label": "Sri Lanka",
+          "value": "sri-lanka"
+        },
+        {
+          "label": "St Kitts and Nevis",
+          "value": "st-kitts-and-nevis"
+        },
+        {
+          "label": "St Lucia",
+          "value": "st-lucia"
+        },
+        {
+          "label": "St Vincent",
+          "value": "st-vincent"
+        },
+        {
+          "label": "Sudan",
+          "value": "sudan"
+        },
+        {
+          "label": "Suriname",
+          "value": "suriname"
+        },
+        {
+          "label": "Swaziland",
+          "value": "swaziland"
+        },
+        {
+          "label": "Sweden",
+          "value": "sweden"
+        },
+        {
+          "label": "Switzerland",
+          "value": "switzerland"
+        },
+        {
+          "label": "Syria",
+          "value": "syria"
+        },
+        {
+          "label": "Tajikistan",
+          "value": "tajikistan"
+        },
+        {
+          "label": "Tanzania",
+          "value": "tanzania"
+        },
+        {
+          "label": "Thailand",
+          "value": "thailand"
+        },
+        {
+          "label": "Togo",
+          "value": "togo"
+        },
+        {
+          "label": "Tonga",
+          "value": "tonga"
+        },
+        {
+          "label": "Trinidad and Tobago",
+          "value": "trinidad-and-tobago"
+        },
+        {
+          "label": "Tunisia",
+          "value": "tunisia"
+        },
+        {
+          "label": "Turkey",
+          "value": "turkey"
+        },
+        {
+          "label": "Turkmenistan",
+          "value": "turkmenistan"
+        },
+        {
+          "label": "Tuvalu",
+          "value": "tuvalu"
+        },
+        {
+          "label": "Uganda",
+          "value": "uganda"
+        },
+        {
+          "label": "Ukraine",
+          "value": "ukraine"
+        },
+        {
+          "label": "United Arab Emirates",
+          "value": "united-arab-emirates"
+        },
+        {
+          "label": "United Kingdom",
+          "value": "united-kingdom"
+        },
+        {
+          "label": "United States",
+          "value": "united-states"
+        },
+        {
+          "label": "Uruguay",
+          "value": "uruguay"
+        },
+        {
+          "label": "Uzbekistan",
+          "value": "uzbekistan"
+        },
+        {
+          "label": "Vanuatu",
+          "value": "vanuatu"
+        },
+        {
+          "label": "Vatican City",
+          "value": "vatican-city"
+        },
+        {
+          "label": "Venezuela",
+          "value": "venezuela"
+        },
+        {
+          "label": "Vietnam",
+          "value": "vietnam"
+        },
+        {
+          "label": "Yemen",
+          "value": "yemen"
+        },
+        {
+          "label": "Zambia",
+          "value": "zambia"
+        },
+        {
+          "label": "Zimbabwe",
+          "value": "zimbabwe"
+        }
+      ],
+      "display_as_result_metadata": true,
       "filterable": true,
+      "key": "location",
+      "name": "Countries",
+      "preposition": "for",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Agriculture",
@@ -920,17 +898,17 @@
           "value": "water-and-sanitation"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "development_sector",
+      "name": "Sector",
+      "preposition": "for",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "eligible_entities",
-      "name": "Eligible organisations",
-      "type": "text",
-      "preposition": "open to",
-      "filterable": true,
-      "display_as_result_metadata": false,
       "allowed_values": [
         {
           "label": "Non-governmental organisations (NGOs)",
@@ -969,17 +947,17 @@
           "value": "organisations-lmic"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "value_of_funding",
-      "name": "Value of funding",
-      "type": "text",
-      "preposition": "with value",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "eligible_entities",
+      "name": "Eligible organisations",
+      "preposition": "open to",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Up to £10,000",
@@ -1002,9 +980,31 @@
           "value": "more-than-1000000"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "value_of_funding",
+      "name": "Value of funding",
+      "preposition": "with value",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "international_development_fund"
+  },
+  "format_name": "International development funding",
+  "name": "International development funding",
+  "organisations": [
+    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
+  "subscription_list_title_prefix": "International development funds",
+  "summary": "<p>The funding finder tool is to help potential applicants to view, sort and filter UK Official Development Assistance (ODA) funding opportunities, across all UK government departments.</p><p>Each funding call will include a high level overview and information on how to apply.</p>",
+  "target_stack": "live",
+  "taxons": [
+    "9fb30a53-70fb-4f1c-878b-0064b202d1ba"
   ]
 }

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -1,31 +1,12 @@
 {
-  "target_stack": "live",
-  "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
   "base_path": "/find-licences",
-  "format_name": "Find and apply for licences",
-  "name": "Find a licence",
-  "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul><div class='application-notice info-notice'><p>This may not include all the licences you need. It will be updated with more licences.</p></div>",
-  "description": "Find licences, permits or certifications you may need for yourself or your business.",
-  "label_text": "Search keywords <span class=\"govuk-!-display-block govuk-!-font-size-16 govuk-!-margin-bottom-2\">for example 'sell alcohol'</span>",
+  "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
   "default_order": "title",
-  "filter": {
-    "format": "licence_transaction"
-  },
-  "open_filter_on_load": true,
-  "show_summaries": true,
-  "organisations": [
-    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
-  ],
+  "description": "Find licences, permits or certifications you may need for yourself or your business.",
   "document_noun": "licence",
   "document_title": "Licence",
   "facets": [
     {
-      "key": "licence_transaction_location",
-      "name": "Location",
-      "type": "text",
-      "preposition": "In",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "England",
@@ -44,20 +25,17 @@
           "value": "northern-ireland"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "licence_transaction_industry",
-      "name": "Business or activity",
-      "type": "text",
-      "preposition": "For",
-      "show_option_select_filter": true,
       "display_as_result_metadata": false,
       "filterable": true,
-      "large": true,
-      "open_on_load": true,
+      "key": "licence_transaction_location",
+      "name": "Location",
+      "preposition": "In",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Advertising and marketing",
@@ -252,30 +230,52 @@
           "value": "veterinary"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "licence_transaction_industry",
+      "large": true,
+      "name": "Business or activity",
+      "open_on_load": true,
+      "preposition": "For",
+      "show_option_select_filter": true,
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "licence_transaction_will_continue_on",
       "name": "Will continue on",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "licence_transaction_continuation_link",
       "name": "Link to competent authority",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "licence_transaction_licence_identifier",
       "name": "Licence identifier",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "licence_transaction"
+  },
+  "format_name": "Find and apply for licences",
+  "label_text": "Search keywords <span class=\"govuk-!-display-block govuk-!-font-size-16 govuk-!-margin-bottom-2\">for example 'sell alcohol'</span>",
+  "name": "Find a licence",
+  "open_filter_on_load": true,
+  "organisations": [
+    "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+  ],
+  "show_summaries": true,
+  "summary": "<p>You may need a licence, permit or certification for:</p><ul><li>some business activities</li><li>other activities, such as street parties</li></ul><div class='application-notice info-notice'><p>This may not include all the licences you need. It will be updated with more licences.</p></div>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
+++ b/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
@@ -1,29 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "cfc808eb-1c34-49d1-bfbd-e14dcb2c6bbe",
   "base_path": "/service-life-saving-maritime-appliances",
-  "format_name": "Find a service station for your inflatable life-saving appliances (format)",
-  "name": "Find a service station for your inflatable life-saving appliances",
+  "content_id": "cfc808eb-1c34-49d1-bfbd-e14dcb2c6bbe",
   "description": "Find Maritime and Coastguard Agency-approved service stations for your inflatable life-saving equipment.",
-  "summary": "<p>UK approved service stations for International Convention for the Safety of Life at Sea (SOLAS)-standard inflatable life-saving appliances (LSAs).</p><p>Vessel owners need to ensure that their LSA is serviced at an approved service station that:</p><ul><li>is authorised to service the particular product make or type</li><li>is accepted by the Maritime and Coastguard Agency (MCA) and complies with International Maritime Organization (IMO) Resolution A.761(18) to maintain proper servicing facilities</li><li>uses only properly trained personnel and has evidence of personnel authorisation certification</li></ul><p>See <a href=\"https://www.gov.uk/government/publications/mgn-548-mf-inflatable-solas-certificated-liferafts-lifejackets-marine-evacuation-systems-and-repair-of-inflated-rescue-boats\">MGN 548 (M+F) Inflatable SOLAS certificated liferafts, lifejackets, marine evacuation systems and repair of inflated rescue boats</a> for more information.</p>",
-  "filter": {
-    "format": "life_saving_maritime_appliance_service_station"
-  },
-  "show_summaries": false,
-  "organisations": [
-    "23a24aa8-1711-42b6-bf6b-47af0f230295"
-  ],
   "document_noun": "station",
   "document_title": "Life Saving Maritime Appliance Service Station",
   "facets": [
     {
-      "key": "life_saving_maritime_appliance_service_station_regions",
-      "name": "Regions in the UK",
-      "short_name": "region",
-      "type": "text",
-      "preposition": "in region",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "East Anglia",
@@ -70,17 +52,18 @@
           "value": "northern-ireland"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "life_saving_maritime_appliance_type",
-      "name": "Appliance type",
-      "type": "text",
-      "preposition": "appliance",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "life_saving_maritime_appliance_service_station_regions",
+      "name": "Regions in the UK",
+      "preposition": "in region",
+      "short_name": "region",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Lifejackets",
@@ -99,17 +82,17 @@
           "value": "inflated-rescue-boats"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "life_saving_maritime_appliance_manufacturer",
-      "name": "Appliance manufacturer",
-      "type": "text",
-      "preposition": "manufactured by",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "life_saving_maritime_appliance_type",
+      "name": "Appliance type",
+      "preposition": "appliance",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Autoflug",
@@ -384,9 +367,26 @@
           "value": "zodiac"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "life_saving_maritime_appliance_manufacturer",
+      "name": "Appliance manufacturer",
+      "preposition": "manufactured by",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "life_saving_maritime_appliance_service_station"
+  },
+  "format_name": "Find a service station for your inflatable life-saving appliances (format)",
+  "name": "Find a service station for your inflatable life-saving appliances",
+  "organisations": [
+    "23a24aa8-1711-42b6-bf6b-47af0f230295"
+  ],
+  "show_summaries": false,
+  "summary": "<p>UK approved service stations for International Convention for the Safety of Life at Sea (SOLAS)-standard inflatable life-saving appliances (LSAs).</p><p>Vessel owners need to ensure that their LSA is serviced at an approved service station that:</p><ul><li>is authorised to service the particular product make or type</li><li>is accepted by the Maritime and Coastguard Agency (MCA) and complies with International Maritime Organization (IMO) Resolution A.761(18) to maintain proper servicing facilities</li><li>uses only properly trained personnel and has evidence of personnel authorisation certification</li></ul><p>See <a href=\"https://www.gov.uk/government/publications/mgn-548-mf-inflatable-solas-certificated-liferafts-lifejackets-marine-evacuation-systems-and-repair-of-inflated-rescue-boats\">MGN 548 (M+F) Inflatable SOLAS certificated liferafts, lifejackets, marine evacuation systems and repair of inflated rescue boats</a> for more information.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -1,36 +1,15 @@
 {
-  "target_stack": "live",
-  "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "base_path": "/maib-reports",
-  "format_name": "Marine Accident Investigation Branch report",
-  "name": "Marine Accident Investigation Branch reports",
+  "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "description": "Find reports of MAIB investigations into marine accidents and incidents",
-  "filter": {
-    "format": "maib_report"
-  },
-  "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
-  "show_summaries": true,
-  "organisations": [
-    "9c66b9a3-1e6a-48e8-974d-2a5635f84679"
-  ],
-  "taxons": [
-    "7a5e878e-2b0f-4c3f-9079-586590a1a194"
-  ],
-  "subscription_list_title_prefix": "Marine Accident Investigation Branch (MAIB) reports",
-  "email_filter_options": {
-    "email_filter_by": "vessel_type",
-    "downcase_email_alert_topic_names": true
-  },
   "document_noun": "report",
   "document_title": "MAIB Report",
+  "email_filter_options": {
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "vessel_type"
+  },
   "facets": [
     {
-      "key": "vessel_type",
-      "name": "Vessel type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Merchant vessel 100 gross tons or over",
@@ -53,17 +32,17 @@
           "value": "recreational-craft-power"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "report_type",
-      "name": "Report type",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "vessel_type",
+      "name": "Vessel type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Investigation report",
@@ -90,18 +69,39 @@
           "value": "discontinued-investigation"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "report_type",
+      "name": "Report type",
+      "preposition": "of type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
-      "short_name": "Occurred",
-      "type": "date",
       "preposition": "occurred",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Occurred",
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "maib_report"
+  },
+  "format_name": "Marine Accident Investigation Branch report",
+  "name": "Marine Accident Investigation Branch reports",
+  "organisations": [
+    "9c66b9a3-1e6a-48e8-974d-2a5635f84679"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
+  "subscription_list_title_prefix": "Marine Accident Investigation Branch (MAIB) reports",
+  "target_stack": "live",
+  "taxons": [
+    "7a5e878e-2b0f-4c3f-9079-586590a1a194"
   ]
 }

--- a/lib/documents/schemas/marine_equipment_approved_recommendations.json
+++ b/lib/documents/schemas/marine_equipment_approved_recommendations.json
@@ -1,41 +1,18 @@
 {
-  "target_stack": "live",
-  "content_id": "49f47764-2b1b-4b0d-9164-4aa6b42a8b63",
   "base_path": "/marine-equipment-approved-recommendations",
-  "format_name": "UK Approved Recommendations – Marine Equipment",
-  "name": "UK Approved Recommendations – Marine Equipment",
+  "content_id": "49f47764-2b1b-4b0d-9164-4aa6b42a8b63",
   "description": "Find recommendations on how to interpret and apply the Merchant Shipping (Marine Equipment) Regulations 2016 as amended.",
-  "filter": {
-    "format": "marine_equipment_approved_recommendation"
-  },
-  "show_summaries": true,
+  "document_noun": "recommendation",
+  "document_title": "Marine Equipment Approved Recommendation",
   "editing_organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"
   ],
-  "organisations": [
-    "23a24aa8-1711-42b6-bf6b-47af0f230295"
-  ],
-  "related": [
-    "9ac82e6a-0fb6-431f-85d8-560361e21d0b"
-  ],
-  "signup_content_id": "512a14c1-260a-4c4e-8de8-643eadf7905c",
   "email_filter_options": {
-    "email_filter_by": "all_selected_facets",
-    "downcase_email_alert_topic_names": true
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "all_selected_facets"
   },
-  "subscription_list_title_prefix": "UK Approved Recommendations for marine equipment",
-  "summary": "<p>Find recommendations on how to interpret and apply the Merchant Shipping (Marine Equipment) Regulations 2016 as amended.</p>",
-  "document_noun": "recommendation",
-  "document_title": "Marine Equipment Approved Recommendation",
   "facets": [
     {
-      "key": "category",
-      "name": "Category",
-      "short_name": "Recommendation type",
-      "type": "text",
-      "preposition": "With recommendation type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Life-saving appliances",
@@ -74,36 +51,59 @@
           "value": "general"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "category",
+      "name": "Category",
+      "preposition": "With recommendation type",
+      "short_name": "Recommendation type",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "year_adopted",
       "name": "Year adopted",
-      "short_name": "Year",
-      "type": "text",
       "preposition": "With year",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "short_name": "Year",
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "reference_number",
       "name": "Reference number",
-      "short_name": "Reference",
-      "type": "text",
       "preposition": "With reference",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "short_name": "Reference",
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "keyword",
       "name": "Keyword",
-      "short_name": "Keyword",
-      "type": "text",
       "preposition": "With keyword",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "short_name": "Keyword",
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "marine_equipment_approved_recommendation"
+  },
+  "format_name": "UK Approved Recommendations – Marine Equipment",
+  "name": "UK Approved Recommendations – Marine Equipment",
+  "organisations": [
+    "23a24aa8-1711-42b6-bf6b-47af0f230295"
+  ],
+  "related": [
+    "9ac82e6a-0fb6-431f-85d8-560361e21d0b"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "512a14c1-260a-4c4e-8de8-643eadf7905c",
+  "subscription_list_title_prefix": "UK Approved Recommendations for marine equipment",
+  "summary": "<p>Find recommendations on how to interpret and apply the Merchant Shipping (Marine Equipment) Regulations 2016 as amended.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/marine_notices.json
+++ b/lib/documents/schemas/marine_notices.json
@@ -1,29 +1,11 @@
 {
-  "target_stack": "draft",
-  "content_id": "d7df3371-2f1a-4307-9aad-a2ef8fa8b9c4",
   "base_path": "/marine-notices",
-  "format_name": "Maritime and Coastguard Agency Marine Notice",
-  "name": "Maritime and Coastguard Agency Marine Notices",
+  "content_id": "d7df3371-2f1a-4307-9aad-a2ef8fa8b9c4",
   "description": "Find marine notices issued by the Marine and Coastguard Agency",
-  "filter": {
-    "format": "marine_notice"
-  },
-  "signup_content_id": "21985d9f-8c84-4fa1-915c-2807eaa37dff",
-  "organisations": [
-    "23a24aa8-1711-42b6-bf6b-47af0f230295"
-  ],
-  "subscription_list_title_prefix": "Marine notices",
-  "summary": "<p>Find marine notices issued by the Maritime and Coastguard Agency</p>",
   "document_noun": "notice",
   "document_title": "Marine Notice",
   "facets": [
     {
-      "key": "marine_notice_type",
-      "name": "Marine notice type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Marine Guidance Note (MGN)",
@@ -58,17 +40,17 @@
           "value": "other"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "marine_notice_vessel_type",
-      "name": "Vessel type",
-      "type": "text",
-      "preposition": "with vessel of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "marine_notice_type",
+      "name": "Marine notice type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Pleasure vessels",
@@ -107,17 +89,17 @@
           "value": "passenger-vessels"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "marine_notice_topic",
-      "name": "Topic",
-      "type": "text",
-      "preposition": "with topic of",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "marine_notice_vessel_type",
+      "name": "Vessel type",
+      "preposition": "with vessel of type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Construction and equipment",
@@ -156,18 +138,36 @@
           "value": "survey-and-inspection"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "marine_notice_topic",
+      "name": "Topic",
+      "preposition": "with topic of",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "issued_date",
       "name": "Issued",
-      "short_name": "Issued",
-      "type": "date",
       "preposition": "issued",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Issued",
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "marine_notice"
+  },
+  "format_name": "Maritime and Coastguard Agency Marine Notice",
+  "name": "Maritime and Coastguard Agency Marine Notices",
+  "organisations": [
+    "23a24aa8-1711-42b6-bf6b-47af0f230295"
+  ],
+  "signup_content_id": "21985d9f-8c84-4fa1-915c-2807eaa37dff",
+  "subscription_list_title_prefix": "Marine notices",
+  "summary": "<p>Find marine notices issued by the Maritime and Coastguard Agency</p>",
+  "target_stack": "draft"
 }

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -1,31 +1,12 @@
 {
-  "target_stack": "live",
-  "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "base_path": "/drug-device-alerts",
-  "format_name": "Medical safety alert",
-  "name": "Alerts, recalls and safety information: medicines and medical devices",
+  "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "description": "Find alerts and recalls issued by MHRA",
-  "filter": {
-    "format": "medical_safety_alert"
-  },
-  "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
-  "show_summaries": true,
-  "organisations": [
-    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
-  ],
-  "taxons": [
-    "51bbdf23-292a-4b74-8a66-f7db6b93b163"
-  ],
-  "related": [
-    "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"
-  ],
-  "topics": [
-    "medicines-medical-devices-blood/medical-devices-regulation-safety",
-    "medicines-medical-devices-blood/vigilance-safety-alerts"
-  ],
+  "document_noun": "message",
+  "document_title": "Medical Safety Alert",
   "email_filter_options": {
-    "email_filter_by": "alert_type",
     "downcase_email_alert_topic_names": true,
+    "email_filter_by": "alert_type",
     "pre_checked_email_alert_checkboxes": [
       "field-safety-notices",
       "national-patient-safety",
@@ -33,16 +14,8 @@
       "medicines-recall-notification"
     ]
   },
-  "document_noun": "message",
-  "document_title": "Medical Safety Alert",
   "facets": [
     {
-      "key": "alert_type",
-      "name": "Message type",
-      "type": "text",
-      "preposition": "for",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Field safety notice",
@@ -61,17 +34,17 @@
           "value": "medicines-recall-notification"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "medical_specialism",
-      "name": "Medical specialty",
-      "type": "text",
-      "preposition": "about",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "alert_type",
+      "name": "Message type",
+      "preposition": "for",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Anaesthetics",
@@ -166,18 +139,45 @@
           "value": "vascular-cardiac-surgery"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "medical_specialism",
+      "name": "Medical specialty",
+      "preposition": "about",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "issued_date",
       "name": "Issued",
-      "short_name": "Issued",
-      "type": "date",
       "preposition": "issued",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Issued",
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "medical_safety_alert"
+  },
+  "format_name": "Medical safety alert",
+  "name": "Alerts, recalls and safety information: medicines and medical devices",
+  "organisations": [
+    "240f72bd-9a4d-4f39-94d9-77235cadde8e"
+  ],
+  "related": [
+    "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
+  "target_stack": "live",
+  "taxons": [
+    "51bbdf23-292a-4b74-8a66-f7db6b93b163"
+  ],
+  "topics": [
+    "medicines-medical-devices-blood/medical-devices-regulation-safety",
+    "medicines-medical-devices-blood/vigilance-safety-alerts"
   ]
 }

--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -1,32 +1,15 @@
 {
-  "target_stack": "live",
-  "content_id": "a22b3f1f-2c91-49a1-a469-ff21d465c543",
   "base_path": "/product-safety-alerts-reports-recalls",
-  "format_name": "Product Safety Alerts, Reports and Recalls",
-  "name": "Product Safety Alerts, Reports and Recalls",
+  "content_id": "a22b3f1f-2c91-49a1-a469-ff21d465c543",
   "description": "Find product safety alerts, unsafe products and recalls",
-  "filter": {
-    "format": "product_safety_alert_report_recall"
-  },
-  "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
-  "organisations": [
-    "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
-  ],
-  "email_filter_options": {
-    "email_filter_by": "product_alert_type",
-    "downcase_email_alert_topic_names": true
-  },
   "document_noun": "report",
   "document_title": "Product Safety Alerts, Reports and Recalls",
+  "email_filter_options": {
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "product_alert_type"
+  },
   "facets": [
     {
-      "key": "product_alert_type",
-      "name": "Alert type",
-      "short_name": "Alert type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Product safety alert",
@@ -41,18 +24,18 @@
           "value": "product-recall"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "product_risk_level",
-      "name": "Risk level",
-      "short_name": "Risk level",
-      "type": "text",
-      "preposition": "that are",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "product_alert_type",
+      "name": "Alert type",
+      "preposition": "of type",
+      "short_name": "Alert type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Serious",
@@ -75,17 +58,18 @@
           "value": "not-provided"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "product_category",
-      "name": "Product category",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "product_risk_level",
+      "name": "Risk level",
+      "preposition": "that are",
+      "short_name": "Risk level",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Adaptors, Plugs and Sockets",
@@ -216,18 +200,17 @@
           "value": "toys"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "product_measure_type",
-      "name": "Measure type",
-      "short_name": "Measure type",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "product_category",
+      "name": "Product category",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Ban on the marketing of the product and any accompanying measures",
@@ -278,18 +261,35 @@
           "value": "other"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "product_measure_type",
+      "name": "Measure type",
+      "preposition": "of type",
+      "short_name": "Measure type",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "product_recall_alert_date",
       "name": "Recall/alert date",
-      "short_name": "Recall/alert date",
-      "type": "date",
       "preposition": "recalled/alerted",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Recall/alert date",
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "product_safety_alert_report_recall"
+  },
+  "format_name": "Product Safety Alerts, Reports and Recalls",
+  "name": "Product Safety Alerts, Reports and Recalls",
+  "organisations": [
+    "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
+  ],
+  "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -1,37 +1,18 @@
 {
-  "target_stack": "live",
-  "content_id": "9018138a-0ca5-4a35-8b7c-3a7f39dc56f8",
   "base_path": "/protected-food-drink-names",
-  "format_name": "Protected geographical food and drink name",
-  "name": "Protected geographical food and drink names",
+  "content_id": "9018138a-0ca5-4a35-8b7c-3a7f39dc56f8",
   "description": "Find protected food and drink names in the official GB registers published by Defra.",
-  "filter": {
-    "format": "protected_food_drink_name"
-  },
-  "show_summaries": true,
-  "signup_content_id": "cff7449e-4181-480f-93e4-91fecfb4c774",
-  "organisations": [
-    "de4e9dc6-cca4-43af-a594-682023b84d6c"
-  ],
-  "subscription_list_title_prefix": "Protected geographical food and drink names",
-  "summary": "<p>Find protected food and drink names in the official GB registers published by Defra. Find out more about the <a href=\"https://www.gov.uk/guidance/protected-geographical-food-and-drink-names-uk-gi-schemes\">UK’s protected food and drinks schemes</a>.</p>",
   "document_noun": "name",
   "document_title": "Protected Geographical Food and Drink Name",
   "facets": [
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "registered_name",
       "name": "Registered name",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "text"
     },
     {
-      "key": "register",
-      "name": "Register",
-      "type": "text",
-      "preposition": "register type",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Foods: designated origin and geographical indication",
@@ -62,17 +43,17 @@
           "value": "american-viticultural-areas"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "register",
+      "name": "Register",
+      "preposition": "register type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "status",
-      "name": "Status",
-      "type": "text",
-      "preposition": "status",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Registered",
@@ -95,18 +76,17 @@
           "value": "cancelled"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "status",
+      "name": "Status",
+      "preposition": "status",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "class_category",
-      "name": "Class or category of product",
-      "short_name": "Class or category",
-      "type": "text",
-      "preposition": "class or category",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "No class or category",
@@ -473,17 +453,18 @@
           "value": "spirit-drink"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "protection_type",
-      "name": "Protection type",
-      "type": "text",
-      "preposition": "protection type",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "class_category",
+      "name": "Class or category of product",
+      "preposition": "class or category",
+      "short_name": "Class or category",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Protected Geographical Indication (PGI)",
@@ -514,17 +495,17 @@
           "value": "american-viticultural-area"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "protection_type",
+      "name": "Protection type",
+      "preposition": "protection type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "country_of_origin",
-      "name": "Country of origin",
-      "type": "text",
-      "preposition": "country of origin",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "United Kingdom",
@@ -815,17 +796,17 @@
           "value": "vietnam"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "country_of_origin",
+      "name": "Country of origin",
+      "preposition": "country of origin",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "traditional_term_grapevine_product_category",
-      "name": "Traditional term grapevine product category",
-      "short_name": "Grapevine product category",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false,
       "allowed_values": [
         {
           "label": "Wine",
@@ -896,16 +877,17 @@
           "value": "wine-vinegar"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "traditional_term_type",
-      "name": "Traditional term type",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "traditional_term_grapevine_product_category",
+      "name": "Traditional term grapevine product category",
+      "short_name": "Grapevine product category",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Description of product characteristic",
@@ -916,16 +898,16 @@
           "value": "in-place-of-pdo-pgi"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "traditional_term_language",
-      "name": "Traditional term language",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "traditional_term_type",
+      "name": "Traditional term type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Bulgarian",
@@ -1028,44 +1010,44 @@
           "value": "swedish"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "date_application",
-      "name": "Date of application",
-      "type": "date",
-      "display_as_result_metadata": false,
-      "filterable": false
-    },
-    {
-      "key": "date_registration",
-      "name": "Date of registration (UK scheme)",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
-      "key": "time_registration",
-      "name": "Time of registration (UK scheme)",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
-    },
-    {
-      "key": "date_registration_eu",
-      "name": "Date of original registration with the EU",
-      "type": "date",
-      "display_as_result_metadata": false,
-      "filterable": false
-    },
-    {
-      "key": "reason_for_protection",
-      "name": "Reason for protection",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "traditional_term_language",
+      "name": "Traditional term language",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "key": "date_application",
+      "name": "Date of application",
+      "type": "date"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "date_registration",
+      "name": "Date of registration (UK scheme)",
+      "type": "date"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "time_registration",
+      "name": "Time of registration (UK scheme)",
+      "type": "text"
+    },
+    {
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "key": "date_registration_eu",
+      "name": "Date of original registration with the EU",
+      "type": "date"
+    },
+    {
       "allowed_values": [
         {
           "label": "UK geographical indication from before 2021",
@@ -1084,16 +1066,34 @@
           "value": "uk-gi-after-2021"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": false,
+      "key": "reason_for_protection",
+      "name": "Reason for protection",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "internal_notes",
       "name": "Internal notes",
-      "type": "text",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "protected_food_drink_name"
+  },
+  "format_name": "Protected geographical food and drink name",
+  "name": "Protected geographical food and drink names",
+  "organisations": [
+    "de4e9dc6-cca4-43af-a594-682023b84d6c"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "cff7449e-4181-480f-93e4-91fecfb4c774",
+  "subscription_list_title_prefix": "Protected geographical food and drink names",
+  "summary": "<p>Find protected food and drink names in the official GB registers published by Defra. Find out more about the <a href=\"https://www.gov.uk/guidance/protected-geographical-food-and-drink-names-uk-gi-schemes\">UK’s protected food and drinks schemes</a>.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -1,36 +1,15 @@
 {
-  "target_stack": "live",
-  "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "base_path": "/raib-reports",
-  "format_name": "Rail Accident Investigation Branch report",
-  "name": "Rail Accident Investigation Branch reports",
+  "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "description": "Find reports of RAIB investigations into rail accidents and incidents",
-  "filter": {
-    "format": "raib_report"
-  },
-  "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
-  "show_summaries": true,
-  "organisations": [
-    "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
-  ],
-  "taxons": [
-    "c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7"
-  ],
-  "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports",
-  "email_filter_options": {
-    "email_filter_by": "railway_type",
-    "downcase_email_alert_topic_names": true
-  },
   "document_noun": "report",
   "document_title": "RAIB Report",
+  "email_filter_options": {
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "railway_type"
+  },
   "facets": [
     {
-      "key": "railway_type",
-      "name": "Railway type",
-      "type": "text",
-      "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Heavy rail",
@@ -49,17 +28,17 @@
           "value": "heritage-railways"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "report_type",
-      "name": "Report type",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "railway_type",
+      "name": "Railway type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Investigation report",
@@ -82,18 +61,39 @@
           "value": "safety-digest"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "report_type",
+      "name": "Report type",
+      "preposition": "of type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
-      "short_name": "Occurred",
-      "type": "date",
       "preposition": "occurred",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "short_name": "Occurred",
+      "type": "date"
     }
+  ],
+  "filter": {
+    "format": "raib_report"
+  },
+  "format_name": "Rail Accident Investigation Branch report",
+  "name": "Rail Accident Investigation Branch reports",
+  "organisations": [
+    "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
+  "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports",
+  "target_stack": "live",
+  "taxons": [
+    "c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7"
   ]
 }

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -1,1001 +1,1001 @@
 {
-  "target_stack": "live",
-  "content_id": "853596e7-8ae3-42bd-838b-25ca3076e35f",
   "base_path": "/research-for-development-outputs",
-  "format_name": "Research for Development Output",
-  "name": "Research for Development Outputs",
+  "content_id": "853596e7-8ae3-42bd-838b-25ca3076e35f",
   "description": "Find outputs from Research for Development projects",
-  "summary": "<p>Research outputs published before 2 September 2020 were published by the Department for International Development (DFID)</p>",
-  "filter": {
-    "format": "research_for_development_output"
-  },
-  "signup_content_id": "fdcbada2-1ad4-4194-98dc-5f04a448316e",
-  "organisations": [
-    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
-  ],
-  "taxons": [
-    "9fb30a53-70fb-4f1c-878b-0064b202d1ba"
-  ],
-  "subscription_list_title_prefix": "Research for Development output",
   "document_noun": "output",
   "document_title": "Research for Development Output",
   "facets": [
     {
+      "allowed_values": [
+        {
+          "label": "Afghanistan",
+          "value": "AF"
+        },
+        {
+          "label": "Albania",
+          "value": "AL"
+        },
+        {
+          "label": "Algeria",
+          "value": "DZ"
+        },
+        {
+          "label": "Andorra",
+          "value": "AD"
+        },
+        {
+          "label": "Angola",
+          "value": "AO"
+        },
+        {
+          "label": "Antigua and Barbuda",
+          "value": "AG"
+        },
+        {
+          "label": "Argentina",
+          "value": "AR"
+        },
+        {
+          "label": "Armenia",
+          "value": "AM"
+        },
+        {
+          "label": "Australia",
+          "value": "AU"
+        },
+        {
+          "label": "Austria",
+          "value": "AT"
+        },
+        {
+          "label": "Azerbaijan",
+          "value": "AZ"
+        },
+        {
+          "label": "Bahamas, The",
+          "value": "BS"
+        },
+        {
+          "label": "Bahrain",
+          "value": "BH"
+        },
+        {
+          "label": "Bangladesh",
+          "value": "BD"
+        },
+        {
+          "label": "Barbados",
+          "value": "BB"
+        },
+        {
+          "label": "Belarus",
+          "value": "BY"
+        },
+        {
+          "label": "Belgium",
+          "value": "BE"
+        },
+        {
+          "label": "Belize",
+          "value": "BZ"
+        },
+        {
+          "label": "Benin",
+          "value": "BJ"
+        },
+        {
+          "label": "Bhutan",
+          "value": "BT"
+        },
+        {
+          "label": "Bolivia",
+          "value": "BO"
+        },
+        {
+          "label": "Bosnia and Herzegovina",
+          "value": "BA"
+        },
+        {
+          "label": "Botswana",
+          "value": "BW"
+        },
+        {
+          "label": "Brazil",
+          "value": "BR"
+        },
+        {
+          "label": "Brunei",
+          "value": "BN"
+        },
+        {
+          "label": "Bulgaria",
+          "value": "BG"
+        },
+        {
+          "label": "Burkina Faso",
+          "value": "BF"
+        },
+        {
+          "label": "Burma",
+          "value": "MM"
+        },
+        {
+          "label": "Burundi",
+          "value": "BI"
+        },
+        {
+          "label": "Cambodia",
+          "value": "KH"
+        },
+        {
+          "label": "Cameroon",
+          "value": "CM"
+        },
+        {
+          "label": "Canada",
+          "value": "CA"
+        },
+        {
+          "label": "Cape Verde",
+          "value": "CV"
+        },
+        {
+          "label": "Central African Republic",
+          "value": "CF"
+        },
+        {
+          "label": "Chad",
+          "value": "TD"
+        },
+        {
+          "label": "Chile",
+          "value": "CL"
+        },
+        {
+          "label": "China",
+          "value": "CN"
+        },
+        {
+          "label": "Colombia",
+          "value": "CO"
+        },
+        {
+          "label": "Comoros",
+          "value": "KM"
+        },
+        {
+          "label": "Congo",
+          "value": "CG"
+        },
+        {
+          "label": "Congo (Democratic Republic)",
+          "value": "CD"
+        },
+        {
+          "label": "Cook Islands",
+          "value": "CK"
+        },
+        {
+          "label": "Costa Rica",
+          "value": "CR"
+        },
+        {
+          "label": "Croatia",
+          "value": "HR"
+        },
+        {
+          "label": "Cuba",
+          "value": "CU"
+        },
+        {
+          "label": "Cyprus",
+          "value": "CY"
+        },
+        {
+          "label": "Czech Republic",
+          "value": "CZ"
+        },
+        {
+          "label": "Denmark",
+          "value": "DK"
+        },
+        {
+          "label": "Djibouti",
+          "value": "DJ"
+        },
+        {
+          "label": "Dominica",
+          "value": "DM"
+        },
+        {
+          "label": "Dominican Republic",
+          "value": "DO"
+        },
+        {
+          "label": "East Timor",
+          "value": "TL"
+        },
+        {
+          "label": "Ecuador",
+          "value": "EC"
+        },
+        {
+          "label": "Egypt",
+          "value": "EG"
+        },
+        {
+          "label": "El Salvador",
+          "value": "SV"
+        },
+        {
+          "label": "Equatorial Guinea",
+          "value": "GQ"
+        },
+        {
+          "label": "Eritrea",
+          "value": "ER"
+        },
+        {
+          "label": "Estonia",
+          "value": "EE"
+        },
+        {
+          "label": "Ethiopia",
+          "value": "ET"
+        },
+        {
+          "label": "Federated States of Micronesia",
+          "value": "FS"
+        },
+        {
+          "label": "Fiji",
+          "value": "FJ"
+        },
+        {
+          "label": "Finland",
+          "value": "FI"
+        },
+        {
+          "label": "France",
+          "value": "FR"
+        },
+        {
+          "label": "Gabon",
+          "value": "GA"
+        },
+        {
+          "label": "Gambia, The",
+          "value": "GM"
+        },
+        {
+          "label": "Georgia",
+          "value": "GE"
+        },
+        {
+          "label": "Germany",
+          "value": "DE"
+        },
+        {
+          "label": "Ghana",
+          "value": "GH"
+        },
+        {
+          "label": "Greece",
+          "value": "GR"
+        },
+        {
+          "label": "Grenada",
+          "value": "GD"
+        },
+        {
+          "label": "Guatemala",
+          "value": "GT"
+        },
+        {
+          "label": "Guinea",
+          "value": "GN"
+        },
+        {
+          "label": "Guinea-Bissau",
+          "value": "GW"
+        },
+        {
+          "label": "Guyana",
+          "value": "GY"
+        },
+        {
+          "label": "Haiti",
+          "value": "HT"
+        },
+        {
+          "label": "Honduras",
+          "value": "HN"
+        },
+        {
+          "label": "Hungary",
+          "value": "HU"
+        },
+        {
+          "label": "Iceland",
+          "value": "IS"
+        },
+        {
+          "label": "India",
+          "value": "IN"
+        },
+        {
+          "label": "Indonesia",
+          "value": "ID"
+        },
+        {
+          "label": "Iran",
+          "value": "IR"
+        },
+        {
+          "label": "Iraq",
+          "value": "IQ"
+        },
+        {
+          "label": "Ireland",
+          "value": "IE"
+        },
+        {
+          "label": "Israel",
+          "value": "IL"
+        },
+        {
+          "label": "Italy",
+          "value": "IT"
+        },
+        {
+          "label": "Ivory Coast",
+          "value": "CI"
+        },
+        {
+          "label": "Jamaica",
+          "value": "JM"
+        },
+        {
+          "label": "Japan",
+          "value": "JP"
+        },
+        {
+          "label": "Jordan",
+          "value": "JO"
+        },
+        {
+          "label": "Kazakhstan",
+          "value": "KZ"
+        },
+        {
+          "label": "Kenya",
+          "value": "KE"
+        },
+        {
+          "label": "Kiribati",
+          "value": "KI"
+        },
+        {
+          "label": "Kosovo",
+          "value": "XK"
+        },
+        {
+          "label": "Kuwait",
+          "value": "KW"
+        },
+        {
+          "label": "Kyrgyzstan",
+          "value": "KG"
+        },
+        {
+          "label": "Laos",
+          "value": "LA"
+        },
+        {
+          "label": "Latvia",
+          "value": "LV"
+        },
+        {
+          "label": "Lebanon",
+          "value": "LB"
+        },
+        {
+          "label": "Lesotho",
+          "value": "LS"
+        },
+        {
+          "label": "Liberia",
+          "value": "LR"
+        },
+        {
+          "label": "Libya",
+          "value": "LY"
+        },
+        {
+          "label": "Liechtenstein",
+          "value": "LI"
+        },
+        {
+          "label": "Lithuania",
+          "value": "LT"
+        },
+        {
+          "label": "Luxembourg",
+          "value": "LU"
+        },
+        {
+          "label": "North Macedonia",
+          "value": "MK"
+        },
+        {
+          "label": "Madagascar",
+          "value": "MG"
+        },
+        {
+          "label": "Malawi",
+          "value": "MW"
+        },
+        {
+          "label": "Malaysia",
+          "value": "MY"
+        },
+        {
+          "label": "Maldives",
+          "value": "MV"
+        },
+        {
+          "label": "Mali",
+          "value": "ML"
+        },
+        {
+          "label": "Malta",
+          "value": "MT"
+        },
+        {
+          "label": "Marshall Islands",
+          "value": "MH"
+        },
+        {
+          "label": "Mauritania",
+          "value": "MR"
+        },
+        {
+          "label": "Mauritius",
+          "value": "MU"
+        },
+        {
+          "label": "Mexico",
+          "value": "MX"
+        },
+        {
+          "label": "Moldova",
+          "value": "MD"
+        },
+        {
+          "label": "Monaco",
+          "value": "MC"
+        },
+        {
+          "label": "Mongolia",
+          "value": "MN"
+        },
+        {
+          "label": "Montenegro",
+          "value": "ME"
+        },
+        {
+          "label": "Morocco",
+          "value": "MA"
+        },
+        {
+          "label": "Mozambique",
+          "value": "MZ"
+        },
+        {
+          "label": "Namibia",
+          "value": "NA"
+        },
+        {
+          "label": "Nauru",
+          "value": "NR"
+        },
+        {
+          "label": "Nepal",
+          "value": "NP"
+        },
+        {
+          "label": "Netherlands",
+          "value": "NL"
+        },
+        {
+          "label": "New Zealand",
+          "value": "NZ"
+        },
+        {
+          "label": "Nicaragua",
+          "value": "NI"
+        },
+        {
+          "label": "Niger",
+          "value": "NE"
+        },
+        {
+          "label": "Nigeria",
+          "value": "NG"
+        },
+        {
+          "label": "North Korea",
+          "value": "KP"
+        },
+        {
+          "label": "Norway",
+          "value": "NO"
+        },
+        {
+          "label": "Oman",
+          "value": "OM"
+        },
+        {
+          "label": "Pakistan",
+          "value": "PK"
+        },
+        {
+          "label": "Palau",
+          "value": "PW"
+        },
+        {
+          "label": "Panama",
+          "value": "PA"
+        },
+        {
+          "label": "Papua New Guinea",
+          "value": "PG"
+        },
+        {
+          "label": "Paraguay",
+          "value": "PY"
+        },
+        {
+          "label": "Peru",
+          "value": "PE"
+        },
+        {
+          "label": "Philippines",
+          "value": "PH"
+        },
+        {
+          "label": "Poland",
+          "value": "PL"
+        },
+        {
+          "label": "Portugal",
+          "value": "PT"
+        },
+        {
+          "label": "Qatar",
+          "value": "QA"
+        },
+        {
+          "label": "Romania",
+          "value": "RO"
+        },
+        {
+          "label": "Russia",
+          "value": "RU"
+        },
+        {
+          "label": "Rwanda",
+          "value": "RW"
+        },
+        {
+          "label": "Samoa",
+          "value": "WS"
+        },
+        {
+          "label": "San Marino",
+          "value": "SM"
+        },
+        {
+          "label": "Sao Tome and Principe",
+          "value": "ST"
+        },
+        {
+          "label": "Saudi Arabia",
+          "value": "SA"
+        },
+        {
+          "label": "Senegal",
+          "value": "SN"
+        },
+        {
+          "label": "Serbia",
+          "value": "RS"
+        },
+        {
+          "label": "Seychelles",
+          "value": "SC"
+        },
+        {
+          "label": "Sierra Leone",
+          "value": "SL"
+        },
+        {
+          "label": "Singapore",
+          "value": "SG"
+        },
+        {
+          "label": "Slovakia",
+          "value": "SK"
+        },
+        {
+          "label": "Slovenia",
+          "value": "SI"
+        },
+        {
+          "label": "Solomon Islands",
+          "value": "SB"
+        },
+        {
+          "label": "Somalia",
+          "value": "SO"
+        },
+        {
+          "label": "South Africa",
+          "value": "ZA"
+        },
+        {
+          "label": "South Korea",
+          "value": "KR"
+        },
+        {
+          "label": "South Sudan",
+          "value": "SS"
+        },
+        {
+          "label": "Spain",
+          "value": "ES"
+        },
+        {
+          "label": "Sri Lanka",
+          "value": "LK"
+        },
+        {
+          "label": "St Kitts and Nevis",
+          "value": "KN"
+        },
+        {
+          "label": "St Lucia",
+          "value": "LC"
+        },
+        {
+          "label": "St Vincent",
+          "value": "VC"
+        },
+        {
+          "label": "Sudan",
+          "value": "SD"
+        },
+        {
+          "label": "Suriname",
+          "value": "SR"
+        },
+        {
+          "label": "Swaziland",
+          "value": "SZ"
+        },
+        {
+          "label": "Sweden",
+          "value": "SE"
+        },
+        {
+          "label": "Switzerland",
+          "value": "CH"
+        },
+        {
+          "label": "Syria",
+          "value": "SY"
+        },
+        {
+          "label": "Tajikistan",
+          "value": "TJ"
+        },
+        {
+          "label": "Tanzania",
+          "value": "TZ"
+        },
+        {
+          "label": "Thailand",
+          "value": "TH"
+        },
+        {
+          "label": "Togo",
+          "value": "TG"
+        },
+        {
+          "label": "Tonga",
+          "value": "TO"
+        },
+        {
+          "label": "Trinidad and Tobago",
+          "value": "TT"
+        },
+        {
+          "label": "Tunisia",
+          "value": "TN"
+        },
+        {
+          "label": "Turkey",
+          "value": "TR"
+        },
+        {
+          "label": "Turkmenistan",
+          "value": "TM"
+        },
+        {
+          "label": "Tuvalu",
+          "value": "TV"
+        },
+        {
+          "label": "Uganda",
+          "value": "UG"
+        },
+        {
+          "label": "Ukraine",
+          "value": "UA"
+        },
+        {
+          "label": "United Arab Emirates",
+          "value": "AE"
+        },
+        {
+          "label": "United Kingdom",
+          "value": "GB"
+        },
+        {
+          "label": "United States",
+          "value": "US"
+        },
+        {
+          "label": "Uruguay",
+          "value": "UY"
+        },
+        {
+          "label": "Uzbekistan",
+          "value": "UZ"
+        },
+        {
+          "label": "Vanuatu",
+          "value": "VU"
+        },
+        {
+          "label": "Vatican City",
+          "value": "VA"
+        },
+        {
+          "label": "Venezuela",
+          "value": "VE"
+        },
+        {
+          "label": "Vietnam",
+          "value": "VN"
+        },
+        {
+          "label": "Yemen",
+          "value": "YE"
+        },
+        {
+          "label": "Zambia",
+          "value": "ZM"
+        },
+        {
+          "label": "Zimbabwe",
+          "value": "ZW"
+        }
+      ],
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "country",
       "name": "Country",
-      "type": "text",
       "preposition": "covering",
-      "display_as_result_metadata": true,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "value": "AF",
-          "label": "Afghanistan"
-        },
-        {
-          "value": "AL",
-          "label": "Albania"
-        },
-        {
-          "value": "DZ",
-          "label": "Algeria"
-        },
-        {
-          "value": "AD",
-          "label": "Andorra"
-        },
-        {
-          "value": "AO",
-          "label": "Angola"
-        },
-        {
-          "value": "AG",
-          "label": "Antigua and Barbuda"
-        },
-        {
-          "value": "AR",
-          "label": "Argentina"
-        },
-        {
-          "value": "AM",
-          "label": "Armenia"
-        },
-        {
-          "value": "AU",
-          "label": "Australia"
-        },
-        {
-          "value": "AT",
-          "label": "Austria"
-        },
-        {
-          "value": "AZ",
-          "label": "Azerbaijan"
-        },
-        {
-          "value": "BS",
-          "label": "Bahamas, The"
-        },
-        {
-          "value": "BH",
-          "label": "Bahrain"
-        },
-        {
-          "value": "BD",
-          "label": "Bangladesh"
-        },
-        {
-          "value": "BB",
-          "label": "Barbados"
-        },
-        {
-          "value": "BY",
-          "label": "Belarus"
-        },
-        {
-          "value": "BE",
-          "label": "Belgium"
-        },
-        {
-          "value": "BZ",
-          "label": "Belize"
-        },
-        {
-          "value": "BJ",
-          "label": "Benin"
-        },
-        {
-          "value": "BT",
-          "label": "Bhutan"
-        },
-        {
-          "value": "BO",
-          "label": "Bolivia"
-        },
-        {
-          "value": "BA",
-          "label": "Bosnia and Herzegovina"
-        },
-        {
-          "value": "BW",
-          "label": "Botswana"
-        },
-        {
-          "value": "BR",
-          "label": "Brazil"
-        },
-        {
-          "value": "BN",
-          "label": "Brunei"
-        },
-        {
-          "value": "BG",
-          "label": "Bulgaria"
-        },
-        {
-          "value": "BF",
-          "label": "Burkina Faso"
-        },
-        {
-          "value": "MM",
-          "label": "Burma"
-        },
-        {
-          "value": "BI",
-          "label": "Burundi"
-        },
-        {
-          "value": "KH",
-          "label": "Cambodia"
-        },
-        {
-          "value": "CM",
-          "label": "Cameroon"
-        },
-        {
-          "value": "CA",
-          "label": "Canada"
-        },
-        {
-          "value": "CV",
-          "label": "Cape Verde"
-        },
-        {
-          "value": "CF",
-          "label": "Central African Republic"
-        },
-        {
-          "value": "TD",
-          "label": "Chad"
-        },
-        {
-          "value": "CL",
-          "label": "Chile"
-        },
-        {
-          "value": "CN",
-          "label": "China"
-        },
-        {
-          "value": "CO",
-          "label": "Colombia"
-        },
-        {
-          "value": "KM",
-          "label": "Comoros"
-        },
-        {
-          "value": "CG",
-          "label": "Congo"
-        },
-        {
-          "value": "CD",
-          "label": "Congo (Democratic Republic)"
-        },
-        {
-          "value": "CK",
-          "label": "Cook Islands"
-        },
-        {
-          "value": "CR",
-          "label": "Costa Rica"
-        },
-        {
-          "value": "HR",
-          "label": "Croatia"
-        },
-        {
-          "value": "CU",
-          "label": "Cuba"
-        },
-        {
-          "value": "CY",
-          "label": "Cyprus"
-        },
-        {
-          "value": "CZ",
-          "label": "Czech Republic"
-        },
-        {
-          "value": "DK",
-          "label": "Denmark"
-        },
-        {
-          "value": "DJ",
-          "label": "Djibouti"
-        },
-        {
-          "value": "DM",
-          "label": "Dominica"
-        },
-        {
-          "value": "DO",
-          "label": "Dominican Republic"
-        },
-        {
-          "value": "TL",
-          "label": "East Timor"
-        },
-        {
-          "value": "EC",
-          "label": "Ecuador"
-        },
-        {
-          "value": "EG",
-          "label": "Egypt"
-        },
-        {
-          "value": "SV",
-          "label": "El Salvador"
-        },
-        {
-          "value": "GQ",
-          "label": "Equatorial Guinea"
-        },
-        {
-          "value": "ER",
-          "label": "Eritrea"
-        },
-        {
-          "value": "EE",
-          "label": "Estonia"
-        },
-        {
-          "value": "ET",
-          "label": "Ethiopia"
-        },
-        {
-          "value": "FS",
-          "label": "Federated States of Micronesia"
-        },
-        {
-          "value": "FJ",
-          "label": "Fiji"
-        },
-        {
-          "value": "FI",
-          "label": "Finland"
-        },
-        {
-          "value": "FR",
-          "label": "France"
-        },
-        {
-          "value": "GA",
-          "label": "Gabon"
-        },
-        {
-          "value": "GM",
-          "label": "Gambia, The"
-        },
-        {
-          "value": "GE",
-          "label": "Georgia"
-        },
-        {
-          "value": "DE",
-          "label": "Germany"
-        },
-        {
-          "value": "GH",
-          "label": "Ghana"
-        },
-        {
-          "value": "GR",
-          "label": "Greece"
-        },
-        {
-          "value": "GD",
-          "label": "Grenada"
-        },
-        {
-          "value": "GT",
-          "label": "Guatemala"
-        },
-        {
-          "value": "GN",
-          "label": "Guinea"
-        },
-        {
-          "value": "GW",
-          "label": "Guinea-Bissau"
-        },
-        {
-          "value": "GY",
-          "label": "Guyana"
-        },
-        {
-          "value": "HT",
-          "label": "Haiti"
-        },
-        {
-          "value": "HN",
-          "label": "Honduras"
-        },
-        {
-          "value": "HU",
-          "label": "Hungary"
-        },
-        {
-          "value": "IS",
-          "label": "Iceland"
-        },
-        {
-          "value": "IN",
-          "label": "India"
-        },
-        {
-          "value": "ID",
-          "label": "Indonesia"
-        },
-        {
-          "value": "IR",
-          "label": "Iran"
-        },
-        {
-          "value": "IQ",
-          "label": "Iraq"
-        },
-        {
-          "value": "IE",
-          "label": "Ireland"
-        },
-        {
-          "value": "IL",
-          "label": "Israel"
-        },
-        {
-          "value": "IT",
-          "label": "Italy"
-        },
-        {
-          "value": "CI",
-          "label": "Ivory Coast"
-        },
-        {
-          "value": "JM",
-          "label": "Jamaica"
-        },
-        {
-          "value": "JP",
-          "label": "Japan"
-        },
-        {
-          "value": "JO",
-          "label": "Jordan"
-        },
-        {
-          "value": "KZ",
-          "label": "Kazakhstan"
-        },
-        {
-          "value": "KE",
-          "label": "Kenya"
-        },
-        {
-          "value": "KI",
-          "label": "Kiribati"
-        },
-        {
-          "value": "XK",
-          "label": "Kosovo"
-        },
-        {
-          "value": "KW",
-          "label": "Kuwait"
-        },
-        {
-          "value": "KG",
-          "label": "Kyrgyzstan"
-        },
-        {
-          "value": "LA",
-          "label": "Laos"
-        },
-        {
-          "value": "LV",
-          "label": "Latvia"
-        },
-        {
-          "value": "LB",
-          "label": "Lebanon"
-        },
-        {
-          "value": "LS",
-          "label": "Lesotho"
-        },
-        {
-          "value": "LR",
-          "label": "Liberia"
-        },
-        {
-          "value": "LY",
-          "label": "Libya"
-        },
-        {
-          "value": "LI",
-          "label": "Liechtenstein"
-        },
-        {
-          "value": "LT",
-          "label": "Lithuania"
-        },
-        {
-          "value": "LU",
-          "label": "Luxembourg"
-        },
-        {
-          "value": "MK",
-          "label": "North Macedonia"
-        },
-        {
-          "value": "MG",
-          "label": "Madagascar"
-        },
-        {
-          "value": "MW",
-          "label": "Malawi"
-        },
-        {
-          "value": "MY",
-          "label": "Malaysia"
-        },
-        {
-          "value": "MV",
-          "label": "Maldives"
-        },
-        {
-          "value": "ML",
-          "label": "Mali"
-        },
-        {
-          "value": "MT",
-          "label": "Malta"
-        },
-        {
-          "value": "MH",
-          "label": "Marshall Islands"
-        },
-        {
-          "value": "MR",
-          "label": "Mauritania"
-        },
-        {
-          "value": "MU",
-          "label": "Mauritius"
-        },
-        {
-          "value": "MX",
-          "label": "Mexico"
-        },
-        {
-          "value": "MD",
-          "label": "Moldova"
-        },
-        {
-          "value": "MC",
-          "label": "Monaco"
-        },
-        {
-          "value": "MN",
-          "label": "Mongolia"
-        },
-        {
-          "value": "ME",
-          "label": "Montenegro"
-        },
-        {
-          "value": "MA",
-          "label": "Morocco"
-        },
-        {
-          "value": "MZ",
-          "label": "Mozambique"
-        },
-        {
-          "value": "NA",
-          "label": "Namibia"
-        },
-        {
-          "value": "NR",
-          "label": "Nauru"
-        },
-        {
-          "value": "NP",
-          "label": "Nepal"
-        },
-        {
-          "value": "NL",
-          "label": "Netherlands"
-        },
-        {
-          "value": "NZ",
-          "label": "New Zealand"
-        },
-        {
-          "value": "NI",
-          "label": "Nicaragua"
-        },
-        {
-          "value": "NE",
-          "label": "Niger"
-        },
-        {
-          "value": "NG",
-          "label": "Nigeria"
-        },
-        {
-          "value": "KP",
-          "label": "North Korea"
-        },
-        {
-          "value": "NO",
-          "label": "Norway"
-        },
-        {
-          "value": "OM",
-          "label": "Oman"
-        },
-        {
-          "value": "PK",
-          "label": "Pakistan"
-        },
-        {
-          "value": "PW",
-          "label": "Palau"
-        },
-        {
-          "value": "PA",
-          "label": "Panama"
-        },
-        {
-          "value": "PG",
-          "label": "Papua New Guinea"
-        },
-        {
-          "value": "PY",
-          "label": "Paraguay"
-        },
-        {
-          "value": "PE",
-          "label": "Peru"
-        },
-        {
-          "value": "PH",
-          "label": "Philippines"
-        },
-        {
-          "value": "PL",
-          "label": "Poland"
-        },
-        {
-          "value": "PT",
-          "label": "Portugal"
-        },
-        {
-          "value": "QA",
-          "label": "Qatar"
-        },
-        {
-          "value": "RO",
-          "label": "Romania"
-        },
-        {
-          "value": "RU",
-          "label": "Russia"
-        },
-        {
-          "value": "RW",
-          "label": "Rwanda"
-        },
-        {
-          "value": "WS",
-          "label": "Samoa"
-        },
-        {
-          "value": "SM",
-          "label": "San Marino"
-        },
-        {
-          "value": "ST",
-          "label": "Sao Tome and Principe"
-        },
-        {
-          "value": "SA",
-          "label": "Saudi Arabia"
-        },
-        {
-          "value": "SN",
-          "label": "Senegal"
-        },
-        {
-          "value": "RS",
-          "label": "Serbia"
-        },
-        {
-          "value": "SC",
-          "label": "Seychelles"
-        },
-        {
-          "value": "SL",
-          "label": "Sierra Leone"
-        },
-        {
-          "value": "SG",
-          "label": "Singapore"
-        },
-        {
-          "value": "SK",
-          "label": "Slovakia"
-        },
-        {
-          "value": "SI",
-          "label": "Slovenia"
-        },
-        {
-          "value": "SB",
-          "label": "Solomon Islands"
-        },
-        {
-          "value": "SO",
-          "label": "Somalia"
-        },
-        {
-          "value": "ZA",
-          "label": "South Africa"
-        },
-        {
-          "value": "KR",
-          "label": "South Korea"
-        },
-        {
-          "value": "SS",
-          "label": "South Sudan"
-        },
-        {
-          "value": "ES",
-          "label": "Spain"
-        },
-        {
-          "value": "LK",
-          "label": "Sri Lanka"
-        },
-        {
-          "value": "KN",
-          "label": "St Kitts and Nevis"
-        },
-        {
-          "value": "LC",
-          "label": "St Lucia"
-        },
-        {
-          "value": "VC",
-          "label": "St Vincent"
-        },
-        {
-          "value": "SD",
-          "label": "Sudan"
-        },
-        {
-          "value": "SR",
-          "label": "Suriname"
-        },
-        {
-          "value": "SZ",
-          "label": "Swaziland"
-        },
-        {
-          "value": "SE",
-          "label": "Sweden"
-        },
-        {
-          "value": "CH",
-          "label": "Switzerland"
-        },
-        {
-          "value": "SY",
-          "label": "Syria"
-        },
-        {
-          "value": "TJ",
-          "label": "Tajikistan"
-        },
-        {
-          "value": "TZ",
-          "label": "Tanzania"
-        },
-        {
-          "value": "TH",
-          "label": "Thailand"
-        },
-        {
-          "value": "TG",
-          "label": "Togo"
-        },
-        {
-          "value": "TO",
-          "label": "Tonga"
-        },
-        {
-          "value": "TT",
-          "label": "Trinidad and Tobago"
-        },
-        {
-          "value": "TN",
-          "label": "Tunisia"
-        },
-        {
-          "value": "TR",
-          "label": "Turkey"
-        },
-        {
-          "value": "TM",
-          "label": "Turkmenistan"
-        },
-        {
-          "value": "TV",
-          "label": "Tuvalu"
-        },
-        {
-          "value": "UG",
-          "label": "Uganda"
-        },
-        {
-          "value": "UA",
-          "label": "Ukraine"
-        },
-        {
-          "value": "AE",
-          "label": "United Arab Emirates"
-        },
-        {
-          "value": "GB",
-          "label": "United Kingdom"
-        },
-        {
-          "value": "US",
-          "label": "United States"
-        },
-        {
-          "value": "UY",
-          "label": "Uruguay"
-        },
-        {
-          "value": "UZ",
-          "label": "Uzbekistan"
-        },
-        {
-          "value": "VU",
-          "label": "Vanuatu"
-        },
-        {
-          "value": "VA",
-          "label": "Vatican City"
-        },
-        {
-          "value": "VE",
-          "label": "Venezuela"
-        },
-        {
-          "value": "VN",
-          "label": "Vietnam"
-        },
-        {
-          "value": "YE",
-          "label": "Yemen"
-        },
-        {
-          "value": "ZM",
-          "label": "Zambia"
-        },
-        {
-          "value": "ZW",
-          "label": "Zimbabwe"
-        }
-      ],
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "allowed_values": [
+        {
+          "label": "Book",
+          "value": "book"
+        },
+        {
+          "label": "Book Chapter",
+          "value": "book_chapter"
+        },
+        {
+          "label": "Briefing",
+          "value": "briefing"
+        },
+        {
+          "label": "Case Study",
+          "value": "case_study"
+        },
+        {
+          "label": "Conference Paper",
+          "value": "conference_paper"
+        },
+        {
+          "label": "Country Report",
+          "value": "country_report"
+        },
+        {
+          "label": "Dataset",
+          "value": "dataset"
+        },
+        {
+          "label": "Discussion Paper",
+          "value": "discussion_paper"
+        },
+        {
+          "label": "Evaluation Report",
+          "value": "evaluation_report"
+        },
+        {
+          "label": "Journal Article",
+          "value": "journal_article"
+        },
+        {
+          "label": "Journal Issue",
+          "value": "journal_issue"
+        },
+        {
+          "label": "Lessons Learned",
+          "value": "lessons_learned"
+        },
+        {
+          "label": "Literature Review",
+          "value": "literature_review"
+        },
+        {
+          "label": "Manual",
+          "value": "manual"
+        },
+        {
+          "label": "Protocol",
+          "value": "protocol"
+        },
+        {
+          "label": "Research Paper",
+          "value": "research_paper"
+        },
+        {
+          "label": "Systematic Review",
+          "value": "systematic_review"
+        },
+        {
+          "label": "Technical Report",
+          "value": "technical_report"
+        },
+        {
+          "label": "Thematic Summary",
+          "value": "thematic_summary"
+        },
+        {
+          "label": "Tool kit",
+          "value": "tool_kit"
+        },
+        {
+          "label": "Training Materials",
+          "value": "training_materials"
+        },
+        {
+          "label": "Working Paper",
+          "value": "working_paper"
+        }
+      ],
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "research_document_type",
       "name": "Document Type",
-      "short_name": "Document Type",
-      "type": "text",
       "preposition": "of type",
-      "display_as_result_metadata": true,
-      "filterable": true,
-      "allowed_values": [
-        {
-          "value": "book",
-          "label": "Book"
-        },
-        {
-          "value": "book_chapter",
-          "label": "Book Chapter"
-        },
-        {
-          "value": "briefing",
-          "label": "Briefing"
-        },
-        {
-          "value": "case_study",
-          "label": "Case Study"
-        },
-        {
-          "value": "conference_paper",
-          "label": "Conference Paper"
-        },
-        {
-          "value": "country_report",
-          "label": "Country Report"
-        },
-        {
-          "value": "dataset",
-          "label": "Dataset"
-        },
-        {
-          "value": "discussion_paper",
-          "label": "Discussion Paper"
-        },
-        {
-          "value": "evaluation_report",
-          "label": "Evaluation Report"
-        },
-        {
-          "value": "journal_article",
-          "label": "Journal Article"
-        },
-        {
-          "value": "journal_issue",
-          "label": "Journal Issue"
-        },
-        {
-          "value": "lessons_learned",
-          "label": "Lessons Learned"
-        },
-        {
-          "value": "literature_review",
-          "label": "Literature Review"
-        },
-        {
-          "value": "manual",
-          "label": "Manual"
-        },
-        {
-          "value": "protocol",
-          "label": "Protocol"
-        },
-        {
-          "value": "research_paper",
-          "label": "Research Paper"
-        },
-        {
-          "value": "systematic_review",
-          "label": "Systematic Review"
-        },
-        {
-          "value": "technical_report",
-          "label": "Technical Report"
-        },
-        {
-          "value": "thematic_summary",
-          "label": "Thematic Summary"
-        },
-        {
-          "value": "tool_kit",
-          "label": "Tool kit"
-        },
-        {
-          "value": "training_materials",
-          "label": "Training Materials"
-        },
-        {
-          "value": "working_paper",
-          "label": "Working Paper"
-        }
-      ],
+      "short_name": "Document Type",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "theme",
-      "name": "Theme",
-      "short_name": "Theme",
-      "type": "text",
-      "preposition": "about",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
-          "value": "agriculture",
-          "label": "Agriculture"
+          "label": "Agriculture",
+          "value": "agriculture"
         },
         {
-          "value": "climate_and_environment",
-          "label": "Climate and Environment"
+          "label": "Climate and Environment",
+          "value": "climate_and_environment"
         },
         {
-          "value": "economic_growth",
-          "label": "Economic Growth"
+          "label": "Economic Growth",
+          "value": "economic_growth"
         },
         {
-          "value": "education",
-          "label": "Education"
+          "label": "Education",
+          "value": "education"
         },
         {
-          "value": "food_and_nutrition",
-          "label": "Food and Nutrition"
+          "label": "Food and Nutrition",
+          "value": "food_and_nutrition"
         },
         {
-          "value": "governance_and_conflict",
-          "label": "Governance and Conflict"
+          "label": "Governance and Conflict",
+          "value": "governance_and_conflict"
         },
         {
-          "value": "health",
-          "label": "Health"
+          "label": "Health",
+          "value": "health"
         },
         {
-          "value": "humanitarian_disasters_and_emergencies",
-          "label": "Humanitarian Disasters and Emergencies"
+          "label": "Humanitarian Disasters and Emergencies",
+          "value": "humanitarian_disasters_and_emergencies"
         },
         {
-          "value": "infrastructure",
-          "label": "Infrastructure"
+          "label": "Infrastructure",
+          "value": "infrastructure"
         },
         {
-          "value": "research_communication_and_uptake",
-          "label": "Research Communication and Uptake"
+          "label": "Research Communication and Uptake",
+          "value": "research_communication_and_uptake"
         },
         {
-          "value": "social_change",
-          "label": "Social Change"
+          "label": "Social Change",
+          "value": "social_change"
         },
         {
-          "value": "water_and_sanitation",
-          "label": "Water and Sanitation"
+          "label": "Water and Sanitation",
+          "value": "water_and_sanitation"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "theme",
+      "name": "Theme",
+      "preposition": "about",
+      "short_name": "Theme",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "first_published_at",
       "name": "First published",
       "short_name": "First published",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": false,
       "key": "authors",
       "name": "Authors",
       "short_name": "Authors",
-      "type": "text",
-      "display_as_result_metadata": true,
-      "filterable": false
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "research_for_development_output"
+  },
+  "format_name": "Research for Development Output",
+  "name": "Research for Development Outputs",
+  "organisations": [
+    "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+  ],
+  "signup_content_id": "fdcbada2-1ad4-4194-98dc-5f04a448316e",
+  "subscription_list_title_prefix": "Research for Development output",
+  "summary": "<p>Research outputs published before 2 September 2020 were published by the Department for International Development (DFID)</p>",
+  "target_stack": "live",
+  "taxons": [
+    "9fb30a53-70fb-4f1c-878b-0064b202d1ba"
   ]
 }

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -1,41 +1,17 @@
 {
-  "target_stack": "live",
-  "content_id": "ce2c1353-2fcb-4c85-ac35-a1c8c3e990cf",
   "base_path": "/residential-property-tribunal-decisions",
-  "format_name": "Residential property tribunal decision",
-  "name": "Residential property tribunal decisions",
+  "content_id": "ce2c1353-2fcb-4c85-ac35-a1c8c3e990cf",
   "description": "Find decisions on Residential Property Tribunal cases in England, Wales and Scotland.",
-  "phase": "beta",
-  "filter": {
-    "format": "residential_property_tribunal_decision"
-  },
-  "show_summaries": true,
+  "document_noun": "decision",
+  "document_title": "Residential Property Tribunal Decision",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "bb2b028f-efaa-44fd-b3f8-971b25cb51a2"
-  ],
-  "taxons": [
-    "357110bb-cbc5-4708-9711-1b26e6c63e86"
-  ],
-  "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",
-  "subscription_list_title_prefix": "Residential property tribunal decisions",
   "email_filter_options": {
     "email_filter_by": "all_selected_facets"
   },
-  "summary": "<p>Find decisions on Residential Property Tribunal cases in England from December 2018 onwards.</p><p>If the decision was about leasehold and was made before December 2018, visit <a href=\"https://decisions.lease-advice.org/\" rel=\"external\">Lease Advice</a>. Other decisions made before December 2018 can be found on <a href=\"https://www.bailii.org/recent-decisions.html\" rel=\"external\">BAILII</a></p>",
-  "document_noun": "decision",
-  "document_title": "Residential Property Tribunal Decision",
   "facets": [
     {
-      "key": "tribunal_decision_category",
-      "name": "Category",
-      "type": "text",
-      "preposition": "categorised as",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Building Safety Act",
@@ -82,17 +58,17 @@
           "value": "tenant-fees-act"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_category",
+      "name": "Category",
+      "preposition": "categorised as",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
-      "key": "tribunal_decision_sub_category",
-      "name": "Sub-category",
-      "type": "text",
-      "preposition": "sub-categorised as",
-      "display_as_result_metadata": true,
-      "filterable": false,
       "allowed_values": [
         {
           "label": "Building Safety Act - Accountable Person",
@@ -347,27 +323,51 @@
           "value": "tenant-fees-act---recovery-of-a-prohibited-payment"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "tribunal_decision_sub_category",
+      "name": "Sub-category",
+      "preposition": "sub-categorised as",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "residential_property_tribunal_decision"
+  },
+  "format_name": "Residential property tribunal decision",
+  "name": "Residential property tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "bb2b028f-efaa-44fd-b3f8-971b25cb51a2"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",
+  "subscription_list_title_prefix": "Residential property tribunal decisions",
+  "summary": "<p>Find decisions on Residential Property Tribunal cases in England from December 2018 onwards.</p><p>If the decision was about leasehold and was made before December 2018, visit <a href=\"https://decisions.lease-advice.org/\" rel=\"external\">Lease Advice</a>. Other decisions made before December 2018 can be found on <a href=\"https://www.bailii.org/recent-decisions.html\" rel=\"external\">BAILII</a></p>",
+  "target_stack": "live",
+  "taxons": [
+    "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ]
 }

--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -1,40 +1,21 @@
 {
-  "target_stack": "live",
-  "content_id": "da025a9f-8293-4fef-869c-12445d364696",
   "base_path": "/service-standard-reports",
-  "name": "Service Standard Reports",
-  "format_name": "Service Assessment and Self Certification",
+  "content_id": "da025a9f-8293-4fef-869c-12445d364696",
+  "default_order": "-assessment_date",
   "description": "A list of service assessments and self certifications",
-  "show_summaries": true,
-  "organisations": [
-    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
-  ],
-  "taxons": [
-    "84630bce-4c1c-4406-a38a-e8c41967b8f7"
-  ],
   "document_noun": "report",
   "document_title": "Service Standard Report",
-  "default_order": "-assessment_date",
-  "filter": {
-    "format": "service_standard_report"
-  },
   "facets": [
     {
-      "key": "assessment_date",
-      "name": "Assessment date",
-      "short_name": "Assessed",
-      "type": "date",
-      "preposition": "assessed",
-      "display_as_result_metadata": true,
-      "filterable": true
-    },
-    {
-      "key": "result",
-      "name": "Result",
-      "short_name": "Result",
-      "type": "text",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "assessment_date",
+      "name": "Assessment date",
+      "preposition": "assessed",
+      "short_name": "Assessed",
+      "type": "date"
+    },
+    {
       "allowed_values": [
         {
           "label": "Met",
@@ -57,17 +38,17 @@
           "value": "green"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "stage",
-      "name": "Stage",
-      "short_name": "Stage",
-      "type": "text",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "result",
+      "name": "Result",
+      "short_name": "Result",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Alpha",
@@ -110,9 +91,28 @@
           "value": "live-amber-evidence-review"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "stage",
+      "name": "Stage",
+      "short_name": "Stage",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "service_standard_report"
+  },
+  "format_name": "Service Assessment and Self Certification",
+  "name": "Service Standard Reports",
+  "organisations": [
+    "2fb482e7-3c4d-496f-887d-f8a55a15e89a"
+  ],
+  "show_summaries": true,
+  "target_stack": "live",
+  "taxons": [
+    "84630bce-4c1c-4406-a38a-e8c41967b8f7"
   ]
 }

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -1,31 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "b8b8fb77-c5e9-41d6-b133-44ecd1958e28",
   "base_path": "/sfo-cases",
-  "format_name": "Find an SFO case",
-  "name": "Find an SFO case",
+  "content_id": "b8b8fb77-c5e9-41d6-b133-44ecd1958e28",
   "description": "Find fraud, bribery and corruption cases investigated by the SFO.",
-  "summary": "<p>This case finder includes all ongoing Serious Fraud Office (SFO) prosecutions and investigations that are in the public domain. This does not include intelligence referrals, covert investigations or proceeds of crime cases.</p><p>For updates on the SFO’s proceeds of crime recovery, see <a href=\"https://www.gov.uk/government/publications/proceeds-of-crime\">this page</a>.</p>",
-  "filter": {
-    "format": "sfo_case"
-  },
-  "related": [
-    "01007fd9-8351-4068-b90c-a9af8edaeb19"
-  ],
-  "show_summaries": true,
-  "organisations": [
-    "ebae4517-422f-44dd-9f87-13304c9815cb"
-  ],
   "document_noun": "case",
   "document_title": "SFO Case",
   "facets": [
     {
-      "key": "sfo_case_state",
-      "name": "Case state",
-      "type": "text",
-      "preposition": "with case state",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Open",
@@ -36,18 +16,38 @@
           "value": "closed"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "sfo_case_state",
+      "name": "Case state",
+      "preposition": "with case state",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": true,
       "key": "sfo_case_date_announced",
       "name": "Date announced",
-      "short_name": "Date announced",
-      "type": "date",
       "preposition": "announced",
-      "display_as_result_metadata": false,
-      "filterable": true
+      "short_name": "Date announced",
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "sfo_case"
+  },
+  "format_name": "Find an SFO case",
+  "name": "Find an SFO case",
+  "organisations": [
+    "ebae4517-422f-44dd-9f87-13304c9815cb"
+  ],
+  "related": [
+    "01007fd9-8351-4068-b90c-a9af8edaeb19"
+  ],
+  "show_summaries": true,
+  "summary": "<p>This case finder includes all ongoing Serious Fraud Office (SFO) prosecutions and investigations that are in the public domain. This does not include intelligence referrals, covert investigations or proceeds of crime cases.</p><p>For updates on the SFO’s proceeds of crime recovery, see <a href=\"https://www.gov.uk/government/publications/proceeds-of-crime\">this page</a>.</p>",
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -1,44 +1,27 @@
 {
-  "target_stack": "live",
-  "content_id": "f722816d-7e12-4055-8e7e-68b2d144e2b6",
   "base_path": "/eu-withdrawal-act-2018-statutory-instruments",
-  "format_name": "EU Withdrawal Act 2018 statutory instrument",
-  "name": "EU Withdrawal Act 2018 statutory instruments",
+  "content_id": "f722816d-7e12-4055-8e7e-68b2d144e2b6",
   "description": "Find EU Withdrawal Act statutory instruments",
-  "summary": "<p>Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.</p><p>Before the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the '<a href=\"https://www.parliament.uk/about/how/laws/secondary-legislation/\">negative procedure</a>'.</p>",
-  "filter": {
-    "format": "statutory_instrument"
-  },
-  "organisations": [],
-  "taxons": [
-    "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
-  ],
   "document_noun": "statutory instrument",
   "document_title": "EU Withdrawal Act 2018 statutory instrument",
   "facets": [
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "laid_date",
       "name": "Laid on",
       "short_name": "Laid on",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": false,
       "key": "sift_end_date",
       "name": "Sift end date",
       "short_name": "Sift end date",
-      "type": "date",
-      "display_as_result_metadata": false,
-      "filterable": false
+      "type": "date"
     },
     {
-      "key": "sifting_status",
-      "name": "Sifting status",
-      "type": "text",
-      "preposition": "with status",
-      "display_as_result_metadata": true,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Open",
@@ -53,17 +36,17 @@
           "value": "withdrawn"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "subject",
-      "name": "Subject",
-      "type": "text",
-      "preposition": "relating to",
       "display_as_result_metadata": true,
       "filterable": true,
+      "key": "sifting_status",
+      "name": "Sifting status",
+      "preposition": "with status",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Business",
@@ -142,9 +125,26 @@
           "value": "work"
         }
       ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "subject",
+      "name": "Subject",
+      "preposition": "relating to",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "statutory_instrument"
+  },
+  "format_name": "EU Withdrawal Act 2018 statutory instrument",
+  "name": "EU Withdrawal Act 2018 statutory instruments",
+  "organisations": [],
+  "summary": "<p>Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.</p><p>Before the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the '<a href=\"https://www.parliament.uk/about/how/laws/secondary-legislation/\">negative procedure</a>'.</p>",
+  "target_stack": "live",
+  "taxons": [
+    "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
   ]
 }

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -1,44 +1,19 @@
 {
-  "target_stack": "live",
-  "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
   "base_path": "/tax-and-chancery-tribunal-decisions",
-  "format_name": "Tax and Chancery tribunal decision",
-  "name": "Tax and Chancery tribunal decisions",
-  "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
-  "phase": "beta",
-  "filter": {
-    "format": "tax_tribunal_decision"
-  },
+  "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
   "default_order": "-tribunal_decision_decision_date",
-  "show_summaries": true,
+  "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
+  "document_noun": "decision",
+  "document_title": "Tax Tribunal Decision",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "1a68b2cc-eb52-4528-8989-429f710da00f"
-  ],
-  "taxons": [
-    "357110bb-cbc5-4708-9711-1b26e6c63e86"
-  ],
-  "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
-  "subscription_list_title_prefix": "Upper Tribunal (Tax and Chancery Chamber) decisions",
   "email_filter_options": {
-    "email_filter_by": "tribunal_decision_category",
-    "downcase_email_alert_topic_names": true
+    "downcase_email_alert_topic_names": true,
+    "email_filter_by": "tribunal_decision_category"
   },
-  "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
-  "document_noun": "decision",
-  "document_title": "Tax Tribunal Decision",
   "facets": [
     {
-      "key": "tribunal_decision_category",
-      "name": "Category",
-      "short_name": "category",
-      "type": "text",
-      "preposition": "categorised as",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Banking",
@@ -65,27 +40,52 @@
           "value": "tax"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_category",
+      "name": "Category",
+      "preposition": "categorised as",
+      "short_name": "category",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Release date",
       "short_name": "Released",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "tax_tribunal_decision"
+  },
+  "format_name": "Tax and Chancery tribunal decision",
+  "name": "Tax and Chancery tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "1a68b2cc-eb52-4528-8989-429f710da00f"
+  ],
+  "phase": "beta",
+  "show_summaries": true,
+  "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
+  "subscription_list_title_prefix": "Upper Tribunal (Tax and Chancery Chamber) decisions",
+  "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
+  "target_stack": "live",
+  "taxons": [
+    "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ]
 }

--- a/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
+++ b/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
@@ -1,26 +1,11 @@
 {
-  "target_stack": "live",
-  "content_id": "be0e45cf-6da6-49c6-9f09-ddca614dbc55",
   "base_path": "/traffic-commissioner-regulatory-decisions",
-  "format_name": "Traffic Commissioner regulatory decision",
-  "name": "Traffic Commissioner regulatory decisions",
+  "content_id": "be0e45cf-6da6-49c6-9f09-ddca614dbc55",
   "description": "Find reports and updates on current and historical Traffic Commissioner regulatory decisions",
-  "filter": {
-    "format": "traffic_commissioner_regulatory_decision"
-  },
-  "organisations": [
-    "78dfc32b-b1ef-44ca-924c-a2cf773e87ca"
-  ],
   "document_noun": "decision",
   "document_title": "Traffic Commissioner Regulatory Decision",
   "facets": [
     {
-      "key": "decision_subject",
-      "name": "Subject",
-      "type": "text",
-      "preposition": "with subject",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "HGV operator",
@@ -35,17 +20,17 @@
           "value": "transport-manager"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "regions",
-      "name": "Region",
-      "type": "text",
-      "preposition": "for decisions in",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "decision_subject",
+      "name": "Subject",
+      "preposition": "with subject",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Eastern",
@@ -80,17 +65,17 @@
           "value": "western"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "case_type",
-      "name": "Case type",
-      "type": "text",
-      "preposition": "of type",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "regions",
+      "name": "Region",
+      "preposition": "for decisions in",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Application",
@@ -109,17 +94,17 @@
           "value": "environmental"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "one"
-      }
-    },
-    {
-      "key": "outcome_type",
-      "name": "Regulatory decision",
-      "type": "text",
-      "preposition": "with outcome",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "case_type",
+      "name": "Case type",
+      "preposition": "of type",
+      "specialist_publisher_properties": {
+        "select": "one"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "No action",
@@ -142,17 +127,32 @@
           "value": "revocation"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "outcome_type",
+      "name": "Regulatory decision",
+      "preposition": "with outcome",
       "specialist_publisher_properties": {
         "select": "one"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": false,
+      "filterable": true,
       "key": "first_published_at",
       "name": "Published",
       "short_name": "Published",
-      "type": "date",
-      "display_as_result_metadata": false,
-      "filterable": true
+      "type": "date"
     }
-  ]
+  ],
+  "filter": {
+    "format": "traffic_commissioner_regulatory_decision"
+  },
+  "format_name": "Traffic Commissioner regulatory decision",
+  "name": "Traffic Commissioner regulatory decisions",
+  "organisations": [
+    "78dfc32b-b1ef-44ca-924c-a2cf773e87ca"
+  ],
+  "target_stack": "live"
 }

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -1,37 +1,14 @@
 {
-  "target_stack": "live",
-  "content_id": "e9e7fcff-bb0d-4723-af25-9f78d730f6f8",
   "base_path": "/administrative-appeals-tribunal-decisions",
-  "format_name": "Administrative appeals tribunal decision",
-  "name": "Administrative appeals tribunal decisions",
+  "content_id": "e9e7fcff-bb0d-4723-af25-9f78d730f6f8",
   "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
-  "filter": {
-    "format": "utaac_decision"
-  },
-  "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
-  "show_summaries": true,
+  "document_noun": "decision",
+  "document_title": "UTAAC Decision",
   "editing_organisations": [
     "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
   ],
-  "organisations": [
-    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
-    "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
-  ],
-  "taxons": [
-    "357110bb-cbc5-4708-9711-1b26e6c63e86"
-  ],
-  "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions",
-  "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>This includes decisions made from January 2016 onwards. You can also search our database of <a rel=\"external\" href=\"https://administrativeappeals.decisions.tribunals.gov.uk\">decisions made in 2015 or earlier</a>.</p>",
-  "document_noun": "decision",
-  "document_title": "UTAAC Decision",
   "facets": [
     {
-      "key": "tribunal_decision_categories",
-      "name": "Categories",
-      "type": "text",
-      "preposition": "categorised as",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Benefits for children",
@@ -286,17 +263,17 @@
           "value": "transport-quality-contract-schemes"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_sub_categories",
-      "name": "Sub-categories",
-      "type": "text",
-      "preposition": "sub-categorised as",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_categories",
+      "name": "Categories",
+      "preposition": "categorised as",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Benefits for children - benefit increases for children",
@@ -2243,17 +2220,17 @@
           "value": "war-pensions-and-armed-forces-compensation-war-pensions-specified-decisions"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "tribunal_decision_judges",
-      "name": "Judges",
-      "type": "text",
-      "preposition": "by judge",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "tribunal_decision_sub_categories",
+      "name": "Sub-categories",
+      "preposition": "sub-categorised as",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Agnew, C",
@@ -2712,27 +2689,50 @@
           "value": "wright-s"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "tribunal_decision_judges",
+      "name": "Judges",
+      "preposition": "by judge",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     },
     {
+      "display_as_result_metadata": true,
+      "filterable": true,
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
-      "type": "date",
-      "display_as_result_metadata": true,
-      "filterable": true
+      "type": "date"
     },
     {
-      "key": "hidden_indexable_content",
-      "name": "Hidden indexable content",
-      "type": "text",
       "display_as_result_metadata": false,
       "filterable": false,
+      "key": "hidden_indexable_content",
+      "name": "Hidden indexable content",
       "specialist_publisher_properties": {
         "omit_from_finder_content_item": true
-      }
+      },
+      "type": "text"
     }
+  ],
+  "filter": {
+    "format": "utaac_decision"
+  },
+  "format_name": "Administrative appeals tribunal decision",
+  "name": "Administrative appeals tribunal decisions",
+  "organisations": [
+    "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+    "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
+  ],
+  "show_summaries": true,
+  "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
+  "subscription_list_title_prefix": "Upper Tribunal Administrative Appeals Chamber decisions",
+  "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>This includes decisions made from January 2016 onwards. You can also search our database of <a rel=\"external\" href=\"https://administrativeappeals.decisions.tribunals.gov.uk\">decisions made in 2015 or earlier</a>.</p>",
+  "target_stack": "live",
+  "taxons": [
+    "357110bb-cbc5-4708-9711-1b26e6c63e86"
   ]
 }

--- a/lib/documents/schemas/veterans_support_organisations.json
+++ b/lib/documents/schemas/veterans_support_organisations.json
@@ -1,35 +1,12 @@
 {
-  "target_stack": "live",
-  "content_id": "0bf7f581-a547-4dd1-aef0-754e0924281d",
   "base_path": "/support-for-veterans",
-  "format_name": "Find support for veterans and their families",
-  "name": "Find support for veterans and their families",
+  "content_id": "0bf7f581-a547-4dd1-aef0-754e0924281d",
+  "default_order": "title",
   "description": "Find support organisations for veterans of the UK armed forces and their families.",
-  "summary": "<p>This directory lists organisations that provide support to veterans of the UK armed forces and their families.</p><p>You can filter results by location and select as many areas of support as you need.</p><p>This should not be taken as an exhaustive list of all services on offer to veterans and their families in the UK.</p><p>The government is not liable for any services that fail to meet an individual's requirements or standards. The inclusion of these organisations or services should not be taken as endorsement by the Office for Veterans’ Affairs.</p><div class=\"example\"><h2>Talk to an adviser</h2><p>The Veterans’ Gateway helpline can provide information and referral support by telephone.</p><p>Phone: 0808 802 1212<br>Monday to Sunday, 8am to 8pm</p></div>",
-  "filter": {
-    "format": "veterans_support_organisation"
-  },
-  "show_summaries": true,
-  "organisations": [
-    "516357f6-92f3-4292-8449-b958e1c63c5f"
-  ],
-  "related": [
-    "df6f3081-b8f0-40a6-9df7-8b415cc4519b",
-    "8d7d88c2-4ea9-4c25-aab2-1988a269177e",
-    "141d388e-d4a0-4774-9767-5a8ba7aedb4e"
-  ],
   "document_noun": "result",
   "document_title": "Veterans Support Organisation",
-  "default_order": "title",
   "facets": [
     {
-      "key": "veterans_support_organisation_health_and_social_care",
-      "name": "Health and Social Care",
-      "short_name": "Health and Social Care",
-      "type": "text",
-      "preposition": "helps with",
-      "display_as_result_metadata": false,
-      "filterable": true,
       "allowed_values": [
         {
           "label": "Mental health",
@@ -48,18 +25,18 @@
           "value": "addiction-support"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_finance",
-      "name": "Finance",
-      "short_name": "Finance",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_health_and_social_care",
+      "name": "Health and Social Care",
+      "preposition": "helps with",
+      "short_name": "Health and Social Care",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Pensions",
@@ -86,18 +63,18 @@
           "value": "funeral-costs"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_legal_and_justice",
-      "name": "Legal and justice",
-      "short_name": "Legal help",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_finance",
+      "name": "Finance",
+      "preposition": "helps with",
+      "short_name": "Finance",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "General legal advice",
@@ -108,18 +85,18 @@
           "value": "support-for-those-in-the-justice-system"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_employment_education_and_training",
-      "name": "Employment, education and training",
-      "short_name": "Employment, education and training",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_legal_and_justice",
+      "name": "Legal and justice",
+      "preposition": "helps with",
+      "short_name": "Legal help",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Transition support",
@@ -142,18 +119,18 @@
           "value": "education-and-other-training"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_housing",
-      "name": "Housing",
-      "short_name": "Housing",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_employment_education_and_training",
+      "name": "Employment, education and training",
+      "preposition": "helps with",
+      "short_name": "Employment, education and training",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Homelessness, crisis accommodation",
@@ -176,18 +153,18 @@
           "value": "buying-a-home"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_families_and_children",
-      "name": "Families and children",
-      "short_name": "Families and children",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_housing",
+      "name": "Housing",
+      "preposition": "helps with",
+      "short_name": "Housing",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Support for spouses and families",
@@ -206,18 +183,18 @@
           "value": "domestic-abuse"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_community_and_social",
-      "name": "Community and social",
-      "short_name": "Community and social",
-      "type": "text",
-      "preposition": "helps with",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_families_and_children",
+      "name": "Families and children",
+      "preposition": "helps with",
+      "short_name": "Families and children",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Drop-in centres",
@@ -240,18 +217,18 @@
           "value": "women-veterans-support"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_region_england",
-      "name": "England",
-      "short_name": "England",
-      "type": "text",
-      "preposition": "location",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_community_and_social",
+      "name": "Community and social",
+      "preposition": "helps with",
+      "short_name": "Community and social",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "North East and Yorkshire",
@@ -282,18 +259,18 @@
           "value": "south-east"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_region_northern_ireland",
-      "name": "Northern Ireland",
-      "short_name": "Northern Ireland",
-      "type": "text",
-      "preposition": "location",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_region_england",
+      "name": "England",
+      "preposition": "location",
+      "short_name": "England",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "North (Coleraine Area)",
@@ -312,18 +289,18 @@
           "value": "west-enniskillen-area"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_region_scotland",
-      "name": "Scotland",
-      "short_name": "Scotland",
-      "type": "text",
-      "preposition": "location",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_region_northern_ireland",
+      "name": "Northern Ireland",
+      "preposition": "location",
+      "short_name": "Northern Ireland",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "The Southern Uplands",
@@ -342,18 +319,18 @@
           "value": "northern-highlands-hebrides-and-the-northern-isles"
         }
       ],
-      "specialist_publisher_properties": {
-        "select": "multiple"
-      }
-    },
-    {
-      "key": "veterans_support_organisation_region_wales",
-      "name": "Wales",
-      "short_name": "Wales",
-      "type": "text",
-      "preposition": "location",
       "display_as_result_metadata": false,
       "filterable": true,
+      "key": "veterans_support_organisation_region_scotland",
+      "name": "Scotland",
+      "preposition": "location",
+      "short_name": "Scotland",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    },
+    {
       "allowed_values": [
         {
           "label": "Mid and West Wales",
@@ -376,9 +353,32 @@
           "value": "south-wales-west"
         }
       ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "veterans_support_organisation_region_wales",
+      "name": "Wales",
+      "preposition": "location",
+      "short_name": "Wales",
       "specialist_publisher_properties": {
         "select": "multiple"
-      }
+      },
+      "type": "text"
     }
-  ]
+  ],
+  "filter": {
+    "format": "veterans_support_organisation"
+  },
+  "format_name": "Find support for veterans and their families",
+  "name": "Find support for veterans and their families",
+  "organisations": [
+    "516357f6-92f3-4292-8449-b958e1c63c5f"
+  ],
+  "related": [
+    "df6f3081-b8f0-40a6-9df7-8b415cc4519b",
+    "8d7d88c2-4ea9-4c25-aab2-1988a269177e",
+    "141d388e-d4a0-4774-9767-5a8ba7aedb4e"
+  ],
+  "show_summaries": true,
+  "summary": "<p>This directory lists organisations that provide support to veterans of the UK armed forces and their families.</p><p>You can filter results by location and select as many areas of support as you need.</p><p>This should not be taken as an exhaustive list of all services on offer to veterans and their families in the UK.</p><p>The government is not liable for any services that fail to meet an individual's requirements or standards. The inclusion of these organisations or services should not be taken as endorsement by the Office for Veterans’ Affairs.</p><div class=\"example\"><h2>Talk to an adviser</h2><p>The Veterans’ Gateway helpline can provide information and referral support by telephone.</p><p>Phone: 0808 802 1212<br>Monday to Sunday, 8am to 8pm</p></div>",
+  "target_stack": "live"
 }

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -216,15 +216,15 @@ RSpec.describe "Facet" do
       facet.specialist_publisher_properties = { select: "one" }
 
       expect(facet.to_finder_schema_attributes.keys).to eq(%i[
-        key
-        name
-        short_name
-        type
-        preposition
+        allowed_values
         display_as_result_metadata
         filterable
-        allowed_values
+        key
+        name
+        preposition
         specialist_publisher_properties
+        short_name
+        type
       ])
     end
   end


### PR DESCRIPTION
The JSON that is generated by the "request edits" form is sorted alphabetically. Whilst there is perhaps a more 'semantic' alternative (with `name` and `format_name` listed together, etc), it isn't a dealbreaker to retain that kind of structure, and we're moving more and more towards a world where schemas are generated rather than hand-crafted. We should optimise for making diffs easier to review, rather than trying to retain an inconsistently applied hierarchical ordering of properties.

This sorting was done by the following script, created by ChatGPT:

```

if [ -z "$1" ]; then
  echo "Usage: $0 <directory>"
  exit 1
fi

DIR="$1"

if [ ! -d "$DIR" ]; then
  echo "Error: Directory $DIR does not exist."
  exit 1
fi

for file in "$DIR"/*.json; do
  # Check if the file exists and is a regular file
  if [ -f "$file" ]; then
    # Use jq to prettify and sort the JSON keys, overwriting the file
    jq -S . "$file" > "$file.tmp" && mv "$file.tmp" "$file"
    echo "Prettified and sorted $file"
  fi
done

echo "All JSON files in $DIR have been prettified and sorted alphabetically."
```

usage:

```
chmod +x prettify_json.sh
./prettify_json.sh lib/documents/schemas
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
