### PR TITLE
Removed unused confirm action policy method aliases from document policy

### DIFF
--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -16,10 +16,8 @@ class DocumentPolicy < ApplicationPolicy
   end
   alias_method :summary?, :can_request_edits_to_finder?
   alias_method :edit_facets?, :can_request_edits_to_finder?
-  alias_method :confirm_facets?, :can_request_edits_to_finder?
   alias_method :update_facets?, :can_request_edits_to_finder?
   alias_method :edit_metadata?, :can_request_edits_to_finder?
-  alias_method :confirm_metadata?, :can_request_edits_to_finder?
   alias_method :update_metadata?, :can_request_edits_to_finder?
   alias_method :zendesk?, :can_request_edits_to_finder?
 


### PR DESCRIPTION
These were missed from #3119 
