### PR TITLE
Add changes to TCRD finder

### DIFF
--- a/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
+++ b/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
@@ -8,6 +8,10 @@
     {
       "allowed_values": [
         {
+          "label": "Driver conduct",
+          "value": "driver-conduct"
+        },
+        {
           "label": "HGV operator",
           "value": "hgv-operator"
         },
@@ -26,7 +30,7 @@
       "name": "Subject",
       "preposition": "with subject",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "multiple"
       },
       "type": "text"
     },
@@ -37,7 +41,7 @@
           "value": "eastern"
         },
         {
-          "label": "London and southeast",
+          "label": "London and South East",
           "value": "london-and-southeast"
         },
         {
@@ -100,31 +104,83 @@
       "name": "Case type",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "multiple"
       },
       "type": "text"
     },
     {
       "allowed_values": [
         {
-          "label": "No action",
-          "value": "no-action"
+          "label": "Application granted as applied for",
+          "value": "application-granted-as-applied-for"
         },
         {
-          "label": "Curtailment",
-          "value": "curtailment"
+          "label": "Application granted in part",
+          "value": "application-granted-in-part"
+        },
+        {
+          "label": "Application granted with conditions",
+          "value": "application-granted-with-conditions"
+        },
+        {
+          "label": "Application refused",
+          "value": "application-refused"
+        },
+        {
+          "label": "Application withdrawn",
+          "value": "application-withdrawn"
+        },
+        {
+          "label": "Conditions imposed on licence",
+          "value": "conditions-imposed-on-licence"
         },
         {
           "label": "Formal warning",
           "value": "formal-warning"
         },
         {
+          "label": "Impounding application granted",
+          "value": "impounding-application-granted"
+        },
+        {
+          "label": "Impounding application refused",
+          "value": "impounding-application-refused"
+        },
+        {
+          "label": "Licence curtailed or authorisation reduced",
+          "value": "curtailment"
+        },
+        {
+          "label": "Licence holder disqualified",
+          "value": "licence-holder-disqualified"
+        },
+        {
+          "label": "Licence revoked",
+          "value": "revocation"
+        },
+        {
+          "label": "Licence suspended",
+          "value": "licence-suspended"
+        },
+        {
           "label": "Loss of repute",
           "value": "loss-of-repute"
         },
         {
-          "label": "Revocation",
-          "value": "revocation"
+          "label": "No action taken",
+          "value": "no-action"
+        },
+        {
+          "label": "Restrictions imposed under Transport Act 1985",
+          "value": "restrictions-imposed-under-transport-act-1985"
+        },
+        {
+          "label": "Penalty imposed under Transport Act 2000",
+          "value": "penalty-imposed-under-transport-act-2000"
+        },
+        {
+          "label": "Transport manager disqualified",
+          "value": "transport-manager-disqualified"
         }
       ],
       "display_as_result_metadata": false,
@@ -133,7 +189,7 @@
       "name": "Regulatory decision",
       "preposition": "with outcome",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "multiple"
       },
       "type": "text"
     },


### PR DESCRIPTION
https://trello.com/c/QUZiTIcs/3268-changes-to-the-specialist-publisher-page-traffic-commissioner-regulatory-decisions-govt-agency-general-issue

When adding a new decision, I request the following changes to be made –

Decision Subject – We need to be able to select multiple options. Options to expand and include Driver Conduct

Region – southeast should be separated and capitalised for consistency South East.

Case Type – need to be able to select multiple options.

Regulatory decision – need to be able to select multiple options and options to be the following:

Licence revoked
Licence holder disqualified
Transport manager disqualified
Licence suspended
Licence curtailed or authorisation reduced
Conditions imposed on licence
Formal warning
No action taken
Application granted as applied for
Application granted in part
Application granted with conditions
Application refused
Application withdrawn
Restrictions imposed under Transport Act 1985
Penalty imposed under Transport Act 2000
Impounding application granted
Impounding application refused

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
