### PR TITLE
Add main facet key to finder schema

### DIFF
--- a/app/presenters/finder_facet_presenter.rb
+++ b/app/presenters/finder_facet_presenter.rb
@@ -33,6 +33,7 @@ private
       "name" => facet_hash["sub_facet_name"],
       "sub_facet_key" => nil,
       "sub_facet_name" => nil,
+      "main_facet_key" => facet_hash["key"],
       "short_name" => facet_hash["sub_facet_name"],
       "preposition" => facet_hash["sub_facet_name"],
     ).compact

--- a/spec/presenters/finders/finder_facet_presenter_spec.rb
+++ b/spec/presenters/finders/finder_facet_presenter_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe FinderFacetPresenter do
         "filterable" => true,
         "key" => "sub_facet_key",
         "name" => "Sub Facet Name",
+        "main_facet_key" => "facet_key",
         "nested_facet" => true,
         "preposition" => "Sub Facet Name",
         "short_name" => "Sub Facet Name",


### PR DESCRIPTION
If the facet is a sub facet, add main facet key so frontend is able to render sub-facet views without having to do a look up of the related main facet. 

https://trello.com/c/y9Wj7iHe/3501-nested-facets-changes-to-frontend-because-of-rendering-app-migration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
