### PR TITLE
Create finders index page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-card';
+@import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/textarea';
 
 @import "./components/govspeak-editor";

--- a/app/controllers/passthrough_controller.rb
+++ b/app/controllers/passthrough_controller.rb
@@ -1,15 +1,21 @@
 class PassthroughController < ApplicationController
-  after_action :skip_authorization
-
+  layout "design_system"
   def index
-    if first_permitted_format
-      redirect_to documents_path(document_type_slug: first_permitted_format.admin_slug)
+    if current_user.preview_design_system?
+      authorize current_user, :index?, policy_class: FinderAdministrationPolicy
     else
-      redirect_to error_path
+      skip_authorization
+      if first_permitted_format
+        redirect_to documents_path(document_type_slug: first_permitted_format.admin_slug)
+      else
+        redirect_to error_path
+      end
     end
   end
 
-  def error; end
+  def error
+    skip_authorization
+  end
 
 private
 

--- a/app/policies/finder_administration_policy.rb
+++ b/app/policies/finder_administration_policy.rb
@@ -10,6 +10,10 @@ class FinderAdministrationPolicy
 
   delegate :gds_editor?, to: :user
 
+  def index?
+    gds_editor?
+  end
+
   def can_request_new_finder?
     gds_editor?
   end

--- a/app/views/passthrough/index.html.erb
+++ b/app/views/passthrough/index.html.erb
@@ -1,0 +1,25 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: root_path
+      },
+    ]
+  } %>
+<% end %>
+<% content_for :page_title, "All finders" %>
+<% content_for :title, "All finders" %>
+
+<section id="finders-table-section">
+  <%= render "govuk_publishing_components/components/table", {
+    first_cell_is_header: true,
+    head: [
+      {
+        text: "Title"
+      },
+    ],
+    rows: formats_user_can_access.sort_by(&:title).map { |format| [{ text: format.title.pluralize }] }
+  } %>
+</section>

--- a/spec/controllers/passthrough_controller_spec.rb
+++ b/spec/controllers/passthrough_controller_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe PassthroughController, type: :controller do
+  render_views
+
+  let(:user) { FactoryBot.create(:gds_editor) }
+
+  context "when the user has permission to view the design system layout" do
+    it "renders the finders table" do
+      log_in_as_design_system_gds_editor
+      get :index
+      expect(response.status).to eq(200)
+      assert_select "#finders-table-section"
+    end
+  end
+end

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -61,6 +61,39 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
     end
   end
 
+  context "when logged in as a design system editor" do
+    before do
+      log_in_as_design_system_editor(:gds_editor)
+    end
+
+    it "has expected finders" do
+      visit "/"
+
+      expect(page).to have_text("AAIB Reports")
+      expect(page).to have_text("Asylum Support Decisions")
+      expect(page).to have_text("Business Finance Support Schemes")
+      expect(page).to have_text("CMA Cases")
+      expect(page).to have_text("Countryside Stewardship Grants")
+      expect(page).to have_text("Drug Safety Updates")
+      expect(page).to have_text("EAT Decisions")
+      expect(page).to have_text("ESI Funds")
+      expect(page).to have_text("ET Decisions")
+      expect(page).to have_text("EU Withdrawal Act 2018 statutory instruments")
+      expect(page).to have_text("Export health certificates")
+      expect(page).to have_text("International Development Funds")
+      expect(page).to have_text("Licences")
+      expect(page).to have_text("MAIB Reports")
+      expect(page).to have_text("Medical Safety Alerts")
+      expect(page).to have_text("Protected Geographical Food and Drink Name")
+      expect(page).to have_text("RAIB Reports")
+      expect(page).to have_text("Research for Development Outputs")
+      expect(page).to have_text("Residential Property Tribunal Decisions")
+      expect(page).to have_text("Service Standard Reports")
+      expect(page).to have_text("Tax Tribunal Decisions")
+      expect(page).to have_text("UTAAC Decisions")
+    end
+  end
+
   context "when logged in as a CMA editor" do
     before do
       stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))


### PR DESCRIPTION
This creates the basic route for the page and displays a basic list of finders using the GOV.UK table component. I want to refactor the routes to set up a finders resource route before I go any further, so I'm looking to merge this PR now so that there isn't an absolute mega PR once the feature is complete. The finders list is behind a feature flag, so users won't be able to see it in its incomplete state.

This depends on #3117, I will rebase it once the other PR has merged.

Here's what it looks like for now:

![Screenshot 2025-05-01 at 10 49 22](https://github.com/user-attachments/assets/9a6a7d09-11f6-458c-bb6e-1fd916750273)

Trello: https://trello.com/c/lRu3iVj3