### PR TITLE
Derive `filter.format` property from `document_title` for new finders

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -83,6 +83,7 @@ private
       :description,
       :summary,
       :show_summaries,
+      :document_title,
       :document_noun,
       organisations: [],
       related: [],
@@ -124,6 +125,10 @@ private
     email_alert = EmailAlert.from_finder_admin_form_params(email_alert_params)
     params_to_overwrite = metadata_params.merge!(email_alert.to_finder_schema_attributes)
     proposed_schema.update(params_to_overwrite.to_unsafe_h)
+
+    if params[:document_title] && proposed_schema.filter.blank?
+      proposed_schema.filter = { "format" => params[:document_title].parameterize(separator: "_") }
+    end
 
     if params[:include_related] != "true"
       proposed_schema.related = nil

--- a/app/views/admin/_metadata_form_fields.html.erb
+++ b/app/views/admin/_metadata_form_fields.html.erb
@@ -110,12 +110,22 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "The document noun (How the documents on the finder are referred to)",
+    text: "Full document noun (Appears in various places in the Specialist Publisher user interface)",
+    heading_size: "s",
+  },
+  name: "document_title",
+  value: schema.document_title,
+  hint: "For example ‘Business Finance Support Scheme’. On Finance and support for your business there’s 151 schemes, which updates when you start selecting filter options"
+} %>
+
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Shortened document noun (How the documents on the finder are referred to)",
     heading_size: "s",
   },
   name: "document_noun",
   value: schema.document_noun,
-  hint: "For example ‘scheme’. On Finance and support for your business there’s 151 schemes, which updates when you start selecting filter options"
+  hint: "For example ‘scheme’. See 'Full document noun' above"
 } %>
 
 <%= render EmailAlertFieldsetComponent.new(email_alert: EmailAlert.from_finder_schema(schema)) %>

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -61,7 +61,11 @@
       value: schema.show_summaries ? "Yes" : "No"
     } if !(defined? previous_schema) || schema.show_summaries != previous_schema.show_summaries),
     ({
-      key: "The document noun (How the documents on the finder are referred to)",
+      key: "Full document noun (Appears in various places in the Specialist Publisher user interface)",
+      value: (schema.document_title || "").humanize
+    } if !(defined? previous_schema) || schema.document_title != previous_schema.document_title),
+    ({
+      key: "Shortened document noun (How the documents on the finder are referred to)",
       value: (schema.document_noun || "").humanize
     } if !(defined? previous_schema) || schema.document_noun != previous_schema.document_noun),
     ({

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe AdminController, type: :controller do
     end
   end
 
+  describe "POST confirm metadata" do
+    it "keeps any existing filter format property even if document title is changed" do
+      stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
+      post :confirm_metadata, params: { document_type_slug: "asylum-support-decisions", email_alert_type: "no", document_title: "Foo Bar" }
+      proposed_schema = controller.instance_variable_get(:@proposed_schema)
+      expect(proposed_schema.format).to eq("asylum_support_decision")
+    end
+
+    it "derives filter format from document title, if no filter format yet defined" do
+      stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))
+      allow(Document).to receive(:finder_schema).and_return(FinderSchema.new)
+      allow(Document).to receive(:admin_slug).and_return("some-finder")
+
+      post :confirm_metadata, params: { document_type_slug: "some-finder", email_alert_type: "no", document_title: "Foo Bar" }
+      proposed_schema = controller.instance_variable_get(:@proposed_schema)
+      expect(proposed_schema.format).to eq("foo_bar")
+    end
+  end
+
   describe "POST edit facets" do
     it "responds successfully" do
       stub_publishing_api_has_content([], hash_including(document_type: Organisation.document_type))

--- a/spec/features/editing_the_cma_case_finder_spec.rb
+++ b/spec/features/editing_the_cma_case_finder_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     fill_in "Link 1", with: "Changed link 1"
     fill_in "Link 2", with: "Changed link 2"
     fill_in "Link 3", with: "Changed link 3"
+    fill_in "document_title", with: "Changed document title"
     fill_in "document_noun", with: "Changed document noun"
     choose "email_alert_type", option: "no"
 
@@ -47,7 +48,8 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page.find(".govuk-summary-list__row", text: "Short description (For search engines)")).to have_selector("dt", text: "Changed description")
     expect(page.find(".govuk-summary-list__row", text: "Summary of the finder (Longer description shown below title)")).to have_selector("dt", text: "Changed summary")
     expect(page.find(".govuk-summary-list__row", text: "Any related links on GOV.UK?")).to have_selector("dt", text: "Yes\nLink 1: Changed link 1\nLink 2: Changed link 2\nLink 3: Changed link 3")
-    expect(page.find(".govuk-summary-list__row", text: "The document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: "Changed document noun")
+    expect(page.find(".govuk-summary-list__row", text: "Full document noun (Appears in various places in the Specialist Publisher user interface)")).to have_selector("dt", text: "Changed document title")
+    expect(page.find(".govuk-summary-list__row", text: "Shortened document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: "Changed document noun")
     expect(page.find(".govuk-summary-list__row", text: "Would you like to set up email alerts for the finder?")).to have_selector("dt", text: "No")
 
     click_button "Submit changes"
@@ -71,6 +73,7 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     fill_in "Link 1", with: ""
     fill_in "Link 2", with: ""
     fill_in "Link 3", with: ""
+    fill_in "document_title", with: ""
     fill_in "document_noun", with: ""
 
     click_button "Submit changes"
@@ -81,7 +84,8 @@ RSpec.feature "Editing the CMA case finder", type: :feature do
     expect(page.find(".govuk-summary-list__row", text: "Short description (For search engines)")).to have_selector("dt", text: /^$/)
     expect(page.find(".govuk-summary-list__row", text: "Summary of the finder (Longer description shown below title)")).to have_selector("dt", text: /^$/)
     expect(page.find(".govuk-summary-list__row", text: "Any related links on GOV.UK?")).to have_selector("dt", text: "Yes")
-    expect(page.find(".govuk-summary-list__row", text: "The document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Full document noun (Appears in various places in the Specialist Publisher user interface)")).to have_selector("dt", text: /^$/)
+    expect(page.find(".govuk-summary-list__row", text: "Shortened document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: /^$/)
 
     click_button "Submit changes"
 

--- a/spec/features/viewing_the_admin_summary_for_cma_cases_spec.rb
+++ b/spec/features/viewing_the_admin_summary_for_cma_cases_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature "Viewing the admin summary for CMA cases", type: :feature do
     expect(page).to have_selector("p", text: "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)")
     expect(page.find(".govuk-summary-list__row", text: "Should summary of each content show under the title in the finder list page?")).to have_selector("dt", text: "No")
     expect(page.find(".govuk-summary-list__row", text: "Organisations the finder should be attached to")).to have_selector("dt", text: "Competition and Markets Authority")
-    expect(page.find(".govuk-summary-list__row", text: "The document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: "Case")
+    expect(page.find(".govuk-summary-list__row", text: "Shortened document noun (How the documents on the finder are referred to)")).to have_selector("dt", text: "Case")
   end
 end


### PR DESCRIPTION
`filter.format` is used to describe the specialist document type. It is the key that is duplicated across Specialist Publisher, Publishing API and Search API.

In many cases, it is identical to the 'document title', lower-cased and snake-cased. So for the "Generate schema" form for new finders, we can derive it from the 'document title' (which we've now added to the 'edit metadata' form, since it was missing before).

Unfortunately, there are several cases where lower-and-snake-casing the document title leads to a filter.format that differs from what we have in the JSON (see below). Therefore I've had to add a guard clause, whereby we ONLY dynamically set the filter.format property (to the lower/snake-cased document title) if it hasn't already been set.

```
FinderSchema.schema_names.map { |name| FinderSchema.load_from_schema(name) }.map { |schema| [schema.format == schema.document_title.parameterize(separator: "_"), schema.format, schema.document_title] }
=> [[true, "aaib_report", "AAIB Report"],
 [false, "ai_assurance_portfolio_technique", "Portfolio of Assurance Techniques"],
 [true, "algorithmic_transparency_record", "Algorithmic transparency record"],
 [true, "animal_disease_case", "Animal disease case"],
 [false, "asylum_support_decision", "Asylum Support Decisions"],
 [true, "business_finance_support_scheme", "Business Finance Support Scheme"],
 [true, "cma_case", "CMA Case"],
 [true, "countryside_stewardship_grant", "Countryside Stewardship Grant"],
 [true, "data_ethics_guidance_document", "Data ethics guidance document"],
 [true, "drcf_digital_markets_research", "DRCF digital markets research"],
 [true, "drug_safety_update", "Drug Safety Update"],
 [false, "employment_appeal_tribunal_decision", "EAT Decision"],
 [false, "employment_tribunal_decision", "ET Decision"],
 [false, "european_structural_investment_fund", "ESI Fund"],
 [true, "export_health_certificate", "Export health certificate"],
 [true, "farming_grant", "Farming Grant"],
 [true, "flood_and_coastal_erosion_risk_management_research_report", "Flood and Coastal Erosion Risk Management Research Report"],
 [true, "international_development_fund", "International Development Fund"],
 [false, "licence_transaction", "Licence"],
 [true, "life_saving_maritime_appliance_service_station", "Life Saving Maritime Appliance Service Station"],
 [true, "maib_report", "MAIB Report"],
 [true, "marine_equipment_approved_recommendation", "Marine Equipment Approved Recommendation"],
 [true, "marine_notice", "Marine Notice"],
 [true, "medical_safety_alert", "Medical Safety Alert"],
 [false, "product_safety_alert_report_recall", "Product Safety Alerts, Reports and Recalls"],
 [false, "protected_food_drink_name", "Protected Geographical Food and Drink Name"],
 [true, "raib_report", "RAIB Report"],
 [true, "research_for_development_output", "Research for Development Output"],
 [true, "residential_property_tribunal_decision", "Residential Property Tribunal Decision"],
 [true, "service_standard_report", "Service Standard Report"],
 [true, "sfo_case", "SFO Case"],
 [false, "statutory_instrument", "EU Withdrawal Act 2018 statutory instrument"],
 [true, "tax_tribunal_decision", "Tax Tribunal Decision"],
 [true, "traffic_commissioner_regulatory_decision", "Traffic Commissioner Regulatory Decision"],
 [true, "utaac_decision", "UTAAC Decision"],
 [true, "veterans_support_organisation", "Veterans Support Organisation"]]
```

Trello: https://trello.com/c/ZiFU2o6B

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
