### PR TITLE
New design system preview button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,3 +4,5 @@
 //= require govuk_publishing_components/components/copy-to-clipboard
 
 //= require components/autocomplete
+//= require components/govspeak-editor
+//= require components/paste-html-to-govspeak

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -1,0 +1,103 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function GovspeakEditor (module) {
+    this.module = module
+  }
+
+  GovspeakEditor.prototype.init = function () {
+    this.previewButton = this.module.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    this.backButton = this.module.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    this.preview = this.module.querySelector('.app-c-govspeak-editor__preview')
+    this.error = this.module.querySelector('.app-c-govspeak-editor__error')
+    this.textareaWrapper = this.module.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    this.textarea = this.textareaWrapper.querySelector('textarea')
+
+    this.previewButton.classList.add(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+
+    this.previewButton.addEventListener('click', this.showPreview.bind(this))
+    this.backButton.addEventListener('click', this.hidePreview.bind(this))
+  }
+
+  GovspeakEditor.prototype.getCsrfToken = function () {
+    return document.querySelector('meta[name="csrf-token"]').content
+  }
+
+  GovspeakEditor.prototype.getRenderedGovspeak = function (body, callback) {
+    const data = this.generateFormData(body)
+
+    const request = new XMLHttpRequest()
+    request.open('POST', '/preview', false)
+    request.setRequestHeader('X-CSRF-Token', this.getCsrfToken())
+    request.onreadystatechange = callback
+    request.send(data)
+  }
+
+  GovspeakEditor.prototype.generateFormData = function (body) {
+    const data = new FormData()
+    data.append('bodyText', body)
+    data.append('authenticity_token', this.getCsrfToken())
+    return data
+  }
+
+  GovspeakEditor.prototype.showPreview = function (event) {
+    event.preventDefault()
+
+    this.backButton.classList.add('app-c-govspeak-editor__back-button--show')
+    this.previewButton.classList.remove(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+
+    this.preview.classList.add('app-c-govspeak-editor__preview--show')
+    this.textareaWrapper.classList.add(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+
+    this.backButton.focus()
+
+    this.getRenderedGovspeak(this.textarea.value, (event) => {
+      const response = event.currentTarget
+
+      if (response.readyState !== 4) {
+        return
+      }
+
+      switch (response.status) {
+        case 200:
+          this.preview.innerHTML = response.responseText
+          break
+        case 403:
+          this.preview.classList.remove('app-c-govspeak-editor__preview--show')
+          this.error.classList.add('app-c-govspeak-editor__error--show')
+      }
+    })
+  }
+
+  GovspeakEditor.prototype.hidePreview = function (event) {
+    event.preventDefault()
+
+    this.backButton.classList.remove('app-c-govspeak-editor__back-button--show')
+    this.previewButton.classList.add(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+
+    this.preview.classList.remove('app-c-govspeak-editor__preview--show')
+    this.error.classList.remove('app-c-govspeak-editor__error--show')
+    this.textareaWrapper.classList.remove(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+
+    this.textarea.focus()
+  }
+
+  Modules.GovspeakEditor = GovspeakEditor
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/paste-html-to-govspeak.js
+++ b/app/assets/javascripts/components/paste-html-to-govspeak.js
@@ -1,0 +1,19 @@
+//= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+'use strict'
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function PasteHtmlToGovspeak ($module) {
+    this.$module = $module
+  }
+
+  PasteHtmlToGovspeak.prototype.init = function () {
+    this.$module.addEventListener(
+      'paste',
+      window.pasteHtmlToGovspeak.pasteListener
+    )
+  }
+
+  Modules.PasteHtmlToGovspeak = PasteHtmlToGovspeak
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/summary-card';
 @import 'govuk_publishing_components/components/textarea';
 
+@import "./components/govspeak-editor";
 @import "./components/autocomplete";
 @import "./components/diff";
 

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -1,0 +1,33 @@
+.app-c-govspeak-editor {
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-c-govspeak-editor__preview-button-wrapper {
+  text-align: right;
+  display: flex;
+  justify-content: end;
+  gap: govuk-spacing(2);
+}
+
+.app-c-govspeak-editor__textarea--hidden {
+  display: none;
+}
+
+.app-c-govspeak-editor__preview {
+  border: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(4);
+}
+
+.app-c-govspeak-editor__preview,
+.app-c-govspeak-editor__error,
+.js-app-c-govspeak-editor__preview-button,
+.js-app-c-govspeak-editor__back-button {
+  display: none;
+}
+
+.app-c-govspeak-editor__preview--show,
+.app-c-govspeak-editor__error--show,
+.app-c-govspeak-editor__preview-button--show,
+.app-c-govspeak-editor__back-button--show {
+  display: block;
+}

--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -2,7 +2,7 @@ class GovspeakController < ApplicationController
   def preview
     skip_authorization
 
-    json_attachments = JSON.parse(params["attachments"])
+    json_attachments = params["attachments"] ? JSON.parse(params["attachments"]) : []
 
     attachments = json_attachments.map do |attachment|
       Attachment.new(attachment)

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -25,8 +25,6 @@
                  html: { class: "new_document" } do |f| %>
       <%= render partial: "shared/form_fields", locals: { f: f } %>
 
-      <%= render partial: "shared/preview_govspeak", locals: {attachments: @document.attachments} %>
-
       <%= render partial: "metadata_fields/#{params[:document_type_slug].underscore}", locals: { f: f } %>
 
       <div class="actions">

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -20,18 +20,22 @@
   maxlength: 280,
 } %>
 
-<%= render "govuk_publishing_components/components/textarea", {
+<%= render "shared/govspeak_editor", {
   label: {
     text: "Body (required)",
     heading_size: "m",
   },
+  id: "#{format_name}_body",
   name: "#{format_name}[body]",
   rows: 20,
+  # value: historical_account.body,
+  # error_items: errors_for(historical_account.errors, :body),
 } %>
 
 <% locale = @document.locale || "en" %>
 <%= render "govuk_publishing_components/components/select", {
-  id: "#{format_name}[locale]",
+  id: "#{format_name}_locale",
+  name: "#{format_name}[locale]",
   label: "Language",
   heading_size: "m",
   full_width: true,

--- a/app/views/shared/_govspeak_editor.html.erb
+++ b/app/views/shared/_govspeak_editor.html.erb
@@ -1,0 +1,88 @@
+<%
+  id ||= "#{name}-#{SecureRandom.hex(4)}"
+  preview_id = "#{id}-preview"
+  error_id = "#{id}-error"
+  label_id = "#{id}-label"
+  label[:bold] ||= false
+  hint ||= nil
+  hint_id ||= "#{id}-hint"
+  value ||= nil
+  error_items ||= nil
+  rows ||= 12
+  right_to_left ||= false
+
+  data_attributes ||= {}
+  data_attributes[:module] ||= ""
+  data_attributes[:module] << " govspeak-editor"
+  data_attributes[:module] = data_attributes[:module].strip
+
+  textarea_data_attributes ||= {}
+  textarea_data_attributes[:module] ||= ""
+  textarea_data_attributes[:module] << " paste-html-to-govspeak"
+  textarea_data_attributes[:module] = textarea_data_attributes[:module].strip
+
+  preview_button_data_attributes ||= {}
+  preview_button_data_attributes["content-target"] = "##{id}"
+
+  classes = "app-c-govspeak-editor govuk-form-group"
+  classes << " govuk-form-group--error" if error_items
+
+  dir = right_to_left ? "rtl" : nil
+%>
+
+<%= tag.div class: classes, data: data_attributes do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half ">
+      <%= render "govuk_publishing_components/components/label", {
+        id: label_id,
+        html_for: id,
+        hint_id: hint_id,
+        hint_text: hint,
+      }.merge(label.symbolize_keys) %>
+    </div>
+    <div class="govuk-grid-column-one-half app-c-govspeak-editor__preview-button-wrapper">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Preview",
+        secondary_quiet: true,
+        margin_bottom: hint ? 5 : 2,
+        classes: "js-app-c-govspeak-editor__preview-button",
+        data_attributes: preview_button_data_attributes,
+        aria_controls: preview_id,
+        aria_describedby: label_id,
+        type: "button",
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Back to edit",
+        secondary_quiet: true,
+        margin_bottom: hint ? 5 : 2,
+        classes: "js-app-c-govspeak-editor__back-button",
+        data_attributes: preview_button_data_attributes,
+        aria_controls: preview_id,
+        aria_describedby: label_id,
+        type: "button",
+      } %>
+    </div>
+  </div>
+  <div class="app-c-govspeak-editor__textarea">
+    <%= render "govuk_publishing_components/components/textarea", {
+      name: name,
+      textarea_id: id,
+      rows: rows,
+      value: value,
+      error_items: error_items,
+      data: textarea_data_attributes,
+      margin_bottom: 0,
+      describedby: hint_id,
+      right_to_left: right_to_left,
+      right_to_left_help: false,
+    } %>
+  </div>
+
+  <%= tag.div class: "app-c-govspeak-editor__preview js-locale-switcher-custom preview govspeak", 'aria-live': "polite", id: preview_id, dir: dir do %>
+    <p class="govuk-body" dir="ltr">Generating preview, please wait.</p>
+  <% end %>
+
+  <%= tag.div class: "app-c-govspeak-editor__error js-locale-switcher-custom", 'aria-live': "polite", id: error_id, dir: dir do %>
+    <p class="govuk-error-message" dir="ltr">There is an error in your Markdown. Select Back to edit and review your markdown.</p>
+  <% end %>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "extends": "stylelint-config-gds/scss"
   },
   "dependencies": {
-    "accessible-autocomplete-multiselect": "alphagov/accessible-autocomplete-multiselect"
+    "accessible-autocomplete-multiselect": "alphagov/accessible-autocomplete-multiselect",
+    "paste-html-to-govspeak": "^0.5.0"
   },
   "devDependencies": {
     "jasmine-browser-runner": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "paste-html-to-govspeak": "^0.5.0"
   },
   "devDependencies": {
-    "jasmine-browser-runner": "^2.5.0",
+    "jasmine-browser-runner": "^3.0.0",
     "jasmine-core": "^5.4.0",
     "postcss": "^8.4.49",
     "standardx": "^7.0.0",

--- a/spec/javascripts/govspeak_editor_spec.js
+++ b/spec/javascripts/govspeak_editor_spec.js
@@ -1,0 +1,317 @@
+describe('GOVUK.Modules.GovspeakEditor', function () {
+  let component, module
+
+  beforeEach(function () {
+    component = document.createElement('div')
+
+    // Preview Button
+    const previewButton = document.createElement('button')
+    previewButton.classList.add('js-app-c-govspeak-editor__preview-button')
+    previewButton.setAttribute('data-content-target', '#textarea_id')
+    previewButton.innerText = 'Preview'
+
+    const backButton = document.createElement('button')
+    backButton.classList.add('js-app-c-govspeak-editor__back-button')
+    backButton.setAttribute('data-content-target', '#textarea_id')
+    backButton.innerText = 'Back to edit'
+
+    // Textarea
+    const textareaSection = document.createElement('div')
+    textareaSection.classList.add('app-c-govspeak-editor__textarea')
+
+    const textarea = document.createElement('textarea')
+    textarea.id = 'textarea_id'
+    textarea.innerText = '## Hello'
+    textareaSection.appendChild(textarea)
+
+    // Preview section
+    const previewSection = document.createElement('div')
+    previewSection.classList.add('app-c-govspeak-editor__preview')
+
+    // Error section
+    const errorSection = document.createElement('div')
+    errorSection.classList.add('app-c-govspeak-editor__error')
+
+    // Append to component
+    component.appendChild(previewButton)
+    component.appendChild(backButton)
+    component.appendChild(textareaSection)
+    component.appendChild(previewSection)
+    component.appendChild(errorSection)
+
+    module = new GOVUK.Modules.GovspeakEditor(component)
+    module.init()
+
+    spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+
+    jasmine.Ajax.install()
+  })
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall()
+  })
+
+  it('renders component correctly', function () {
+    expect(
+      component.querySelectorAll('.js-app-c-govspeak-editor__preview-button')
+        .length
+    ).toEqual(1)
+
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__textarea').length
+    ).toEqual(1)
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__textarea textarea')
+        .length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__textarea')
+    ).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__preview').length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__preview')
+    ).not.toHaveClass('app-c-govspeak-editor__preview--show')
+
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__error').length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__error')
+    ).not.toHaveClass('app-c-govspeak-editor__error--show')
+  })
+
+  it('shows preview section when button clicked', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const textareaSection = component.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+  })
+
+  it('shows textarea section when you toggle back to edit', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const textareaSection = component.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+    expect(previewButton.innerText).toEqual('Preview')
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+
+    backButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+    expect(previewButton.innerText).toEqual('Preview')
+  })
+
+  it('renders govspeak correctly on preview', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
+    })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(html)
+  })
+
+  it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const errorSection = component.querySelector(
+      '.app-c-govspeak-editor__error'
+    )
+
+    jasmine.Ajax.stubRequest(
+      '/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 403,
+      contentType: 'text/html'
+    })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(errorSection.classList).toContain(
+      'app-c-govspeak-editor__error--show'
+    )
+    expect(previewSection.classList).not.toContain(
+      'app-c-govspeak-editor__preview--show'
+    )
+  })
+
+  it('hides the error message when the user returns to the editor view', function () {
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const errorSection = component.querySelector(
+      '.app-c-govspeak-editor__error'
+    )
+
+    errorSection.classList.add('app-c-govspeak-editor__error--show')
+
+    backButton.dispatchEvent(new Event('click'))
+
+    expect(errorSection.classList).not.toContain(
+      'app-c-govspeak-editor__error--show'
+    )
+  })
+
+  it('renders govspeak correctly with changing content', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const textarea = component.querySelector('#textarea_id')
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
+    })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(html)
+
+    // back to edit
+    previewButton.dispatchEvent(new Event('click'))
+
+    textarea.innerText = '## Hello this is a heading'
+    const newHtml = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello this is a heading</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: newHtml
+    })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(newHtml)
+  })
+
+  it('generates form data correctly', function () {
+    const formData = module.generateFormData('some text')
+
+    expect(Array.from(formData.entries())).toEqual([
+      ['bodyText', 'some text'],
+      ['authenticity_token', 'a-csrf-token']
+    ])
+  })
+})

--- a/spec/javascripts/paste_html_to_govspeak_spec.js
+++ b/spec/javascripts/paste_html_to_govspeak_spec.js
@@ -1,0 +1,29 @@
+describe('GOVUK.Modules.PasteHtmlToGovspeak', function () {
+  let textarea
+
+  function createHtmlPasteEvent (html = null) {
+    const event = new window.Event('paste')
+    event.clipboardData = {
+      getData: (type) => {
+        if (type === 'text/html') {
+          return html
+        }
+      }
+    }
+
+    return event
+  }
+
+  beforeEach(function () {
+    textarea = document.createElement('textarea')
+
+    const pasteHtmlToGovspeak = new GOVUK.Modules.PasteHtmlToGovspeak(textarea)
+    pasteHtmlToGovspeak.init()
+  })
+
+  it('responds to a paste event by converting the HTML to Govspeak', function () {
+    textarea.dispatchEvent(createHtmlPasteEvent('<h2>This is a h2</h2>'))
+
+    expect(textarea.value).toEqual('## This is a h2')
+  })
+})

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -10,7 +10,8 @@
     "**/*[sS]pec.?(m)js"
   ],
   "helpers": [
-    "helpers/*.js"
+    "helpers/*.js",
+    "https://unpkg.com/jasmine-ajax@4.0.0/lib/mock-ajax.js"
   ],
   "browser": {
     "name": "headlessChrome"

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,13 +147,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accepts@npm:~1.3.8":
-  version: 1.3.8
-  resolution: "accepts@npm:1.3.8"
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
   dependencies:
-    mime-types: "npm:~2.1.34"
-    negotiator: "npm:0.6.3"
-  checksum: 50c43d32e7b50285ebe84b613ee4a3aa426715a7d131b65b786e2ead0fd76b6b60091b9916d3478a75f11f162628a2139991b6c03ab3f1d9ab7c86075dc8eab4
+    mime-types: ^3.0.0
+    negotiator: ^1.0.0
+  checksum: 49fe6c050cb6f6ff4e771b4d88324fca4d3127865f2473872e818dca127d809ba3aa8fdfc7acb51dd3c5bade7311ca6b8cfff7015ea6db2f7eb9c8444d223a4f
   languageName: node
   linkType: hard
 
@@ -277,13 +277,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"array-flatten@npm:1.1.1":
-  version: 1.1.1
-  resolution: "array-flatten@npm:1.1.1"
-  checksum: a9925bf3512d9dce202112965de90c222cd59a4fbfce68a0951d25d965cf44642931f40aac72309c41f12df19afa010ecadceb07cfff9ccc1621e99d89ab5f3b
-  languageName: node
-  linkType: hard
-
 "array-includes@npm:^3.1.1":
   version: 3.1.2
   resolution: "array-includes@npm:3.1.2"
@@ -362,23 +355,20 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.3":
-  version: 1.20.3
-  resolution: "body-parser@npm:1.20.3"
+"body-parser@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "body-parser@npm:2.2.0"
   dependencies:
-    bytes: 3.1.2
-    content-type: ~1.0.5
-    debug: 2.6.9
-    depd: 2.0.0
-    destroy: 1.2.0
-    http-errors: 2.0.0
-    iconv-lite: 0.4.24
-    on-finished: 2.4.1
-    qs: 6.13.0
-    raw-body: 2.5.2
-    type-is: ~1.6.18
-    unpipe: 1.0.0
-  checksum: 1a35c59a6be8d852b00946330141c4f142c6af0f970faa87f10ad74f1ee7118078056706a05ae3093c54dabca9cd3770fa62a170a85801da1a4324f04381167d
+    bytes: ^3.1.2
+    content-type: ^1.0.5
+    debug: ^4.4.0
+    http-errors: ^2.0.0
+    iconv-lite: ^0.6.3
+    on-finished: ^2.4.1
+    qs: ^6.14.0
+    raw-body: ^3.0.0
+    type-is: ^2.0.0
+  checksum: 7fe3a2d288f0b632528d6ccb90052d1a9492c5b79d5716d32c8de1f5fb8237b0d31ee5050e1d0b7ff143a492ff151804612c6e2686a222a1d4c9e2e6531b8fb2
   languageName: node
   linkType: hard
 
@@ -410,10 +400,20 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
+  languageName: node
+  linkType: hard
+
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+  checksum: b2863d74fcf2a6948221f65d95b91b4b2d90cfe8927650b506141e669f7d5de65cea191bf788838bc40d13846b7886c5bc5c84ab96c3adbcf88ad69a72fcdc6b
   languageName: node
   linkType: hard
 
@@ -427,16 +427,13 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "call-bind@npm:1.0.7"
+"call-bound@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
   dependencies:
-    es-define-property: ^1.0.0
-    es-errors: ^1.3.0
-    function-bind: ^1.1.2
-    get-intrinsic: ^1.2.4
-    set-function-length: ^1.2.1
-  checksum: 295c0c62b90dd6522e6db3b0ab1ce26bdf9e7404215bda13cfee25b626b5ff1a7761324d58d38b1ef1607fc65aca2d06e44d2e18d0dfc6c14b465b00d8660029
+    call-bind-apply-helpers: ^1.0.2
+    get-intrinsic: ^1.3.0
+  checksum: 2f6399488d1c272f56306ca60ff696575e2b7f31daf23bc11574798c84d9f2759dceb0cb1f471a85b77f28962a7ac6411f51d283ea2e45319009a19b6ccab3b2
   languageName: node
   linkType: hard
 
@@ -531,40 +528,33 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4":
-  version: 0.5.4
-  resolution: "content-disposition@npm:0.5.4"
+"content-disposition@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "content-disposition@npm:1.0.0"
   dependencies:
-    safe-buffer: "npm:5.2.1"
-  checksum: afb9d545e296a5171d7574fcad634b2fdf698875f4006a9dd04a3e1333880c5c0c98d47b560d01216fb6505a54a2ba6a843ee3a02ec86d7e911e8315255f56c3
+    safe-buffer: 5.2.1
+  checksum: b27e2579fefe0ecf78238bb652fbc750671efce8344f0c6f05235b12433e6a965adb40906df1ac1fdde23e8f9f0e58385e44640e633165420f3f47d830ae0398
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4":
-  version: 1.0.4
-  resolution: "content-type@npm:1.0.4"
-  checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
-  languageName: node
-  linkType: hard
-
-"content-type@npm:~1.0.5":
+"content-type@npm:^1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:1.0.6":
-  version: 1.0.6
-  resolution: "cookie-signature@npm:1.0.6"
-  checksum: f4e1b0a98a27a0e6e66fd7ea4e4e9d8e038f624058371bf4499cfcd8f3980be9a121486995202ba3fca74fbed93a407d6d54d43a43f96fd28d0bd7a06761591a
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 1ad4f9b3907c9f3673a0f0a07c0a23da7909ac6c9204c5d80a0ec102fe50ccc45f27fdf496361840d6c132c5bb0037122c0a381f856d070183d1ebe3e5e041ff
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0":
-  version: 0.6.0
-  resolution: "cookie@npm:0.6.0"
-  checksum: f56a7d32a07db5458e79c726b77e3c2eff655c36792f2b6c58d351fb5f61531e5b1ab7f46987150136e366c65213cbe31729e02a3eaed630c3bf7334635fb410
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 9bf8555e33530affd571ea37b615ccad9b9a34febbf2c950c86787088eb00a8973690833b0f8ebd6b69b753c62669ea60cec89178c1fb007bf0749abed74f93e
   languageName: node
   linkType: hard
 
@@ -629,7 +619,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.6.9":
+"debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -647,6 +637,18 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
     supports-color:
       optional: true
   checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.5, debug@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
   languageName: node
   linkType: hard
 
@@ -669,17 +671,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"define-data-property@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "define-data-property@npm:1.1.4"
-  dependencies:
-    es-define-property: ^1.0.0
-    es-errors: ^1.3.0
-    gopd: ^1.0.1
-  checksum: 8068ee6cab694d409ac25936eb861eea704b7763f7f342adbdfe337fc27c78d7ae0eff2364b2917b58c508d723c7a074326d068eef2e45c4edcd85cf94d0313b
-  languageName: node
-  linkType: hard
-
 "define-properties@npm:^1.1.3":
   version: 1.1.3
   resolution: "define-properties@npm:1.1.3"
@@ -689,17 +680,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0":
+"depd@npm:2.0.0, depd@npm:^2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: abbe19c768c97ee2eed6282d8ce3031126662252c58d711f646921c9623f9052e3e1906443066beec1095832f534e57c523b7333f8e7e0d93051ab6baef5ab3a
-  languageName: node
-  linkType: hard
-
-"destroy@npm:1.2.0":
-  version: 1.2.0
-  resolution: "destroy@npm:1.2.0"
-  checksum: 0acb300b7478a08b92d810ab229d5afe0d2f4399272045ab22affa0d99dbaf12637659411530a6fcd597a9bdac718fc94373a61a95b4651bbc7b83684a565e38
   languageName: node
   linkType: hard
 
@@ -737,6 +721,17 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.1
+    es-errors: ^1.3.0
+    gopd: ^1.2.0
+  checksum: 149207e36f07bd4941921b0ca929e3a28f1da7bd6b6ff8ff7f4e2f2e460675af4576eeba359c635723dc189b64cdd4787e0255897d5b135ccc5d15cb8685fc90
   languageName: node
   linkType: hard
 
@@ -786,14 +781,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"encodeurl@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "encodeurl@npm:1.0.2"
-  checksum: e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
-  languageName: node
-  linkType: hard
-
-"encodeurl@npm:~2.0.0":
+"encodeurl@npm:^2.0.0":
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
@@ -864,12 +852,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"es-define-property@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "es-define-property@npm:1.0.0"
-  dependencies:
-    get-intrinsic: ^1.2.4
-  checksum: f66ece0a887b6dca71848fa71f70461357c0e4e7249696f81bad0a1f347eed7b31262af4a29f5d726dc026426f085483b6b90301855e647aa8e21936f07293c6
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 0512f4e5d564021c9e3a644437b0155af2679d10d80f21adaf868e64d30efdfbd321631956f20f42d655fedb2e3a027da479fad3fa6048f768eb453a80a5f80a
   languageName: node
   linkType: hard
 
@@ -877,6 +863,15 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: ^1.3.0
+  checksum: 214d3767287b12f36d3d7267ef342bbbe1e89f899cfd67040309fc65032372a8e60201410a99a1645f2f90c1912c8c49c8668066f6bdd954bcd614dda2e3da97
   languageName: node
   linkType: hard
 
@@ -891,7 +886,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"escape-html@npm:~1.0.3":
+"escape-html@npm:^1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -1166,49 +1161,45 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
   languageName: node
   linkType: hard
 
-"express@npm:^4.19.2":
-  version: 4.20.0
-  resolution: "express@npm:4.20.0"
+"express@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "express@npm:5.1.0"
   dependencies:
-    accepts: ~1.3.8
-    array-flatten: 1.1.1
-    body-parser: 1.20.3
-    content-disposition: 0.5.4
-    content-type: ~1.0.4
-    cookie: 0.6.0
-    cookie-signature: 1.0.6
-    debug: 2.6.9
-    depd: 2.0.0
-    encodeurl: ~2.0.0
-    escape-html: ~1.0.3
-    etag: ~1.8.1
-    finalhandler: 1.2.0
-    fresh: 0.5.2
-    http-errors: 2.0.0
-    merge-descriptors: 1.0.3
-    methods: ~1.1.2
-    on-finished: 2.4.1
-    parseurl: ~1.3.3
-    path-to-regexp: 0.1.10
-    proxy-addr: ~2.0.7
-    qs: 6.11.0
-    range-parser: ~1.2.1
-    safe-buffer: 5.2.1
-    send: 0.19.0
-    serve-static: 1.16.0
-    setprototypeof: 1.2.0
-    statuses: 2.0.1
-    type-is: ~1.6.18
-    utils-merge: 1.0.1
-    vary: ~1.1.2
-  checksum: faa11bffa16be97b26d9f38187e569378c01cad0b92fbd02094fb4e35a224dc5177cc9cc6849141702da80d2d8cbe857c60a7e622e8106695405dc27e38fb3ee
+    accepts: ^2.0.0
+    body-parser: ^2.2.0
+    content-disposition: ^1.0.0
+    content-type: ^1.0.5
+    cookie: ^0.7.1
+    cookie-signature: ^1.2.1
+    debug: ^4.4.0
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    etag: ^1.8.1
+    finalhandler: ^2.1.0
+    fresh: ^2.0.0
+    http-errors: ^2.0.0
+    merge-descriptors: ^2.0.0
+    mime-types: ^3.0.0
+    on-finished: ^2.4.1
+    once: ^1.4.0
+    parseurl: ^1.3.3
+    proxy-addr: ^2.0.7
+    qs: ^6.14.0
+    range-parser: ^1.2.1
+    router: ^2.2.0
+    send: ^1.1.0
+    serve-static: ^2.2.0
+    statuses: ^2.0.1
+    type-is: ^2.0.1
+    vary: ^1.1.2
+  checksum: 06e6141780c6c4780111f971ce062c83d4cf4862c40b43caf1d95afcbb58d7422c560503b8c9d04c7271511525d09cbdbe940bcaad63970fd4c1b9f6fd713bdb
   languageName: node
   linkType: hard
 
@@ -1311,18 +1302,17 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.2.0":
-  version: 1.2.0
-  resolution: "finalhandler@npm:1.2.0"
+"finalhandler@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "finalhandler@npm:2.1.0"
   dependencies:
-    debug: "npm:2.6.9"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    on-finished: "npm:2.4.1"
-    parseurl: "npm:~1.3.3"
-    statuses: "npm:2.0.1"
-    unpipe: "npm:~1.0.0"
-  checksum: 92effbfd32e22a7dff2994acedbd9bcc3aa646a3e919ea6a53238090e87097f8ef07cced90aa2cc421abdf993aefbdd5b00104d55c7c5479a8d00ed105b45716
+    debug: ^4.4.0
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    on-finished: ^2.4.1
+    parseurl: ^1.3.3
+    statuses: ^2.0.1
+  checksum: 27ca9cc83b1384ba37959eb95bc7e62bc0bf4d6f6af63f6d38821cf7499b113e34b23f96a2a031616817f73986f94deea67c2f558de9daf406790c181a2501df
   languageName: node
   linkType: hard
 
@@ -1396,10 +1386,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"fresh@npm:0.5.2":
-  version: 0.5.2
-  resolution: "fresh@npm:0.5.2"
-  checksum: 13ea8b08f91e669a64e3ba3a20eb79d7ca5379a81f1ff7f4310d54e2320645503cc0c78daedc93dfb6191287295f6479544a649c64d8e41a1c0fb0c221552346
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 38b9828352c6271e2a0dd8bdd985d0100dbbc4eb8b6a03286071dd6f7d96cfaacd06d7735701ad9a95870eb3f4555e67c08db1dcfe24c2e7bb87383c72fae1d2
   languageName: node
   linkType: hard
 
@@ -1442,27 +1432,31 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2":
-  version: 1.1.1
-  resolution: "get-intrinsic@npm:1.1.1"
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
-    function-bind: "npm:^1.1.1"
-    has: "npm:^1.0.3"
-    has-symbols: "npm:^1.0.1"
-  checksum: a9fe2ca8fa3f07f9b0d30fb202bcd01f3d9b9b6b732452e79c48e79f7d6d8d003af3f9e38514250e3553fdc83c61650851cb6870832ac89deaaceb08e3721a17
+    call-bind-apply-helpers: ^1.0.2
+    es-define-property: ^1.0.1
+    es-errors: ^1.3.0
+    es-object-atoms: ^1.1.1
+    function-bind: ^1.1.2
+    get-proto: ^1.0.1
+    gopd: ^1.2.0
+    has-symbols: ^1.1.0
+    hasown: ^2.0.2
+    math-intrinsics: ^1.1.0
+  checksum: 301008e4482bb9a9cb49e132b88fee093bff373b4e6def8ba219b1e96b60158a6084f273ef5cafe832e42cd93462f4accb46a618d35fe59a2b507f2388c5b79d
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "get-intrinsic@npm:1.2.4"
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
   dependencies:
-    es-errors: ^1.3.0
-    function-bind: ^1.1.2
-    has-proto: ^1.0.1
-    has-symbols: ^1.0.3
-    hasown: ^2.0.0
-  checksum: 414e3cdf2c203d1b9d7d33111df746a4512a1aa622770b361dadddf8ed0b5aeb26c560f49ca077e24bfafb0acb55ca908d1f709216ccba33ffc548ec8a79a951
+    dunder-proto: ^1.0.1
+    es-object-atoms: ^1.0.0
+  checksum: 4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -1561,12 +1555,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"gopd@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "gopd@npm:1.0.1"
-  dependencies:
-    get-intrinsic: ^1.1.3
-  checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: cc6d8e655e360955bdccaca51a12a474268f95bb793fc3e1f2bdadb075f28bfd1fd988dab872daf77a61d78cbaf13744bc8727a17cfb1d150d76047d805375f3
   languageName: node
   linkType: hard
 
@@ -1591,22 +1583,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-property-descriptors@npm:1.0.2"
-  dependencies:
-    es-define-property: ^1.0.0
-  checksum: fcbb246ea2838058be39887935231c6d5788babed499d0e9d0cc5737494c48aba4fe17ba1449e0d0fbbb1e36175442faa37f9c427ae357d6ccb1d895fbcd3de3
-  languageName: node
-  linkType: hard
-
-"has-proto@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "has-proto@npm:1.0.3"
-  checksum: fe7c3d50b33f50f3933a04413ed1f69441d21d2d2944f81036276d30635cad9279f6b43bc8f32036c31ebdfcf6e731150f46c1907ad90c669ffe9b066c3ba5c4
-  languageName: node
-  linkType: hard
-
 "has-symbols@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-symbols@npm:1.0.1"
@@ -1614,10 +1590,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has-symbols@npm:1.0.3"
-  checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: b2316c7302a0e8ba3aaba215f834e96c22c86f192e7310bdf689dd0e6999510c89b00fbc5742571507cebf25764d68c988b3a0da217369a73596191ac0ce694b
   languageName: node
   linkType: hard
 
@@ -1630,7 +1606,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.0":
+"hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
@@ -1653,7 +1629,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0":
+"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
   version: 2.0.0
   resolution: "http-errors@npm:2.0.0"
   dependencies:
@@ -1666,12 +1642,12 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "iconv-lite@npm:0.6.3"
   dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: bd9f120f5a5b306f0bc0b9ae1edeb1577161503f5f8252a20f1a9e56ef8775c9959fd01c55f2d3a39d9a8abaf3e30c1abeb1895f367dcbbe0a8fd1c9ca01c4f6
+    safer-buffer: ">= 2.1.2 < 3.0.0"
+  checksum: 3f60d47a5c8fc3313317edfd29a00a692cc87a19cac0159e2ce711d0ebc9019064108323b5e493625e25594f11c6236647d8e256fbe7a58f4a3b33b89e6d30bf
   languageName: node
   linkType: hard
 
@@ -1853,6 +1829,13 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 0b46517ad47b00b6358fd6553c83ec1f6ba9acd7ffb3d30a0bf519c5c69e7147c132430452351b8a9fc198f8dd6c4f76f8e6f5a7f100f8c77d57d9e0f4261a8a
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-regex@npm:1.1.1"
@@ -1919,19 +1902,19 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"jasmine-browser-runner@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "jasmine-browser-runner@npm:2.5.0"
+"jasmine-browser-runner@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "jasmine-browser-runner@npm:3.0.0"
   dependencies:
     ejs: ^3.1.6
-    express: ^4.19.2
+    express: ^5.0.0
     glob: ^10.0.0
     selenium-webdriver: ^4.12.0
   peerDependencies:
-    jasmine-core: ^5.0.0
+    jasmine-core: ^5.5.0
   bin:
     jasmine-browser-runner: bin/jasmine-browser-runner
-  checksum: e6ed14fb514ff8599c65e720ad91c1ee1edc940916aba73434a8ba7742edaa27d7044bf7bf7eea1667f91df82760c761f23ef64a96b6c914824be4c07695e67e
+  checksum: 682b8fbaa90342ec25d7db11a38c3c8fc2d8458f4cf0b39b85c98feb42dfe11902890248a58bd7febf8ac5c4e19905cf43d411b98dd81c0becd9554211e5ae46
   languageName: node
   linkType: hard
 
@@ -2189,6 +2172,13 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 0e513b29d120f478c85a70f49da0b8b19bc638975eca466f2eeae0071f3ad00454c621bf66e16dd435896c208e719fc91ad79bbfba4e400fe0b372e7c1c9c9a2
+  languageName: node
+  linkType: hard
+
 "mathml-tag-names@npm:^2.1.3":
   version: 2.1.3
   resolution: "mathml-tag-names@npm:2.1.3"
@@ -2203,10 +2193,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"media-typer@npm:0.3.0":
-  version: 0.3.0
-  resolution: "media-typer@npm:0.3.0"
-  checksum: af1b38516c28ec95d6b0826f6c8f276c58aec391f76be42aa07646b4e39d317723e869700933ca6995b056db4b09a78c92d5440dc23657e6764be5d28874bba1
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: a58dd60804df73c672942a7253ccc06815612326dc1c0827984b1a21704466d7cde351394f47649e56cf7415e6ee2e26e000e81b51b3eebb5a93540e8bf93cbd
   languageName: node
   linkType: hard
 
@@ -2217,10 +2207,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:1.0.3":
-  version: 1.0.3
-  resolution: "merge-descriptors@npm:1.0.3"
-  checksum: 52117adbe0313d5defa771c9993fe081e2d2df9b840597e966aadafde04ae8d0e3da46bac7ca4efc37d4d2b839436582659cd49c6a43eacb3fe3050896a105d1
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: e383332e700a94682d0125a36c8be761142a1320fc9feeb18e6e36647c9edf064271645f5669b2c21cf352116e561914fd8aa831b651f34db15ef4038c86696a
   languageName: node
   linkType: hard
 
@@ -2228,13 +2218,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
-  languageName: node
-  linkType: hard
-
-"methods@npm:~1.1.2":
-  version: 1.1.2
-  resolution: "methods@npm:1.1.2"
-  checksum: 0917ff4041fa8e2f2fda5425a955fe16ca411591fbd123c0d722fcf02b73971ed6f764d85f0a6f547ce49ee0221ce2c19a5fa692157931cecb422984f1dcd13a
   languageName: node
   linkType: hard
 
@@ -2248,28 +2231,19 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: e99aaf2f23f5bd607deb08c83faba5dd25cf2fec90a7cc5b92d8260867ee08dab65312e1a589e60093dc7796d41e5fae013268418482f1db4c7d52d0a0960ac9
   languageName: node
   linkType: hard
 
-"mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
   dependencies:
-    mime-db: "npm:1.52.0"
-  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
-  languageName: node
-  linkType: hard
-
-"mime@npm:1.6.0":
-  version: 1.6.0
-  resolution: "mime@npm:1.6.0"
-  bin:
-    mime: cli.js
-  checksum: fef25e39263e6d207580bdc629f8872a3f9772c923c7f8c7e793175cee22777bbe8bba95e5d509a40aaa292d8974514ce634ae35769faa45f22d17edda5e8557
+    mime-db: ^1.54.0
+  checksum: 8d497ad5cb2dd1210ac7d049b5de94af0b24b45a314961e145b44389344604d54752f03bc00bf880c0da60a214be6fb6d423d318104f02c28d95dd8ebeea4fb4
   languageName: node
   linkType: hard
 
@@ -2339,7 +2313,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.1.3":
+"ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -2362,10 +2336,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"negotiator@npm:0.6.3":
-  version: 0.6.3
-  resolution: "negotiator@npm:0.6.3"
-  checksum: b8ffeb1e262eff7968fc90a2b6767b04cfd9842582a9d0ece0af7049537266e7b2506dfb1d107a32f06dd849ab2aea834d5830f7f4d0e5cb7d36e1ae55d021d9
+"negotiator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "negotiator@npm:1.0.0"
+  checksum: 20ebfe79b2d2e7cf9cbc8239a72662b584f71164096e6e8896c8325055497c96f6b80cd22c258e8a2f2aa382a787795ec3ee8b37b422a302c7d4381b0d5ecfbb
   languageName: node
   linkType: hard
 
@@ -2395,10 +2369,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.1":
-  version: 1.13.2
-  resolution: "object-inspect@npm:1.13.2"
-  checksum: 9f850b3c045db60e0e97746e809ee4090d6ce62195af17dd1e9438ac761394a7d8ec4f7906559aea5424eaf61e35d3e53feded2ccd5f62fcc7d9670d3c8eb353
+"object-inspect@npm:^1.13.3":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 582810c6a8d2ef988ea0a39e69e115a138dad8f42dd445383b394877e5816eb4268489f316a6f74ee9c4e0a984b3eab1028e3e79d62b1ed67c726661d55c7a8b
   languageName: node
   linkType: hard
 
@@ -2406,13 +2380,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   version: 1.8.0
   resolution: "object-inspect@npm:1.8.0"
   checksum: 1bb4ed43972ad29537bee9b2b3f543d7e6463ee3b929048ecddcb50f7796c418c679ba2104f2e37cd7fa486782b6278b9d1c9cccb4bbc7ca17cd529f3ae4dc1f
-  languageName: node
-  linkType: hard
-
-"object-inspect@npm:^1.9.0":
-  version: 1.12.0
-  resolution: "object-inspect@npm:1.12.0"
-  checksum: 2b36d4001a9c921c6b342e2965734519c9c58c355822243c3207fbf0aac271f8d44d30d2d570d450b2cc6f0f00b72bcdba515c37827d2560e5f22b1899a31cf4
   languageName: node
   linkType: hard
 
@@ -2471,7 +2438,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1":
+"on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -2480,7 +2447,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -2600,7 +2567,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
@@ -2652,10 +2619,10 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: ab7a3b7a0b914476d44030340b0a65d69851af2a0f33427df1476100ccb87d409c39e2182837a96b98fb38c4ef2ba6b87bdad62bb70a2c153876b8061760583c
+"path-to-regexp@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: 56e13e45962e776e9e7cd72e87a441cfe41f33fd539d097237ceb16adc922281136ca12f5a742962e33d8dda9569f630ba594de56d8b7b6e49adf31803c5e771
   languageName: node
   linkType: hard
 
@@ -2863,7 +2830,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -2880,40 +2847,31 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
+"qs@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
   dependencies:
-    side-channel: ^1.0.4
-  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
+    side-channel: ^1.1.0
+  checksum: 189b52ad4e9a0da1a16aff4c58b2a554a8dad9bd7e287c7da7446059b49ca2e33a49e570480e8be406b87fccebf134f51c373cbce36c8c83859efa0c9b71d635
   languageName: node
   linkType: hard
 
-"qs@npm:6.13.0":
-  version: 6.13.0
-  resolution: "qs@npm:6.13.0"
-  dependencies:
-    side-channel: ^1.0.6
-  checksum: e9404dc0fc2849245107108ce9ec2766cde3be1b271de0bf1021d049dc5b98d1a2901e67b431ac5509f865420a7ed80b7acb3980099fe1c118a1c5d2e1432ad8
-  languageName: node
-  linkType: hard
-
-"range-parser@npm:~1.2.1":
+"range-parser@npm:^1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
   languageName: node
   linkType: hard
 
-"raw-body@npm:2.5.2":
-  version: 2.5.2
-  resolution: "raw-body@npm:2.5.2"
+"raw-body@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "raw-body@npm:3.0.0"
   dependencies:
     bytes: 3.1.2
     http-errors: 2.0.0
-    iconv-lite: 0.4.24
+    iconv-lite: 0.6.3
     unpipe: 1.0.0
-  checksum: ba1583c8d8a48e8fbb7a873fdbb2df66ea4ff83775421bfe21ee120140949ab048200668c47d9ae3880012f6e217052690628cf679ddfbd82c9fc9358d574676
+  checksum: 25b7cf7964183db322e819050d758a5abd0f22c51e9f37884ea44a9ed6855a1fb61f8caa8ec5b61d07e69f54db43dbbc08ad98ef84556696d6aa806be247af0e
   languageName: node
   linkType: hard
 
@@ -3047,6 +3005,19 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: ^4.4.0
+    depd: ^2.0.0
+    is-promise: ^4.0.0
+    parseurl: ^1.3.3
+    path-to-regexp: ^8.0.0
+  checksum: 4c3bec8011ed10bb07d1ee860bc715f245fff0fdff991d8319741d2932d89c3fe0a56766b4fa78e95444bc323fd2538e09c8e43bfbd442c2a7fab67456df7fa5
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.1.10
   resolution: "run-parallel@npm:1.1.10"
@@ -3068,7 +3039,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3":
+"safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
@@ -3115,71 +3086,34 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"send@npm:0.18.0":
-  version: 0.18.0
-  resolution: "send@npm:0.18.0"
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "send@npm:1.2.0"
   dependencies:
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
-    mime: "npm:1.6.0"
-    ms: "npm:2.1.3"
-    on-finished: "npm:2.4.1"
-    range-parser: "npm:~1.2.1"
-    statuses: "npm:2.0.1"
-  checksum: 74fc07ebb58566b87b078ec63e5a3e41ecd987e4272ba67b7467e86c6ad51bc6b0b0154133b6d8b08a2ddda360464f71382f7ef864700f34844a76c8027817a8
+    debug: ^4.3.5
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    etag: ^1.8.1
+    fresh: ^2.0.0
+    http-errors: ^2.0.0
+    mime-types: ^3.0.1
+    ms: ^2.1.3
+    on-finished: ^2.4.1
+    range-parser: ^1.2.1
+    statuses: ^2.0.1
+  checksum: 7557ee6c1c257a1c53b402b4fba8ed88c95800b08abe085fc79e0824869274f213491be2efb2df3de228c70e4d40ce2019e5f77b58c42adb97149135420c3f34
   languageName: node
   linkType: hard
 
-"send@npm:0.19.0":
-  version: 0.19.0
-  resolution: "send@npm:0.19.0"
+"serve-static@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "serve-static@npm:2.2.0"
   dependencies:
-    debug: 2.6.9
-    depd: 2.0.0
-    destroy: 1.2.0
-    encodeurl: ~1.0.2
-    escape-html: ~1.0.3
-    etag: ~1.8.1
-    fresh: 0.5.2
-    http-errors: 2.0.0
-    mime: 1.6.0
-    ms: 2.1.3
-    on-finished: 2.4.1
-    range-parser: ~1.2.1
-    statuses: 2.0.1
-  checksum: 5ae11bd900c1c2575525e2aa622e856804e2f96a09281ec1e39610d089f53aa69e13fd8db84b52f001d0318cf4bb0b3b904ad532fc4c0014eb90d32db0cff55f
-  languageName: node
-  linkType: hard
-
-"serve-static@npm:1.16.0":
-  version: 1.16.0
-  resolution: "serve-static@npm:1.16.0"
-  dependencies:
-    encodeurl: ~1.0.2
-    escape-html: ~1.0.3
-    parseurl: ~1.3.3
-    send: 0.18.0
-  checksum: a479dfe7e9fa7e8cb3ceccb0d944a3c72bb8f88d78472e30989f58fe15a92cfc909ab05a5c7cda2d1a6aa2663ab503ad1e2f40653740346e53e72b3ba41b6951
-  languageName: node
-  linkType: hard
-
-"set-function-length@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "set-function-length@npm:1.2.2"
-  dependencies:
-    define-data-property: ^1.1.4
-    es-errors: ^1.3.0
-    function-bind: ^1.1.2
-    get-intrinsic: ^1.2.4
-    gopd: ^1.0.1
-    has-property-descriptors: ^1.0.2
-  checksum: a8248bdacdf84cb0fab4637774d9fb3c7a8e6089866d04c817583ff48e14149c87044ce683d7f50759a8c50fb87c7a7e173535b06169c87ef76f5fb276dfff72
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    parseurl: ^1.3.3
+    send: ^1.2.0
+  checksum: 74f39e88f0444aa6732aae3b9597739c47552adecdc83fa32aa42555e76f1daad480d791af73894655c27a2d378275a461e691cead33fb35d8b976f1e2d24665
   languageName: node
   linkType: hard
 
@@ -3213,6 +3147,41 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "side-channel-list@npm:1.0.0"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.3
+  checksum: 603b928997abd21c5a5f02ae6b9cc36b72e3176ad6827fab0417ead74580cc4fb4d5c7d0a8a2ff4ead34d0f9e35701ed7a41853dac8a6d1a664fcce1a044f86f
+  languageName: node
+  linkType: hard
+
+"side-channel-map@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-map@npm:1.0.1"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+  checksum: 42501371cdf71f4ccbbc9c9e2eb00aaaab80a4c1c429d5e8da713fd4d39ef3b8d4a4b37ed4f275798a65260a551a7131fd87fe67e922dba4ac18586d6aab8b06
+  languageName: node
+  linkType: hard
+
+"side-channel-weakmap@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "side-channel-weakmap@npm:1.0.2"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+    side-channel-map: ^1.0.1
+  checksum: a815c89bc78c5723c714ea1a77c938377ea710af20d4fb886d362b0d1f8ac73a17816a5f6640f354017d7e292a43da9c5e876c22145bac00b76cfb3468001736
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.2, side-channel@npm:^1.0.3":
   version: 1.0.3
   resolution: "side-channel@npm:1.0.3"
@@ -3223,26 +3192,16 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "side-channel@npm:1.0.4"
+"side-channel@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "side-channel@npm:1.1.0"
   dependencies:
-    call-bind: "npm:^1.0.0"
-    get-intrinsic: "npm:^1.0.2"
-    object-inspect: "npm:^1.9.0"
-  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "side-channel@npm:1.0.6"
-  dependencies:
-    call-bind: ^1.0.7
     es-errors: ^1.3.0
-    get-intrinsic: ^1.2.4
-    object-inspect: ^1.13.1
-  checksum: bfc1afc1827d712271453e91b7cd3878ac0efd767495fd4e594c4c2afaa7963b7b510e249572bfd54b0527e66e4a12b61b80c061389e129755f34c493aad9b97
+    object-inspect: ^1.13.3
+    side-channel-list: ^1.0.0
+    side-channel-map: ^1.0.1
+    side-channel-weakmap: ^1.0.2
+  checksum: bf73d6d6682034603eb8e99c63b50155017ed78a522d27c2acec0388a792c3ede3238b878b953a08157093b85d05797217d270b7666ba1f111345fbe933380ff
   languageName: node
   linkType: hard
 
@@ -3335,7 +3294,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   resolution: "specialist-publisher@workspace:."
   dependencies:
     accessible-autocomplete-multiselect: alphagov/accessible-autocomplete-multiselect
-    jasmine-browser-runner: ^2.5.0
+    jasmine-browser-runner: ^3.0.0
     jasmine-core: ^5.4.0
     paste-html-to-govspeak: ^0.5.0
     postcss: ^8.4.49
@@ -3394,7 +3353,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"statuses@npm:2.0.1":
+"statuses@npm:2.0.1, statuses@npm:^2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
@@ -3774,17 +3733,18 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"type-is@npm:~1.6.18":
-  version: 1.6.18
-  resolution: "type-is@npm:1.6.18"
+"type-is@npm:^2.0.0, type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
   dependencies:
-    media-typer: "npm:0.3.0"
-    mime-types: "npm:~2.1.24"
-  checksum: 2c8e47675d55f8b4e404bcf529abdf5036c537a04c2b20177bcf78c9e3c1da69da3942b1346e6edb09e823228c0ee656ef0e033765ec39a70d496ef601a0c657
+    content-type: ^1.0.5
+    media-typer: ^1.1.0
+    mime-types: ^3.0.0
+  checksum: 0266e7c782238128292e8c45e60037174d48c6366bb2d45e6bd6422b611c193f83409a8341518b6b5f33f8e4d5a959f38658cacfea77f0a3505b9f7ac1ddec8f
   languageName: node
   linkType: hard
 
-"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
+"unpipe@npm:1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
@@ -3807,13 +3767,6 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"utils-merge@npm:1.0.1":
-  version: 1.0.1
-  resolution: "utils-merge@npm:1.0.1"
-  checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
-  languageName: node
-  linkType: hard
-
 "v8-compile-cache@npm:^2.0.3":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
@@ -3831,7 +3784,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
-"vary@npm:~1.1.2":
+"vary@npm:^1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b

--- a/yarn.lock
+++ b/yarn.lock
@@ -2607,6 +2607,13 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"paste-html-to-govspeak@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "paste-html-to-govspeak@npm:0.5.0"
+  checksum: faee1c3787cc6a3ab20a987f7f04058e19f8b09a28799f780e856234b9511c6fbd00241010015bfbbd4c2e42822e6f2856440403b688d641ec0c14d5181c713f
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -3330,6 +3337,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
     accessible-autocomplete-multiselect: alphagov/accessible-autocomplete-multiselect
     jasmine-browser-runner: ^2.5.0
     jasmine-core: ^5.4.0
+    paste-html-to-govspeak: ^0.5.0
     postcss: ^8.4.49
     standardx: ^7.0.0
     stylelint: ^16.10.0


### PR DESCRIPTION
Port over the GovSpeak Editor from Whitehall so we have a styled design system text area with a functional Preview button.

Removed some functionality that are currently not used in Specialist Publisher.
e.g. Rendering of Images and Attachment when rendering GovSpeak Editor preview. This is because Specialist Publisher does not support image uploading currently, and attachments are only available on the edit screens, which are not yet transitioning to the new design system. 

Removing the unused code instead of just leaving them there because the way it is implemented is different in Whitehall. The way we gather the image IDs and Attachment IDs are different and not currently implemented in Specialist Publisher. We can probably make that decision when we get to the point of transitioning Edit screens and Attachments and hence requiring to preview them. Another card has been created for Preview Button for Attachments.

https://trello.com/c/BvKeF7Vw/3641-design-system-add-new-document-preview-button

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
