### PR TITLE
Add new finder for authorised fuels (Defra)

### DIFF
--- a/app/models/authorised_fuel.rb
+++ b/app/models/authorised_fuel.rb
@@ -1,0 +1,11 @@
+class AuthorisedFuel < Document
+  apply_validations
+
+  FORMAT_SPECIFIC_FIELDS = format_specific_fields
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+end

--- a/app/views/metadata_fields/_authorised_fuels.erb
+++ b/app/views/metadata_fields/_authorised_fuels.erb
@@ -1,0 +1,2 @@
+<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
+<% end %>

--- a/lib/documents/schemas/authorised_fuels.json
+++ b/lib/documents/schemas/authorised_fuels.json
@@ -1,0 +1,149 @@
+{
+  "base_path": "/authorised-fuels",
+  "content_id": "d3a313e3-6a05-4286-b9c4-5d5cc807f600",
+  "description": "Find authorised fuels you can burn in smoke control areas in England, Scotland, Wales and Northern Ireland.",
+  "document_noun": "fuel",
+  "document_title": "Authorised fuel",
+  "facets": [
+    {
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "authorised_fuel_name",
+      "name": "Fuel name",
+      "preposition": "fuel",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "short_name": "Fuel",
+      "type": "text"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "authorised_fuel_manufacturer_name",
+      "name": "Manufacturer name",
+      "preposition": "manufacturer",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "short_name": "Manufacturer",
+      "type": "text"
+    },
+    {
+      "allowed_values": [
+        {
+          "label": "Biomass",
+          "value": "biomass"
+        },
+        {
+          "label": "Liquid",
+          "value": "liquid"
+        },
+        {
+          "label": "Mineral",
+          "value": "mineral"
+        },
+        {
+          "label": "Multifuel",
+          "value": "multifuel"
+        },
+        {
+          "label": "Wood-based",
+          "value": "woodbased"
+        },
+        {
+          "label": "Wood",
+          "value": "wood"
+        },
+        {
+          "label": "Other",
+          "value": "other"
+        }
+      ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "authorised_fuel_type",
+      "name": "Fuel type",
+      "preposition": "fuel type",
+      "specialist_publisher_properties": {
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    },
+    {
+      "allowed_values": [
+        {
+          "label": "England,",
+          "value": "england"
+        },
+        {
+          "label": "Scotland",
+          "value": "scotland"
+        },
+        {
+          "label": "Wales",
+          "value": "wales"
+        },
+        {
+          "label": "Northern Ireland",
+          "value": "northern-ireland"
+        }
+      ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "authorised_fuel_country",
+      "name": "Country",
+      "preposition": "country",
+      "specialist_publisher_properties": {
+        "select": "multiple",
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "authorised_fuel_date_the_fuel_was_authorised",
+      "name": "Date the fuel was authorised",
+      "preposition": "date authorised",
+      "short_name": "Date authorised",
+      "type": "date"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "authorised_fuel_address",
+      "name": "Address",
+      "preposition": "address",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    }
+  ],
+  "filter": {
+    "format": "authorised_fuel"
+  },
+  "name": "Find authorised fuels for smoke control areas",
+  "organisations": [
+    "de4e9dc6-cca4-43af-a594-682023b84d6c"
+  ],
+  "related": [
+    "d826ea5a-aa78-439c-873a-1360293e4b01",
+    "0b60a7d2-8a7d-478c-b5b3-e3e9ec9c896f"
+  ],
+  "show_summaries": true,
+  "summary": "<p>Find authorised fuels you can burn in smoke control areas in England, Scotland, Wales and Northern Ireland.</p>\r\n<p>In smoke control areas, you:</p>\r\n<p><ul><li>- cannot release smoke from a chimney</li>\r\n<li>- can only burn authorised fuel, unless you use an appliance approved by Defra (also known as an ‘exempt appliance’ or ‘Defra approved appliance’)</li>\r\n</ul></p>\r\n<p><a href=\"https://www.gov.uk/smoke-control-area-rules\">Check the rules for smoke control areas</a>.</p>\r\n<p>Link to new <a href=\"https://www.gov.uk/defra-approved-appliances\">specialist finder for approved appliances</a>.</p>",
+  "target_stack": "draft"
+}

--- a/spec/features/creating_an_authorised_fuel_spec.rb
+++ b/spec/features/creating_an_authorised_fuel_spec.rb
@@ -1,0 +1,131 @@
+require "spec_helper"
+
+RSpec.feature "Creating an authorised fuel", type: :feature do
+  let(:authorised_fuel) { FactoryBot.create(:authorised_fuel) }
+  let(:content_id) { authorised_fuel["content_id"] }
+  let(:save_button_disable_with_message) { page.find_button("Save as draft")["data-disable-with"] }
+
+  before do
+    log_in_as_editor(:gds_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_publishing_api_has_content([authorised_fuel], hash_including(document_type: AuthorisedFuel.document_type))
+    stub_publishing_api_has_item(authorised_fuel)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+  end
+
+  scenario "visiting the new document page" do
+    visit "/authorised-fuels"
+    click_link "Add another Authorised fuel"
+
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq("/authorised-fuels/new")
+  end
+
+  scenario "with valid data" do
+    visit "/authorised-fuels/new"
+
+    fill_in "Title", with: "Example authorised fuel"
+    fill_in "Summary", with: "This is the summary of an example authorised fuel"
+    fill_in "Body", with: "## Header#{"\n\nThis is the long body of an example authorised fuel" * 2}"
+    fill_in "Fuel name", with: "Fuel name"
+    fill_in "Manufacturer name", with: "Fuel manufacturer name"
+    select "Biomass", from: "Fuel type"
+    select "England", from: "Country"
+    fill_in "Address", with: "123 Rocket Street"
+
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+    expect(save_button_disable_with_message).to eq("Saving...")
+
+    click_button "Save as draft"
+
+    expected_sent_payload = {
+      "base_path" => "/authorised-fuels/example-authorised-fuel",
+      "title" => "Example authorised fuel",
+      "description" => "This is the summary of an example authorised fuel",
+      "document_type" => "authorised_fuel",
+      "schema_name" => "specialist_document",
+      "publishing_app" => "specialist-publisher",
+      "rendering_app" => "government-frontend",
+      "locale" => "en",
+      "phase": "live",
+      "details" => {
+        "body" =>
+          [
+            {
+              "content_type" => "text/govspeak",
+              "content" => "## Header\r\n\r\nThis is the long body of an example authorised fuel\r\n\r\nThis is the long body of an example authorised fuel",
+            },
+          ],
+        "metadata" => {
+          "authorised_fuel_name" => "Fuel name",
+          "authorised_fuel_manufacturer_name" => "Fuel manufacturer name",
+          "authorised_fuel_type" => %w[biomass],
+          "authorised_fuel_country" => %w[england],
+          "authorised_fuel_address" => "123 Rocket Street",
+        },
+        "max_cache_time" => 10,
+        "headers" => [
+          { "text" => "Header", "level" => 2, "id" => "header" },
+        ],
+        "temporary_update_type" => false,
+      },
+      "routes" => [
+        {
+          "path" => "/authorised-fuels/example-authorised-fuel",
+          "type" => "exact",
+        },
+      ],
+      "redirects" => [],
+      "update_type" => "major",
+      "links" =>
+        {
+          "finder" => %w[d3a313e3-6a05-4286-b9c4-5d5cc807f600],
+        },
+    }
+
+    assert_publishing_api_put_content(content_id, expected_sent_payload)
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example authorised fuel")
+    expect(page).to have_content("Bulk published false")
+  end
+
+  scenario "with no data" do
+    visit "/authorised-fuels/new"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css(".elements-error-summary")
+    expect(page).to have_css(".form-group.elements-error")
+    expect(page).to have_css(".elements-error-message")
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Summary can't be blank")
+    expect(page).to have_content("Body can't be blank")
+  end
+
+  scenario "with invalid data" do
+    visit "/authorised-fuels/new"
+
+    fill_in "Title", with: "Example authorised fuel"
+    fill_in "Summary", with: "This is the summary of an example authorised fuel"
+    fill_in "Body", with: "<script>alert('hello')</script>"
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css(".elements-error-summary")
+    expect(page).to have_css(".elements-error-message")
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Body cannot include invalid Govspeak")
+    expect(page).to have_content("Authorised fuel country can't be blank")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -825,4 +825,21 @@ FactoryBot.define do
       end
     end
   end
+
+  factory :authorised_fuel, parent: :document do
+    base_path { "/authorised-fuels/example-document" }
+    document_type { "authorised_fuel" }
+
+    transient do
+      default_metadata do
+        {
+          "authorised_fuel_name" => "Rocket fuel",
+          "authorised_fuel_manufacturer_name" => "Fuel manufacturer name",
+          "authorised_fuel_type" => %w[biomass liquid],
+          "authorised_fuel_country" => %w[England],
+          "authorised_fuel_address" => "123 Rocket Street",
+        }
+      end
+    end
+  end
 end

--- a/spec/models/authorised_fuel_spec.rb
+++ b/spec/models/authorised_fuel_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "models/valid_against_schema"
+
+RSpec.describe AuthorisedFuel do
+  let(:payload) { FactoryBot.create(:authorised_fuel) }
+  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
+  subject(:authorised_fuel) { described_class.from_publishing_api(payload) }
+
+  it "is not exportable" do
+    expect(described_class).not_to be_exportable
+  end
+
+  describe "validations" do
+    it "is valid from the payload" do
+      expect(authorised_fuel).to be_valid
+    end
+
+    it "is invalid if required fields are missing" do
+      authorised_fuel.authorised_fuel_name = nil
+      authorised_fuel.authorised_fuel_manufacturer_name = nil
+      authorised_fuel.authorised_fuel_type = nil
+      authorised_fuel.authorised_fuel_country = nil
+      authorised_fuel.authorised_fuel_address = nil
+
+      expect(authorised_fuel).not_to be_valid
+      expect(authorised_fuel.errors["authorised_fuel_name"]).to eq(["can't be blank"])
+      expect(authorised_fuel.errors["authorised_fuel_manufacturer_name"]).to eq(["can't be blank"])
+      expect(authorised_fuel.errors["authorised_fuel_type"]).to eq(["can't be blank"])
+      expect(authorised_fuel.errors["authorised_fuel_country"]).to eq(["can't be blank"])
+      expect(authorised_fuel.errors["authorised_fuel_address"]).to eq(["can't be blank"])
+    end
+  end
+end


### PR DESCRIPTION
Few links missing, but ready to deploy to draft stack.

[Trello](https://trello.com/c/uXFmHp7z/3381-new-specialist-finder-for-defra-fuels)