### PR TITLE
Change target stack to live for HMRC contacts finder

### DIFF
--- a/lib/documents/schemas/hmrc_contacts.json
+++ b/lib/documents/schemas/hmrc_contacts.json
@@ -136,5 +136,5 @@
   "show_table_of_contents": false,
   "show_metadata_block": false,
   "summary": "TBC",
-  "target_stack": "draft"
+  "target_stack": "live"
 }


### PR DESCRIPTION
This is so we can go live with the finder.