### PR TITLE
Change finder presenter logic for nested facets

### DIFF
--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -27,14 +27,6 @@ class FinderContentItemPresenter
     file.fetch("content_id")
   end
 
-  def self.facets_without_specialist_publisher_properties(facets)
-    facets.reject { |facet| facet["specialist_publisher_properties"]&.fetch("omit_from_finder_content_item", false) }
-          .map do |facet|
-      facet.delete("specialist_publisher_properties")
-      facet
-    end
-  end
-
 private
 
   def title
@@ -60,7 +52,7 @@ private
       signup_link: file.fetch("signup_link", nil),
       summary: file.fetch("summary", nil),
       label_text: file.fetch("label_text", nil),
-      facets: FinderContentItemPresenter.facets_without_specialist_publisher_properties(file.fetch("facets", nil)),
+      facets: FinderFacetPresenter.new(file.fetch("facets", nil)).to_json,
       default_order: file.fetch("default_order", nil),
       default_documents_per_page: 50,
     }.reject { |_, value| value.nil? }

--- a/app/presenters/finder_facet_presenter.rb
+++ b/app/presenters/finder_facet_presenter.rb
@@ -1,0 +1,19 @@
+class FinderFacetPresenter
+  def initialize(facets)
+    @facets = facets
+  end
+
+  def to_json(*_args)
+    facets_without_specialist_publisher_properties(@facets)
+  end
+
+private
+
+  def facets_without_specialist_publisher_properties(facets)
+    facets.reject { |facet| facet["specialist_publisher_properties"]&.fetch("omit_from_finder_content_item", false) }
+          .map do |facet|
+      facet.delete("specialist_publisher_properties")
+      facet
+    end
+  end
+end

--- a/app/presenters/finder_facet_presenter.rb
+++ b/app/presenters/finder_facet_presenter.rb
@@ -4,7 +4,9 @@ class FinderFacetPresenter
   end
 
   def to_json(*_args)
-    facets_without_specialist_publisher_properties(@facets)
+    facets_without_specialist_publisher_properties(@facets).map { |facet|
+      facet["nested_facet"] ? [main_facet_hash_without_sub_facets(facet), sub_facet_hash(facet)] : facet
+    }.flatten
   end
 
 private
@@ -14,6 +16,36 @@ private
           .map do |facet|
       facet.delete("specialist_publisher_properties")
       facet
+    end
+  end
+
+  def main_facet_hash_without_sub_facets(facet_hash)
+    hash_dup = facet_hash.dup
+    hash_dup["allowed_values"] = hash_dup["allowed_values"].map { |v| v.except("sub_facets") }
+
+    hash_dup
+  end
+
+  def sub_facet_hash(facet_hash)
+    facet_hash.merge(
+      "allowed_values" => sub_facet_allowed_values(facet_hash),
+      "key" => facet_hash["sub_facet_key"],
+      "name" => facet_hash["sub_facet_name"],
+      "sub_facet_key" => nil,
+      "sub_facet_name" => nil,
+      "short_name" => facet_hash["sub_facet_name"],
+      "preposition" => facet_hash["sub_facet_name"],
+    ).compact
+  end
+
+  def sub_facet_allowed_values(facet_hash)
+    facet_hash["allowed_values"].each_with_object([]) do |allowed_value, sub_facets|
+      main_label = allowed_value["label"]
+      main_value = allowed_value["value"]
+
+      allowed_value["sub_facets"]&.each do |sub_facet|
+        sub_facets << sub_facet.merge("main_facet_label" => main_label, "main_facet_value" => main_value)
+      end
     end
   end
 end

--- a/lib/documents/schemas/trademark_decisions.json
+++ b/lib/documents/schemas/trademark_decisions.json
@@ -2,7 +2,7 @@
   "base_path": "/trademark-decisions",
   "content_id": "9f8388a8-9559-4a75-96f3-4a0a1027b5e8",
   "description": "Find Intellectual Property (Trade Mark,) related decisions for the U.K.",
-  "document_noun": "Decision",
+  "document_noun": "decision",
   "document_title": "Trademark Decision",
   "facets": [
     {

--- a/lib/documents/schemas/trademark_decisions.json
+++ b/lib/documents/schemas/trademark_decisions.json
@@ -56,7 +56,7 @@
       "filterable": true,
       "key": "trademark_decision_type_of_hearing",
       "name": "Type of hearing",
-      "preposition": "with",
+      "preposition": "Type of hearing",
       "short_name": "Type of hearing",
       "specialist_publisher_properties": {
         "select": "one"
@@ -258,7 +258,7 @@
       "filterable": true,
       "key": "trademark_decision_class",
       "name": "Class",
-      "preposition": "with",
+      "preposition": "Class",
       "short_name": "Class",
       "specialist_publisher_properties": {
         "select": "one",
@@ -273,7 +273,7 @@
       "filterable": true,
       "key": "trademark_decision_date",
       "name": "Decision date",
-      "preposition": "with",
+      "preposition": "Decision date",
       "specialist_publisher_properties": {
         "validations": {
           "required": {}
@@ -901,7 +901,7 @@
       "filterable": true,
       "key": "trademark_decision_appointed_person_hearing_officer",
       "name": "Appointed person/hearing officer",
-      "preposition": "with",
+      "preposition": "Appointed person/hearing officer",
       "show_option_select_filter": true,
       "specialist_publisher_properties": {
         "select": "one",
@@ -1608,7 +1608,7 @@
       "key": "trademark_decision_grounds_section",
       "name": "Grounds Section",
       "nested_facet": true,
-      "preposition": "with",
+      "preposition": "Grounds section",
       "short_name": "Grounds section",
       "specialist_publisher_properties": {
         "select": "multiple",

--- a/spec/presenters/finders/finder_content_item_presenter_spec.rb
+++ b/spec/presenters/finders/finder_content_item_presenter_spec.rb
@@ -11,48 +11,13 @@ RSpec.describe FinderContentItemPresenter do
           payload, Time.zone.parse("2016-01-01T00:00:00-00:00")
         )
 
+        expect_any_instance_of(FinderFacetPresenter).to receive(:to_json).and_call_original
+
         presented_data = presenter.to_json
 
         expect(presented_data[:schema_name]).to eq("finder")
         expect(presented_data).to be_valid_against_publisher_schema("finder")
       end
-    end
-  end
-
-  describe ".facets_without_specialist_publisher_properties" do
-    it "removes facets that should not be included in the finder content item" do
-      facets = [
-        { "bar" => "baz" },
-        {
-          "foo" => "bar",
-          "specialist_publisher_properties" => {
-            "omit_from_finder_content_item" => true,
-          },
-        },
-      ]
-      facets_without_specialist_publisher_properties = [
-        { "bar" => "baz" },
-      ]
-
-      expect(FinderContentItemPresenter.facets_without_specialist_publisher_properties(facets))
-        .to eq(facets_without_specialist_publisher_properties)
-    end
-
-    it "strips specialist_publisher_properties hash if present" do
-      facets = [
-        {
-          "foo" => "bar",
-          "specialist_publisher_properties" => {
-            "select" => "one",
-          },
-        },
-      ]
-      facets_without_specialist_publisher_properties = [
-        { "foo" => "bar" },
-      ]
-
-      expect(FinderContentItemPresenter.facets_without_specialist_publisher_properties(facets))
-        .to eq(facets_without_specialist_publisher_properties)
     end
   end
 end

--- a/spec/presenters/finders/finder_facet_presenter_spec.rb
+++ b/spec/presenters/finders/finder_facet_presenter_spec.rb
@@ -34,5 +34,109 @@ RSpec.describe FinderFacetPresenter do
       presented_facets = FinderFacetPresenter.new(facets).to_json
       expect(presented_facets).to eq(facets_without_specialist_publisher_properties)
     end
+
+    it "returns two distinct main and sub facets for a finder with one nested facet defined in the schema" do
+      facets_from_schema = [{
+        "allowed_values" => [
+          {
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1",
+            "sub_facets" => [
+              {
+                "label" => "Allowed value 1 Sub facet Value 1",
+                "value" => "allowed-value-1-sub-facet-value-1",
+              },
+              {
+                "label" => "Allowed value 1 Sub facet Value 2",
+                "value" => "allowed-value-1-sub-facet-value-2",
+              },
+            ],
+          },
+          {
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2",
+            "sub_facets" => [
+              {
+                "label" => "Allowed value 2 Sub facet Value 1",
+                "value" => "allowed-value-2-sub-facet-value-1",
+              },
+            ],
+          },
+          {
+            "label" => "Allowed value 3",
+            "value" => "allowed-value-3",
+          },
+        ],
+        "display_as_result_metadata" => true,
+        "filterable" => true,
+        "key" => "facet_key",
+        "name" => "Facet Name",
+        "nested_facet" => true,
+        "preposition" => "Facet Name",
+        "short_name" => "Short Name",
+        "sub_facet_key" => "sub_facet_key",
+        "sub_facet_name" => "Sub Facet Name",
+        "type" => "text",
+      }]
+      main_facet_hash = {
+        "allowed_values" => [
+          {
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2",
+          },
+          {
+            "label" => "Allowed value 3",
+            "value" => "allowed-value-3",
+          },
+        ],
+        "display_as_result_metadata" => true,
+        "filterable" => true,
+        "key" => "facet_key",
+        "name" => "Facet Name",
+        "nested_facet" => true,
+        "preposition" => "Facet Name",
+        "short_name" => "Short Name",
+        "sub_facet_name" => "Sub Facet Name",
+        "sub_facet_key" => "sub_facet_key",
+        "type" => "text",
+      }
+      sub_facet_hash = {
+        "allowed_values" => [
+          {
+            "label" => "Allowed value 1 Sub facet Value 1",
+            "value" => "allowed-value-1-sub-facet-value-1",
+            "main_facet_label" => "Allowed value 1",
+            "main_facet_value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 1 Sub facet Value 2",
+            "value" => "allowed-value-1-sub-facet-value-2",
+            "main_facet_label" => "Allowed value 1",
+            "main_facet_value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 2 Sub facet Value 1",
+            "value" => "allowed-value-2-sub-facet-value-1",
+            "main_facet_label" => "Allowed value 2",
+            "main_facet_value" => "allowed-value-2",
+          },
+        ],
+        "display_as_result_metadata" => true,
+        "filterable" => true,
+        "key" => "sub_facet_key",
+        "name" => "Sub Facet Name",
+        "nested_facet" => true,
+        "preposition" => "Sub Facet Name",
+        "short_name" => "Sub Facet Name",
+        "type" => "text",
+      }
+
+      presented_data = FinderFacetPresenter.new(facets_from_schema).to_json
+      expect(presented_data).to eq([main_facet_hash, sub_facet_hash])
+    end
   end
 end

--- a/spec/presenters/finders/finder_facet_presenter_spec.rb
+++ b/spec/presenters/finders/finder_facet_presenter_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe FinderFacetPresenter do
+  describe "#to_json" do
+    it "removes facets that should not be included in the finder content item" do
+      facets = [
+        { "bar" => "baz" },
+        {
+          "foo" => "bar",
+          "specialist_publisher_properties" => {
+            "omit_from_finder_content_item" => true,
+          },
+        },
+      ]
+
+      keys = FinderFacetPresenter.new(facets).to_json.map(&:keys).flatten
+      expect(keys).to include("bar")
+      expect(keys).to_not include("foo")
+    end
+
+    it "strips specialist_publisher_properties hash if present" do
+      facets = [
+        {
+          "foo" => "bar",
+          "specialist_publisher_properties" => {
+            "select" => "one",
+          },
+        },
+      ]
+      facets_without_specialist_publisher_properties = [
+        { "foo" => "bar" },
+      ]
+
+      presented_facets = FinderFacetPresenter.new(facets).to_json
+      expect(presented_facets).to eq(facets_without_specialist_publisher_properties)
+    end
+  end
+end


### PR DESCRIPTION
Changing nested facets implementation. We now send two distinct facets in the publishing-api load, corresponding to the main and sub facet, respectively, in order to minimise how much we need to change Finder Frontend down the line.

[Trello](https://trello.com/c/skH2B2fH/3373-nested-facets-finder-frontend)
