### PR TITLE
Changes to UKHSA

### DIFF
--- a/lib/documents/schemas/ukhsa_data_access_approvals.json
+++ b/lib/documents/schemas/ukhsa_data_access_approvals.json
@@ -64,13 +64,20 @@
       "type": "text"
     },
     {
+      "allowed_values": [
+        {
+          "label": "Placeholder organisation",
+          "value": "placeholder-organisation"
+        }
+      ],
       "display_as_result_metadata": true,
-      "filterable": false,
-      "key": "ukhsa_applicant_organisation_name",
+      "filterable": true,
+      "key": "ukhsa_organisation_name",
       "name": "Applicant organisation name",
       "preposition": "Organisation",
       "short_name": "Organisation name",
       "specialist_publisher_properties": {
+        "select": "one",
         "validations": {
           "required": {}
         }
@@ -80,16 +87,16 @@
     {
       "allowed_values": [
         {
+        "label": "Academia (University)",
+        "value": "academia-university"
+        },
+        {
           "label": "Charity",
           "value": "charity"
         },
         {
           "label": "Commercial / Industry",
           "value": "commercial-industry"
-        },
-        {
-          "label": "Local authority",
-          "value": "local-authority"
         },
         {
           "label": "CQC Registered Health or/and Adult Social Care Provider",
@@ -100,12 +107,12 @@
           "value": "government-agency"
         },
         {
-          "label": "Public health agency",
-          "value": "public-health-agency"
+          "label": "Local authority",
+          "value": "local-authority"
         },
         {
-          "label": "Academia (University)",
-          "value": "academia-university"
+          "label": "Public health agency",
+          "value": "public-health-agency"
         },
         {
           "label": "Other",
@@ -133,8 +140,12 @@
           "value": "personally-identifiable"
         },
         {
-          "label": "De-personalised",
+          "label": "Depersonalised",
           "value": "depersonalised"
+        },
+        {
+          "label": "Anonymous",
+          "value": "anonymous"
         }
       ],
       "display_as_result_metadata": true,
@@ -451,7 +462,7 @@
   "filter": {
     "format": "ukhsa_data_access_approval"
   },
-  "name": "UKHSA Data Access Approvals Register",
+  "name": "Find out who is approved to access UKHSA data for research and other secondary uses",
   "organisations": [
     "80091cd8-7a8f-41ef-8faf-8af91fce4fdb"
   ],
@@ -460,6 +471,6 @@
   ],
   "show_summaries": true,
   "show_metadata_block": true,
-  "summary": "The Data Access Approvals Register sets out the organisations that the UK Health Security Agency (UKHSA) which have been approved to access protected data for specific secondary purposes, such as research, service evaluation, clinical audit, or surveillance. Access to UKHSA protected data is granted in line with the conditions and safeguards defined in the UKHSA's Data Access Approval Standards, ensuring data is used responsibly and securely. The register helps maintain transparency and accountability by providing a clear record of who has been granted permission to use UKHSA data.",
+  "summary": "The Data Access Approvals Register sets out the organisations that the UK Health Security Agency (UKHSA) which have been approved to access data for specific secondary purposes, such as research, service evaluation, clinical audit, or surveillance. Access to UKHSA protected data is granted in line with the conditions and safeguards defined in the UKHSA's Data Access Approval Standards, ensuring data is used responsibly and securely. The register helps maintain transparency and accountability by providing a clear record of who has been granted permission to use UKHSA data.",
   "target_stack": "draft"
 }

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -917,7 +917,7 @@ FactoryBot.define do
         {
           "ukhsa_approval_status" => "active",
           "ukhsa_access_type" => "file-transfer-to-organisation",
-          "ukhsa_applicant_organisation_name" => "Some organisation",
+          "ukhsa_organisation_name" => "placeholder-organisation",
           "ukhsa_applicant_organisation_type" => %w[public-health-agency],
           "ukhsa_classification_identification_risk" => "personally-identifiable",
           "ukhsa_dataset" => %w[childrens-hiv-and-aids-reporting-system-chars covid19-hospitalisation-in-england-surveillance-system-chess],


### PR DESCRIPTION
* Changed title to “Find out who is approved to access UKHSA data for research and other secondary uses”
* Org name - changed to a filterable set (with a placeholder value for now) - single select
* Alphabetical order for org type (but left other as last option)
* Changed classification values (add new, rename)
* Removed "protected" from summary
 

[Trello](https://trello.com/c/zubgVL1V/3569-specialist-finder-for-ukhsa-data-releases)
