### PR TITLE
Add editorial remark to finder change confirmation forms

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -81,6 +81,7 @@ private
         name: current_user.name,
         email: current_user.email,
       },
+      editorial_remark: params[:editorial_remark],
     }
   end
 

--- a/app/views/admin/_confirmation_page.html.erb
+++ b/app/views/admin/_confirmation_page.html.erb
@@ -12,19 +12,28 @@
 
     <%= render(partial: "diff", locals: { old_schema: @current_format.finder_schema, new_schema: @proposed_schema }) %>
 
-    <p class="govuk-body govuk-body govuk-!-margin-top-7">
-      By submitting you are confirming that these changes are required to the specialist finder.
-    </p>
+    <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        name: "editorial_remark",
+        id: "editorial_remark",
+        label: {
+          text: "Tell us about your changes (optional)",
+        },
+        hint: "Please add any further information you think may be helpful related to these changes, including specific dates or deadlines, if you have them."
+      } %>
 
-    <div class="govuk-button-group govuk-!-margin-top-7">
-      <%= form_tag "/admin/zendesk/#{current_format.admin_slug}", method: 'post' do %>
+      <p class="govuk-body govuk-body govuk-!-margin-top-7">
+        By submitting you are confirming that these changes are required to the specialist finder.
+      </p>
+
+      <div class="govuk-button-group govuk-!-margin-top-7">
         <%= hidden_field_tag :proposed_schema, JSON.pretty_generate(JSON.parse(@proposed_schema.to_json)) %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit changes"
         } %>
-      <% end %>
 
-      <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
+        <%= link_to("Cancel", "/admin/#{current_format.admin_slug}", class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe AdminController, type: :controller do
       stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
       get :summary, params: { document_type_slug: "asylum-support-decisions" }
       expect(response.status).to eq(200)
+      within "form" do
+        assert_select "textarea[name=\"editorial_remark\"]"
+      end
     end
   end
 
@@ -62,7 +65,13 @@ RSpec.describe AdminController, type: :controller do
         end
       end
 
-      post :zendesk, params: { document_type_slug: "cma-cases", proposed_schema: "{ \"foo\": \"bar\" }" }
+      editorial_remark = "This is a high priority request."
+
+      post :zendesk, params: {
+        document_type_slug: "cma-cases",
+        proposed_schema: "{ \"foo\": \"bar\" }",
+        editorial_remark:,
+      }
 
       expected_payload = {
         subject: "Specialist Finder Edit Request: CMA Cases",
@@ -76,6 +85,7 @@ RSpec.describe AdminController, type: :controller do
           name: user.name,
           email: user.email,
         },
+        editorial_remark:,
       }.to_json
 
       assert_requested(stub_post)


### PR DESCRIPTION
We are including an editorial remark textarea on the confirmation form so that the publisher can communicate when they need changes completed by, or any other information we should know.

This information will be included in the payload sent to Zendesk.

## Screenshot

![Screenshot 2025-01-23 at 10 51 05](https://github.com/user-attachments/assets/0ae0d4c0-b280-40c0-95b0-33845b7343cb)

I would have gone for a bit more margin between the schema details and the textarea label but the details component doesn't provide a way to override the bottom margin and the textarea component doesn't provide a way to override the top margin.

Trello: https://trello.com/c/hLwpyjxM
