### PR TITLE
Fix 'short_name' facet attribute order

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -20,8 +20,8 @@ class Facet
       key:,
       name:,
       preposition:,
-      specialist_publisher_properties:,
       short_name:,
+      specialist_publisher_properties:,
       type:,
     }.compact
   end

--- a/lib/documents/schemas/trademark_decisions.json
+++ b/lib/documents/schemas/trademark_decisions.json
@@ -274,12 +274,12 @@
       "key": "trademark_decision_date",
       "name": "Decision date",
       "preposition": "Decision date",
+      "short_name": "Date",
       "specialist_publisher_properties": {
         "validations": {
           "required": {}
         }
       },
-      "short_name": "Date",
       "type": "date"
     },
     {
@@ -903,13 +903,13 @@
       "name": "Appointed person/hearing officer",
       "preposition": "Appointed person/hearing officer",
       "show_option_select_filter": true,
+      "short_name": "Hearing officer",
       "specialist_publisher_properties": {
         "select": "one",
         "validations": {
           "required": {}
         }
       },
-      "short_name": "Hearing officer",
       "type": "text"
     },
     {

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -236,8 +236,8 @@ RSpec.describe "Facet" do
         key
         name
         preposition
-        specialist_publisher_properties
         short_name
+        specialist_publisher_properties
         type
       ])
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
