### PR TITLE
Use the document list component to render the finder links on the finders index page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,9 +34,7 @@ private
   end
 
   def document_models
-    @document_models ||= FinderSchema.schema_names.map do |schema_name|
-      schema_name.singularize.camelize.constantize
-    end
+    @document_models ||= FinderSchema.document_models
   end
 
   def set_authenticated_user_header

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -298,6 +298,10 @@ class Document
     finder_schema.document_title
   end
 
+  def self.description
+    finder_schema.description
+  end
+
   def self.admin_slug
     title.parameterize.pluralize
   end

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -19,6 +19,12 @@ class FinderSchema
     new.from_json(File.read(Rails.root.join("lib/documents/schemas/#{type}.json")))
   end
 
+  def self.document_models
+    schema_names.map do |schema_name|
+      schema_name.singularize.camelize.constantize
+    end
+  end
+
   attribute :base_path
   attribute :beta
   attribute :beta_message

--- a/app/views/finders/index.html.erb
+++ b/app/views/finders/index.html.erb
@@ -12,14 +12,16 @@
 <% content_for :page_title, "All finders" %>
 <% content_for :title, "All finders" %>
 
-<section id="finders-table-section">
-  <%= render "govuk_publishing_components/components/table", {
-    first_cell_is_header: true,
-    head: [
+<section id="finders-list-section">
+  <%= render "govuk_publishing_components/components/document_list", {
+    items: formats_user_can_access.sort_by(&:title).map do |format|
       {
-        text: "Title"
-      },
-    ],
-    rows: formats_user_can_access.sort_by(&:title).map { |format| [{ text: format.title.pluralize }] }
+        link: {
+          text: format.title.pluralize,
+          path: finder_path(format.admin_slug),
+          description: format.description,
+        }
+      }
+    end
   } %>
 </section>

--- a/spec/controllers/finder_controller_spec.rb
+++ b/spec/controllers/finder_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FindersController, type: :controller do
       log_in_as_gds_editor
       get :index
       expect(response.status).to eq(200)
-      assert_select "#finders-table-section"
+      assert_select "#finders-list-section"
     end
   end
 

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -69,28 +69,12 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
     it "has expected finders" do
       visit "/"
 
-      expect(page).to have_text("AAIB Reports")
-      expect(page).to have_text("Asylum Support Decisions")
-      expect(page).to have_text("Business Finance Support Schemes")
-      expect(page).to have_text("CMA Cases")
-      expect(page).to have_text("Countryside Stewardship Grants")
-      expect(page).to have_text("Drug Safety Updates")
-      expect(page).to have_text("EAT Decisions")
-      expect(page).to have_text("ESI Funds")
-      expect(page).to have_text("ET Decisions")
-      expect(page).to have_text("EU Withdrawal Act 2018 statutory instruments")
-      expect(page).to have_text("Export health certificates")
-      expect(page).to have_text("International Development Funds")
-      expect(page).to have_text("Licences")
-      expect(page).to have_text("MAIB Reports")
-      expect(page).to have_text("Medical Safety Alerts")
-      expect(page).to have_text("Protected Geographical Food and Drink Name")
-      expect(page).to have_text("RAIB Reports")
-      expect(page).to have_text("Research for Development Outputs")
-      expect(page).to have_text("Residential Property Tribunal Decisions")
-      expect(page).to have_text("Service Standard Reports")
-      expect(page).to have_text("Tax Tribunal Decisions")
-      expect(page).to have_text("UTAAC Decisions")
+      document_models = FinderSchema.schema_names.map do |schema_name|
+        schema_name.singularize.camelize.constantize
+      end
+      document_models.each do |document_model|
+        expect(page).to have_link(document_model.title.pluralize, href: finder_path(document_model.admin_slug))
+      end
     end
   end
 

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -69,10 +69,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
     it "has expected finders" do
       visit "/"
 
-      document_models = FinderSchema.schema_names.map do |schema_name|
-        schema_name.singularize.camelize.constantize
-      end
-      document_models.each do |document_model|
+      FinderSchema.document_models.each do |document_model|
         expect(page).to have_link(document_model.title.pluralize, href: finder_path(document_model.admin_slug))
       end
     end


### PR DESCRIPTION
### What

Use the document list component to render the list of links to the finder summary pages.
Trello: https://trello.com/c/lRu3iVj3

### Screenshot

![Screenshot 2025-05-09 at 11 06 30 (2)](https://github.com/user-attachments/assets/278fcb47-e515-41ba-bffb-04f1ca7acff4)

Note that as per the discussion on the Trello card the design has changed from the design attached to the Trello card. The "updated" and "status" columns from the original design would require fetching information about finder editions from Publishing API, which we decided was adding a level of complexity that was not justified by the value of the additional columns. Having a table with one column didn't make sense, so we switched to the document list component.

As an aside, I don't particularly like the fact that the finders index route fetches the document models from the finder schema model only to reach back to the finder schema to access the information for the document list. We have to do this because the authorisation is applied to each document model individually in the `formats_user_can_access` method on the application controller. I did start exploring whether this could be refactored to use a [Pundit scope](https://github.com/varvet/pundit?tab=readme-ov-file#scopes), but the rest of the system is very tightly coupled to the authorisation layer and the refactor became unnacceptably effortful for a ticket of this size. I would like to revisit it at some point though. 
