### PR TITLE
Include 'show_option_select_filter' attribute in schema generation

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -112,6 +112,7 @@ private
         :key,
         :name,
         :short_name,
+        :show_option_select_filter,
         :type,
         :preposition,
         :display_as_result_metadata,

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -11,6 +11,7 @@ class Facet
   attribute :filterable, :boolean
   attribute :allowed_values
   attribute :specialist_publisher_properties
+  attribute :show_option_select_filter, :boolean
 
   def to_finder_schema_attributes
     {
@@ -21,6 +22,7 @@ class Facet
       name:,
       preposition:,
       short_name:,
+      show_option_select_filter:,
       specialist_publisher_properties:,
       type:,
     }.compact
@@ -38,6 +40,7 @@ class Facet
       facet.filterable = params["filterable"]
       facet.allowed_values = facet_allowed_values(params["allowed_values"], params["type"])
       facet.specialist_publisher_properties = facet_specialist_publisher_properties(params["type"], params["validations"])
+      facet.show_option_select_filter = nil_if_false(params["show_option_select_filter"])
       facet
     end
 
@@ -49,6 +52,10 @@ class Facet
 
     def nil_if_blank(str)
       str.presence
+    end
+
+    def nil_if_false(str)
+      str == "true" ? true : nil
     end
 
     def facet_type(type)

--- a/app/views/admin/_facet_fields.html.erb
+++ b/app/views/admin/_facet_fields.html.erb
@@ -123,3 +123,23 @@
   value: facet["preposition"],
   hint: "Example: In Find funding for land or farms,  selecting an option in the filter ‘Area of interest’ displays the preposition ‘With’ before the selected option"
 } %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Should filter values be searchable?",
+  heading_size: "s",
+  hint: "This option provides a search box for users to filter the list of options.",
+  name: "facets[#{index}][show_option_select_filter]",
+  inline: true,
+  items: [
+    {
+      value: "true",
+      text: "Yes",
+      checked: facet["show_option_select_filter"]
+    },
+    {
+      value: "false",
+      text: "No",
+      checked: !facet["show_option_select_filter"]
+    }
+  ]
+} %>

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Facet" do
         "preposition" => "sector",
         "display_as_result_metadata" => "false",
         "filterable" => "true",
+        "show_option_select_filter" => "true",
         "allowed_values" => "existing value {existing-value}\nnew value",
       }
       facet = Facet.from_finder_admin_form_params(params)
@@ -21,6 +22,7 @@ RSpec.describe "Facet" do
       expect(facet.preposition).to eq("sector")
       expect(facet.display_as_result_metadata).to eq(false)
       expect(facet.filterable).to eq(true)
+      expect(facet.show_option_select_filter).to eq(true)
     end
 
     it "derives the key from the name if no key provided" do
@@ -39,7 +41,7 @@ RSpec.describe "Facet" do
       expect(facet.preposition).to eq(nil)
     end
 
-    describe "inferring the boolean value, or absence of a value, for 'display_as_result_metadata' and 'filterable'" do
+    describe "inferring the boolean value, or absence of a value, for 'display_as_result_metadata', 'filterable' and 'show_option_select_filter'" do
       it "converts 'true' to true for 'display_as_result_metadata'" do
         facet = Facet.from_finder_admin_form_params({ "display_as_result_metadata" => "true" })
         expect(facet.display_as_result_metadata).to eq(true)
@@ -68,6 +70,16 @@ RSpec.describe "Facet" do
       it "sets 'filterable' to 'nil' for any other values" do
         facet = Facet.from_finder_admin_form_params({ "filterable" => "" })
         expect(facet.filterable).to eq(nil)
+      end
+
+      it "converts 'true' to true for 'show_option_select_filter'" do
+        facet = Facet.from_finder_admin_form_params({ "show_option_select_filter" => "true" })
+        expect(facet.show_option_select_filter).to eq(true)
+      end
+
+      it "sets 'show_option_select_filter' to 'nil' if 'false' is passed" do
+        facet = Facet.from_finder_admin_form_params({ "show_option_select_filter" => "false" })
+        expect(facet.show_option_select_filter).to eq(nil)
       end
     end
 
@@ -183,6 +195,7 @@ RSpec.describe "Facet" do
         { label: "existing value", value: "existing-value" },
         { label: "new value", value: "new-value" },
       ]
+      facet.show_option_select_filter = true
       facet.specialist_publisher_properties = { select: "one" }
 
       expect(facet.to_finder_schema_attributes).to eq({
@@ -197,6 +210,7 @@ RSpec.describe "Facet" do
           { label: "existing value", value: "existing-value" },
           { label: "new value", value: "new-value" },
         ],
+        show_option_select_filter: true,
         specialist_publisher_properties: { select: "one" },
       })
     end


### PR DESCRIPTION
This commit adds `show_option_select_filter` to the finder admin UI, and thus generates it as part of the proposed schema for the Zendesk load. This is an option we only use for Licence finder and Trademark Decisions. But it is handy to have it included so that we don't get unnecessary diffs when editing those finders.

It's also handy to have it as a viable option on the admin UI. This option enables the kind of search seen for Appointed person/ hearing officer [here](https://draft-origin.publishing.service.gov.uk/trademark-decisions). 

In Specialist Publisher:
> ![Screenshot 2025-03-05 at 15 50 11](https://github.com/user-attachments/assets/e3f3513c-4204-4274-ab39-6f7bbeb4dfd1)

On Finder Frontend:
> ![Screenshot 2025-03-07 at 11 48 55](https://github.com/user-attachments/assets/d3e0ad6c-78f1-421d-bd9c-844286fd8b3f)
