### PR TITLE
Ipo designs finder

### DIFF
--- a/app/models/design_decision.rb
+++ b/app/models/design_decision.rb
@@ -1,0 +1,11 @@
+class DesignDecision < Document
+  apply_validations
+
+  FORMAT_SPECIFIC_FIELDS = format_specific_fields
+
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+
+  def initialize(params = {})
+    super(params, FORMAT_SPECIFIC_FIELDS)
+  end
+end

--- a/app/views/metadata_fields/_design_decisions.html.erb
+++ b/app/views/metadata_fields/_design_decisions.html.erb
@@ -1,0 +1,2 @@
+<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
+<% end %>

--- a/lib/documents/schemas/design_decisions.json
+++ b/lib/documents/schemas/design_decisions.json
@@ -1,0 +1,106 @@
+{
+  "base_path": "/designs-decisions",
+  "content_id": "d35b914f-a875-4ee0-b307-991269dc26df",
+  "description": "Find Intellectual Property (Registered Design) related decisions for the U.K.",
+  "document_noun": "decision",
+  "document_title": "Design Decision",
+  "facets": [
+    {
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "design_decision_british_library_number",
+      "name": "British Library number",
+      "short_name": "BL number",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    },
+    {
+      "allowed_values": [
+        {
+          "label": "Leisa Davies",
+          "value": "leisa-davies"
+        },
+        {
+          "label": "James Hopkins",
+          "value": "james-hopkins"
+        },
+        {
+          "label": "Rosie Le Breton",
+          "value": "rosie-le"
+        },
+        {
+          "label": "Arran Cooper",
+          "value": "arran-cooper"
+        },
+        {
+          "label": "Allan James",
+          "value": "allan-james"
+        },
+        {
+          "label": "Clare Boucher",
+          "value": "clare-boucher"
+        },
+        {
+          "label": "Al Skilton",
+          "value": "al-skilton"
+        }
+      ],
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "design_decision_hearing_officer",
+      "name": "Hearing officer",
+      "preposition": "Hearing officer",
+      "short_name": "Hearing officer",
+      "show_option_select_filter": true,
+      "specialist_publisher_properties": {
+        "select": "one",
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "key": "design_decision_date",
+      "name": "Decision date",
+      "preposition": "Decision date",
+      "short_name": "Date",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "date"
+    },
+    {
+      "display_as_result_metadata": true,
+      "filterable": false,
+      "key": "design_decision_litigants",
+      "name": "Litigants",
+      "short_name": "Litigants",
+      "specialist_publisher_properties": {
+        "validations": {
+          "required": {}
+        }
+      },
+      "type": "text"
+    }
+  ],
+  "filter": {
+    "format": "design_decision"
+  },
+  "name": "Find Intellectual Property related legal decisions",
+  "organisations": [
+    "5d6f9583-991f-413d-ae83-be7274e5eae4"
+  ],
+  "show_summaries": true,
+  "show_metadata_block": true,
+  "summary": "To find Intellectual Property (Registered Designs) related decisions for the U.K.\r\n\r\n##Note\r\n\r\nEvery effort is made to ensure design hearing decisions have been accurately recorded, but some errors may have been introduced during conversion for the web.\r\n\r\nCopies of any documents annexed to a decision are available from:\r\n\r\n$C\r\nTribunal Section,<br>Intellectual Property Office,<br>Concept House,<br>Cardiff Road,<br>Newport,<br>South Wales<br>NP10 8QQ\r\n$C",
+  "target_stack": "draft"
+}

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -856,6 +856,22 @@ FactoryBot.define do
     end
   end
 
+  factory :design_decision, parent: :document do
+    base_path { "/designs-decisions/example-document" }
+    document_type { "design_decision" }
+
+    transient do
+      default_metadata do
+        {
+          "design_decision_british_library_number" => "BL123456",
+          "design_decision_date" => "2015-11-16",
+          "design_decision_hearing_officer" => "leisa-davies",
+          "design_decision_litigants" => "A vs B",
+        }
+      end
+    end
+  end
+
   factory :export_health_certificate, parent: :document do
     base_path { "/export-health-certificates/example-document" }
     document_type { "export_health_certificate" }


### PR DESCRIPTION
Designs finder, for IPO. An old request, preceding the [trademarks finder](https://github.com/alphagov/specialist-publisher/pull/2923). Similar fields, no nested facets required. 

Some requirements still to be ironed out, but can release in draft.

- Index view Specialist Publisher
![index](https://github.com/user-attachments/assets/07c2be12-1b9a-4bb4-872d-28511873fed0)
- Blank document 
![blank document](https://github.com/user-attachments/assets/1557b52f-4aaf-4114-b16c-f25729e22d3a)
- Saved document summary
![Saved document summary](https://github.com/user-attachments/assets/d209d38d-af33-4244-909d-388adc416627)
- Finder Summary
![Finder Summary with note](https://github.com/user-attachments/assets/9b4fcd77-d702-4b34-b836-449d3d7e541e)
- Finder search results with metadata showing
![Finder search results with metadata](https://github.com/user-attachments/assets/9b956253-8353-4777-8240-875083979c65)
- British library number search (free text)
![BL free text search](https://github.com/user-attachments/assets/994c3b8b-1ece-4530-b614-5c344a185b31)
- Hearing officer facet (itself searchable)
![hearing officer search](https://github.com/user-attachments/assets/e6736604-c21e-41a7-8991-eddae8f2713e)
- Litigants free search test
![Litigants search](https://github.com/user-attachments/assets/bcafcd71-8b38-488e-89f1-aac29f7002f1)
- Decision date search
![decision search](https://github.com/user-attachments/assets/22e64735-3359-45cf-9d42-51f6123d2320)



[Trello](https://trello.com/c/aqI41ZNk/3615-ipo-design-decisions-finder)