### PR TITLE
Remove unused property `format_name`

### DIFF
--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -31,7 +31,6 @@ class FinderSchema
   attribute :email_filter_options
   attribute :facets, default: []
   attribute :filter
-  attribute :format_name
   attribute :label_text
   attribute :name
   attribute :organisations, default: []

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -54,7 +54,6 @@ private
       beta_message: file.fetch("beta_message", nil),
       document_noun: file.fetch("document_noun"),
       filter: file.fetch("filter", nil),
-      format_name: file.fetch("format_name", nil),
       open_filter_on_load: file.fetch("open_filter_on_load", nil),
       logo_path: file.fetch("logo_path", nil),
       show_summaries: file.fetch("show_summaries", false),

--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -129,7 +129,6 @@
   "filter": {
     "format": "aaib_report"
   },
-  "format_name": "Air Accidents Investigation Branch report",
   "name": "Air Accidents Investigation Branch reports",
   "organisations": [
     "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -314,7 +314,6 @@
   "filter": {
     "format": "ai_assurance_portfolio_technique"
   },
-  "format_name": "Find out about artificial intelligence (AI) assurance techniques",
   "name": "Find out about artificial intelligence (AI) assurance techniques",
   "organisations": [
     "c352c234-8083-47ec-8a4b-0edd45c31263"

--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -470,7 +470,6 @@
   "filter": {
     "format": "algorithmic_transparency_record"
   },
-  "format_name": "Find out how algorithmic tools are used in public organisations",
   "name": "Find out how algorithmic tools are used in public organisations",
   "organisations": [
     "96ae61d6-c2a1-48cb-8e67-da9d105ae381",

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -195,7 +195,6 @@
   "filter": {
     "format": "animal_disease_case"
   },
-  "format_name": "Notifiable animal disease cases and control zone",
   "name": "Notifiable animal disease cases and control zones",
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c",

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -315,7 +315,6 @@
   "filter": {
     "format": "asylum_support_decision"
   },
-  "format_name": "Asylum support tribunal decision",
   "name": "Asylum support tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -258,7 +258,6 @@
   "filter": {
     "format": "business_finance_support_scheme"
   },
-  "format_name": "Business finance support scheme",
   "name": "Finance and support for your business",
   "organisations": [
     "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -403,7 +403,6 @@
   "filter": {
     "format": "cma_case"
   },
-  "format_name": "Competition and Markets Authority case",
   "name": "Competition and Markets Authority cases and projects",
   "organisations": [
     "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"

--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -209,7 +209,6 @@
   "filter": {
     "format": "countryside_stewardship_grant"
   },
-  "format_name": "Countryside Stewardship grant",
   "name": "Countryside Stewardship grant finder",
   "organisations": [
     "e8fae147-6232-4163-a3f1-1c15b755a8a4",

--- a/lib/documents/schemas/data_ethics_guidance_documents.json
+++ b/lib/documents/schemas/data_ethics_guidance_documents.json
@@ -265,7 +265,6 @@
   "filter": {
     "format": "data_ethics_guidance_document"
   },
-  "format_name": "Find data ethics guidance, standards and frameworks",
   "name": "Find data ethics guidance, standards and frameworks",
   "organisations": [
     "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/lib/documents/schemas/drcf_digital_markets_researches.json
+++ b/lib/documents/schemas/drcf_digital_markets_researches.json
@@ -311,7 +311,6 @@
   "filter": {
     "format": "drcf_digital_markets_research"
   },
-  "format_name": "Digital Regulation Cooperation Forum digital markets research",
   "name": "Digital Regulation Cooperation Forum digital markets research",
   "organisations": [
     "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -135,7 +135,6 @@
   "filter": {
     "format": "drug_safety_update"
   },
-  "format_name": "Drug Safety Update",
   "name": "Drug Safety Update",
   "organisations": [
     "240f72bd-9a4d-4f39-94d9-77235cadde8e"

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -1055,7 +1055,6 @@
   "filter": {
     "format": "employment_appeal_tribunal_decision"
   },
-  "format_name": "Employment appeal tribunal decision",
   "name": "Employment appeal tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -307,7 +307,6 @@
   "filter": {
     "format": "employment_tribunal_decision"
   },
-  "format_name": "Employment tribunal decision",
   "name": "Employment tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -182,7 +182,6 @@
   "filter": {
     "format": "european_structural_investment_fund"
   },
-  "format_name": "ESIF call for proposals",
   "name": "European Structural and Investment Funds (ESIF)",
   "organisations": [
     "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -1005,7 +1005,6 @@
   "filter": {
     "format": "export_health_certificate"
   },
-  "format_name": "Export health certificate",
   "name": "Find an export health certificate",
   "organisations": [
     "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"

--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -200,7 +200,6 @@
   "filter": {
     "format": "farming_grant"
   },
-  "format_name": "Find funding for land or farms",
   "name": "Find funding for land or farms",
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c",

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -347,7 +347,6 @@
   "filter": {
     "format": "flood_and_coastal_erosion_risk_management_research_report"
   },
-  "format_name": "Flood and Coastal Erosion Risk Management (FCERM) research report",
   "name": "Flood and Coastal Erosion Risk Management (FCERM) research reports",
   "organisations": [
     "6fc7e0f4-1322-4469-af66-abec10c26883"

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -994,7 +994,6 @@
   "filter": {
     "format": "international_development_fund"
   },
-  "format_name": "International development funding",
   "name": "International development funding",
   "organisations": [
     "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -274,7 +274,6 @@
   "filter": {
     "format": "licence_transaction"
   },
-  "format_name": "Find and apply for licences",
   "label_text": "Search keywords <span class=\"govuk-!-display-block govuk-!-font-size-16 govuk-!-margin-bottom-2\">for example 'sell alcohol'</span>",
   "name": "Find a licence",
   "open_filter_on_load": true,

--- a/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
+++ b/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
@@ -387,7 +387,6 @@
   "filter": {
     "format": "life_saving_maritime_appliance_service_station"
   },
-  "format_name": "Find a service station for your inflatable life-saving appliances (format)",
   "name": "Find a service station for your inflatable life-saving appliances",
   "organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -97,7 +97,6 @@
   "filter": {
     "format": "maib_report"
   },
-  "format_name": "Marine Accident Investigation Branch report",
   "name": "Marine Accident Investigation Branch reports",
   "organisations": [
     "9c66b9a3-1e6a-48e8-974d-2a5635f84679"

--- a/lib/documents/schemas/marine_equipment_approved_recommendations.json
+++ b/lib/documents/schemas/marine_equipment_approved_recommendations.json
@@ -93,7 +93,6 @@
   "filter": {
     "format": "marine_equipment_approved_recommendation"
   },
-  "format_name": "UK Approved Recommendations – Marine Equipment",
   "name": "UK Approved Recommendations – Marine Equipment",
   "organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"

--- a/lib/documents/schemas/marine_notices.json
+++ b/lib/documents/schemas/marine_notices.json
@@ -175,7 +175,6 @@
   "filter": {
     "format": "marine_notice"
   },
-  "format_name": "Maritime and Coastguard Agency Marine Notice",
   "name": "Maritime and Coastguard Agency Marine Notices",
   "organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -170,7 +170,6 @@
   "filter": {
     "format": "medical_safety_alert"
   },
-  "format_name": "Medical safety alert",
   "name": "Alerts, recalls and safety information: medicines and medical devices",
   "organisations": [
     "240f72bd-9a4d-4f39-94d9-77235cadde8e"

--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -293,7 +293,6 @@
   "filter": {
     "format": "product_safety_alert_report_recall"
   },
-  "format_name": "Product Safety Alerts, Reports and Recalls",
   "name": "Product Safety Alerts, Reports and Recalls",
   "organisations": [
     "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -1106,7 +1106,6 @@
   "filter": {
     "format": "protected_food_drink_name"
   },
-  "format_name": "Protected geographical food and drink name",
   "name": "Protected geographical food and drink names",
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c"

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -89,7 +89,6 @@
   "filter": {
     "format": "raib_report"
   },
-  "format_name": "Rail Accident Investigation Branch report",
   "name": "Rail Accident Investigation Branch reports",
   "organisations": [
     "013872d8-8bbb-4e80-9b79-45c7c5cf9177"

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -997,7 +997,6 @@
   "filter": {
     "format": "research_for_development_output"
   },
-  "format_name": "Research for Development Output",
   "name": "Research for Development Outputs",
   "organisations": [
     "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -366,7 +366,6 @@
   "filter": {
     "format": "residential_property_tribunal_decision"
   },
-  "format_name": "Residential property tribunal decision",
   "name": "Residential property tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -105,7 +105,6 @@
   "filter": {
     "format": "service_standard_report"
   },
-  "format_name": "Service Assessment and Self Certification",
   "name": "Service Standard Reports",
   "organisations": [
     "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -47,7 +47,6 @@
   "filter": {
     "format": "sfo_case"
   },
-  "format_name": "Find an SFO case",
   "name": "Find an SFO case",
   "organisations": [
     "ebae4517-422f-44dd-9f87-13304c9815cb"

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -145,7 +145,6 @@
   "filter": {
     "format": "statutory_instrument"
   },
-  "format_name": "EU Withdrawal Act 2018 statutory instrument",
   "name": "EU Withdrawal Act 2018 statutory instruments",
   "organisations": [],
   "summary": "<p>Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.</p><p>Before the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the '<a href=\"https://www.parliament.uk/about/how/laws/secondary-legislation/\">negative procedure</a>'.</p>",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -76,7 +76,6 @@
   "filter": {
     "format": "tax_tribunal_decision"
   },
-  "format_name": "Tax and Chancery tribunal decision",
   "name": "Tax and Chancery tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
+++ b/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
@@ -222,7 +222,6 @@
   "filter": {
     "format": "traffic_commissioner_regulatory_decision"
   },
-  "format_name": "Traffic Commissioner regulatory decision",
   "name": "Traffic Commissioner regulatory decisions",
   "organisations": [
     "78dfc32b-b1ef-44ca-924c-a2cf773e87ca"

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -2732,7 +2732,6 @@
   "filter": {
     "format": "utaac_decision"
   },
-  "format_name": "Administrative appeals tribunal decision",
   "name": "Administrative appeals tribunal decisions",
   "organisations": [
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",

--- a/lib/documents/schemas/veterans_support_organisations.json
+++ b/lib/documents/schemas/veterans_support_organisations.json
@@ -368,7 +368,6 @@
   "filter": {
     "format": "veterans_support_organisation"
   },
-  "format_name": "Find support for veterans and their families",
   "name": "Find support for veterans and their families",
   "organisations": [
     "516357f6-92f3-4292-8449-b958e1c63c5f"


### PR DESCRIPTION
This doesn't appear to be used anywhere in Specialist Publisher, Finder Frontend or Search API.

Sister PRs:

- https://github.com/alphagov/publishing-api/pull/3112
- https://github.com/alphagov/finder-frontend/pull/3644
- https://github.com/alphagov/govuk-developer-docs/pull/4971

Trello: https://trello.com/c/ZiFU2o6B/

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
