### PR TITLE
Skip authorisation for finders index action

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,7 +1,7 @@
 class FindersController < ApplicationController
   layout "design_system"
   def index
-    authorize FinderSchema, :index?
+    skip_authorization
   end
 
   def new

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,27 +1,10 @@
 class ApplicationPolicy
-  attr_reader :user, :document_class
+  attr_reader :user, :record
 
-  def initialize(user, document_class)
+  def initialize(user, record)
     @user = user
-    @document_class = document_class
-  end
-
-  def user_organisation_owns_document_type?
-    document_class.schema_organisations.include?(user.organisation_content_id) ||
-      document_class.schema_editing_organisations.include?(user.organisation_content_id)
-  end
-
-  def departmental_editor?
-    user_organisation_owns_document_type? && user.permissions.include?("editor")
-  end
-
-  def writer?
-    user_organisation_owns_document_type?
+    @record = record
   end
 
   delegate :gds_editor?, to: :user
-
-  def document_type_editor?
-    user.permissions.include?("#{document_class.name.underscore}_editor")
-  end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -29,4 +29,23 @@ class DocumentPolicy < ApplicationPolicy
 
   alias_method :unpublish?, :publish?
   alias_method :discard?, :publish?
+
+private
+
+  def user_organisation_owns_document_type?
+    record.schema_organisations.include?(user.organisation_content_id) ||
+      record.schema_editing_organisations.include?(user.organisation_content_id)
+  end
+
+  def departmental_editor?
+    user_organisation_owns_document_type? && user.permissions.include?("editor")
+  end
+
+  def writer?
+    user_organisation_owns_document_type?
+  end
+
+  def document_type_editor?
+    user.permissions.include?("#{record.name.underscore}_editor")
+  end
 end

--- a/app/policies/finder_schema_policy.rb
+++ b/app/policies/finder_schema_policy.rb
@@ -1,8 +1,4 @@
 class FinderSchemaPolicy < ApplicationPolicy
-  def index?
-    document_type_editor? || gds_editor? || departmental_editor? || writer?
-  end
-
   def can_request_new_finder?
     gds_editor?
   end

--- a/spec/controllers/finder_controller_spec.rb
+++ b/spec/controllers/finder_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FindersController, type: :controller do
 
   describe "GET finder index page" do
     it "renders the finders index table" do
-      log_in_as_gds_editor
+      log_in_as FactoryBot.create(:writer)
       get :index
       expect(response.status).to eq(200)
       assert_select "#finders-list-section"


### PR DESCRIPTION
There's no need to authorize the finders index action, as all users should be able to view the list of finders scoped to their permission level. The index method on the finder schmea policy was failing for non GDS editor users because it was attempting to check the schema organisations for the finder schema class, when no such method exists.

To avoid reoccurrence of such issues in future I have moved any behaviour in the application policy which was in fact specific to documents into the document policy class.

Trello: https://trello.com/c/lRu3iVj3
