### PR TITLE
Provide design system implementation of documents index page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,7 @@ $govuk-page-width: 1140px;
 @import "./components/diff";
 
 @import "./govspeak-help";
+
+.bg-light-grey {
+  background-color: govuk-colour("light-grey");
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,6 +21,7 @@ class DocumentsController < ApplicationController
     end
     @response = current_format.all(page, per_page, query: @query, organisation: @organisation)
     @paged_documents = PaginationPresenter.new(@response, per_page)
+    render design_system_view(:index, "documents/legacy/index_legacy")
   end
 
   def new
@@ -95,7 +96,7 @@ class DocumentsController < ApplicationController
 private
 
   def get_layout
-    if %w[new create].include?(action_name) && current_user.preview_design_system?
+    if %w[new create index].include?(action_name) && current_user.preview_design_system?
       "design_system"
     else
       "legacy_application"

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -11,6 +11,16 @@ module OrganisationsHelper
     [["All organisations", "all"]].concat(organisations_options)
   end
 
+  def organisation_options_for_design_system(selected_organisation_content_id)
+    all_organisations.sort_by { |org| org.title.downcase.strip }.map do |organisation|
+      {
+        text: organisation.title,
+        value: organisation.content_id,
+        selected: organisation.content_id == selected_organisation_content_id,
+      }
+    end
+  end
+
   def selected_organisation_or_current(organisation)
     organisation.presence || current_user.organisation_content_id
   end

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -5,6 +5,12 @@ module StateHelper
     "label label-default"
   end
 
+  def design_system_classes_for_frontend(document)
+    return "govuk-tag govuk-tag--blue" if state_for_frontend(document) =~ /draft/
+
+    "govuk-tag govuk-tag--green"
+  end
+
   def state_for_frontend(document)
     compose_state(document.state_history.to_h)
   end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,57 +1,148 @@
-<%= content_for :page_title, current_format.title.pluralize %>
+<% content_for :page_title, "#{current_format.title} finder" %>
 
 <% content_for :breadcrumbs do %>
-  <li class='active'><%= current_format.title.pluralize %></li>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: "#{current_format.title} finder",
+        url: documents_path(current_format.admin_slug)
+      },
+    ]
+  } %>
 <% end %>
 
-<h1 class="page-header"><%= current_format.title.pluralize %></h1>
+<% content_for :title do %>
+  <%= "#{current_format.title} finder" %>
+<% end %>
 
-<div class="row">
-  <div class="col-md-12 text-right">
-    <p>
-      <% if current_format.target_stack == "draft" %>
-        <%= link_to "Preview draft (opens in new tab)", current_format.draft_url, target: "_blank" %>
-      <% elsif current_format.target_stack == "live" %>
-        <%= link_to "View on website (opens in new tab)", current_format.live_url, target: "_blank" %>
-      <% end %>
-    </p>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/inset_text", {} do %>
+  <% if current_format.target_stack == "draft" %>
+    <%= link_to "Preview draft (opens in new tab)", current_format.draft_url, class: "govuk-link", target: "_blank", rel: "noopener" %>
+  <% elsif current_format.target_stack == "live" %>
+    <%= link_to "View on website (opens in new tab)", current_format.live_url, class: "govuk-link", target: "_blank", rel: "noopener" %>
+  <% end %>
+<% end %>
 
-<div class="row">
-  <div class="sidebar col-md-3">
-    <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'action-link' %>
-    <hr>
-    <%= link_to "Finder setup", finder_path(current_format.admin_slug), class: 'action-link' %>
+<%= render "govuk_publishing_components/components/secondary_navigation", {
+  aria_label: "Finder navigation",
+  items: [
+    {
+      label: "Finder documents",
+      href: documents_path(params[:document_type_slug]),
+      current: true,
+    },
+    {
+      label: "Finder setup",
+      href: finder_path(current_format.admin_slug),
+    },
+  ]
+} %>
 
-    <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "add-vertical-margins well") do %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "govuk-!-padding-3 bg-light-grey") do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Filter by",
+        margin_bottom: 6,
+      } %>
+
       <% if current_format.has_organisations? %>
-        <%= label_tag "organisation", "Organisation" %>
-        <%= select_tag "organisation",
-              options_for_select(organisations_options_with_all, selected_organisation_or_current(@organisation)),
-              class: "select2 form-control add-bottom-margin" %>
+        <%= render "govuk_publishing_components/components/select", {
+          id: "filter-organisations",
+          label: "Organisations",
+          options: organisation_options_for_design_system(selected_organisation_or_current(@organisation))
+        } %>
       <% end %>
 
-      <%= label_tag "query", "Search" %>
-      <%= text_field_tag("query", @query, class: "form-control add-bottom-margin") %>
+      <%= render "govuk_publishing_components/components/input", {
+        type: "search",
+        label: {
+          text: "Title",
+        },
+        name: "query",
+        value: @query,
+        heading_level: 3,
+        heading_size: "s",
+      } %>
 
-      <%= submit_tag "Search", name: nil, class: "btn btn-default" %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Filter",
+        type: "submit",
+      } %>
+
+      <p class="govuk-!-margin-top-6">
+        <%= link_to "Clear all filters", documents_path(current_format.admin_slug), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
     <% end %>
     <% if current_format.exportable? %>
-      <%= link_to "Export document list to CSV", export_documents_path(current_format.admin_slug, query: @query) %>
+      <%= link_to "Export document list to CSV", export_documents_path(current_format.admin_slug, query: @query), class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>
   </div>
 
-  <div class="col-md-9">
+  <section class="govuk-grid-column-two-thirds" id="document-index-section">
+    <p class="govuk-body govuk-!-text-align-right govuk-!-margin-bottom-6">
+      <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'govuk-link' %>
+    </p>
     <% if !@paged_documents.empty? %>
-      <ul class="document-list">
-        <%= render partial: 'document', collection: @paged_documents %>
-      </ul>
-      <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
+      <%= render "govuk_publishing_components/components/table", {
+        first_cell_is_header: true,
+        head: [
+          {
+            text: "Title"
+          },
+          {
+            text: "Updated",
+          },
+          {
+            text: "Status",
+          },
+          {
+            text: tag.span("Link", class: "govuk-visually-hidden")
+          },
+        ],
+        rows: @paged_documents.map do |document|
+          [
+            {
+              text: document.title,
+            },
+            {
+              text: "Updated #{time_ago_in_words(document.last_edited_at)} ago",
+            },
+            {
+              text: tag.span(state_for_frontend(document).titleize, class: design_system_classes_for_frontend(document)),
+            },
+            {
+              text: link_to(
+                sanitize("View #{tag.span(document.title, class: "govuk-visually-hidden")}"),
+                document_path(current_format.admin_slug, content_id_and_locale: "#{document.content_id}:#{document.locale}"),
+                class: "govuk-link",
+                ),
+            },
+          ]
+        end
+      } %>
+
+      <%= render "govuk_publishing_components/components/previous_and_next_navigation", {
+        previous_page: ({
+          url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page - 1),
+          title: "Previous page",
+          label: "1 of #{@paged_documents.total_pages}",
+        } if @paged_documents.current_page > 1),
+        next_page: ({
+          url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page + 1),
+          title: "Next page",
+          label: "#{@paged_documents.current_page + 1} of #{@paged_documents.total_pages}",
+        } if @paged_documents.current_page < @paged_documents.total_pages)
+      }.compact %>
     <% elsif @query %>
-      <p class="no-content no-content-bordered">Your search – <%= @query %> – did not match any documents.</p>
+      <p class="govuk-body">Your filter – <%= @query %> – did not match any documents.</p>
     <% else %>
-      <p class="no-content no-content-bordered">No <%= current_format.title.pluralize %> available.</p>
+      <p class="govuk-body">No <%= current_format.title.pluralize %> available.</p>
     <% end %>
-  </div>
+  </section>
 </div>

--- a/app/views/documents/legacy/index_legacy.html.erb
+++ b/app/views/documents/legacy/index_legacy.html.erb
@@ -1,0 +1,57 @@
+<%= content_for :page_title, current_format.title.pluralize %>
+
+<% content_for :breadcrumbs do %>
+  <li class='active'><%= current_format.title.pluralize %></li>
+<% end %>
+
+<h1 class="page-header"><%= current_format.title.pluralize %></h1>
+
+<div class="row">
+  <div class="col-md-12 text-right">
+    <p>
+      <% if current_format.target_stack == "draft" %>
+        <%= link_to "Preview draft (opens in new tab)", current_format.draft_url, target: "_blank" %>
+      <% elsif current_format.target_stack == "live" %>
+        <%= link_to "View on website (opens in new tab)", current_format.live_url, target: "_blank" %>
+      <% end %>
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="sidebar col-md-3">
+    <%= link_to "Add another #{current_format.title}", new_document_path(current_format.admin_slug), class: 'action-link' %>
+    <hr>
+    <%= link_to "Finder setup", finder_path(current_format.admin_slug), class: 'action-link' %>
+
+    <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "add-vertical-margins well") do %>
+      <% if current_format.has_organisations? %>
+        <%= label_tag "organisation", "Organisation" %>
+        <%= select_tag "organisation",
+              options_for_select(organisations_options_with_all, selected_organisation_or_current(@organisation)),
+              class: "select2 form-control add-bottom-margin" %>
+      <% end %>
+
+      <%= label_tag "query", "Search" %>
+      <%= text_field_tag("query", @query, class: "form-control add-bottom-margin") %>
+
+      <%= submit_tag "Search", name: nil, class: "btn btn-default" %>
+    <% end %>
+    <% if current_format.exportable? %>
+      <%= link_to "Export document list to CSV", export_documents_path(current_format.admin_slug, query: @query) %>
+    <% end %>
+  </div>
+
+  <div class="col-md-9">
+    <% if !@paged_documents.empty? %>
+      <ul class="document-list">
+        <%= render partial: 'document', collection: @paged_documents %>
+      </ul>
+      <%= paginate @paged_documents, :theme => 'twitter-bootstrap-3' %>
+    <% elsif @query %>
+      <p class="no-content no-content-bordered">Your search – <%= @query %> – did not match any documents.</p>
+    <% else %>
+      <p class="no-content no-content-bordered">No <%= current_format.title.pluralize %> available.</p>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/searching_and_filtering_cma_cases_design_system.spec.rb
+++ b/spec/features/searching_and_filtering_cma_cases_design_system.spec.rb
@@ -1,0 +1,127 @@
+require "spec_helper"
+
+RSpec.feature "Searching and filtering", type: :feature do
+  let(:test_date) { Date.new(2016, 1, 11) }
+  let(:cma_cases) do
+    ten_example_cases = 10.times.collect do |n|
+      FactoryBot.create(
+        :cma_case,
+        "title" => "Example CMA Case #{n}",
+        "description" => "This is the summary of example CMA case #{n}",
+        "base_path" => "/cma-cases/example-cma-case-#{n}",
+        "publication_state" => "draft",
+        "last_edited_at" => (test_date - (n + 1).days).iso8601,
+        "public_updated_at" => (test_date - (10 - n).days).iso8601,
+      )
+    end
+    ten_example_cases[1]["publication_state"] = "published"
+    ten_example_cases[1]["state_history"] = { "1" => "published" }
+    ten_example_cases[2]["publication_state"] = "draft"
+    ten_example_cases[2]["state_history"] = { "1" => "published", "2" => "unpublished", "3" => "draft" }
+    ten_example_cases
+  end
+
+  before do
+    log_in_as_design_system_editor(:cma_editor)
+  end
+
+  scenario "visiting the index of a live finder has a link to 'view on website'" do
+    stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
+
+    visit "/cma-cases"
+
+    expect(page).to have_link("View on website (opens in new tab)", href: "http://www.dev.gov.uk/cma-cases")
+  end
+
+  scenario "visiting the index of a draft finder has a link to 'preview draft'" do
+    stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
+
+    allow(CmaCase).to receive(:target_stack).and_return("draft")
+
+    visit "/cma-cases"
+
+    expect(page).to have_link("Preview draft (opens in new tab)", href: "http://draft-origin.dev.gov.uk/cma-cases")
+  end
+
+  context "visiting the index with results" do
+    before do
+      stub_publishing_api_has_content(cma_cases, hash_including(document_type: CmaCase.document_type))
+    end
+
+    scenario "viewing the unfiltered items" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector("#document-index-section table tbody tr", count: 10)
+      expect(page).to have_content("Example CMA Case 0")
+      expect(page).to have_link("View Example CMA Case 0", href: document_path("cma-cases", content_id_and_locale: "#{cma_cases.first['content_id']}:en"))
+      expect(page).to have_content("Example CMA Case 1")
+      expect(page).to have_content("Example CMA Case 2")
+    end
+
+    scenario "viewing the publication state on the index page" do
+      visit "/cma-cases"
+
+      within("#document-index-section table tbody tr:nth-child(1)") do
+        expect(page).to have_content("DRAFT")
+      end
+
+      within("#document-index-section table tbody tr:nth-child(2)") do
+        expect(page).to have_content("PUBLISHED")
+      end
+
+      within("#document-index-section table tbody tr:nth-child(3)") do
+        expect(page).to have_content("UNPUBLISHED WITH NEW DRAFT")
+      end
+    end
+
+    scenario "viewing the last_edited_at field on the index page" do
+      Timecop.freeze(test_date) do
+        visit "/cma-cases"
+
+        within("#document-index-section table tbody tr:nth-child(1)") do
+          expect(page).to have_content("Updated 1 day ago")
+        end
+
+        within("#document-index-section table tbody tr:nth-child(10)") do
+          expect(page).to have_content("Updated 10 days ago")
+        end
+      end
+    end
+
+    scenario "filtering the items with some results returned" do
+      stub_publishing_api_has_content([cma_cases.first], hash_including(document_type: CmaCase.document_type, q: "0"))
+
+      visit "/cma-cases"
+
+      expect(page).not_to have_select("Organisation")
+
+      fill_in "Title", with: "0"
+      click_button "Filter"
+      expect(page).to have_content("Example CMA Case 0")
+      expect(page).to have_selector("#document-index-section table tbody tr", count: 1)
+    end
+
+    scenario "filtering the items with no results returned" do
+      stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type, q: "abcdef"))
+
+      visit "/cma-cases"
+      fill_in "Title", with: "abcdef"
+      click_button "Filter"
+      expect(page).to have_content("Your filter – abcdef – did not match any documents.")
+    end
+  end
+
+  context "visiting the index with no results" do
+    before do
+      stub_publishing_api_has_content([], hash_including(document_type: CmaCase.document_type))
+    end
+
+    scenario "viewing the unfiltered items" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("No CMA Cases available.")
+    end
+  end
+end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe OrganisationsHelper, type: :helper do
+  describe "#organisation_options_for_design_system" do
+    it "returns a sorted list of organisation hashes with the correct selected organisation" do
+      organisations = []
+      5.times do |n|
+        organisations.push(Organisation.new("title" => "Organisation #{n}", "content_id" => SecureRandom.uuid))
+      end
+      expect(Organisation).to receive(:all).and_return(organisations.shuffle)
+      selected_organisation = organisations.first
+
+      result = organisation_options_for_design_system(selected_organisation.content_id)
+      expected_result = organisations.map do |organisation|
+        {
+          text: organisation.title,
+          value: organisation.content_id,
+          selected: selected_organisation.content_id == organisation.content_id,
+        }
+      end
+      expect(result).to eq(expected_result)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/7cMAnBlD

## Screenshot

![Screenshot 2025-05-12 at 13 32 38 (2)](https://github.com/user-attachments/assets/69037f39-80d5-45d0-89ab-3a9a72dcbc0d)

One thing worth mentioning is that the GOV.UK Publishing Components library does not yet implement the full GOV.UK frontend pagination component. It would be preferable to implement the full pagination component if it becomes available in the future.


