### PR TITLE
Add HMRC Contacts Finder

### DIFF
--- a/app/models/hmrc_contact.rb
+++ b/app/models/hmrc_contact.rb
@@ -1,0 +1,11 @@
+class HmrcContact < Document
+  apply_validations
+
+  FORMAT_SPECIFIC_FIELDS = format_specific_fields
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+end

--- a/app/views/metadata_fields/_hmrc_contacts.html.erb
+++ b/app/views/metadata_fields/_hmrc_contacts.html.erb
@@ -1,0 +1,2 @@
+<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
+<% end %>

--- a/lib/documents/schemas/hmrc_contacts.json
+++ b/lib/documents/schemas/hmrc_contacts.json
@@ -1,0 +1,138 @@
+{
+  "base_path": "/find-hmrc-contacts",
+  "content_id": "4f5d1173-1634-4c3c-b341-28679d149cae",
+  "description": "TBC",
+  "document_noun": "contact",
+  "document_title": "HMRC Contact",
+  "facets": [
+    {
+      "allowed_values": [
+        {
+          "label": "Agents",
+          "value": "agents"
+        },
+        {
+          "label": "Bereavement",
+          "value": "bereavement"
+        },
+        {
+          "label": "Campaigns",
+          "value": "campaigns"
+        },
+        {
+          "label": "Capital Gains Tax",
+          "value": "capital-gains-tax"
+        },
+        {
+          "label": "Change personal details",
+          "value": "change-personal-details"
+        },
+        {
+          "label": "Charities and clubs",
+          "value": "charities-and-clubs"
+        },
+        {
+          "label": "Child Benefit and other benefits",
+          "value": "child-benefit-and-other-benefits"
+        },
+        {
+          "label": "Complaints",
+          "value": "complaints"
+        },
+        {
+          "label": "Construction Industry Scheme",
+          "value": "construction-industry-scheme"
+        },
+        {
+          "label": "Corporation Tax",
+          "value": "corporation-tax"
+        },
+        {
+          "label": "Customs and Excise",
+          "value": "customs-and-excise"
+        },
+        {
+          "label": "Cymraeg / Welsh",
+          "value": "cymraeg--welsh"
+        },
+        {
+          "label": "Employers",
+          "value": "employers"
+        },
+        {
+          "label": "Fraud and tax evasion",
+          "value": "fraud-and-tax-evasion"
+        },
+        {
+          "label": "Income Tax",
+          "value": "income-tax"
+        },
+        {
+          "label": "National Insurance",
+          "value": "national-insurance"
+        },
+        {
+          "label": "Non-UK Residents",
+          "value": "nonuk-residents"
+        },
+        {
+          "label": "Online Services",
+          "value": "online-services"
+        },
+        {
+          "label": "Paying",
+          "value": "paying"
+        },
+        {
+          "label": "Pension Schemes",
+          "value": "pension-schemes"
+        },
+        {
+          "label": "Self Assessment",
+          "value": "self-assessment"
+        },
+        {
+          "label": "Self-employed",
+          "value": "selfemployed"
+        },
+        {
+          "label": "Stamp Taxes",
+          "value": "stamp-taxes"
+        },
+        {
+          "label": "Tax credits",
+          "value": "tax-credits"
+        },
+        {
+          "label": "Tax on savings and investments",
+          "value": "tax-on-savings-and-investments"
+        },
+        {
+          "label": "Textphone",
+          "value": "textphone"
+        },
+        {
+          "label": "VAT",
+          "value": "vat"
+        }
+      ],
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "key": "topics",
+      "name": "Topics",
+      "specialist_publisher_properties": {
+        "select": "multiple"
+      },
+      "type": "text"
+    }
+  ],
+  "filter": {
+    "format": "hmrc_contact"
+  },
+  "name": "Contact HM Revenue & Customs",
+  "organisations": [
+    "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+  ],
+  "summary": "TBC",
+  "target_stack": "draft"
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -225,6 +225,19 @@ FactoryBot.define do
     end
   end
 
+  factory :hmrc_contact, parent: :document do
+    base_path { "/find-hmrc-contacts/example-document" }
+    document_type { "hmrc_contact" }
+
+    transient do
+      default_metadata do
+        {
+          "topics" => %w[agents],
+        }
+      end
+    end
+  end
+
   factory :life_saving_maritime_appliance_service_station, parent: :document do
     base_path { "/service-life-saving-maritime-appliances/example-document" }
     document_type { "life_saving_maritime_appliance_service_station" }


### PR DESCRIPTION
This commit adds the configuration for an MVP new "HMRC Contacts" finder, which will replace the HMRC Contacts Admin application.

On investigation, Specialist Publisher [already has all of the necessary features for an MVP](https://docs.google.com/document/d/1tUsNpogqSE1Cygd75f80grk4pFb1F9zq0_W9mDWyNRA/edit).

For context, here is an example contact page: <https://www.gov.uk/government/organisations/hm-revenue-customs/contact/annual-tax-on-enveloped-dwellings-ated>

As described in the [conclusion of the investigation](https://docs.google.com/document/d/1tUsNpogqSE1Cygd75f80grk4pFb1F9zq0_W9mDWyNRA/edit?tab=t.0#heading=h.usmu79bsr27g), to make this one relatively small and simple page, the publisher has to edit five different forms (across a total of 8 form submissions):

- [Contact form](https://contacts-admin.integration.publishing.service.gov.uk/admin/contacts/annual-tax-on-enveloped-dwellings-ated/edit)
- [Online link form](https://contacts-admin.integration.publishing.service.gov.uk/admin/contacts/annual-tax-on-enveloped-dwellings-ated/contact_form_links) (three times)
- [Email address form](https://contacts-admin.integration.publishing.service.gov.uk/admin/contacts/annual-tax-on-enveloped-dwellings-ated/email_addresses)
- [Postal address form](https://contacts-admin.integration.publishing.service.gov.uk/admin/contacts/annual-tax-on-enveloped-dwellings-ated/post_addresses) (twice)
- [Phone number form](https://contacts-admin.integration.publishing.service.gov.uk/admin/contacts/annual-tax-on-enveloped-dwellings-ated/phone_numbers)

That is a _lot_ of complexity to have to carry across to Specialist Publisher. So we're going with the alternative: with some relatively modest GovSpeak, we can generate exactly the same page using the 'Body' field that's already included on all specialist finders.

With this Body (alongside a title of `Annual Tax on Enveloped Dwellings`, summary of `Email, call or write to HMRC for help with ATED, including making payments and returns` and topic of `Stamp taxes`), we end up with exactly the same rendered GovSpeak as the 'contact admin' alternative approach.±

± with the one exception of the "Related content" sidebar, which we can simply incorporate into the GovSpeak below the content. We don't see any particular reason why it needs to appear on the side.

## GovSpeak for specialist document

```md
## Online

[Find out what you need to pay and how to appoint an agent or adviser to act on your behalf](https://www.gov.uk/guidance/annual-tax-on-enveloped-dwellings-the-basics)

[Find out how to work out the value of your property](https://www.gov.uk/guidance/annual-tax-on-enveloped-dwellings-pre-return-banding-checks)

[Pay Annual Tax on Enveloped Dwellings](https://www.gov.uk/guidance/pay-annual-tax-on-enveloped-dwellings)

## Email

Email HMRC to ask for a paper ATED return if you cannot file a return online
[paperforms.ated@hmrc.gov.uk](mailto:paperforms.ated@hmrc.gov.uk)

HMRC will contact you by letter or phone if they need to discuss any personal or confidential information.

## Phone

Call HMRC for general enquiries about ATED.

$C
Telephone:
**0300 200 3510**

Outside UK:
**+44 1726 209 042**
$C

Opening times:

Monday to Friday: 8:30am to 5pm

[Find out about call charges](https://www.gov.uk/call-charges)

## Post

### ATED queries and paper returns

Write to HMRC at this address to:

*   get answers to administrative enquiries
*   send completed ATED paper returns
*   get help with technical tax enquiries (for example, understanding ATED legislation)

Do not write to this address to apply for non-statutory clearances, find out [how to use the Non-Statutory Clearance Service](https://www.gov.uk/guidance/non-statutory-clearance-service-guidance).

You do not need to include a street name or PO box when writing to this address.

Couriers should use a [different address](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/couriers).

$A
Stamp Taxes
HMRC
BX9 1HD
United Kingdom
$A

### Payments

Read [pay Annual Tax on Enveloped Dwellings](https://www.gov.uk/pay-annual-tax-on-enveloped-dwellings) to find out how to pay by cheque before you post your payment to this address.

You do not need to include a street name or PO box when writing to this address, and should allow 3 working days for your payment to reach HMRC.

Couriers should use a [different address](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/couriers).

$A
HM Revenue and Customs
Bradford
BD98 1YY
United Kingdom
$A

---

- [Annual Tax on Enveloped Dwellings](https://www.gov.uk/annual-tax-on-enveloped-dwellings-the-basics)
- [Annual Tax on Enveloped Dwellings: work out the value of your property](https://www.gov.uk/annual-tax-on-enveloped-dwellings-pre-return-banding-checks)
- [Pay Annual Tax on Enveloped Dwellings](https://www.gov.uk/pay-annual-tax-on-enveloped-dwellings)
```

## Screenshots

| Current contact page | New specialist document output |
|----------------------|--------------------------------|
|![before](https://github.com/user-attachments/assets/7d0ba48c-7ec3-4654-9d7a-a4207b5ff0d6)|![after](https://github.com/user-attachments/assets/8a3e61d2-24a6-43bf-bae2-55d30b8e273c)|

(Screenshot slightly broken because of the sticky "Contents" footer, but does render fine!)

Specialist Publisher specialist doc:

![specialist-publisher staging publishing service gov uk_hmrc-contacts_2d424f44-40d0-4d21-847b-efa0b345c199_en](https://github.com/user-attachments/assets/76f8a165-98f6-4cb0-a00f-3add6c1e60d2)

Edit page:

![specialist-publisher staging publishing service gov uk_hmrc-contacts_2d424f44-40d0-4d21-847b-efa0b345c199_en_edit](https://github.com/user-attachments/assets/4e838a76-880c-4b49-a175-e5f7dac444b0)

Specialist Publisher index page:

![specialist-publisher staging publishing service gov uk_hmrc-contacts](https://github.com/user-attachments/assets/28f63171-4e8c-46b7-95b4-aa9a51e990e3)


---

## Welsh

GovSpeak determined by copying the contents of <https://www.gov.uk/government/organisations/hm-revenue-customs/contact/treth-enillion-cyfalaf> and pasting into https://govspeak-preview.publishing.service.gov.uk/:

```md
## Phone

Ar gyfer ymholiadau cyffredinol ynghylch Treth Enillion Cyfalaf, ffoniwch CThEM.  
Bydd angen eich Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad arnoch.

Telephone:  
0300 200 1900

Textphone:  
0300 200 3319

Outside UK:  
+44 300 200 1900

Opening times:

Dydd Llun – Dydd Gwener: 08:30 – 17:00  
[Gwybodaeth am gostau galwadau](https://www.gov.uk/costau-galwadau)

[Find out about call charges](https://www.gov.uk/call-charges)

## Post

Ysgrifennwch at CThEM am help gydag ymholiadau cyffredinol ynghylch Treth Enillion Cyfalaf.  
Does dim rhaid i chi gynnwys enw stryd, enw dinas na blwch Swyddfa’r Post pan fyddwch yn ysgrifennu i’r cyfeiriad hwn.  
Dylai negeswyr ddefnyddio cyfeiriad gwahanol.

Gwasanaeth Cwsmeriaid Cymraeg CThEM  
HMRC  
BX9 1ST  
United Kingdom  

Fel arfer, caiff Treth Enillion Cyfalaf ei talu drwy Hunanasesiad. Er mwyn talu’ch treth drwy siec, dilynwch y cyfarwyddiadau talu:

- ar gyfer Hunanasesiad
- os gwnaethoch ddefnyddio’r gwasanaeth Treth Enillion Cyfalaf ar-lein (a elwir hefyd yn ‘Trafodion Amser Real’)
- os gwnaethoch ddefnyddio’r gwasanaeth [Treth Enillion Cyfalaf ar eiddo yn y DU](https://www.tax.service.gov.uk/capital-gains-tax-uk-property/start)

Caniatewch 3 diwrnod gwaith i’r taliad gyrraedd CThEM.  
Does dim rhaid i chi gynnwys enw stryd na blwch Swyddfa’r Post pan fyddwch yn anfon siec i’r cyfeiriad hwn.  
Dylai negeswyr ddefnyddio cyfeiriad gwahanol.

Gwasanaeth Cwsmeriaid Cymraeg CThEM  
HMRC  
BX9 1ST  
United Kingdom  

## Other contacts

- [Treth Incwm, Hunanasesiad a mwy](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/welsh-language-helplines)
```

Set language of doc to "Welsh" and topics to "Cymraeg / Welsh", "Capital Gains Tax", "Paying", "Self Assessment" and "Textphone" and title to "Treth Enillion Cyfalaf".

Trello: https://trello.com/c/TPduM6sI/3449-hmrc-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
