### PR TITLE
Make document validation schema-driven - presence only

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -104,19 +104,19 @@ private
   end
 
   def facets_params
-    allowed_facet_params = %i[
-      key
-      name
-      short_name
-      type
-      preposition
-      display_as_result_metadata
-      filterable
-      allowed_values
-      _destroy
-    ]
     params.permit(
-      facets: allowed_facet_params,
+      facets: [
+        :key,
+        :name,
+        :short_name,
+        :type,
+        :preposition,
+        :display_as_result_metadata,
+        :filterable,
+        :allowed_values,
+        :_destroy,
+        { validations: [] },
+      ],
     )
   end
 

--- a/app/models/algorithmic_transparency_record.rb
+++ b/app/models/algorithmic_transparency_record.rb
@@ -1,9 +1,5 @@
 class AlgorithmicTransparencyRecord < Document
-  validates :algorithmic_transparency_record_organisation, presence: true
-  validates :algorithmic_transparency_record_organisation_type, presence: true
-  validates :algorithmic_transparency_record_phase, presence: true
-  validates :algorithmic_transparency_record_date_published, presence: true
-  validates :algorithmic_transparency_record_atrs_version, presence: true
+  apply_validations
 
   FORMAT_SPECIFIC_FIELDS = %i[
     algorithmic_transparency_record_organisation

--- a/app/models/animal_disease_case.rb
+++ b/app/models/animal_disease_case.rb
@@ -1,8 +1,6 @@
 class AnimalDiseaseCase < Document
-  validates :disease_type, presence: true
-  validates :zone_restriction, presence: true
-  validates :zone_type, presence: true
-  validates :disease_case_opened_date, presence: true, date: true
+  apply_validations
+  validates :disease_case_opened_date, date: true
   validates :disease_case_closed_date, date: true
   validates_with OpenBeforeClosedValidator, opened_date: :disease_case_opened_date, closed_date: :disease_case_closed_date
 

--- a/app/models/asylum_support_decision.rb
+++ b/app/models/asylum_support_decision.rb
@@ -1,10 +1,7 @@
 class AsylumSupportDecision < Document
-  validates :tribunal_decision_categories, presence: true
-  validates :tribunal_decision_decision_date, presence: true, date: true
-  validates :tribunal_decision_judges, presence: true
-  validates :tribunal_decision_landmark, presence: true
-  validates :tribunal_decision_reference_number, presence: true
-  validates :tribunal_decision_sub_categories, presence: true, asylum_support_decision_sub_category: true
+  apply_validations
+  validates :tribunal_decision_decision_date, date: true
+  validates :tribunal_decision_sub_categories, asylum_support_decision_sub_category: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     hidden_indexable_content

--- a/app/models/business_finance_support_scheme.rb
+++ b/app/models/business_finance_support_scheme.rb
@@ -1,10 +1,6 @@
 class BusinessFinanceSupportScheme < Document
-  validates :business_sizes, presence: true
-  validates :business_stages, presence: true
+  apply_validations
   validates :continuation_link, presence: true
-  validates :industries, presence: true
-  validates :regions, presence: true
-  validates :types_of_support, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     business_sizes

--- a/app/models/cma_case.rb
+++ b/app/models/cma_case.rb
@@ -1,7 +1,5 @@
 class CmaCase < Document
-  validates :market_sector, presence: true
-  validates :case_type, presence: true
-  validates :case_state, presence: true
+  apply_validations
   validates :opened_date, allow_blank: true, date: true
   validates :closed_date, allow_blank: true, date: true
   validates_with OpenBeforeClosedValidator, opened_date: :opened_date, closed_date: :closed_date

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -370,6 +370,15 @@ class Document
     []
   end
 
+  def self.apply_validations
+    finder_schema.facets.each do |facet|
+      key = facet["key"]
+      validations = facet.dig("specialist_publisher_properties", "validations") || {}
+
+      validates key.to_sym, presence: validations.fetch("required").deep_symbolize_keys if validations.key?("required")
+    end
+  end
+
 private
 
   def param_value(params, key)

--- a/app/models/drcf_digital_markets_research.rb
+++ b/app/models/drcf_digital_markets_research.rb
@@ -1,11 +1,6 @@
 class DrcfDigitalMarketsResearch < Document
-  validates :digital_market_research_category, presence: true
-  validates :digital_market_research_publisher, presence: true
-  validates :digital_market_research_area, presence: true
-  validates :digital_market_research_topic, presence: true
-  validates :digital_market_research_publish_date,
-            presence: true,
-            date: true
+  apply_validations
+  validates :digital_market_research_publish_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     digital_market_research_category

--- a/app/models/employment_appeal_tribunal_decision.rb
+++ b/app/models/employment_appeal_tribunal_decision.rb
@@ -1,7 +1,6 @@
 class EmploymentAppealTribunalDecision < Document
-  validates :tribunal_decision_categories, presence: true
-  validates :tribunal_decision_decision_date, presence: true, date: true
-  validates :tribunal_decision_landmark, presence: true
+  apply_validations
+  validates :tribunal_decision_decision_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     hidden_indexable_content

--- a/app/models/employment_tribunal_decision.rb
+++ b/app/models/employment_tribunal_decision.rb
@@ -1,7 +1,6 @@
 class EmploymentTribunalDecision < Document
-  validates :tribunal_decision_categories, presence: true
-  validates :tribunal_decision_country, presence: true
-  validates :tribunal_decision_decision_date, presence: true, date: true
+  apply_validations
+  validates :tribunal_decision_decision_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     hidden_indexable_content

--- a/app/models/export_health_certificate.rb
+++ b/app/models/export_health_certificate.rb
@@ -1,7 +1,5 @@
 class ExportHealthCertificate < Document
-  validates :certificate_status, presence: true
-  validates :commodity_type, presence: true
-  validates :destination_country, presence: true
+  apply_validations
 
   FORMAT_SPECIFIC_FIELDS = %i[
     certificate_status

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -37,7 +37,7 @@ class Facet
       facet.display_as_result_metadata = params["display_as_result_metadata"]
       facet.filterable = params["filterable"]
       facet.allowed_values = facet_allowed_values(params["allowed_values"], params["type"])
-      facet.specialist_publisher_properties = facet_specialist_publisher_properties(params["type"])
+      facet.specialist_publisher_properties = facet_specialist_publisher_properties(params["type"], params["validations"])
       facet
     end
 
@@ -67,13 +67,32 @@ class Facet
       end
     end
 
-    def facet_specialist_publisher_properties(type)
+    def facet_specialist_publisher_properties(type, validations)
+      properties = facet_specialist_publisher_properties_select(type).merge(facet_specialist_publisher_properties_validations(validations))
+
+      properties.presence
+    end
+
+    def facet_specialist_publisher_properties_select(type)
       case type
       when "enum_text_multiple"
         { select: "multiple" }
       when "enum_text_single"
         { select: "one" }
+      else
+        {}
       end
+    end
+
+    def facet_specialist_publisher_properties_validations(validations)
+      return {} unless validations
+
+      rules = {}
+      validations.each do |key|
+        rules[key.to_sym] = {}
+      end
+
+      { validations: rules }
     end
 
     def facet_types_that_allow_enum_values

--- a/app/models/farming_grant.rb
+++ b/app/models/farming_grant.rb
@@ -1,5 +1,5 @@
 class FarmingGrant < Document
-  validates :payment_types, presence: true
+  apply_validations
 
   FORMAT_SPECIFIC_FIELDS = %i[
     areas_of_interest

--- a/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
+++ b/app/models/flood_and_coastal_erosion_risk_management_research_report.rb
@@ -1,10 +1,7 @@
 class FloodAndCoastalErosionRiskManagementResearchReport < Document
-  validates :flood_and_coastal_erosion_category, presence: true
+  apply_validations
   validates :date_of_completion, date: true
   validates :date_of_start, date: true
-  validates :project_code, presence: true
-  validates :project_status, presence: true
-  validates :topics, presence: true
   validates :primary_publishing_organisation, presence: true
 
   FORMAT_SPECIFIC_FIELDS = %i[

--- a/app/models/licence_transaction.rb
+++ b/app/models/licence_transaction.rb
@@ -16,10 +16,9 @@ class LicenceTransaction < Document
     change_note
   ]
 
+  apply_validations
   validates_with LinkOrIdentifierValidator
   validates :primary_publishing_organisation, presence: true
-  validates :licence_transaction_industry, presence: true
-  validates :licence_transaction_location, presence: true
   validates :licence_transaction_licence_identifier, format: {
     with: /\A[0-9]{3,4}-[1-7]-[1-9]\z/,
     allow_blank: true,

--- a/app/models/life_saving_maritime_appliance_service_station.rb
+++ b/app/models/life_saving_maritime_appliance_service_station.rb
@@ -1,6 +1,5 @@
 class LifeSavingMaritimeApplianceServiceStation < Document
-  validates :life_saving_maritime_appliance_service_station_regions, presence: true
-  validates :life_saving_maritime_appliance_manufacturer, presence: true
+  apply_validations
 
   FORMAT_SPECIFIC_FIELDS = %i[
     life_saving_maritime_appliance_service_station_regions

--- a/app/models/maib_report.rb
+++ b/app/models/maib_report.rb
@@ -1,5 +1,6 @@
 class MaibReport < Document
-  validates :date_of_occurrence, presence: true, date: true
+  apply_validations
+  validates :date_of_occurrence, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     date_of_occurrence

--- a/app/models/marine_notice.rb
+++ b/app/models/marine_notice.rb
@@ -1,8 +1,6 @@
 class MarineNotice < Document
-  validates :issued_date, presence: true, date: true
-  validates :marine_notice_type, presence: true
-  validates :marine_notice_vessel_type, presence: true
-  validates :marine_notice_topic, presence: true
+  apply_validations
+  validates :issued_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     marine_notice_type

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -1,6 +1,6 @@
 class MedicalSafetyAlert < Document
-  validates :alert_type, presence: true
-  validates :issued_date, presence: true, date: true
+  apply_validations
+  validates :issued_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     alert_type

--- a/app/models/product_safety_alert_report_recall.rb
+++ b/app/models/product_safety_alert_report_recall.rb
@@ -1,8 +1,5 @@
 class ProductSafetyAlertReportRecall < Document
-  validates :product_alert_type, presence: true
-  validates :product_risk_level, presence: true
-  validates :product_category, presence: true
-  validates :product_measure_type, presence: true
+  apply_validations
   validates :product_recall_alert_date, allow_blank: true, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[

--- a/app/models/protected_food_drink_name.rb
+++ b/app/models/protected_food_drink_name.rb
@@ -1,18 +1,9 @@
 class ProtectedFoodDrinkName < Document
-  validates :registered_name, presence: true
-  validates :register, presence: true
-  validates :status, presence: true
-  validates :class_category, presence: true
-  validates :protection_type, presence: true
-  validates :country_of_origin, presence: true
-  validates :traditional_term_grapevine_product_category, presence: true, allow_blank: true
-  validates :traditional_term_type, presence: true, allow_blank: true
-  validates :traditional_term_language, presence: true, allow_blank: true
-  validates :reason_for_protection, presence: true, allow_blank: true
-  validates :date_application, presence: true, date: true, allow_blank: true
-  validates :date_registration, presence: true, date: true, allow_blank: true
-  validates :time_registration, presence: true, time: true, allow_blank: true
-  validates :date_registration_eu, presence: true, date: true, allow_blank: true
+  apply_validations
+  validates :date_application, date: true
+  validates :date_registration, date: true
+  validates :time_registration, time: true
+  validates :date_registration_eu, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     registered_name

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -1,5 +1,6 @@
 class RaibReport < Document
-  validates :date_of_occurrence, presence: true, date: true
+  apply_validations
+  validates :date_of_occurrence, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     date_of_occurrence

--- a/app/models/research_for_development_output.rb
+++ b/app/models/research_for_development_output.rb
@@ -1,7 +1,6 @@
 class ResearchForDevelopmentOutput < Document
-  validates :first_published_at, presence: true, date: true
-  validates :theme, presence: true
-  validates :research_document_type, presence: true
+  apply_validations
+  validates :first_published_at, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     research_document_type

--- a/app/models/residential_property_tribunal_decision.rb
+++ b/app/models/residential_property_tribunal_decision.rb
@@ -1,7 +1,7 @@
 class ResidentialPropertyTribunalDecision < Document
-  validates :tribunal_decision_category, presence: true
-  validates :tribunal_decision_sub_category, presence: true, residential_property_tribunal_decision_sub_category: true
-  validates :tribunal_decision_decision_date, presence: true, date: true
+  apply_validations
+  validates :tribunal_decision_sub_category, residential_property_tribunal_decision_sub_category: true
+  validates :tribunal_decision_decision_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     hidden_indexable_content

--- a/app/models/sfo_case.rb
+++ b/app/models/sfo_case.rb
@@ -1,6 +1,6 @@
 class SfoCase < Document
-  validates :sfo_case_state, presence: true
-  validates :sfo_case_date_announced, presence: true, date: true
+  apply_validations
+  validates :sfo_case_date_announced, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     sfo_case_state

--- a/app/models/statutory_instrument.rb
+++ b/app/models/statutory_instrument.rb
@@ -1,9 +1,8 @@
 class StatutoryInstrument < Document
+  apply_validations
   validates :laid_date, date: true
   validates :sift_end_date, date: true
   validates :sift_end_date, absence: { message: "must be blank when withdrawn" }, if: :withdrawn_sifting_status?
-  validates :sifting_status, presence: true
-  validates :subject, presence: true
   validates :primary_publishing_organisation, presence: true
   validates :withdrawn_date, presence: true, date: true, if: :withdrawn_sifting_status?
   validates :withdrawn_date, absence: { message: "must be blank if not withdrawn" }, unless: :withdrawn_sifting_status?

--- a/app/models/tax_tribunal_decision.rb
+++ b/app/models/tax_tribunal_decision.rb
@@ -1,5 +1,5 @@
 class TaxTribunalDecision < Document
-  validates :tribunal_decision_category, presence: true
+  apply_validations
   validates :tribunal_decision_decision_date, allow_blank: true, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[

--- a/app/models/traffic_commissioner_regulatory_decision.rb
+++ b/app/models/traffic_commissioner_regulatory_decision.rb
@@ -1,9 +1,6 @@
 class TrafficCommissionerRegulatoryDecision < Document
-  validates :decision_subject, presence: true
-  validates :regions, presence: true
-  validates :case_type, presence: true
-  validates :outcome_type, presence: true
-  validates :first_published_at, presence: true, date: true
+  apply_validations
+  validates :first_published_at, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     decision_subject

--- a/app/models/utaac_decision.rb
+++ b/app/models/utaac_decision.rb
@@ -1,8 +1,6 @@
 class UtaacDecision < Document
-  validates :tribunal_decision_categories, presence: true
-  validates :tribunal_decision_sub_categories, presence: false
-  validates :tribunal_decision_decision_date, presence: true, date: true
-  validates :tribunal_decision_judges, presence: true
+  apply_validations
+  validates :tribunal_decision_decision_date, date: true
 
   FORMAT_SPECIFIC_FIELDS = %i[
     hidden_indexable_content

--- a/app/views/admin/_facet_fields.html.erb
+++ b/app/views/admin/_facet_fields.html.erb
@@ -49,6 +49,21 @@
     ]
 } %>
 
+<%= render "govuk_publishing_components/components/checkboxes", {
+  id: "facets-#{index}-validations",
+  name: "facets[#{index}][validations][]",
+  heading: "Validation",
+  heading_size: "s",
+  hint_text: "Select the type of validation that should be applied to the filter.",
+  items: [
+    {
+      label: "Required",
+      value: "required",
+      checked: facet.dig("specialist_publisher_properties", "validations")&.key?("required"),
+    }
+  ]
+} %>
+
 <%= render "govuk_publishing_components/components/textarea", {
   label: {
     text: "Filter options ('Multiple select' or 'One option' only)",

--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -149,7 +149,10 @@
       "preposition": "Organisation",
       "short_name": "Organisation",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -191,7 +194,10 @@
       "preposition": "Organisation type",
       "short_name": "Organisation type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -346,7 +352,10 @@
       "preposition": "Phase",
       "short_name": "Phase",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -427,6 +436,11 @@
       "name": "Date published",
       "preposition": "Date published",
       "short_name": "Date published",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {
@@ -436,6 +450,11 @@
       "name": "ATRS version",
       "preposition": "ATRS version",
       "short_name": "ATRS version",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "text"
     },
     {

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -54,7 +54,10 @@
       "preposition": "of disease type",
       "short_name": "type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -76,7 +79,10 @@
       "preposition": "with control zone restriction",
       "short_name": "Control zone restriction",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -146,7 +152,10 @@
       "preposition": "with control zone type",
       "short_name": "Control zone type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -166,6 +175,11 @@
       "name": "Case opened date",
       "preposition": "opened",
       "short_name": "Opened",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -29,7 +29,10 @@
       "name": "Category",
       "preposition": "categorised as",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -118,7 +121,10 @@
       "name": "Sub-category",
       "preposition": "sub-categorised as",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -239,7 +245,10 @@
       "name": "Judges",
       "preposition": "by judge",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -259,7 +268,10 @@
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -268,6 +280,11 @@
       "filterable": false,
       "key": "tribunal_decision_reference_number",
       "name": "Reference number",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "text"
     },
     {
@@ -277,6 +294,11 @@
       "name": "Decision date",
       "preposition": "decided",
       "short_name": "Decided",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -39,7 +39,10 @@
       "name": "Type of support",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -64,7 +67,10 @@
       "name": "Business stage",
       "preposition": "for businesses which are",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -145,7 +151,10 @@
       "name": "Industry",
       "preposition": "for businesses in",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -174,7 +183,10 @@
       "name": "Number of employees",
       "preposition": "for businesses with",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -235,7 +247,10 @@
       "name": "Region",
       "preposition": "for businesses in",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     }

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -74,7 +74,10 @@
       "name": "Case type",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -95,7 +98,10 @@
       "name": "Case state",
       "preposition": "which are",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -232,7 +238,10 @@
       "name": "Market sector",
       "preposition": "about",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },

--- a/lib/documents/schemas/drcf_digital_markets_researches.json
+++ b/lib/documents/schemas/drcf_digital_markets_researches.json
@@ -23,7 +23,10 @@
       "preposition": "",
       "short_name": "Category",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -81,7 +84,10 @@
       "preposition": "",
       "short_name": "Publisher",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -119,7 +125,10 @@
       "preposition": "",
       "short_name": "Research area",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -277,7 +286,10 @@
       "preposition": "",
       "short_name": "Research topic",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -288,6 +300,11 @@
       "name": "Research publish date",
       "preposition": "research published",
       "short_name": "Research published",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -197,7 +197,10 @@
       "name": "Category",
       "preposition": "categorised as",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -1018,7 +1021,10 @@
       "key": "tribunal_decision_landmark",
       "name": "Landmark",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -1028,6 +1034,11 @@
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -41,7 +41,10 @@
       "name": "Country",
       "preposition": "by country",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -270,7 +273,10 @@
       "name": "Jurisdiction code",
       "preposition": "by jurisdiction",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -280,6 +286,11 @@
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -925,7 +925,10 @@
       "preposition": "to",
       "short_name": "Destination",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -967,7 +970,10 @@
       "preposition": "of type",
       "short_name": "Commodity",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -988,7 +994,10 @@
       "name": "Certificate status",
       "preposition": "with status",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     }

--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -189,7 +189,10 @@
       "name": "Payment types",
       "preposition": "payment type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     }

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -42,7 +42,10 @@
       "name": "Category",
       "preposition": "with category",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -283,7 +286,10 @@
       "name": "Topics",
       "preposition": "with topics",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -304,7 +310,10 @@
       "name": "Project status",
       "preposition": "with project status",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -313,6 +322,11 @@
       "filterable": false,
       "key": "project_code",
       "name": "Project code",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "text"
     },
     {

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -31,7 +31,10 @@
       "name": "Location",
       "preposition": "In",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -239,7 +242,10 @@
       "preposition": "For",
       "show_option_select_filter": true,
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },

--- a/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
+++ b/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
@@ -59,7 +59,10 @@
       "preposition": "in region",
       "short_name": "region",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -373,7 +376,10 @@
       "name": "Appliance manufacturer",
       "preposition": "manufactured by",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     }

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -86,6 +86,11 @@
       "name": "Date of occurrence",
       "preposition": "occurred",
       "short_name": "Occurred",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/marine_notices.json
+++ b/lib/documents/schemas/marine_notices.json
@@ -46,7 +46,10 @@
       "name": "Marine notice type",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -95,7 +98,10 @@
       "name": "Vessel type",
       "preposition": "with vessel of type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -144,7 +150,10 @@
       "name": "Topic",
       "preposition": "with topic of",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -155,6 +164,11 @@
       "name": "Issued",
       "preposition": "issued",
       "short_name": "Issued",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -40,7 +40,10 @@
       "name": "Message type",
       "preposition": "for",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -156,6 +159,11 @@
       "name": "Issued",
       "preposition": "issued",
       "short_name": "Issued",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -31,7 +31,10 @@
       "preposition": "of type",
       "short_name": "Alert type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -65,7 +68,10 @@
       "preposition": "that are",
       "short_name": "Risk level",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -202,7 +208,10 @@
       "name": "Product category",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -264,7 +273,10 @@
       "preposition": "of type",
       "short_name": "Measure type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -10,6 +10,11 @@
       "filterable": false,
       "key": "registered_name",
       "name": "Registered name",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "text"
     },
     {
@@ -49,7 +54,10 @@
       "name": "Register",
       "preposition": "register type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -82,7 +90,10 @@
       "name": "Status",
       "preposition": "status",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -460,7 +471,10 @@
       "preposition": "class or category",
       "short_name": "Class or category",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -501,7 +515,10 @@
       "name": "Protection type",
       "preposition": "protection type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -802,7 +819,10 @@
       "name": "Country of origin",
       "preposition": "country of origin",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -78,6 +78,11 @@
       "name": "Date of occurrence",
       "preposition": "occurred",
       "short_name": "Occurred",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -900,7 +900,10 @@
       "preposition": "of type",
       "short_name": "Document Type",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -962,7 +965,10 @@
       "preposition": "about",
       "short_name": "Theme",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -972,6 +978,11 @@
       "key": "first_published_at",
       "name": "First published",
       "short_name": "First published",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -64,7 +64,10 @@
       "name": "Category",
       "preposition": "categorised as",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -329,7 +332,10 @@
       "name": "Sub-category",
       "preposition": "sub-categorised as",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -339,6 +345,11 @@
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -22,7 +22,10 @@
       "name": "Case state",
       "preposition": "with case state",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -33,6 +36,11 @@
       "name": "Date announced",
       "preposition": "announced",
       "short_name": "Date announced",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -42,7 +42,10 @@
       "name": "Sifting status",
       "preposition": "with status",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -131,7 +134,10 @@
       "name": "Subject",
       "preposition": "relating to",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     }

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -47,7 +47,10 @@
       "preposition": "categorised as",
       "short_name": "category",
       "specialist_publisher_properties": {
-        "select": "one"
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },

--- a/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
+++ b/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
@@ -30,7 +30,10 @@
       "name": "Subject",
       "preposition": "with subject",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -75,7 +78,10 @@
       "name": "Region",
       "preposition": "for decisions in",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -104,7 +110,10 @@
       "name": "Case type",
       "preposition": "of type",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -189,7 +198,10 @@
       "name": "Regulatory decision",
       "preposition": "with outcome",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -199,6 +211,11 @@
       "key": "first_published_at",
       "name": "Published",
       "short_name": "Published",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     }
   ],

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -269,7 +269,10 @@
       "name": "Categories",
       "preposition": "categorised as",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -2695,7 +2698,10 @@
       "name": "Judges",
       "preposition": "by judge",
       "specialist_publisher_properties": {
-        "select": "multiple"
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
       },
       "type": "text"
     },
@@ -2705,6 +2711,11 @@
       "key": "tribunal_decision_decision_date",
       "name": "Decision date",
       "short_name": "Decided",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
       "type": "date"
     },
     {

--- a/spec/features/editing_the_cma_case_filters_and_options_spec.rb
+++ b/spec/features/editing_the_cma_case_filters_and_options_spec.rb
@@ -49,6 +49,10 @@ RSpec.feature "Editing the CMA case finder filters and options", type: :feature 
     choose "#{inserted_facet}[display_as_result_metadata]", option: "false", visible: false
     fill_in "#{inserted_facet}[preposition]", with: "of type NEW"
 
+    within find("fieldset", text: "Filter 2") do
+      check "Required", visible: false
+    end
+
     click_button "Submit changes"
 
     expect(page).to have_selector(".govuk-summary-list__row", text: "Case type Updated (click on 'View diff' for details)")

--- a/spec/lib/documents/schemas/finder_schemas_validation_spec.rb
+++ b/spec/lib/documents/schemas/finder_schemas_validation_spec.rb
@@ -16,12 +16,21 @@ RSpec.describe "Sense-checks for every finder schema" do
       finder_schema["facets"].each do |facet|
         next unless facet["specialist_publisher_properties"]
 
-        valid_values = [
-          { "select" => "one" },
-          { "select" => "multiple" },
-          { "omit_from_finder_content_item" => true },
-        ]
-        expect(valid_values).to include(facet["specialist_publisher_properties"]), "In the '#{finder_schema['filter']['format']}' finder, facet '#{facet['key']}' has an invalid 'specialist_publisher_properties' value"
+        valid_keys = %w[select omit_from_finder_content_item validations]
+        facet["specialist_publisher_properties"].each_key do |key|
+          expect(valid_keys).to include(key), "In the '#{finder_schema['filter']['format']}' finder, facet '#{facet['key']}' has an invalid 'specialist_publisher_properties' key: '#{key}'"
+        end
+      end
+    end
+
+    it "has valid 'validations' configuration" do
+      finder_schema["facets"].each do |facet|
+        next unless facet["specialist_publisher_properties"] && facet["specialist_publisher_properties"]["validations"]
+
+        valid_validation_keys = %w[required]
+        facet["specialist_publisher_properties"]["validations"].each_key do |key|
+          expect(valid_validation_keys).to include(key), "In the '#{finder_schema['filter']['format']}' finder, facet '#{facet['key']}' has an invalid 'validations' key: '#{key}'"
+        end
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -7,15 +7,68 @@ RSpec.describe Document do
         "My Document Type"
       end
 
+      def self.document_type
+        "my_document_type"
+      end
+
       attr_accessor :field1, :field2, :field3
 
       def initialize(params = {})
         super(params, %i[field1 field2 field3])
       end
+
+      apply_validations
     end
   end
+  let(:finder_schema) do
+    schema = FinderSchema.new
+    schema.assign_attributes({
+      base_path: "/my-document-types",
+      target_stack: "live",
+      filter: {
+        "format" => "my_format",
+      },
+      content_id: @finder_content_id,
+    })
+    schema
+  end
+  let(:payload_attributes) do
+    {
+      document_type: "my_document_type",
+      title: "Example document",
+      description: "This is a summary",
+      base_path: "/my-document-types/example-document",
+      details: {
+        body: [
+          {
+            content_type: "text/govspeak",
+            content: "This is the body of an example document",
+          },
+        ],
+        metadata: {
+          field1: "2015-12-01",
+          field2: "open",
+          field3: %w[x y z],
+        },
+      },
+      links: {
+        finder: [@finder_content_id],
+      },
+    }
+  end
+  let(:payload) { FactoryBot.create(:document, payload_attributes) }
+  let(:document) { MyDocumentType.from_publishing_api(payload) }
 
-  before { stub_const("MyDocumentType", document_sub_class) }
+  before do
+    allow(FinderSchema).to receive(:load_from_schema).with("my_document_types").and_return(finder_schema)
+    stub_const("MyDocumentType", document_sub_class)
+  end
+
+  before(:all) do
+    # this value is cached in the Document as a class variable, so we need it
+    # to not change between tests
+    @finder_content_id = SecureRandom.uuid
+  end
 
   it "has a document_type for building URLs" do
     expect(MyDocumentType.admin_slug).to eq("my-document-types")
@@ -121,731 +174,679 @@ RSpec.describe Document do
     end
   end
 
-  before(:all) do
-    # this value is cached in the Document as a class variable, so we need it
-    # to not change between tests
-    @finder_content_id = SecureRandom.uuid
-  end
+  describe ".from_publishing_api" do
+    context "for a published document" do
+      let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
 
-  let(:finder_schema) do
-    schema = FinderSchema.new
-    schema.assign_attributes({
-      base_path: "/my-document-types",
-      target_stack: "live",
-      filter: {
-        "format" => "my_format",
-      },
-      content_id: @finder_content_id,
-    })
-    schema
-  end
+      it "sets the top-level attributes on a document" do
+        expect(document.base_path).to eq(payload["base_path"])
+        expect(document.content_id).to eq(payload["content_id"])
+        expect(document.title).to eq(payload["title"])
+        expect(document.summary).to eq(payload["description"])
+        expect(document.publication_state).to eq(payload["publication_state"])
+        expect(document.public_updated_at).to eq(payload["public_updated_at"])
+        expect(document.first_published_at).to eq(payload["first_published_at"])
+        expect(document.update_type).to eq(nil)
+        expect(document.state_history).to eq(payload["state_history"])
+        expect(document.rendering_app).to eq("government-frontend")
+      end
 
-  let(:payload_attributes) do
-    {
-      document_type: "my_document_type",
-      title: "Example document",
-      description: "This is a summary",
-      base_path: "/my-document-types/example-document",
-      details: {
-        body: [
+      context "when bulk published is true" do
+        let(:payload_attributes) do
           {
-            content_type: "text/govspeak",
-            content: "This is the body of an example document",
-          },
-        ],
-        metadata: {
-          field1: "2015-12-01",
-          field2: "open",
-          field3: %w[x y z],
-        },
-      },
-      links: {
-        finder: [@finder_content_id],
-      },
-    }
-  end
-  let(:payload) { FactoryBot.create(:document, payload_attributes) }
-  let(:document) { MyDocumentType.from_publishing_api(payload) }
-
-  context "with stubbed FinderSchema" do
-    before do
-      allow(FinderSchema).to receive(:load_from_schema).with("my_document_types")
-        .and_return(finder_schema)
-    end
-
-    describe ".from_publishing_api" do
-      context "for a published document" do
-        let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
-
-        it "sets the top-level attributes on a document" do
-          expect(document.base_path).to eq(payload["base_path"])
-          expect(document.content_id).to eq(payload["content_id"])
-          expect(document.title).to eq(payload["title"])
-          expect(document.summary).to eq(payload["description"])
-          expect(document.publication_state).to eq(payload["publication_state"])
-          expect(document.public_updated_at).to eq(payload["public_updated_at"])
-          expect(document.first_published_at).to eq(payload["first_published_at"])
-          expect(document.update_type).to eq(nil)
-          expect(document.state_history).to eq(payload["state_history"])
-          expect(document.rendering_app).to eq("government-frontend")
-        end
-
-        context "when bulk published is true" do
-          let(:payload_attributes) do
-            {
-              details: {
-                metadata: {
-                  bulk_published: true,
-                },
+            details: {
+              metadata: {
+                bulk_published: true,
               },
-            }
-          end
-
-          specify { expect(document.bulk_published).to eq(true) }
+            },
+          }
         end
 
-        context "when bulk published is not present in metadata" do
-          let(:payload_attributes) do
-            {
-              details: {
-                metadata: {},
-              },
-            }
-          end
+        specify { expect(document.bulk_published).to eq(true) }
+      end
 
-          specify { expect(document.bulk_published).to eq(false) }
+      context "when bulk published is not present in metadata" do
+        let(:payload_attributes) do
+          {
+            details: {
+              metadata: {},
+            },
+          }
         end
 
-        context "when the body contains multiple content types" do
-          let(:payload_attributes) do
-            {
-              details: {
-                body: [
-                  { content_type: "text/govspeak", content: "# hello" },
-                  { content_type: "text/html", content: "<h1>hello</h1>" },
-                ],
-              },
-            }
-          end
+        specify { expect(document.bulk_published).to eq(false) }
+      end
 
-          it "sets the body to the content of the govspeak type" do
-            expect(document.body).to eq("# hello")
-          end
+      context "when the body contains multiple content types" do
+        let(:payload_attributes) do
+          {
+            details: {
+              body: [
+                { content_type: "text/govspeak", content: "# hello" },
+                { content_type: "text/html", content: "<h1>hello</h1>" },
+              ],
+            },
+          }
         end
 
-        context "when the body is just a string" do
-          let(:payload_attributes) do
-            {
-              details: {
-                body: "This is just a string.",
-              },
-            }
-          end
-
-          it "sets the body to that string" do
-            expect(document.body).to eq("This is just a string.")
-          end
-        end
-
-        it "sets its attachments collection from the payload" do
-          expect(document.attachments).to be_an(AttachmentCollection)
-        end
-
-        it "sets format specific fields for the document subclass" do
-          expect(document.format_specific_fields).to eq(%i[field1 field2 field3])
-
-          expect(document.field1).to eq("2015-12-01")
-          expect(document.field2).to eq("open")
-          expect(document.field3).to eq(%w[x y z])
+        it "sets the body to the content of the govspeak type" do
+          expect(document.body).to eq("# hello")
         end
       end
 
-      context "when the document is redrafted" do
-        let(:payload) do
+      context "when the body is just a string" do
+        let(:payload_attributes) do
+          {
+            details: {
+              body: "This is just a string.",
+            },
+          }
+        end
+
+        it "sets the body to that string" do
+          expect(document.body).to eq("This is just a string.")
+        end
+      end
+
+      it "sets its attachments collection from the payload" do
+        expect(document.attachments).to be_an(AttachmentCollection)
+      end
+
+      it "sets format specific fields for the document subclass" do
+        expect(document.format_specific_fields).to eq(%i[field1 field2 field3])
+
+        expect(document.field1).to eq("2015-12-01")
+        expect(document.field2).to eq("open")
+        expect(document.field3).to eq(%w[x y z])
+      end
+    end
+
+    context "when the document is redrafted" do
+      let(:payload) do
+        FactoryBot.create(
+          :document,
+          :redrafted,
+          payload_attributes.merge(update_type: "minor"),
+        )
+      end
+      it "sets the update type" do
+        expect(document.update_type).to eq(payload["update_type"])
+      end
+    end
+
+    context "when the document has a temporary update type" do
+      let(:payload_attributes) { { details: { temporary_update_type: true } } }
+
+      it "sets update type to nil and clears the temporary update type" do
+        expect(document.update_type).to be_nil
+        expect(document.temporary_update_type).to eq(false)
+      end
+    end
+  end
+
+  context "successful #publish" do
+    let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
+    before do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      stub_publishing_api_publish(document.content_id, {})
+      stub_publishing_api_has_item(payload)
+      @email_alert_api = stub_email_alert_api_accepts_content_change
+    end
+
+    it "sends a payload to Publishing API" do
+      expect(document.publish).to eq(true)
+
+      assert_publishing_api_publish(document.content_id)
+    end
+
+    it "alerts the email API for major updates" do
+      document.update_type = "major"
+
+      expect(document.publish).to eq(true)
+
+      assert_email_alert_api_content_change_created(
+        "tags" => {
+          "format" => "my_format",
+          "field1" => "2015-12-01",
+          "field2" => "open",
+          "field3" => %w[x y z],
+        },
+        "document_type" => "my_document_type",
+      )
+    end
+
+    context "document is redrafted with a minor edit" do
+      let(:minor_change_document) do
+        MyDocumentType.from_publishing_api(
+          FactoryBot.create(
+            :document,
+            payload_attributes.merge(
+              publication_state: "published",
+              update_type: "minor",
+              content_id: document.content_id,
+            ),
+          ),
+        )
+      end
+
+      it "doesn't alert the email API for minor updates" do
+        expect(minor_change_document.publish).to eq(true)
+
+        expect(@email_alert_api).to_not have_been_requested
+      end
+    end
+
+    context "document has never been published" do
+      let(:unpublished_document) do
+        MyDocumentType.from_publishing_api(
+          FactoryBot.create(
+            :document,
+            payload_attributes.merge(
+              first_published_at: nil,
+              publication_state: "draft",
+              content_id: document.content_id,
+            ),
+          ),
+        )
+      end
+
+      it 'saves a "First published." change note before asking the api to publish' do
+        Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC")) do
+          unpublished_document.publish
+
+          changed_json = {
+            update_type: "major",
+            change_note: "First published.",
+          }
+
+          assert_publishing_api_put_content(unpublished_document.content_id, request_json_includes(changed_json))
+        end
+      end
+
+      context "when the document has previously been unpublished" do
+        before do
+          document.state_history = { "1" => "unpublished", "2" => "draft" }
+        end
+
+        it "asynchronously restores attachments" do
+          expect(AttachmentRestoreWorker).to receive(:perform_async)
+            .with(document.content_id, document.locale)
+
+          document.publish
+        end
+      end
+    end
+
+    shared_examples_for "publishing changes to a document that has previously been published" do
+      let(:published_document) do
+        MyDocumentType.from_publishing_api(
           FactoryBot.create(
             :document,
             :redrafted,
-            payload_attributes.merge(update_type: "minor"),
-          )
-        end
-        it "sets the update type" do
-          expect(document.update_type).to eq(payload["update_type"])
-        end
-      end
-
-      context "when the document has a temporary update type" do
-        let(:payload_attributes) { { details: { temporary_update_type: true } } }
-
-        it "sets update type to nil and clears the temporary update type" do
-          expect(document.update_type).to be_nil
-          expect(document.temporary_update_type).to eq(false)
-        end
-      end
-    end
-
-    context "successful #publish" do
-      let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
-      before do
-        stub_any_publishing_api_put_content
-        stub_any_publishing_api_patch_links
-        stub_publishing_api_publish(document.content_id, {})
-        stub_publishing_api_has_item(payload)
-        @email_alert_api = stub_email_alert_api_accepts_content_change
-      end
-
-      it "sends a payload to Publishing API" do
-        expect(document.publish).to eq(true)
-
-        assert_publishing_api_publish(document.content_id)
-      end
-
-      it "alerts the email API for major updates" do
-        document.update_type = "major"
-
-        expect(document.publish).to eq(true)
-
-        assert_email_alert_api_content_change_created(
-          "tags" => {
-            "format" => "my_format",
-            "field1" => "2015-12-01",
-            "field2" => "open",
-            "field3" => %w[x y z],
-          },
-          "document_type" => "my_document_type",
+            payload_attributes.merge(
+              publication_state:,
+              content_id: document.content_id,
+            ),
+          ),
         )
       end
 
-      context "document is redrafted with a minor edit" do
-        let(:minor_change_document) do
-          MyDocumentType.from_publishing_api(
-            FactoryBot.create(
-              :document,
-              payload_attributes.merge(
-                publication_state: "published",
-                update_type: "minor",
-                content_id: document.content_id,
-              ),
-            ),
-          )
-        end
+      it 'does not add a "First published" change note before asking the api to publish' do
+        published_document.publish
 
-        it "doesn't alert the email API for minor updates" do
-          expect(minor_change_document.publish).to eq(true)
-
-          expect(@email_alert_api).to_not have_been_requested
-        end
-      end
-
-      context "document has never been published" do
-        let(:unpublished_document) do
-          MyDocumentType.from_publishing_api(
-            FactoryBot.create(
-              :document,
-              payload_attributes.merge(
-                first_published_at: nil,
-                publication_state: "draft",
-                content_id: document.content_id,
-              ),
-            ),
-          )
-        end
-
-        it 'saves a "First published." change note before asking the api to publish' do
-          Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC")) do
-            unpublished_document.publish
-
-            changed_json = {
-              update_type: "major",
-              change_note: "First published.",
-            }
-
-            assert_publishing_api_put_content(unpublished_document.content_id, request_json_includes(changed_json))
-          end
-        end
-
-        context "when the document has previously been unpublished" do
-          before do
-            document.state_history = { "1" => "unpublished", "2" => "draft" }
-          end
-
-          it "asynchronously restores attachments" do
-            expect(AttachmentRestoreWorker).to receive(:perform_async)
-              .with(document.content_id, document.locale)
-
-            document.publish
-          end
-        end
-      end
-
-      shared_examples_for "publishing changes to a document that has previously been published" do
-        let(:published_document) do
-          MyDocumentType.from_publishing_api(
-            FactoryBot.create(
-              :document,
-              :redrafted,
-              payload_attributes.merge(
-                publication_state:,
-                content_id: document.content_id,
-              ),
-            ),
-          )
-        end
-
-        it 'does not add a "First published" change note before asking the api to publish' do
-          published_document.publish
-
-          assert_no_publishing_api_put_content(published_document.content_id)
-        end
-      end
-
-      context "when document is in live state" do
-        let(:publication_state) { "published" }
-        it_behaves_like "publishing changes to a document that has previously been published"
-      end
-
-      context "when document is in redrafted state" do
-        let(:publication_state) { "draft" }
-        it_behaves_like "publishing changes to a document that has previously been published"
-      end
-
-      context "when document is in unpublished state" do
-        let(:publication_state) { "unpublished" }
-        it_behaves_like "publishing changes to a document that has previously been published"
-      end
-
-      context "when document is in superseded state" do
-        let(:publication_state) { "superseded" }
-        it_behaves_like "publishing changes to a document that has previously been published"
+        assert_no_publishing_api_put_content(published_document.content_id)
       end
     end
 
-    context "unsuccessful #publish" do
-      let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
+    context "when document is in live state" do
+      let(:publication_state) { "published" }
+      it_behaves_like "publishing changes to a document that has previously been published"
+    end
 
+    context "when document is in redrafted state" do
+      let(:publication_state) { "draft" }
+      it_behaves_like "publishing changes to a document that has previously been published"
+    end
+
+    context "when document is in unpublished state" do
+      let(:publication_state) { "unpublished" }
+      it_behaves_like "publishing changes to a document that has previously been published"
+    end
+
+    context "when document is in superseded state" do
+      let(:publication_state) { "superseded" }
+      it_behaves_like "publishing changes to a document that has previously been published"
+    end
+  end
+
+  context "unsuccessful #publish" do
+    let(:payload) { FactoryBot.create(:document, :published, payload_attributes) }
+
+    it "notifies GovukError and returns false if publishing-api does not return status 200" do
+      expect(GovukError).to receive(:notify)
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      stub_publishing_api_publish(document.content_id, {}, status: 503)
+      expect(document.publish).to eq(false)
+    end
+  end
+
+  describe "#unpublish" do
+    before do
+      stub_publishing_api_has_item(payload)
+      document = MyDocumentType.find(payload["content_id"], payload["locale"])
+      stub_publishing_api_unpublish(document.content_id, body: { locale: document.locale, type: "gone" })
+    end
+
+    it "sends correct payload to publishing api" do
+      expect(document.unpublish).to eq(true)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", locale: document.locale)
+    end
+
+    it "deletes document attachments" do
+      expect(AttachmentDeleteWorker).to receive(:perform_async).with(payload["content_id"], payload["locale"])
+
+      document.unpublish
+    end
+
+    context "with an alternative path" do
+      it "sends correct payload to publishing api" do
+        stub_publishing_api_has_lookups("/foo" => SecureRandom.uuid)
+        stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", locale: document.locale, alternative_path: "/foo" })
+
+        expect(document.unpublish("/foo")).to eq(true)
+
+        assert_publishing_api_unpublish(document.content_id, type: "redirect", locale: document.locale, alternative_path: "/foo")
+      end
+    end
+
+    context "unsuccessful #unpublish" do
       it "notifies GovukError and returns false if publishing-api does not return status 200" do
         expect(GovukError).to receive(:notify)
-        stub_any_publishing_api_put_content
-        stub_any_publishing_api_patch_links
-        stub_publishing_api_publish(document.content_id, {}, status: 503)
-        expect(document.publish).to eq(false)
+        stub_publishing_api_unpublish(document.content_id, { body: { type: "gone", locale: document.locale } }, status: 409)
+        expect(document.unpublish).to eq(false)
       end
     end
+  end
 
-    describe "#unpublish" do
-      before do
-        stub_publishing_api_has_item(payload)
-        document = MyDocumentType.find(payload["content_id"], payload["locale"])
-        stub_publishing_api_unpublish(document.content_id, body: { locale: document.locale, type: "gone" })
-      end
+  describe "#discard" do
+    let(:content_id) { payload.fetch("content_id") }
 
-      it "sends correct payload to publishing api" do
-        expect(document.unpublish).to eq(true)
-
-        assert_publishing_api_unpublish(document.content_id, type: "gone", locale: document.locale)
-      end
-
-      it "deletes document attachments" do
-        expect(AttachmentDeleteWorker).to receive(:perform_async).with(payload["content_id"], payload["locale"])
-
-        document.unpublish
-      end
-
-      context "with an alternative path" do
-        it "sends correct payload to publishing api" do
-          stub_publishing_api_has_lookups("/foo" => SecureRandom.uuid)
-          stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", locale: document.locale, alternative_path: "/foo" })
-
-          expect(document.unpublish("/foo")).to eq(true)
-
-          assert_publishing_api_unpublish(document.content_id, type: "redirect", locale: document.locale, alternative_path: "/foo")
-        end
-      end
-
-      context "unsuccessful #unpublish" do
-        it "notifies GovukError and returns false if publishing-api does not return status 200" do
-          expect(GovukError).to receive(:notify)
-          stub_publishing_api_unpublish(document.content_id, { body: { type: "gone", locale: document.locale } }, status: 409)
-          expect(document.unpublish).to eq(false)
-        end
-      end
+    it "sends a discard draft request to the publishing api" do
+      stub_publishing_api_discard_draft(content_id)
+      document.discard
+      assert_publishing_api_discard_draft(content_id)
     end
 
-    describe "#discard" do
-      let(:content_id) { payload.fetch("content_id") }
-
-      it "sends a discard draft request to the publishing api" do
-        stub_publishing_api_discard_draft(content_id)
-        document.discard
-        assert_publishing_api_discard_draft(content_id)
-      end
-
-      it "returns true if the draft was discarded successfully" do
-        stub_publishing_api_discard_draft(content_id)
-        expect(document.discard).to eq(true)
-      end
-
-      it "returns false if the draft could not be discarded" do
-        stub_request(:any, /discard/).to_raise(GdsApi::HTTPErrorResponse)
-        expect(document.discard).to eq(false)
-      end
+    it "returns true if the draft was discarded successfully" do
+      stub_publishing_api_discard_draft(content_id)
+      expect(document.discard).to eq(true)
     end
 
-    describe "#save" do
-      before do
-        stub_publishing_api_has_item(payload)
-        Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC"))
-      end
+    it "returns false if the draft could not be discarded" do
+      stub_request(:any, /discard/).to_raise(GdsApi::HTTPErrorResponse)
+      expect(document.discard).to eq(false)
+    end
+  end
 
-      it "saves document" do
-        stub_any_publishing_api_put_content
-        stub_any_publishing_api_patch_links
-
-        c = MyDocumentType.find(payload["content_id"], payload["locale"])
-        expect(c.save).to eq(true)
-
-        expected_payload = write_payload(payload.deep_stringify_keys)
-        assert_publishing_api_put_content(c.content_id, expected_payload)
-      end
-
-      it "returns false without making any Publishing API calls if the document is invalid" do
-        stub = stub_any_publishing_api_call
-
-        document.title = nil # this is an invalid title
-        expect(document).to_not be_valid
-
-        expect(document.save).to be_falsey
-        expect(stub).to_not have_been_requested
-      end
-
-      it "returns false if the Publishing API calls fail" do
-        stub_publishing_api_isnt_available
-        expect(document.save).to be_falsey
-      end
-
-      describe "validations" do
-        subject { Document.from_publishing_api(payload) }
-
-        context "when the document is a draft" do
-          let(:payload) { FactoryBot.create(:document) }
-
-          it "does not require an update_type" do
-            subject.update_type = ""
-            expect(subject).to be_valid
-          end
-
-          it "does not require a change_note" do
-            subject.change_note = ""
-            expect(subject).to be_valid
-          end
-        end
-
-        context "when the document is published" do
-          let(:payload) do
-            FactoryBot.create(:document, :published, state_history: { "1" => "published" })
-          end
-
-          it "requires an update_type" do
-            subject.update_type = ""
-            subject.change_note = "change note"
-
-            expect(subject).not_to be_valid
-          end
-
-          it "requires a change_note" do
-            subject.update_type = "major"
-            subject.change_note = ""
-
-            expect(subject).not_to be_valid
-          end
-        end
-
-        context "when the document is unpublished" do
-          let(:payload) do
-            FactoryBot.create(:document, :unpublished, state_history: { "1" => "published", "2" => "unpublished" })
-          end
-
-          it "requires an update_type" do
-            subject.update_type = ""
-            subject.change_note = "change note"
-
-            expect(subject).not_to be_valid
-          end
-
-          it "requires a change_note" do
-            subject.update_type = "major"
-            subject.change_note = ""
-
-            expect(subject).not_to be_valid
-          end
-        end
-
-        context "when the document is brand new" do
-          subject { Document.new }
-
-          before do
-            subject.title = "Title"
-            subject.summary = "Summary"
-            subject.body = "Body"
-          end
-
-          it "does not require an update_type" do
-            subject.update_type = ""
-            expect(subject).to be_valid
-          end
-
-          it "does not require a change_note" do
-            subject.change_note = ""
-            expect(subject).to be_valid
-          end
-        end
-      end
+  describe "#save" do
+    before do
+      stub_publishing_api_has_item(payload)
+      Timecop.freeze(Time.zone.parse("2015-12-18 10:12:26 UTC"))
     end
 
-    describe ".find" do
-      before do
-        stub_publishing_api_has_item(payload)
-      end
+    it "saves document" do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
 
-      it "returns a document" do
-        found_document = MyDocumentType.find(document.content_id, document.locale)
+      c = MyDocumentType.find(payload["content_id"], payload["locale"])
+      expect(c.save).to eq(true)
 
-        expect(found_document.base_path).to eq(payload["base_path"])
-        expect(found_document.title).to     eq(payload["title"])
-        expect(found_document.summary).to   eq(payload["description"])
-        expect(found_document.body).to      eq(payload["details"]["body"][0]["content"])
-        expect(found_document.field3).to    eq(payload["details"]["metadata"]["field3"])
-      end
-
-      describe "when called on the Document superclass" do
-        it "returns an instance of the subclass with matching document_type" do
-          found_document = Document.find(document.content_id, document.locale)
-          expect(found_document).to be_a(MyDocumentType)
-        end
-      end
-
-      describe "when called on a class that mismatches the document_type" do
-        it "raises a helpful error" do
-          expect {
-            CmaCase.find(document.content_id, document.locale)
-          }.to raise_error(/wrong type/)
-        end
-      end
+      expected_payload = write_payload(payload.deep_stringify_keys)
+      assert_publishing_api_put_content(c.content_id, expected_payload)
     end
 
-    describe "attachment methods" do
-      let(:attachment) { Attachment.new }
+    it "returns false without making any Publishing API calls if the document is invalid" do
+      stub = stub_any_publishing_api_call
 
-      describe "#attachments=" do
-        it "creates an AttachmentCollection with the given attachments" do
-          subject.attachments = [attachment]
+      document.title = nil # this is an invalid title
+      expect(document).to_not be_valid
 
-          expect(subject.attachments).to be_kind_of(AttachmentCollection)
-          expect(subject.attachments.first).to eq(attachment)
-        end
-      end
-
-      describe "#attachments" do
-        it "returns an empty AttachmentCollection if none is set" do
-          expect(subject.attachments).to be_kind_of(AttachmentCollection)
-          expect(subject.attachments.count).to eq(0)
-        end
-      end
-
-      describe "#upload_attachment" do
-        before do
-          subject.attachments = [attachment]
-        end
-
-        it "saves itself on successful attachment upload" do
-          expect(subject.attachments).to receive(:upload).and_return(true)
-          expect(subject).to receive(:save)
-          subject.upload_attachment(attachment)
-        end
-
-        it "returns false on failed attachment upload" do
-          expect(subject.attachments).to receive(:upload).and_return(false)
-
-          expect(subject.upload_attachment(attachment)).to eq(false)
-        end
-      end
-
-      describe "#delete_attachment" do
-        before do
-          subject.attachments = [attachment]
-        end
-
-        it "deletes its attachment on a successful API call" do
-          expect(subject.attachments).to receive(:remove).and_return(true)
-          expect(subject).to receive(:save)
-          subject.delete_attachment(attachment)
-          expect subject.attachments.count == 0
-        end
-
-        it "returns false and preserves its attachment on a failed call" do
-          expect(subject.attachments).to receive(:remove).and_return(false)
-          expect(subject.delete_attachment(attachment)).to eq(false)
-          expect subject.attachments.count == 1
-        end
-      end
+      expect(document.save).to be_falsey
+      expect(stub).to_not have_been_requested
     end
 
-    describe "#set_temporary_update_type!" do
-      before { subject.publication_state = "published" }
+    it "returns false if the Publishing API calls fail" do
+      stub_publishing_api_isnt_available
+      expect(document.save).to be_falsey
+    end
 
-      context "when the document has an update_type" do
-        before do
+    describe "validations" do
+      subject { Document.from_publishing_api(payload) }
+
+      context "when the document is a draft" do
+        let(:payload) { FactoryBot.create(:document) }
+
+        it "does not require an update_type" do
+          subject.update_type = ""
+          expect(subject).to be_valid
+        end
+
+        it "does not require a change_note" do
+          subject.change_note = ""
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when the document is published" do
+        let(:payload) do
+          FactoryBot.create(:document, :published, state_history: { "1" => "published" })
+        end
+
+        it "requires an update_type" do
+          subject.update_type = ""
+          subject.change_note = "change note"
+
+          expect(subject).not_to be_valid
+        end
+
+        it "requires a change_note" do
           subject.update_type = "major"
-          subject.set_temporary_update_type!
-        end
+          subject.change_note = ""
 
-        it "preserves the existing attributes" do
-          expect(subject.update_type).to eq("major")
-          expect(subject.temporary_update_type).to be_falsey
+          expect(subject).not_to be_valid
         end
       end
 
-      context "when the document does not have an update_type" do
+      context "when the document is unpublished" do
+        let(:payload) do
+          FactoryBot.create(:document, :unpublished, state_history: { "1" => "published", "2" => "unpublished" })
+        end
+
+        it "requires an update_type" do
+          subject.update_type = ""
+          subject.change_note = "change note"
+
+          expect(subject).not_to be_valid
+        end
+
+        it "requires a change_note" do
+          subject.update_type = "major"
+          subject.change_note = ""
+
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when the document is brand new" do
+        subject { Document.new }
+
         before do
-          subject.update_type = nil
-          subject.set_temporary_update_type!
+          subject.title = "Title"
+          subject.summary = "Summary"
+          subject.body = "Body"
         end
 
-        it "sets update_type to minor and temporary_update_type to true" do
-          expect(subject.update_type).to eq("minor")
-          expect(subject.temporary_update_type).to eq(true)
+        it "does not require an update_type" do
+          subject.update_type = ""
+          expect(subject).to be_valid
+        end
+
+        it "does not require a change_note" do
+          subject.change_note = ""
+          expect(subject).to be_valid
         end
       end
     end
+  end
 
-    context "change_note" do
-      subject { MyDocumentType.new }
+  describe ".find" do
+    before do
+      stub_publishing_api_has_item(payload)
+    end
 
-      it "sets the change note when it is a major update" do
+    it "returns a document" do
+      found_document = MyDocumentType.find(document.content_id, document.locale)
+
+      expect(found_document.base_path).to eq(payload["base_path"])
+      expect(found_document.title).to     eq(payload["title"])
+      expect(found_document.summary).to   eq(payload["description"])
+      expect(found_document.body).to      eq(payload["details"]["body"][0]["content"])
+      expect(found_document.field3).to    eq(payload["details"]["metadata"]["field3"])
+    end
+
+    describe "when called on the Document superclass" do
+      it "returns an instance of the subclass with matching document_type" do
+        found_document = Document.find(document.content_id, document.locale)
+        expect(found_document).to be_a(MyDocumentType)
+      end
+    end
+
+    describe "when called on a class that mismatches the document_type" do
+      it "raises a helpful error" do
+        expect {
+          CmaCase.find(document.content_id, document.locale)
+        }.to raise_error(/wrong type/)
+      end
+    end
+  end
+
+  describe "attachment methods" do
+    let(:attachment) { Attachment.new }
+
+    describe "#attachments=" do
+      it "creates an AttachmentCollection with the given attachments" do
+        subject.attachments = [attachment]
+
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.first).to eq(attachment)
+      end
+    end
+
+    describe "#attachments" do
+      it "returns an empty AttachmentCollection if none is set" do
+        expect(subject.attachments).to be_kind_of(AttachmentCollection)
+        expect(subject.attachments.count).to eq(0)
+      end
+    end
+
+    describe "#upload_attachment" do
+      before do
+        subject.attachments = [attachment]
+      end
+
+      it "saves itself on successful attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(true)
+        expect(subject).to receive(:save)
+        subject.upload_attachment(attachment)
+      end
+
+      it "returns false on failed attachment upload" do
+        expect(subject.attachments).to receive(:upload).and_return(false)
+
+        expect(subject.upload_attachment(attachment)).to eq(false)
+      end
+    end
+
+    describe "#delete_attachment" do
+      before do
+        subject.attachments = [attachment]
+      end
+
+      it "deletes its attachment on a successful API call" do
+        expect(subject.attachments).to receive(:remove).and_return(true)
+        expect(subject).to receive(:save)
+        subject.delete_attachment(attachment)
+        expect subject.attachments.count == 0
+      end
+
+      it "returns false and preserves its attachment on a failed call" do
+        expect(subject.attachments).to receive(:remove).and_return(false)
+        expect(subject.delete_attachment(attachment)).to eq(false)
+        expect subject.attachments.count == 1
+      end
+    end
+  end
+
+  describe "#set_temporary_update_type!" do
+    before { subject.publication_state = "published" }
+
+    context "when the document has an update_type" do
+      before do
         subject.update_type = "major"
-        subject.change_note = "some change note"
-
-        expect(subject.change_note).to eq("some change note")
+        subject.set_temporary_update_type!
       end
 
-      it "does not set the change note when it is a minor update" do
-        subject.update_type = "minor"
-        subject.change_note = "some change note"
-
-        expect(subject.change_note).to be_nil
+      it "preserves the existing attributes" do
+        expect(subject.update_type).to eq("major")
+        expect(subject.temporary_update_type).to be_falsey
       end
+    end
 
-      it "does not the change note when the update_type is not set" do
+    context "when the document does not have an update_type" do
+      before do
         subject.update_type = nil
-        subject.change_note = "some change note"
+        subject.set_temporary_update_type!
+      end
 
-        expect(subject.change_note).to be_nil
+      it "sets update_type to minor and temporary_update_type to true" do
+        expect(subject.update_type).to eq("minor")
+        expect(subject.temporary_update_type).to eq(true)
       end
     end
+  end
 
-    context "#first_draft?" do
-      subject { MyDocumentType.new }
-      it "is true if the state_history is less than 2" do
-        subject.state_history = nil
-        expect(subject.first_draft?).to eq(true)
-      end
+  context "change_note" do
+    subject { MyDocumentType.new }
 
-      it "is true if the state_history indicates it has not been published" do
-        subject.state_history = { "1" => "draft" }
-        expect(subject.first_draft?).to eq(true)
-      end
+    it "sets the change note when it is a major update" do
+      subject.update_type = "major"
+      subject.change_note = "some change note"
 
-      it "is false if the state_history indicates it has been published" do
-        subject.state_history = { "3" => "draft", "2" => "published", "1" => "superseded" }
-        expect(subject.first_draft?).to eq(false)
-      end
-
-      it "is true if there is a first_published_at and a state history indicating it has not been published" do
-        subject.state_history = { "1" => "draft" }
-        subject.first_published_at = "2019-02-21T00:00:00+00:00"
-        expect(subject.first_draft?).to eq(true)
-      end
+      expect(subject.change_note).to eq("some change note")
     end
 
-    context "saving a draft where another draft has the same base_path" do
-      before do
-        stub_any_publishing_api_put_content
-          .to_raise(GdsApi::HTTPErrorResponse.new(422, "base path=/foo/bar conflicts with content_id=123"))
-      end
+    it "does not set the change note when it is a minor update" do
+      subject.update_type = "minor"
+      subject.change_note = "some change note"
 
-      subject do
-        MyDocumentType.new(
-          title: "A document",
-          summary: "An introduction",
-          body: "Some text",
-        )
-      end
-
-      it "cannot be saved" do
-        expect(subject.save).to be false
-      end
-
-      it "populates an error on the document" do
-        subject.save
-        expect(subject.errors[:base]).to eq(["Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title."])
-      end
+      expect(subject.change_note).to be_nil
     end
 
-    context "a draft where a published item has the same base_path" do
-      let(:content_id) { SecureRandom.uuid }
-      let(:locale) { "en" }
-      let(:published) { FactoryBot.create(:document, document_type: "my_document_type", content_id:) }
+    it "does not the change note when the update_type is not set" do
+      subject.update_type = nil
+      subject.change_note = "some change note"
 
-      before do
-        stub_request(:get, %r{/v2/content/#{content_id}})
-          .to_return(status: 200,
-                     body: published.merge(warnings: { "content_item_blocking_publish" => "foo" }).to_json)
-      end
+      expect(subject.change_note).to be_nil
+    end
+  end
 
-      subject { described_class.find(content_id, locale) }
-
-      it "cannot be published" do
-        expect(subject.publish).to be false
-      end
-
-      it "populates warnings on the document" do
-        expect(subject.warnings).to eq("content_item_blocking_publish" => "foo")
-      end
-
-      it "can be saved" do
-        stub_any_publishing_api_put_content
-        stub_any_publishing_api_patch_links
-        subject.update_type = "minor"
-        expect(subject.save).to be true
-      end
+  context "#first_draft?" do
+    subject { MyDocumentType.new }
+    it "is true if the state_history is less than 2" do
+      subject.state_history = nil
+      expect(subject.first_draft?).to eq(true)
     end
 
-    describe "#taxons" do
-      it "delegates to the FinderSchema" do
-        document = MyDocumentType.new
-        allow(document.finder_schema).to receive(:taxons).and_return(%w[foo])
-        expect(document.taxons).to eq(%w[foo])
-      end
+    it "is true if the state_history indicates it has not been published" do
+      subject.state_history = { "1" => "draft" }
+      expect(subject.first_draft?).to eq(true)
     end
 
-    describe "#target_stack" do
-      it "delegates to the FinderSchema" do
-        allow(MyDocumentType.finder_schema).to receive(:target_stack).and_return("draft")
-        expect(MyDocumentType.target_stack).to eq("draft")
-      end
+    it "is false if the state_history indicates it has been published" do
+      subject.state_history = { "3" => "draft", "2" => "published", "1" => "superseded" }
+      expect(subject.first_draft?).to eq(false)
     end
 
-    describe "#primary_publishing_organisation" do
-      it "returns the first organisation from the FinderSchema" do
-        document = MyDocumentType.new
-        allow(document.finder_schema).to receive(:organisations).and_return(%w[foo bar])
-        expect(document.primary_publishing_organisation).to eq("foo")
-      end
+    it "is true if there is a first_published_at and a state history indicating it has not been published" do
+      subject.state_history = { "1" => "draft" }
+      subject.first_published_at = "2019-02-21T00:00:00+00:00"
+      expect(subject.first_draft?).to eq(true)
+    end
+  end
+
+  context "saving a draft where another draft has the same base_path" do
+    before do
+      stub_any_publishing_api_put_content
+        .to_raise(GdsApi::HTTPErrorResponse.new(422, "base path=/foo/bar conflicts with content_id=123"))
+    end
+
+    subject do
+      MyDocumentType.new(
+        title: "A document",
+        summary: "An introduction",
+        body: "Some text",
+      )
+    end
+
+    it "cannot be saved" do
+      expect(subject.save).to be false
+    end
+
+    it "populates an error on the document" do
+      subject.save
+      expect(subject.errors[:base]).to eq(["Warning: This document's URL is already used on GOV.UK. You can't publish it until you change the title."])
+    end
+  end
+
+  context "a draft where a published item has the same base_path" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
+    let(:published) { FactoryBot.create(:document, document_type: "my_document_type", content_id:) }
+
+    before do
+      stub_request(:get, %r{/v2/content/#{content_id}})
+        .to_return(status: 200,
+                   body: published.merge(warnings: { "content_item_blocking_publish" => "foo" }).to_json)
+    end
+
+    subject { described_class.find(content_id, locale) }
+
+    it "cannot be published" do
+      expect(subject.publish).to be false
+    end
+
+    it "populates warnings on the document" do
+      expect(subject.warnings).to eq("content_item_blocking_publish" => "foo")
+    end
+
+    it "can be saved" do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      subject.update_type = "minor"
+      expect(subject.save).to be true
+    end
+  end
+
+  describe "#taxons" do
+    it "delegates to the FinderSchema" do
+      document = MyDocumentType.new
+      allow(document.finder_schema).to receive(:taxons).and_return(%w[foo])
+      expect(document.taxons).to eq(%w[foo])
+    end
+  end
+
+  describe "#target_stack" do
+    it "delegates to the FinderSchema" do
+      allow(MyDocumentType.finder_schema).to receive(:target_stack).and_return("draft")
+      expect(MyDocumentType.target_stack).to eq("draft")
+    end
+  end
+
+  describe "#primary_publishing_organisation" do
+    it "returns the first organisation from the FinderSchema" do
+      document = MyDocumentType.new
+      allow(document.finder_schema).to receive(:organisations).and_return(%w[foo bar])
+      expect(document.primary_publishing_organisation).to eq("foo")
     end
   end
 
   describe ".title" do
     it "delegates to the FinderSchema" do
-      expect(AaibReport.finder_schema).to receive(:document_title).and_call_original
+      allow(FinderSchema).to receive(:load_from_schema).and_return(finder_schema)
+      expect(AaibReport.finder_schema).to receive(:document_title).and_return("AAIB Report")
       expect(AaibReport.title).to eq("AAIB Report")
     end
   end
@@ -884,6 +885,75 @@ RSpec.describe Document do
       doc = MyDocumentType.new(update_type: "minor")
       doc.disable_email_alert = false
       expect(doc.send_email_on_publish?).to be false
+    end
+  end
+
+  describe ".apply_validations" do
+    context "required" do
+      let(:finder_schema) do
+        schema = FinderSchema.new
+        schema.assign_attributes({
+          base_path: "/my-document-types",
+          target_stack: "live",
+          filter: {
+            "format" => "my_format",
+          },
+          content_id: @finder_content_id,
+          facets: [
+            {
+              "key" => "field1",
+              "name" => "field1 name",
+              "type" => "text",
+              "specialist_publisher_properties" => {
+                "validations" => {
+                  "required" => {},
+                },
+              },
+            },
+            {
+              "key" => "field2",
+              "name" => "field2 name",
+              "type" => "text",
+              "specialist_publisher_properties" => {
+                "validations" => {
+                  "required" => { "message" => "can't be empty - custom" },
+                },
+              },
+            },
+          ],
+        })
+        schema
+      end
+
+      let(:payload_attributes) do
+        {
+          document_type: "my_document_type",
+          title: "Example document",
+          description: "This is a summary",
+          base_path: "/my-document-types/example-document",
+          details: {
+            body: [
+              {
+                content_type: "text/govspeak",
+                content: "This is the body of an example document",
+              },
+            ],
+            metadata: {
+              field1: "",
+              field2: nil,
+            },
+          },
+          links: {
+            finder: [@finder_content_id],
+          },
+        }
+      end
+
+      it "is invalid without required field" do
+        expect(document).to be_invalid
+        expect(document.errors[:field1]).to eq(["can't be blank"])
+        expect(document.errors[:field2]).to eq(["can't be empty - custom"])
+      end
     end
   end
 end

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -152,6 +152,20 @@ RSpec.describe "Facet" do
         expect(facet.type).to eq("date")
         expect(facet.specialist_publisher_properties).to eq(nil)
       end
+
+      it "adds presence validations to the specialist_publisher_properties if type is text" do
+        params = { "type" => "enum_text_single", "validations" => %w[required] }
+        facet = Facet.from_finder_admin_form_params(params)
+        expect(facet.type).to eq("text")
+        expect(facet.specialist_publisher_properties).to eq({ select: "one", validations: { required: {} } })
+      end
+
+      it "adds presence validations to the specialist_publisher_properties if type is date" do
+        params = { "type" => "date", "validations" => %w[required] }
+        facet = Facet.from_finder_admin_form_params(params)
+        expect(facet.type).to eq("date")
+        expect(facet.specialist_publisher_properties).to eq({ validations: { required: {} } })
+      end
     end
   end
 


### PR DESCRIPTION
Apply model validations based on schema configuration.

> ![Screenshot 2025-01-27 at 18 16 31](https://github.com/user-attachments/assets/0322ffa6-3de6-4691-aee3-76470cba0612)

[Trello](https://trello.com/c/PArCm42y/3292-make-specialist-publisher-validation-schema-driven)