### PR TITLE
Link to finder documents page instead of finder setup page from finders index

### DIFF
--- a/app/views/finders/index.html.erb
+++ b/app/views/finders/index.html.erb
@@ -18,7 +18,7 @@
       {
         link: {
           text: format.title.pluralize,
-          path: finder_path(format.admin_slug),
+          path: documents_path(format.admin_slug),
           description: format.description,
         }
       }

--- a/spec/features/selecting_a_finder_spec.rb
+++ b/spec/features/selecting_a_finder_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "The root specialist-publisher page", type: :feature do
       visit "/"
 
       FinderSchema.document_models.each do |document_model|
-        expect(page).to have_link(document_model.title.pluralize, href: finder_path(document_model.admin_slug))
+        expect(page).to have_link(document_model.title.pluralize, href: documents_path(document_model.admin_slug))
       end
     end
   end


### PR DESCRIPTION
Most users are more likely to want to go to the document list for a finder than they are to the schema configuration, so it makes sense to link to the documents page rather than the finder setup from the finders list.

Trello: https://trello.com/c/lRu3iVj3