### PR TITLE
Re-enable tests

### DIFF
--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 128
+          chrome-version: 120
           install-chromedriver: true
           install-dependencies: true
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 120
+          chrome-version: 135
           install-chromedriver: true
           install-dependencies: true
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -37,13 +37,13 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/specialist-publisher
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,6 +18,16 @@ jobs:
     name: Run RSpec
     runs-on: ubuntu-latest
     steps:
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
+
       - name: Setup MongoDB
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
         with:

--- a/app/assets/javascripts/form_change_protection.js
+++ b/app/assets/javascripts/form_change_protection.js
@@ -29,15 +29,15 @@
       var current = formChangeProtection.serialisedFormValues()
 
       if (current !== formChangeProtection.initialState) {
-        return formChangeProtection.message
+        confirm(formChangeProtection.message)
       }
     },
 
     preventLossOfUnsavedChanges: function () {
-      $(window).bind('beforeunload', this.alertIfUnsavedChanges)
+      $(window).bind('pagehide', this.alertIfUnsavedChanges)
       // unbind when the form is submitted to stop the alert
       this.$form.bind('submit', function () {
-        $(window).unbind('beforeunload')
+        $(window).unbind('pagehide')
       })
     }
   }

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
   let(:locale) { cma_case["locale"] }
 
   before do
+    Capybara.current_driver = Capybara.javascript_driver
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
@@ -17,7 +18,7 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
     visit "/cma-cases"
   end
 
-  xcontext "a new document" do
+  context "a new document" do
     before do
       click_on "Add another CMA Case"
 
@@ -79,7 +80,7 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
     end
   end
 
-  xcontext "an existing document" do
+  context "an existing document" do
     before do
       click_on "Example document"
       click_on "Edit document"

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -31,6 +31,8 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       fill_in "cma_case[closed_date(1i)]", with: "2015"
       fill_in "cma_case[closed_date(2i)]", with: "01"
       fill_in "cma_case[closed_date(3i)]", with: "01"
+      select2 "Mergers", from: "Case type"
+      select2 "Closed", from: "Case state"
       select2 "Energy", from: "Market sector"
     end
 
@@ -68,6 +70,8 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
 
     scenario "when changes are saved" do
       click_button "Save as draft"
+
+      expect(current_path).to eq("/cma-cases/#{content_id}:#{locale}")
 
       within(".alert-success") do
         expect(page).to have_content("Created Example CMA Case")

--- a/spec/features/unsaved_changes_spec.rb
+++ b/spec/features/unsaved_changes_spec.rb
@@ -1,13 +1,15 @@
 require "spec_helper"
 
-RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
+RSpec.feature "Unsaved changes to a document", type: :feature do
   let(:message) { "You have unsaved changes that will be lost if you leave this page." }
   let(:cma_case) { FactoryBot.create(:cma_case) }
   let(:content_id) { cma_case["content_id"] }
   let(:locale) { cma_case["locale"] }
 
   before do
-    Capybara.current_driver = Capybara.javascript_driver
+    # Switch to BiDi driver for interacting with browser dialogs
+    Capybara.current_driver = :bidi_headless_chrome_driver
+
     allow(SecureRandom).to receive(:uuid).and_return(content_id)
     stub_any_publishing_api_put_content
     stub_any_publishing_api_patch_links
@@ -16,6 +18,10 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
 
     log_in_as_editor(:cma_editor)
     visit "/cma-cases"
+  end
+
+  after do
+    Capybara.current_driver = Capybara.default_driver
   end
 
   context "a new document" do
@@ -42,6 +48,8 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       end
 
       expect(current_path).to eq("/cma-cases/new")
+
+      click_button "Save as draft"
     end
 
     scenario "when an 'Your documents' is clicked and the confirmation is accepted" do
@@ -66,12 +74,12 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       end
 
       expect(current_path).to eq("/cma-cases/new")
+
+      click_button "Save as draft"
     end
 
     scenario "when changes are saved" do
       click_button "Save as draft"
-
-      expect(current_path).to eq("/cma-cases/#{content_id}:#{locale}")
 
       within(".alert-success") do
         expect(page).to have_content("Created Example CMA Case")
@@ -104,6 +112,8 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       end
 
       expect(current_path).to eq("/cma-cases/#{content_id}:#{locale}/edit")
+
+      click_button "Save as draft"
     end
 
     scenario "when an 'Add attachment' is clicked and the confirmation is accepted" do
@@ -128,6 +138,8 @@ RSpec.feature "Unsaved changes to a document", type: :feature, js: true do
       end
 
       expect(current_path).to eq("/cma-cases/#{content_id}:#{locale}/edit")
+
+      click_button "Save as draft"
     end
 
     scenario "when changes are saved" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,4 +83,4 @@ Capybara.register_driver :nearly_headless_chrome do |app|
 end
 Capybara.javascript_driver = :nearly_headless_chrome
 
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,9 +70,12 @@ RSpec.configure do |config|
   config.order = "random"
 end
 
-Capybara.register_driver :headless_chrome do |app|
-  chrome_options = GovukTest.headless_chrome_selenium_options
+Capybara.register_driver :nearly_headless_chrome do |app|
+  # chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
   chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument('--disable-gpu')
+  chrome_options.add_argument('--window-size=1400,1400')
 
   Capybara::Selenium::Driver.new(
     app,
@@ -80,4 +83,6 @@ Capybara.register_driver :headless_chrome do |app|
     options: chrome_options,
   )
 end
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :nearly_headless_chrome
+
+Capybara.default_max_wait_time = 5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,6 +95,7 @@ Capybara.register_driver :bidi_headless_chrome_driver do |app|
   # Switch to using the WebDriver BiDi (Bi-Directional) protocol for this driver, see https://w3c.github.io/webdriver-bidi/ for more info
   # The BiDi protocol can interact with browser dialogs effectively
   chrome_options.add_option(:web_socket_url, true)
+  chrome_options.add_option(:page_load_strategy, 'none')
 
   Capybara::Selenium::Driver.new(
     app,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,10 +72,8 @@ end
 
 Capybara.register_driver :nearly_headless_chrome do |app|
   chrome_options = GovukTest.headless_chrome_selenium_options
-  # chrome_options = Selenium::WebDriver::Chrome::Options.new
   chrome_options.add_argument("--no-sandbox")
-  chrome_options.add_argument('--disable-gpu')
-  # chrome_options.add_argument('--window-size=1400,1400')
+  chrome_options.add_argument("--disable-gpu")
 
   Capybara::Selenium::Driver.new(
     app,
@@ -85,4 +83,4 @@ Capybara.register_driver :nearly_headless_chrome do |app|
 end
 Capybara.javascript_driver = :nearly_headless_chrome
 
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = 10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,3 +69,15 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 end
+
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--no-sandbox")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end
+Capybara.javascript_driver = :headless_chrome

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,11 +71,11 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver :nearly_headless_chrome do |app|
-  # chrome_options = GovukTest.headless_chrome_selenium_options
-  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  # chrome_options = Selenium::WebDriver::Chrome::Options.new
   chrome_options.add_argument("--no-sandbox")
   chrome_options.add_argument('--disable-gpu')
-  chrome_options.add_argument('--window-size=1400,1400')
+  # chrome_options.add_argument('--window-size=1400,1400')
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
These tests were temporarily disabled in https://github.com/alphagov/specialist-publisher/pull/2715.

Taking inspiration from https://github.com/alphagov/whitehall/pull/10074, we're adapting our CI so that we can re-enable the tests.

Similar problems affected other apps around the time the most recent ubuntu-latest image for GitHub Actions was released: https://github.com/actions/runner-images/pull/11761

In those cases, the fix was to re-install a different version of Chrome. Summary of changes:

- add `--no-sandbox` flag to Chromedriver startup (GovukTest will do this for us if we set the `GOVUK_TEST_CHROME_NO_SANDBOX` environment variable, but the theory is that making the change here keeps all these temporary fixes in one place)
- remove the version of Chrome that the actions/runner-images image bundles for us, so that Selenium doesn't try to use it
- install an old version of Chrome and Chromedriver

Trello: https://trello.com/c/7FTvIbPD/3589-re-enable-tests-disabled-due-to-unable-to-find-modal-dialog-error

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
