### PR TITLE
Nested facet - add custom nested type and change presenter logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
-    gds-api-adapters (98.3.0)
+    gds-api-adapters (98.4.0)
       addressable
       link_header
       null_logger
@@ -317,10 +317,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.6.0)
+    mime-types (3.6.1)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0304)
+    mime-types-data (3.2025.0318)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.5)

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -65,7 +65,13 @@ class Facet
     end
 
     def facet_type(type)
-      facet_text_types.include?(type) ? "text" : type
+      if facet_text_types.include?(type)
+        "text"
+      elsif facet_nested_types.include?(type)
+        "nested"
+      else
+        type
+      end
     end
 
     def facet_allowed_values(values, type)
@@ -112,9 +118,9 @@ class Facet
 
     def facet_specialist_publisher_properties_select(type)
       case type
-      when "enum_text_multiple", "nested"
+      when "enum_text_multiple", "nested_enum_text_multiple"
         { select: "multiple" }
-      when "enum_text_single"
+      when "enum_text_single", "nested_enum_text_single"
         { select: "one" }
       else
         {}
@@ -133,11 +139,15 @@ class Facet
     end
 
     def facet_types_that_allow_enum_values
-      facet_text_types + %w[nested]
+      facet_text_types + facet_nested_types
     end
 
     def facet_text_types
       %w[enum_text_multiple enum_text_single]
+    end
+
+    def facet_nested_types
+      %w[nested_enum_text_multiple nested_enum_text_single]
     end
   end
 end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -12,7 +12,6 @@ class Facet
   attribute :allowed_values
   attribute :specialist_publisher_properties
   attribute :show_option_select_filter, :boolean
-  attribute :nested_facet, :boolean
   attribute :sub_facet_name
   attribute :sub_facet_key
 
@@ -23,7 +22,6 @@ class Facet
       filterable:,
       key:,
       name:,
-      nested_facet:,
       preposition:,
       short_name:,
       show_option_select_filter:,
@@ -47,7 +45,6 @@ class Facet
       facet.allowed_values = facet_allowed_values(params["allowed_values"], params["type"])
       facet.specialist_publisher_properties = facet_specialist_publisher_properties(params["type"], params["validations"])
       facet.show_option_select_filter = nil_if_false(params["show_option_select_filter"])
-      facet.nested_facet = nil_if_blank(params["sub_facet"])
       facet.sub_facet_name = extract_label_and_value(params["sub_facet"], "_").first if params["sub_facet"].present?
       facet.sub_facet_key = facet_key(extract_label_and_value(params["sub_facet"], "_").last, facet.sub_facet_name) if params["sub_facet"].present?
       facet
@@ -68,7 +65,7 @@ class Facet
     end
 
     def facet_type(type)
-      facet_types_that_allow_enum_values.include?(type) ? "text" : type
+      facet_text_types.include?(type) ? "text" : type
     end
 
     def facet_allowed_values(values, type)
@@ -115,7 +112,7 @@ class Facet
 
     def facet_specialist_publisher_properties_select(type)
       case type
-      when "enum_text_multiple"
+      when "enum_text_multiple", "nested"
         { select: "multiple" }
       when "enum_text_single"
         { select: "one" }
@@ -136,6 +133,10 @@ class Facet
     end
 
     def facet_types_that_allow_enum_values
+      facet_text_types + %w[nested]
+    end
+
+    def facet_text_types
       %w[enum_text_multiple enum_text_single]
     end
   end

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -71,9 +71,9 @@ class FinderSchema
 
   def humanized_facet_value(facet_key, value)
     type = facet_data_for(facet_key).fetch("type", nil)
-    if type == "text" && allowed_values_for(facet_key).empty?
+    if %w[text nested].include?(type) && allowed_values_for(facet_key).empty?
       value
-    elsif %w[hidden text].include?(type)
+    elsif %w[hidden text nested].include?(type)
       Array(value).map do |v|
         value_label_mapping_for(facet_key, v).fetch("label") { value }
       end
@@ -91,7 +91,7 @@ class FinderSchema
   end
 
   def nested_facets
-    facets.select { |facet| facet["nested_facet"] }
+    facets.select { |facet| facet["type"] == "nested" }
   end
 
 private

--- a/app/presenters/finder_facet_presenter.rb
+++ b/app/presenters/finder_facet_presenter.rb
@@ -4,9 +4,9 @@ class FinderFacetPresenter
   end
 
   def to_json(*_args)
-    facets_without_specialist_publisher_properties(@facets).map { |facet|
-      facet["type"] == "nested" ? [main_facet_hash_without_sub_facets(facet), sub_facet_hash(facet)] : facet
-    }.flatten
+    facets_without_specialist_publisher_properties(@facets).map do |facet|
+      facet["type"] == "nested" ? hash_with_parent_references(facet) : facet
+    end
   end
 
 private
@@ -19,34 +19,13 @@ private
     end
   end
 
-  def main_facet_hash_without_sub_facets(facet_hash)
-    hash_dup = facet_hash.dup
-    hash_dup["allowed_values"] = hash_dup["allowed_values"].map { |v| v.except("sub_facets") }
-
-    hash_dup
-  end
-
-  def sub_facet_hash(facet_hash)
-    facet_hash.merge(
-      "allowed_values" => sub_facet_allowed_values(facet_hash),
-      "key" => facet_hash["sub_facet_key"],
-      "name" => facet_hash["sub_facet_name"],
-      "sub_facet_key" => nil,
-      "sub_facet_name" => nil,
-      "main_facet_key" => facet_hash["key"],
-      "short_name" => facet_hash["sub_facet_name"],
-      "preposition" => facet_hash["sub_facet_name"],
-    ).compact
-  end
-
-  def sub_facet_allowed_values(facet_hash)
-    facet_hash["allowed_values"].each_with_object([]) do |allowed_value, sub_facets|
-      main_label = allowed_value["label"]
-      main_value = allowed_value["value"]
-
+  def hash_with_parent_references(facet_hash)
+    facet_hash["allowed_values"].each do |allowed_value|
       allowed_value["sub_facets"]&.each do |sub_facet|
-        sub_facets << sub_facet.merge("main_facet_label" => main_label, "main_facet_value" => main_value)
+        sub_facet["main_facet_label"] = allowed_value["label"]
+        sub_facet["main_facet_value"] = allowed_value["value"]
       end
     end
+    facet_hash
   end
 end

--- a/app/presenters/finder_facet_presenter.rb
+++ b/app/presenters/finder_facet_presenter.rb
@@ -5,7 +5,7 @@ class FinderFacetPresenter
 
   def to_json(*_args)
     facets_without_specialist_publisher_properties(@facets).map { |facet|
-      facet["nested_facet"] ? [main_facet_hash_without_sub_facets(facet), sub_facet_hash(facet)] : facet
+      facet["type"] == "nested" ? [main_facet_hash_without_sub_facets(facet), sub_facet_hash(facet)] : facet
     }.flatten
   end
 

--- a/app/views/admin/_facet_fields.html.erb
+++ b/app/views/admin/_facet_fields.html.erb
@@ -45,6 +45,11 @@
       text: "Date",
       value: "date",
       selected: facet["type"] == "date",
+    },
+    {
+      text: "Nested",
+      value: "nested",
+      selected: facet["type"] == "nested",
     }
   ]
 } %>
@@ -70,7 +75,7 @@
     heading_size: "s",
   },
   name: "facets[#{index}][sub_facet]",
-  value: facet["nested_facet"] ? "#{facet["sub_facet_name"]} {#{facet["sub_facet_key"]}}" : "",
+  value: facet["type"] == "nested" ? "#{facet["sub_facet_name"]} {#{facet["sub_facet_key"]}}" : "",
   hint: "The name of the sub-facet (only relevant for nested facets). Once saved, a key will be generated alongside it in the format 'Name {auto-generated-key-name}'. Do not edit the key."
 } %>
 
@@ -82,7 +87,7 @@
   hint: sanitize("Put each option on a new line. The underlying name for existing (live) options will appear in curly braces: please don't edit these, and don't add them for new options (they'll be created automatically later on in the process). Example:<br><strong>Pre-existing value {pre-existing-value}</strong><br><strong>New value</strong><br>If this is a nested facet, add nested options on subsequent lines, prefixed with a '-':<br><strong>Main Facet Value</strong><br><strong>- Sub Facet Value</strong><br><em>optional blank line</em><br><strong>Another Main Facet Value</strong>"),
   name: "facets[#{index}][allowed_values]",
   rows: 5,
-  value: admin_facet_value_from_allowed_values(facet["allowed_values"], nested_facet: facet["nested_facet"]),
+  value: admin_facet_value_from_allowed_values(facet["allowed_values"], nested_facet: facet["type"] == "nested"),
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/admin/_facet_fields.html.erb
+++ b/app/views/admin/_facet_fields.html.erb
@@ -47,9 +47,14 @@
       selected: facet["type"] == "date",
     },
     {
-      text: "Nested",
-      value: "nested",
-      selected: facet["type"] == "nested",
+      text: "Nested - One option",
+      value: "nested_enum_text_single",
+      selected: facet["type"] == "nested" && facet.dig("specialist_publisher_properties", "select") == "one",
+    },
+    {
+      text: "Nested - Multiple select",
+      value: "nested_enum_text_multiple",
+      selected: facet["type"] == "nested" && facet.dig("specialist_publisher_properties", "select") == "multiple",
     }
   ]
 } %>

--- a/lib/documents/schemas/trademark_decisions.json
+++ b/lib/documents/schemas/trademark_decisions.json
@@ -1607,7 +1607,6 @@
       "filterable": true,
       "key": "trademark_decision_grounds_section",
       "name": "Grounds Section",
-      "nested_facet": true,
       "preposition": "Grounds section",
       "short_name": "Grounds section",
       "specialist_publisher_properties": {
@@ -1618,7 +1617,7 @@
       },
       "sub_facet_key": "trademark_decision_grounds_sub_section",
       "sub_facet_name": "Grounds Sub Section",
-      "type": "text"
+      "type": "nested"
     }
   ],
   "filter": {

--- a/spec/features/editing_the_trademark_decision_filters_and_options_spec.rb
+++ b/spec/features/editing_the_trademark_decision_filters_and_options_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Editing the Trademark Decisions finder filters and options", type
       inserted_facet = "facets[8]"
       fill_in "#{inserted_facet}[name]", with: "New filter"
       fill_in "#{inserted_facet}[short_name]", with: "short name"
-      select "Nested", from: "#{inserted_facet}[type]"
+      select "Nested - Multiple select", from: "#{inserted_facet}[type]"
       check "Required", visible: false
       fill_in "#{inserted_facet}[sub_facet]", with: "Sub Facet Name"
       fill_in "#{inserted_facet}[allowed_values]", with: "Main Facet 1{main-facet-1}\nSub Facet 11{sub-facet-11}\nSub Facet 12 NEW\r\n\r\nMain Facet 2{main-facet-2}\nSub Facet 21{sub-facet-21}\nSub Facet 22{sub-facet-22}\r\n\r\nMain Facet 3{main-facet-3}"

--- a/spec/features/editing_the_trademark_decision_filters_and_options_spec.rb
+++ b/spec/features/editing_the_trademark_decision_filters_and_options_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Editing the Trademark Decisions finder filters and options", type
       inserted_facet = "facets[8]"
       fill_in "#{inserted_facet}[name]", with: "New filter"
       fill_in "#{inserted_facet}[short_name]", with: "short name"
-      select "One option", from: "#{inserted_facet}[type]"
+      select "Nested", from: "#{inserted_facet}[type]"
       check "Required", visible: false
       fill_in "#{inserted_facet}[sub_facet]", with: "Sub Facet Name"
       fill_in "#{inserted_facet}[allowed_values]", with: "Main Facet 1{main-facet-1}\nSub Facet 11{sub-facet-11}\nSub Facet 12 NEW\r\n\r\nMain Facet 2{main-facet-2}\nSub Facet 21{sub-facet-21}\nSub Facet 22{sub-facet-22}\r\n\r\nMain Facet 3{main-facet-3}"

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -102,8 +102,17 @@ RSpec.describe "Facet" do
         ])
       end
 
-      it "also works for the 'nested type" do
-        params = { "type" => "nested", "allowed_values" => "Foo {food}\nBart {bar}" }
+      it "also works for the 'nested_enum_text_single' type" do
+        params = { "type" => "nested_enum_text_single", "allowed_values" => "Foo {food}\nBart {bar}" }
+        facet = Facet.from_finder_admin_form_params(params)
+        expect(facet.allowed_values).to eq([
+          { label: "Foo", value: "food" },
+          { label: "Bart", value: "bar" },
+        ])
+      end
+
+      it "also works for the 'nested_enum_text_multiple' type" do
+        params = { "type" => "nested_enum_text_multiple", "allowed_values" => "Foo {food}\nBart {bar}" }
         facet = Facet.from_finder_admin_form_params(params)
         expect(facet.allowed_values).to eq([
           { label: "Foo", value: "food" },
@@ -198,7 +207,7 @@ RSpec.describe "Facet" do
     context "when the facet is nested" do
       it "builds a facet containing its sub-facet's data" do
         params = {
-          "type" => "nested",
+          "type" => "nested_enum_text_multiple",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "existing value {existing-value}\n- new sub facet value",
         }
@@ -251,7 +260,7 @@ RSpec.describe "Facet" do
 
       it "derives the keys for main and sub facets, in kebab-case, from the label if no key provided" do
         params = {
-          "type" => "nested",
+          "type" => "nested_enum_text_multiple",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "Main Facet 1\n- Sub Facet 11\n- Sub Facet 12\nMain Facet 2\n- Sub Facet 21\n- Sub Facet 22\nMain Facet 3",
         }
@@ -297,7 +306,7 @@ RSpec.describe "Facet" do
 
       it "uses any pre-supplied keys in curly brackets, if provided" do
         params = {
-          "type" => "nested",
+          "type" => "nested_enum_text_single",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "Main Facet 1{main-facet-1}\n- Sub Facet 11{sub-facet-11}\n- Sub Facet 12 NEW\nMain Facet 2{main-facet-2}\n- Sub Facet 21{sub-facet-21}\n- Sub Facet 22{sub-facet-22}\nMain Facet 3{main-facet-3}",
         }

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Facet" do
       expect(facet.preposition).to eq(nil)
     end
 
-    describe "inferring the boolean value, or absence of a value, for 'display_as_result_metadata', 'filterable', 'show_option_select_filter', and 'nested_facet'" do
+    describe "inferring the boolean value, or absence of a value, for 'display_as_result_metadata', 'filterable', 'show_option_select_filter'" do
       it "converts 'true' to true for 'display_as_result_metadata'" do
         facet = Facet.from_finder_admin_form_params({ "display_as_result_metadata" => "true" })
         expect(facet.display_as_result_metadata).to eq(true)
@@ -81,16 +81,6 @@ RSpec.describe "Facet" do
         facet = Facet.from_finder_admin_form_params({ "show_option_select_filter" => "false" })
         expect(facet.show_option_select_filter).to eq(nil)
       end
-
-      it "sets 'nested_facet' to 'true' is 'sub_facet' is present" do
-        facet = Facet.from_finder_admin_form_params({ "sub_facet" => "some string" })
-        expect(facet.nested_facet).to eq(true)
-      end
-
-      it "sets 'nested_facet' to 'nil' if 'sub_facet' is blank" do
-        facet = Facet.from_finder_admin_form_params({ "sub_facet" => "" })
-        expect(facet.nested_facet).to eq(nil)
-      end
     end
 
     describe "constructing the allowed_values" do
@@ -105,6 +95,15 @@ RSpec.describe "Facet" do
 
       it "also works for the enum_text_single 'type'" do
         params = { "type" => "enum_text_single", "allowed_values" => "Foo {food}\nBart {bar}" }
+        facet = Facet.from_finder_admin_form_params(params)
+        expect(facet.allowed_values).to eq([
+          { label: "Foo", value: "food" },
+          { label: "Bart", value: "bar" },
+        ])
+      end
+
+      it "also works for the 'nested type" do
+        params = { "type" => "nested", "allowed_values" => "Foo {food}\nBart {bar}" }
         facet = Facet.from_finder_admin_form_params(params)
         expect(facet.allowed_values).to eq([
           { label: "Foo", value: "food" },
@@ -199,12 +198,12 @@ RSpec.describe "Facet" do
     context "when the facet is nested" do
       it "builds a facet containing its sub-facet's data" do
         params = {
-          "type" => "enum_text_multiple",
+          "type" => "nested",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "existing value {existing-value}\n- new sub facet value",
         }
         facet = Facet.from_finder_admin_form_params(params)
-        expect(facet.nested_facet).to eq(true)
+        expect(facet.type).to eq("nested")
         expect(facet.sub_facet_key).to eq("some_sub_facet_key")
         expect(facet.sub_facet_name).to eq("Some sub facet name")
         expect(facet.allowed_values).to eq([{
@@ -252,12 +251,12 @@ RSpec.describe "Facet" do
 
       it "derives the keys for main and sub facets, in kebab-case, from the label if no key provided" do
         params = {
-          "type" => "enum_text_multiple",
+          "type" => "nested",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "Main Facet 1\n- Sub Facet 11\n- Sub Facet 12\nMain Facet 2\n- Sub Facet 21\n- Sub Facet 22\nMain Facet 3",
         }
         facet = Facet.from_finder_admin_form_params(params)
-        expect(facet.nested_facet).to eq(true)
+        expect(facet.type).to eq("nested")
         expect(facet.sub_facet_key).to eq("some_sub_facet_key")
         expect(facet.sub_facet_name).to eq("Some sub facet name")
         expect(facet.allowed_values).to eq([
@@ -298,12 +297,12 @@ RSpec.describe "Facet" do
 
       it "uses any pre-supplied keys in curly brackets, if provided" do
         params = {
-          "type" => "enum_text_multiple",
+          "type" => "nested",
           "sub_facet" => "Some sub facet name {some_sub_facet_key}",
           "allowed_values" => "Main Facet 1{main-facet-1}\n- Sub Facet 11{sub-facet-11}\n- Sub Facet 12 NEW\nMain Facet 2{main-facet-2}\n- Sub Facet 21{sub-facet-21}\n- Sub Facet 22{sub-facet-22}\nMain Facet 3{main-facet-3}",
         }
         facet = Facet.from_finder_admin_form_params(params)
-        expect(facet.nested_facet).to eq(true)
+        expect(facet.type).to eq("nested")
         expect(facet.sub_facet_key).to eq("some_sub_facet_key")
         expect(facet.sub_facet_name).to eq("Some sub facet name")
         expect(facet.allowed_values).to eq([
@@ -350,8 +349,7 @@ RSpec.describe "Facet" do
       facet.key = "foo"
       facet.name = "Foo"
       facet.short_name = "f"
-      facet.type = "text"
-      facet.nested_facet = true
+      facet.type = "nested"
       facet.preposition = "sector"
       facet.display_as_result_metadata = false
       facet.filterable = true
@@ -366,8 +364,7 @@ RSpec.describe "Facet" do
         key: "foo",
         name: "Foo",
         short_name: "f",
-        type: "text",
-        nested_facet: true,
+        type: "nested",
         preposition: "sector",
         display_as_result_metadata: false,
         filterable: true,

--- a/spec/models/finder_schema_spec.rb
+++ b/spec/models/finder_schema_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe FinderSchema do
             "facets" => [
               {
                 "key" => "parent_facet_key",
+                "type" => "nested",
                 "name" => "Parent facet name",
                 "sub_facet_key" => "sub_facet_key",
                 "sub_facet_name" => "Sub Facet Name",
@@ -201,8 +202,8 @@ RSpec.describe FinderSchema do
           },
         )
 
-        expect(FinderSchema.new(properties).humanized_facet_value("sub_facet_key", "sub-facet-value-1")).to eq("Facet label - Sub Facet label 1")
-        expect(FinderSchema.new(properties).humanized_facet_value("sub_facet_key", "sub-facet-value-2")).to eq("Facet label - Sub Facet label 2")
+        expect(FinderSchema.new(properties).humanized_facet_value("sub_facet_key", "sub-facet-value-1")).to eq(["Facet label - Sub Facet label 1"])
+        expect(FinderSchema.new(properties).humanized_facet_value("sub_facet_key", "sub-facet-value-2")).to eq(["Facet label - Sub Facet label 2"])
       end
 
       it "returns received value if subfacets are not defined" do

--- a/spec/presenters/finders/finder_facet_presenter_spec.rb
+++ b/spec/presenters/finders/finder_facet_presenter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe FinderFacetPresenter do
       expect(presented_facets).to eq(facets_without_specialist_publisher_properties)
     end
 
-    it "returns two distinct main and sub facets for a finder with one nested facet defined in the schema" do
+    it "returns main facet label and value references in the sub-facet structure" do
       facets_from_schema = [{
         "allowed_values" => [
           {
@@ -43,11 +43,11 @@ RSpec.describe FinderFacetPresenter do
             "value" => "allowed-value-1",
             "sub_facets" => [
               {
-                "label" => "Allowed value 1 Sub facet Value 1",
+                "label" => "Sub facet Value 1",
                 "value" => "allowed-value-1-sub-facet-value-1",
               },
               {
-                "label" => "Allowed value 1 Sub facet Value 2",
+                "label" => "Sub facet Value 2",
                 "value" => "allowed-value-1-sub-facet-value-2",
               },
             ],
@@ -57,7 +57,7 @@ RSpec.describe FinderFacetPresenter do
             "value" => "allowed-value-2",
             "sub_facets" => [
               {
-                "label" => "Allowed value 2 Sub facet Value 1",
+                "label" => "Sub facet Value 1",
                 "value" => "allowed-value-2-sub-facet-value-1",
               },
             ],
@@ -77,15 +77,37 @@ RSpec.describe FinderFacetPresenter do
         "sub_facet_name" => "Sub Facet Name",
         "type" => "nested",
       }]
-      main_facet_hash = {
+      main_facet_hash = [{
         "allowed_values" => [
           {
             "label" => "Allowed value 1",
             "value" => "allowed-value-1",
+            "sub_facets" => [
+              {
+                "label" => "Sub facet Value 1",
+                "value" => "allowed-value-1-sub-facet-value-1",
+                "main_facet_label" => "Allowed value 1",
+                "main_facet_value" => "allowed-value-1",
+              },
+              {
+                "label" => "Sub facet Value 2",
+                "value" => "allowed-value-1-sub-facet-value-2",
+                "main_facet_label" => "Allowed value 1",
+                "main_facet_value" => "allowed-value-1",
+              },
+            ],
           },
           {
             "label" => "Allowed value 2",
             "value" => "allowed-value-2",
+            "sub_facets" => [
+              {
+                "label" => "Sub facet Value 1",
+                "value" => "allowed-value-2-sub-facet-value-1",
+                "main_facet_label" => "Allowed value 2",
+                "main_facet_value" => "allowed-value-2",
+              },
+            ],
           },
           {
             "label" => "Allowed value 3",
@@ -98,43 +120,13 @@ RSpec.describe FinderFacetPresenter do
         "name" => "Facet Name",
         "preposition" => "Facet Name",
         "short_name" => "Short Name",
-        "sub_facet_name" => "Sub Facet Name",
         "sub_facet_key" => "sub_facet_key",
+        "sub_facet_name" => "Sub Facet Name",
         "type" => "nested",
-      }
-      sub_facet_hash = {
-        "allowed_values" => [
-          {
-            "label" => "Allowed value 1 Sub facet Value 1",
-            "value" => "allowed-value-1-sub-facet-value-1",
-            "main_facet_label" => "Allowed value 1",
-            "main_facet_value" => "allowed-value-1",
-          },
-          {
-            "label" => "Allowed value 1 Sub facet Value 2",
-            "value" => "allowed-value-1-sub-facet-value-2",
-            "main_facet_label" => "Allowed value 1",
-            "main_facet_value" => "allowed-value-1",
-          },
-          {
-            "label" => "Allowed value 2 Sub facet Value 1",
-            "value" => "allowed-value-2-sub-facet-value-1",
-            "main_facet_label" => "Allowed value 2",
-            "main_facet_value" => "allowed-value-2",
-          },
-        ],
-        "display_as_result_metadata" => true,
-        "filterable" => true,
-        "key" => "sub_facet_key",
-        "name" => "Sub Facet Name",
-        "main_facet_key" => "facet_key",
-        "preposition" => "Sub Facet Name",
-        "short_name" => "Sub Facet Name",
-        "type" => "nested",
-      }
+      }]
 
       presented_data = FinderFacetPresenter.new(facets_from_schema).to_json
-      expect(presented_data).to eq([main_facet_hash, sub_facet_hash])
+      expect(presented_data).to eq(main_facet_hash)
     end
   end
 end

--- a/spec/presenters/finders/finder_facet_presenter_spec.rb
+++ b/spec/presenters/finders/finder_facet_presenter_spec.rb
@@ -71,12 +71,11 @@ RSpec.describe FinderFacetPresenter do
         "filterable" => true,
         "key" => "facet_key",
         "name" => "Facet Name",
-        "nested_facet" => true,
         "preposition" => "Facet Name",
         "short_name" => "Short Name",
         "sub_facet_key" => "sub_facet_key",
         "sub_facet_name" => "Sub Facet Name",
-        "type" => "text",
+        "type" => "nested",
       }]
       main_facet_hash = {
         "allowed_values" => [
@@ -97,12 +96,11 @@ RSpec.describe FinderFacetPresenter do
         "filterable" => true,
         "key" => "facet_key",
         "name" => "Facet Name",
-        "nested_facet" => true,
         "preposition" => "Facet Name",
         "short_name" => "Short Name",
         "sub_facet_name" => "Sub Facet Name",
         "sub_facet_key" => "sub_facet_key",
-        "type" => "text",
+        "type" => "nested",
       }
       sub_facet_hash = {
         "allowed_values" => [
@@ -130,10 +128,9 @@ RSpec.describe FinderFacetPresenter do
         "key" => "sub_facet_key",
         "name" => "Sub Facet Name",
         "main_facet_key" => "facet_key",
-        "nested_facet" => true,
         "preposition" => "Sub Facet Name",
         "short_name" => "Sub Facet Name",
-        "type" => "text",
+        "type" => "nested",
       }
 
       presented_data = FinderFacetPresenter.new(facets_from_schema).to_json


### PR DESCRIPTION
Changes:
- introduce custom "nested" type to replace `nested_facet` flag
- revert presenter logic so that we send a single cohesive "nested" load to Publishing API.

### Admin area changes
- New type value
> ![Screenshot 2025-03-13 at 10 37 18](https://github.com/user-attachments/assets/68b46ff9-a442-4919-acc9-d554c9ae51b4)

- Existing Grounds section facet UI
> ![Screenshot 2025-03-13 at 10 32 24](https://github.com/user-attachments/assets/b1d2bd66-ffba-4bdf-9e42-7d297a875e89)

- Existing grounds section facet generated schema in admin area (no change other than type)
> ![Screenshot 2025-03-12 at 13 18 16](https://github.com/user-attachments/assets/407be773-79df-4a35-a428-869052dde76e)

- New facet added with nested multiple type - diff in admin area (no change other than type)
> ![Screenshot 2025-03-12 at 13 19 07](https://github.com/user-attachments/assets/7f09a8c3-b0e8-4d45-b717-7f42d8c42e87)

- New facet added with nested single type - diff in admin area (no change other than type)
> ![Screenshot 2025-03-13 at 10 36 28](https://github.com/user-attachments/assets/d3b03ba3-3a49-47d3-93f5-dd2715edb723)



[Trello](https://trello.com/c/EeZOA3iW/3534-spike-replicating-taxons-approach-for-nested-facets)