### PR TITLE
Add the document list publishing component styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/checkboxes';
 @import 'govuk_publishing_components/components/date-input';
 @import 'govuk_publishing_components/components/details';
+@import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-alert';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';


### PR DESCRIPTION
The document list component is used on the finders index template, but we weren't adding the styles to the build. This should have been added in #3130 
