### PR TITLE
Fix editorial_remark sending

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -67,12 +67,14 @@ private
       description: "Developer - raise a PR replacing this schema with the schema below: " \
         "https://github.com/alphagov/specialist-publisher/edit/main/lib/documents/schemas/#{current_format.document_type.pluralize}.json" \
         "\r\n---\r\n" \
-        "```\r\n#{params[:proposed_schema]}\r\n```",
+        "```\r\n#{params[:proposed_schema]}\r\n```" \
+        "\r\n---\r\n" \
+        "Editorial remarks:" \
+        "\r\n#{params[:editorial_remark]}",
       requester: {
         name: current_user.name,
         email: current_user.email,
       },
-      editorial_remark: params[:editorial_remark],
     }
   end
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -96,12 +96,14 @@ RSpec.describe AdminController, type: :controller do
         description: "Developer - raise a PR replacing this schema with the schema below: " \
           "https://github.com/alphagov/specialist-publisher/edit/main/lib/documents/schemas/cma_cases.json" \
           "\r\n---\r\n" \
-          "```\r\n{ \"foo\": \"bar\" }\r\n```",
+          "```\r\n{ \"foo\": \"bar\" }\r\n```" \
+          "\r\n---\r\n" \
+          "Editorial remarks:" \
+          "\r\n#{editorial_remark}",
         requester: {
           name: user.name,
           email: user.email,
         },
-        editorial_remark:,
       }.to_json
 
       assert_requested(stub_post)


### PR DESCRIPTION
The `GdsApi.support_api.raise_support_ticket` method has no concept of an `editorial_remark` property in its payload. We have to inject the editorial remark into the main `description` property. Currently, any submitted editorial remarks are lost.

Trello: https://trello.com/c/ZiFU2o6B

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
