### PR TITLE
[DO NOT MERGE] Change rendering app to frontend

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -103,7 +103,7 @@ class Document
   end
 
   def rendering_app
-    "government-frontend"
+    "frontend"
   end
 
   delegate :document_type, to: :class

--- a/docs/updating-existing-organisation-data.md
+++ b/docs/updating-existing-organisation-data.md
@@ -2,7 +2,7 @@
 
 Departments will sometimes ask for functional data for particular specialist publisher organisation to be updated. Examples of this include adding or updating a new sub-category or specifying the content id of the organisation so that it will be applied to the associated finder page.
 
-This data can be found in `lib/documents/schemas`. These schemas follow the same format and are fairly self explanatory in relation to what needs to be updated. Check the apps which render the content for specialist publisher ([finder-frontend](https://github.com/alphagov/finder-frontend) and [government-frontend](https://github.com/alphagov/government-frontend)) and the specialist publisher code itself for more details about how a particular piece of data is used or presented.
+This data can be found in `lib/documents/schemas`. These schemas follow the same format and are fairly self explanatory in relation to what needs to be updated. Check the apps which render the content for specialist publisher ([finder-frontend](https://github.com/alphagov/finder-frontend) and [frontend](https://github.com/alphagov/frontend)) and the specialist publisher code itself for more details about how a particular piece of data is used or presented.
 
 ## Updating an organisation's finder page
 

--- a/spec/features/creating_a_trademark_decision_spec.rb
+++ b/spec/features/creating_a_trademark_decision_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Creating a Trademark Decision", type: :feature do
       "document_type": "trademark_decision",
       "schema_name": "specialist_document",
       "publishing_app": "specialist-publisher",
-      "rendering_app": "government-frontend",
+      "rendering_app": "frontend",
       "locale": "en",
       "phase": "live",
       "details": {

--- a/spec/features/editing_a_trademark_decision_spec.rb
+++ b/spec/features/editing_a_trademark_decision_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Creating a Trademark Decision", type: :feature do
       "document_type": "trademark_decision",
       "schema_name": "specialist_document",
       "publishing_app": "specialist-publisher",
-      "rendering_app": "government-frontend",
+      "rendering_app": "frontend",
       "locale": "en",
       "phase": "live",
       "details": {

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -117,7 +117,7 @@ FactoryBot.define do
     schema_name { "specialist_document" }
     document_type { nil }
     publishing_app { "specialist-publisher" }
-    rendering_app { "government-frontend" }
+    rendering_app { "frontend" }
     locale { "en" }
     phase { "live" }
     redirects { [] }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Document do
         expect(document.first_published_at).to eq(payload["first_published_at"])
         expect(document.update_type).to eq(nil)
         expect(document.state_history).to eq(payload["state_history"])
-        expect(document.rendering_app).to eq("government-frontend")
+        expect(document.rendering_app).to eq("frontend")
       end
 
       context "when bulk published is true" do


### PR DESCRIPTION
[Trello](https://trello.com/c/RrUeLTKc)

As part of [RFC 175] many of the document types that were served by government-frontend are being moved to frontend.

This change is dependent on:
https://github.com/alphagov/frontend/pull/4600

Once these changes have been merged, all specialist_documents will be republished using the `republish:all` rake task.

[RFC 175]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-175-frontend-fewer-apps.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
