### PR TITLE
Replace title component with heading

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,6 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-card';
 @import 'govuk_publishing_components/components/textarea';
-@import 'govuk_publishing_components/components/title';
 
 @import "./components/add-another";
 @import "./components/autocomplete";

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -53,11 +53,12 @@
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <%= render "govuk_publishing_components/components/title", {
+            <%= render "govuk_publishing_components/components/heading", {
               context: yield(:context),
-              title: yield(:title),
-              margin_top: 0,
+              text: yield(:title),
               margin_bottom: 0,
+              font_size: "xl",
+              heading_level: 1,
             } %>
           </div>
         </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace the title component with the heading component.

- should still be a h1 and visually identical
- heading has no margin top, so matches the previous margin_top: 0 option on title

Confession: I've not actually run this locally to check it visually, but I've done this in a lot of applications now and I'm reasonably confident it will work.

## Why

The title component is being decommissioned and we've already removed the margin_top option from it as part of some other work. This means that with the latest changes a big space will suddenly appear above it. But if we switch it to the heading component, it looks exactly the same and won't have this problem.

## Visual changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-remove-margintop-option-from-shared-helper