### PR TITLE
Default `subscription_list_title_prefix` to empty string, not hash

### DIFF
--- a/app/presenters/finder_signup_content_item_presenter.rb
+++ b/app/presenters/finder_signup_content_item_presenter.rb
@@ -125,7 +125,7 @@ private
       "email_filter_facets" => email_filter_facets,
       "email_filter_by" => email_filter_by,
       "filter" => schema.fetch("filter", nil),
-      "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", {}),
+      "subscription_list_title_prefix" => schema.fetch("subscription_list_title_prefix", ""),
     }
   end
 


### PR DESCRIPTION
Historically, `subscription_list_title_prefix` has always defaulted to an empty hash if not specified in the finder schema. This is despite there being no corresponding test for an empty hash in finder-frontend, and [something of an assumption](https://github.com/alphagov/finder-frontend/blob/20e6a1edf6da22d7b7cb453a913d4e2d54154a44/features/fixtures/research_and_statistics_email_signup.json#L41) that a 'nil' `subscription_list_title_prefix` should have the value of `""` (this test has been in place for five years).

Adding the following test to finder-frontend (inspired by the 'facet_connector' test below it) passes, indicating that Finder Frontend can cope with either "" or `{}`, seemingly by accident.

```
  context "when subscription_list_title_prefix is an empty hash" do
    let(:content_item) { research_and_stats_finder_signup_content_item }
    let(:filter) { { "content_store_document_type" => %w[statistics_published research] } }
    let(:subscription_list_title_prefix) { {} }
    let(:facets) { content_item["details"].fetch("email_filter_facets", []) }

    it {
      expect(subject).to eq("All documents filtered by Statistics (published) and Research")
    }
  end
```

Where this has become a problem, therefore, was after merging https://github.com/alphagov/publishing-api/pull/3086. We have tidied up the schemas such that there are no hash values for this property anymore, and we've now removed hashes as an option in Publishing API. This was causing an error in Sentry at the point of publishing the finder:
https://govuk.sentry.io/issues/6232406401/?alert_rule_id=283807&alert_type=issue&notification_uuid=9fabf64a-f452-443d-86ba-4195f0b1f8cc&project=202253&referrer=slack

```
[{"schema":{"scheme":null,"user":null,"password":null,"host":null,"port":null,"path":"1fc1f7f7-1455-5ae2-8167-315f796accc0","query":null,"fragment":""},"fragment":"#/details/subscription_list_title_prefix","message":"The property '#/details/subscription_list_title_prefix' of type object did not match the following type: string in schema 1fc1f7f7-1455-5ae2-8167-315f796accc0#","failed_attribute":"TypeV4"}]
```

The fallback to an empty string was the final piece of the puzzle. Tested running the publish rake task locally, and no longer getting an error from Publishing API.

Trello: https://trello.com/c/3tKfYiAe/3348-specialist-finder-edit-request-product-safety-alerts-reports-and-recalls

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
