### PR TITLE
Remove direct rackup dependency as Puma now specifies a compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,6 @@ gem "mongoid"
 gem "multi_json"
 gem "plek"
 gem "pundit"
-# TODO: remove after next version of Puma is released
-# See https://github.com/puma/puma/pull/3532
-# `require: false` is needed because you can't actually `require "rackup"`
-# due to a different bug: https://github.com/rack/rackup/commit/d03e1789
-gem "rackup", "1.0.0", require: false
 gem "select2-rails", "< 4" # v4 changes the generated HTML and breaks the e2e tests
 gem "sentry-sidekiq"
 gem "stringex"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -839,7 +839,6 @@ DEPENDENCIES
   pry-rails
   puma
   pundit
-  rackup (= 1.0.0)
   rails (= 7.2)
   rails-controller-testing
   rspec-rails


### PR DESCRIPTION
Now we've upgraded to a newer version of Puma, we no longer need to directly depend on a specific version of the Rackup gem.

trello: https://trello.com/c/gQ5F9ysj
