### PR TITLE
Added a dartsass watch rake task which uses polling to detect SCSS changes

### DIFF
--- a/lib/tasks/dartsass.rake
+++ b/lib/tasks/dartsass.rake
@@ -1,0 +1,8 @@
+require "dartsass/runner"
+
+namespace :dartsass do
+  desc "Watch and build your Dart Sass CSS on file changes, using polling"
+  task watch_poll: :environment do
+    system(*Dartsass::Runner.dartsass_compile_command, "--watch", "--poll", exception: true)
+  end
+end


### PR DESCRIPTION
The default dartsass watch command does not seem to work from inside GOV.UK docker, at least on MacOS machines. Using the polling option to poll the filesystem for changes works. It's a bit slow but beats using `rails precompile:assets` every time we make a change
