### PR TITLE
Toggle table of contents

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -86,6 +86,7 @@ private
       :summary,
       :show_summaries,
       :show_metadata_block,
+      :show_table_of_contents,
       :document_title,
       :document_noun,
       organisations: [],

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -31,6 +31,7 @@ class FinderSchema
   attribute :email_filter_options
   attribute :facets, default: []
   attribute :filter
+  attribute :show_table_of_contents, :boolean, default: false
   attribute :label_text
   attribute :name
   attribute :organisations, default: []

--- a/app/presenters/finder_content_item_presenter.rb
+++ b/app/presenters/finder_content_item_presenter.rb
@@ -50,6 +50,7 @@ private
       logo_path: file.fetch("logo_path", nil),
       show_summaries: file.fetch("show_summaries", false),
       show_metadata_block: file.fetch("show_metadata_block", false),
+      show_table_of_contents: file.fetch("show_table_of_contents", false),
       signup_link: file.fetch("signup_link", nil),
       summary:,
       label_text: file.fetch("label_text", nil),

--- a/app/views/admin/_metadata_form_fields.html.erb
+++ b/app/views/admin/_metadata_form_fields.html.erb
@@ -128,6 +128,27 @@
   ]
 } %>
 
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Should a table of contents be displayed on each document page?",
+  heading_size: "s",
+  hint: "Example: Commonly used to list the contents of a page with links pointing to headings within the document, but can also be used for a list of links to other pages.",
+  name: "show_table_of_contents",
+  inline: true,
+  items: [
+    {
+      value: "true",
+      text: "Yes",
+      checked: schema.show_table_of_contents
+    },
+    {
+      value: "false",
+      text: "No",
+      checked: !schema.show_table_of_contents
+    }
+  ]
+} %>
+
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: "Full document noun (Appears in various places in the Specialist Publisher user interface)",

--- a/app/views/admin/_metadata_summary_card.html.erb
+++ b/app/views/admin/_metadata_summary_card.html.erb
@@ -65,6 +65,10 @@
       value: schema.show_metadata_block ? "Yes" : "No"
     } if !(defined? previous_schema) || schema.show_metadata_block != previous_schema.show_metadata_block),
     ({
+      key: "Should a table of contents be displayed on each document page?",
+      value: schema.show_table_of_contents ? "Yes" : "No"
+    } if !(defined? previous_schema) || schema.show_table_of_contents != previous_schema.show_table_of_contents),
+    ({
       key: "Full document noun (Appears in various places in the Specialist Publisher user interface)",
       value: (schema.document_title || "").humanize
     } if !(defined? previous_schema) || schema.document_title != previous_schema.document_title),

--- a/lib/documents/schemas/aaib_reports.json
+++ b/lib/documents/schemas/aaib_reports.json
@@ -134,6 +134,7 @@
     "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"
   ],
   "phase": "live",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "target_stack": "live",

--- a/lib/documents/schemas/ai_assurance_portfolio_techniques.json
+++ b/lib/documents/schemas/ai_assurance_portfolio_techniques.json
@@ -321,6 +321,7 @@
   "related": [
     "4519b26b-6312-4855-bc45-828123bd8a2f"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "summary": "Find out what AI assurance is and what effective AI assurance techniques you can use in your organisation. You can also read examples of AI assurance in practice across a variety of sectors.",
   "target_stack": "live"

--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -479,6 +479,7 @@
   "related": [
     "9be2896c-2c32-4108-a465-e37ba16f6dd1"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "99f5bacb-d1ef-4b93-87ef-bae129fed396",

--- a/lib/documents/schemas/animal_disease_cases.json
+++ b/lib/documents/schemas/animal_disease_cases.json
@@ -205,6 +205,7 @@
     "af8eee5a-632a-4b8e-bb59-8fc5204892bc",
     "5fa8f693-7631-11e4-a3cb-005056011aef"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "e39c8c6e-b4c2-4dec-84fd-7f3d77f96a7d",
   "subscription_list_title_prefix": "Notifiable animal disease cases and control zones",

--- a/lib/documents/schemas/asylum_support_decisions.json
+++ b/lib/documents/schemas/asylum_support_decisions.json
@@ -321,6 +321,7 @@
     "7141e343-e7bb-483b-920a-c6a5cf8f758c"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "307ea825-594c-4d88-85c9-0809fdc9c79e",

--- a/lib/documents/schemas/business_finance_support_schemes.json
+++ b/lib/documents/schemas/business_finance_support_schemes.json
@@ -266,6 +266,7 @@
     "3d582854-ffc7-4d41-9266-ee87b9e6d230",
     "89edffd2-3046-40bd-810c-cc1a13c05b6a"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "32e87f32-8e37-4186-bc0c-fbed4c0f0239",

--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -410,6 +410,7 @@
   "related": [
     "46708567-70a6-4f20-8257-6c222b3d8cb3"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "subscription_list_title_prefix": "CMA cases",

--- a/lib/documents/schemas/countryside_stewardship_grants.json
+++ b/lib/documents/schemas/countryside_stewardship_grants.json
@@ -217,6 +217,7 @@
   "related": [
     "5e91c0bf-187d-4fa0-a6ef-992736d5644c"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "summary": "Search for options, supplements and capital items to include in your Countryside Stewardship application. Find out about each [Countryside Stewardship scheme and check if you’re eligible before you apply for a grant](/guidance/countryside-stewardship-get-funding-to-protect-and-improve-the-land-you-manage).",
   "target_stack": "live",

--- a/lib/documents/schemas/data_ethics_guidance_documents.json
+++ b/lib/documents/schemas/data_ethics_guidance_documents.json
@@ -270,6 +270,7 @@
     "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   ],
   "related": [],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "summary": "Find guidance for the responsible use and development of data and data technologies, including artificial intelligence (AI), developed by and for government and public sector bodies.\r\n\r\nIf you have suggestions for guidance, email [data.ethics@digital.cabinet-office.gov.uk](mailto:data.ethics@digital.cabinet-office.gov.uk).",

--- a/lib/documents/schemas/drcf_digital_markets_researches.json
+++ b/lib/documents/schemas/drcf_digital_markets_researches.json
@@ -315,6 +315,7 @@
   "organisations": [
     "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "summary": "Find research about digital markets and regulation carried out by public authorities, curated by the [Digital Regulation Cooperation Forum (DRCF)](government/collections/the-digital-regulation-cooperation-forum)",
   "target_stack": "live"

--- a/lib/documents/schemas/drug_safety_updates.json
+++ b/lib/documents/schemas/drug_safety_updates.json
@@ -199,6 +199,7 @@
     "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
     "c953a82b-e9ff-4551-9324-dfdf40ab85e6"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_link": "https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044",

--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -1061,6 +1061,7 @@
     "caeb418c-d11c-4352-92e9-47b21289f696"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",

--- a/lib/documents/schemas/employment_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_tribunal_decisions.json
@@ -313,6 +313,7 @@
     "8bb37087-a5a7-4493-8afe-900b36ebc927"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",

--- a/lib/documents/schemas/esi_funds.json
+++ b/lib/documents/schemas/esi_funds.json
@@ -189,6 +189,7 @@
     "de4e9dc6-cca4-43af-a594-682023b84d6c",
     "e8fae147-6232-4163-a3f1-1c15b755a8a4"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "a4815714-e5d5-4e1b-8543-3ce10139988f",
   "subscription_list_title_prefix": "European Structural and Investment Fund",

--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -1010,6 +1010,7 @@
     "4ad67f14-6f9c-4fa4-80ab-687b6d81ea6f"
   ],
   "parent": "03f78404-e87c-4c2a-954b-f6ee9403efb8",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "9a5260d2-07e7-45dc-a24a-791b02e4a9da",
   "subscription_list_title_prefix": "Export health certificates",

--- a/lib/documents/schemas/farming_grants.json
+++ b/lib/documents/schemas/farming_grants.json
@@ -206,6 +206,7 @@
     "e8fae147-6232-4163-a3f1-1c15b755a8a4"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "2cd12e92-3b68-4cb1-bafe-fde6a7939afb",

--- a/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
+++ b/lib/documents/schemas/flood_and_coastal_erosion_risk_management_research_reports.json
@@ -351,6 +351,7 @@
   "organisations": [
     "6fc7e0f4-1322-4469-af66-abec10c26883"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "0b3468bb-ccbe-4c97-9d94-870ae02e977d",
   "subscription_list_title_prefix": "Flood and Coastal Erosion Risk Management research reports",

--- a/lib/documents/schemas/hmrc_contacts.json
+++ b/lib/documents/schemas/hmrc_contacts.json
@@ -133,6 +133,7 @@
   "organisations": [
     "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "summary": "TBC",
   "target_stack": "draft"

--- a/lib/documents/schemas/hmrc_contacts.json
+++ b/lib/documents/schemas/hmrc_contacts.json
@@ -133,7 +133,7 @@
   "organisations": [
     "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
   ],
-  "show_table_of_contents": true,
+  "show_table_of_contents": false,
   "show_metadata_block": true,
   "summary": "TBC",
   "target_stack": "draft"

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -998,6 +998,7 @@
   "organisations": [
     "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",

--- a/lib/documents/schemas/licence_transactions.json
+++ b/lib/documents/schemas/licence_transactions.json
@@ -280,6 +280,7 @@
   "organisations": [
     "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "summary": "You may need a licence, permit or certification for:\r\n\r\n* some business activities\r\n\r\n* other activities, such as street parties\r\n\r\n^This may not include all the licences you need. It will be updated with more licences.^",

--- a/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
+++ b/lib/documents/schemas/life_saving_maritime_appliance_service_stations.json
@@ -391,6 +391,7 @@
   "organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": false,
   "summary": "UK approved service stations for International Convention for the Safety of Life at Sea (SOLAS)-standard inflatable life-saving appliances (LSAs).\r\n\r\nVessel owners need to ensure that their LSA is serviced at an approved service station that:\r\n\r\n* is authorised to service the particular product make or type\r\n\r\n* is accepted by the Maritime and Coastguard Agency (MCA) and complies with International Maritime Organization (IMO) Resolution A.761(18) to maintain proper servicing facilities\r\n\r\n* uses only properly trained personnel and has evidence of personnel authorisation certification\r\n\r\nSee [MGN 548 (M+F) Inflatable SOLAS certificated liferafts, lifejackets, marine evacuation systems and repair of inflated rescue boats](https://www.gov.uk/government/publications/mgn-548-mf-inflatable-solas-certificated-liferafts-lifejackets-marine-evacuation-systems-and-repair-of-inflated-rescue-boats) for more information.",

--- a/lib/documents/schemas/maib_reports.json
+++ b/lib/documents/schemas/maib_reports.json
@@ -101,6 +101,7 @@
   "organisations": [
     "9c66b9a3-1e6a-48e8-974d-2a5635f84679"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",

--- a/lib/documents/schemas/marine_equipment_approved_recommendations.json
+++ b/lib/documents/schemas/marine_equipment_approved_recommendations.json
@@ -100,6 +100,7 @@
   "related": [
     "9ac82e6a-0fb6-431f-85d8-560361e21d0b"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "512a14c1-260a-4c4e-8de8-643eadf7905c",

--- a/lib/documents/schemas/marine_notices.json
+++ b/lib/documents/schemas/marine_notices.json
@@ -179,6 +179,7 @@
   "organisations": [
     "23a24aa8-1711-42b6-bf6b-47af0f230295"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "21985d9f-8c84-4fa1-915c-2807eaa37dff",
   "subscription_list_title_prefix": "Marine notices",

--- a/lib/documents/schemas/medical_safety_alerts.json
+++ b/lib/documents/schemas/medical_safety_alerts.json
@@ -249,6 +249,7 @@
   "related": [
     "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",

--- a/lib/documents/schemas/product_safety_alert_report_recalls.json
+++ b/lib/documents/schemas/product_safety_alert_report_recalls.json
@@ -297,6 +297,7 @@
   "organisations": [
     "a0ee18e7-9e1e-4ba1-aed5-f3f287dce752"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "bb6047de-3854-4774-a5d5-fc66fed4f792",
   "target_stack": "live"

--- a/lib/documents/schemas/protected_food_drink_names.json
+++ b/lib/documents/schemas/protected_food_drink_names.json
@@ -1110,6 +1110,7 @@
   "organisations": [
     "de4e9dc6-cca4-43af-a594-682023b84d6c"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "cff7449e-4181-480f-93e4-91fecfb4c774",

--- a/lib/documents/schemas/raib_reports.json
+++ b/lib/documents/schemas/raib_reports.json
@@ -93,6 +93,7 @@
   "organisations": [
     "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -1001,6 +1001,7 @@
   "organisations": [
     "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "fdcbada2-1ad4-4194-98dc-5f04a448316e",
   "subscription_list_title_prefix": "Research for Development output",

--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -372,6 +372,7 @@
     "bb2b028f-efaa-44fd-b3f8-971b25cb51a2"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "8a6239e1-76cf-41a0-9295-0ae1182080d2",

--- a/lib/documents/schemas/service_standard_reports.json
+++ b/lib/documents/schemas/service_standard_reports.json
@@ -109,6 +109,7 @@
   "organisations": [
     "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "target_stack": "live",

--- a/lib/documents/schemas/sfo_cases.json
+++ b/lib/documents/schemas/sfo_cases.json
@@ -54,6 +54,7 @@
   "related": [
     "01007fd9-8351-4068-b90c-a9af8edaeb19"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "summary": "This case finder includes all ongoing Serious Fraud Office (SFO) prosecutions and investigations that are in the public domain. This does not include intelligence referrals, covert investigations or proceeds of crime cases.\r\n\r\nFor updates on the SFO’s proceeds of crime recovery, see [this page](https://www.gov.uk/government/publications/proceeds-of-crime).",

--- a/lib/documents/schemas/statutory_instruments.json
+++ b/lib/documents/schemas/statutory_instruments.json
@@ -147,6 +147,7 @@
   },
   "name": "EU Withdrawal Act 2018 statutory instruments",
   "organisations": [],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "summary": "Find proposed negative statutory instruments (SIs) under the EU (Withdrawal) Act 2018.\r\n\r\nBefore the SIs are formally 'laid' in Parliament, they have to go through a sifting process. A new committee in the House of Commons and the Secondary Legislation Scrutiny Committee in the House of Lords will consider the suitability of the [negative procedure](https://www.parliament.uk/about/how/laws/secondary-legislation/).",
   "target_stack": "live",

--- a/lib/documents/schemas/tax_tribunal_decisions.json
+++ b/lib/documents/schemas/tax_tribunal_decisions.json
@@ -82,6 +82,7 @@
     "1a68b2cc-eb52-4528-8989-429f710da00f"
   ],
   "phase": "beta",
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",

--- a/lib/documents/schemas/trademark_decisions.json
+++ b/lib/documents/schemas/trademark_decisions.json
@@ -1632,6 +1632,7 @@
     "9f37f0c4-5f25-4961-b24b-486b52756431",
     "5f5961ca-7631-11e4-a3cb-005056011aef"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "summary": "Find Intellectual Property (Trade Mark,) related decisions for the U.K.",

--- a/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
+++ b/lib/documents/schemas/traffic_commissioner_regulatory_decisions.json
@@ -226,6 +226,7 @@
   "organisations": [
     "78dfc32b-b1ef-44ca-924c-a2cf773e87ca"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "signup_content_id": "b65c9331-5c34-4201-9c30-1ea64f03f49a",
   "subscription_list_title_prefix": "Traffic Commissioner regulatory decisions",

--- a/lib/documents/schemas/utaac_decisions.json
+++ b/lib/documents/schemas/utaac_decisions.json
@@ -2737,6 +2737,7 @@
     "6f757605-ab8f-4b62-84e4-99f79cf085c2",
     "4c2e325a-2d95-442b-856a-e7fb9f9e3cf8"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "signup_content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",

--- a/lib/documents/schemas/veterans_support_organisations.json
+++ b/lib/documents/schemas/veterans_support_organisations.json
@@ -377,6 +377,7 @@
     "8d7d88c2-4ea9-4c25-aab2-1988a269177e",
     "141d388e-d4a0-4774-9767-5a8ba7aedb4e"
   ],
+  "show_table_of_contents": true,
   "show_metadata_block": true,
   "show_summaries": true,
   "summary": "This directory lists organisations that provide support to veterans of the UK armed forces and their families.\r\n\r\nYou can filter results by location and select as many areas of support as you need.\r\n\r\nThis should not be taken as an exhaustive list of all services on offer to veterans and their families in the UK.\r\n\r\nThe government is not liable for any services that fail to meet an individual's requirements or standards.\r\n\r\nThe inclusion of these organisations or services should not be taken as endorsement by the Office for Veterans’ Affairs.\r\n\r\n$E ##Talk to an adviser\r\n\r\nThe Veterans’ Gateway helpline can provide information and referral support by telephone.\r\n\r\nPhone: 0808 802 1212  <br>Monday to Sunday, 8am to 8pm $E",

--- a/spec/features/generating_a_new_finder_spec.rb
+++ b/spec/features/generating_a_new_finder_spec.rb
@@ -48,4 +48,16 @@ RSpec.feature "Generating a new finder", type: :feature do
     expect(page).to have_field("Title of the finder", with: "Finder with metadata block")
     expect(page).to have_checked_field("show_metadata_block", with: "true")
   end
+
+  scenario "setting show_table_of_contents value and generating a schema" do
+    visit "admin/new"
+
+    fill_in("Title of the finder", with: "Finder with contents list")
+    choose("Yes", name: "show_table_of_contents")
+    click_button("Generate schema")
+
+    expect(page).to have_selector(".govuk-details")
+    expect(page).to have_field("Title of the finder", with: "Finder with contents list")
+    expect(page).to have_checked_field("show_table_of_contents", with: "true")
+  end
 end


### PR DESCRIPTION
This change updates the backend to expose the hide_contents_list property to frontend applications.

The property is now defined at the schema level, providing more explicit control over its rendering. We recently implemented a [similar feature for the metadata block ](https://github.com/alphagov/specialist-publisher/pull/3076). 

Tests in this PR depend on example schemas from the Publishing API repository, which may cause CI failures until the related changes are merged.

**Associated PRs**

[Publishing API](https://github.com/alphagov/publishing-api/pull/3265)
[Frontend](https://github.com/alphagov/frontend/pull/4740)
[Government-Frontend](https://github.com/alphagov/government-frontend/pull/3645)


[Trello](https://trello.com/c/2eakEGOo/3570-make-it-possible-to-hide-the-table-of-contents-on-specialist-documents)

