### PR TITLE
Fix some exceptions from generic testing

### DIFF
--- a/spec/features/creating_a_new_document_spec.rb
+++ b/spec/features/creating_a_new_document_spec.rb
@@ -6,7 +6,6 @@ EXCEPTIONS_TO_GENERAL_TESTING = %w[
   licence_transaction
   research_for_development_output
   statutory_instrument
-  marine_equipment_approved_recommendation
   protected_food_drink_name
 ].freeze
 
@@ -54,6 +53,9 @@ RSpec.feature "Creating a document", type: :feature do
           fill_in "#{document_type}[#{key}(3i)]", with: "01"
         elsif properties.key?("select")
           select facet["allowed_values"].first["label"], from: facet["name"], match: :first
+        elsif facet["key"] == "year_adopted"
+          # This is custom for marine_equipment_approved_recommendation
+          fill_in facet["name"], with: "2014"
         else
           fill_in facet["name"], with: "Example #{facet['name']}"
         end

--- a/spec/features/design_system/creating_a_new_document_design_system_spec.rb
+++ b/spec/features/design_system/creating_a_new_document_design_system_spec.rb
@@ -6,7 +6,6 @@ EXCEPTIONS_TO_GENERAL_TESTING = %w[
   licence_transaction
   research_for_development_output
   statutory_instrument
-  marine_equipment_approved_recommendation
   protected_food_drink_name
 ].freeze
 
@@ -52,6 +51,9 @@ RSpec.feature "Creating a document", type: :feature do
           fill_in "#{document_type}[#{key}(1i)]", with: "2014"
           fill_in "#{document_type}[#{key}(2i)]", with: "01"
           fill_in "#{document_type}[#{key}(3i)]", with: "01"
+        elsif facet["key"] == "year_adopted"
+          # This is custom for marine_equipment_approved_recommendation
+          fill_in facet["name"], with: "2014"
         elsif properties["select"] == "one"
           select facet["allowed_values"].first["label"], from: facet["name"], match: :first
         elsif properties["select"] == "multiple"


### PR DESCRIPTION
## Fix `marine_equipment`
Document type `marine_equipment_approved_recommendation` was excluded from generic testing because it was failing validations due to a custom text field that takes a year value.

Added a tiny bit of logic to deal with this case. This makes it more obvious that we're making use of such date variations (for future design system date component improvements), and it enables us to run the entire test suite for this document types, so we don't have gaps in coverage. 

## Note on `protected_food_drink_name`
`protected_food_drink_name` should have also been included in generic testing with a similar fix (it has a text field that takes a validated time value, similar to the above case). Nonetheless, for some reason it passes validation with no summary, thus breaking some tests. I tested in deployed environments too, it seems to be the case everywhere. Could not get to the bottom of it, so left it as an exception for now. Hope it gets fixed when migrating to DS.

![Screenshot 2025-05-19 at 15 28 11](https://github.com/user-attachments/assets/f310ee19-2e8f-498e-b85a-c407ffbea541)
