### PR TITLE
Migrate research for development output to design system

### DIFF
--- a/app/components/facet_input_component/single_select_component.html.erb
+++ b/app/components/facet_input_component/single_select_component.html.erb
@@ -5,11 +5,5 @@
   heading_size: "m",
   full_width: true,
   error_message: @error_message,
-  options: @allowed_values.inject([{}]) do |options, item|
-    options << {
-      text: item["label"],
-      value: item["value"],
-      selected: item["value"] == @document.send(@facet_key),
-    }
-  end,
+  options: @options,
 } %>

--- a/app/components/facet_input_component/single_select_component.rb
+++ b/app/components/facet_input_component/single_select_component.rb
@@ -1,12 +1,19 @@
 class FacetInputComponent::SingleSelectComponent < ViewComponent::Base
   include ErrorsHelper
 
-  def initialize(document, document_type, facet_key, facet_name, allowed_values)
+  def initialize(document, document_type, facet_key, facet_name, allowed_values, allow_blank_option: true)
     @document = document
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @allowed_values = allowed_values
+    allowed_values_to_options = allowed_values.map do |item|
+      {
+        text: item["label"],
+        value: item["value"],
+        selected: item["value"] == @document.send(@facet_key),
+      }
+    end
+    @options = allow_blank_option ? [{}] + allowed_values_to_options : allowed_values_to_options
     @error_message = errors_for_input(document.errors, facet_key)
   end
 end

--- a/app/helpers/legacy/research_for_development_outputs_helper.rb
+++ b/app/helpers/legacy/research_for_development_outputs_helper.rb
@@ -1,4 +1,4 @@
-module ResearchForDevelopmentOutputsHelper
+module Legacy::ResearchForDevelopmentOutputsHelper
   ##
   # Only exists here - rather than in the finder schema - because
   # specialist-frontend won't allow us to suppress any metadata that's

--- a/app/models/research_for_development_output.rb
+++ b/app/models/research_for_development_output.rb
@@ -1,5 +1,6 @@
 class ResearchForDevelopmentOutput < Document
   apply_validations
+  validates :review_status, presence: true
 
   FORMAT_SPECIFIC_FIELDS = format_specific_fields + [:review_status]
 

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -1,35 +1,24 @@
-<%= render layout: 'shared/form_group', locals: { f: f, field: :research_document_type, label: 'Document type' } do %>
-  <%=
-    f.select :research_document_type, select_options_for_facet(f.object.allowed_values(:research_document_type)),
-      { include_blank: true },
-      { class: 'select2', multiple: false, data: { placeholder: 'Select document type' } }
-  %>
-<% end %>
+<% finder_schema = f.object.class.finder_schema %>
+<%= render FacetInputComponent.new(@document, finder_schema.get_facet(:research_document_type)) %>
 
 <%= render layout: 'shared/form_group', locals: { f: f, field: :authors, label: 'Authors' } do %>
   <%= f.text_field :author_tags, class: 'form-control free-form-list', data: { placeholder: 'Add authors' } %>
 <% end %>
 
-<%= render layout: 'shared/form_group', locals: { f: f, field: :country, label: 'Countries' } do %>
-  <%=
-    f.select :country, select_options_for_facet(f.object.allowed_values(:country)),
-      { include_blank: true },
-      { class: 'select2', multiple: true, data: { placeholder: 'Select countries' } }
-  %>
-<% end %>
+<%= render FacetInputComponent.new(@document, finder_schema.get_facet(:country)) %>
+<%= render FacetInputComponent.new(@document, finder_schema.get_facet(:theme)) %>
+<%= render FacetInputComponent.new(@document, finder_schema.get_facet(:first_published_at)) %>
 
-<%= render layout: 'shared/form_group', locals: { f: f, field: :theme, label: 'Themes' } do %>
-  <%=
-    f.select :theme, select_options_for_facet(f.object.allowed_values(:theme)),
-             { include_blank: false },
-             { class: 'select2', multiple: true, data: { placeholder: 'Select themes' } }
-  %>
-<% end %>
-<%= render layout: "shared/legacy/date_fields_legacy", locals: { f: f, field: :first_published_at, format: :research_for_development_output } do %>
-<% end %>
-<% # TODO: this field prevents us moving to the shared view. It uses this weird 'ResearchForDevelopmentOutputsHelper' helper %>
-<%= render layout: 'shared/form_group', locals: { f: f, field: :review_status, label: 'Review status' } do %>
-  <%= f.select :review_status, review_status_options,
-    {},
-    { class: 'form-control' } %>
-<% end %>
+<% # TODO: this field prevents us moving to the shared view. It is not a schema listed facet %>
+<% review_status_options = [
+  {
+    "label" => "Unreviewed",
+    "value" => "unreviewed",
+  },
+  {
+    "label" => "Peer reviewed",
+    "value" => "peer-reviewed",
+  },
+] %>
+<%= render FacetInputComponent::SingleSelectComponent.new(@document, @document_type, :review_status, "Review status", review_status_options, allow_blank_option: false) %>
+

--- a/app/views/metadata_fields_legacy/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields_legacy/_research_for_development_outputs.html.erb
@@ -27,7 +27,7 @@
 <% end %>
 <%= render layout: "shared/legacy/date_fields_legacy", locals: { f: f, field: :first_published_at, format: :research_for_development_output } do %>
 <% end %>
-<% # TODO: this field prevents us moving to the shared view. It uses this weird 'ResearchForDevelopmentOutputsHelper' helper %>
+<% # TODO: this field prevents us moving to the shared view. It is not a schema listed facet %>
 <%= render layout: 'shared/form_group', locals: { f: f, field: :review_status, label: 'Review status' } do %>
   <%= f.select :review_status, review_status_options,
     {},

--- a/spec/features/design_system/creating_a_research_for_development_output_spec.rb
+++ b/spec/features/design_system/creating_a_research_for_development_output_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+
+RSpec.feature "Creating a Research for Development Output ", type: :feature do
+  let(:document) { FactoryBot.create(:research_for_development_output) }
+  let(:content_id) { document["content_id"] }
+  let(:document_type) { :research_for_development_output }
+  let(:document_model) { document_type.to_s.camelize.constantize }
+  let(:base_path) { "/#{document_model.admin_slug}" }
+  let(:new_document_path) { "#{base_path}/new" }
+  let(:schema) { document_model.finder_schema }
+
+  before do
+    log_in_as_design_system_editor(:gds_editor)
+    allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+    stub_publishing_api_has_content([document], hash_including(document_type: document_type.to_s))
+    stub_publishing_api_has_item(document)
+  end
+
+  scenario "creating a new document" do
+    visit base_path
+    click_link "Add another #{schema.document_title}"
+    expect(page.status_code).to eq(200)
+    expect(page.current_path).to eq(new_document_path)
+  end
+
+  scenario "saving a new document with no data" do
+    visit new_document_path
+    fill_in "Body", with: ""
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(422)
+
+    expect(page).to have_css(".govuk-error-message", text: "Title can't be blank")
+    expect(page).to have_css(".govuk-error-message", text: "Summary can't be blank")
+    expect(page).to have_css(".govuk-error-message", text: "Body can't be blank")
+
+    schema.facets.each do |facet|
+      properties = facet["specialist_publisher_properties"] || {}
+      validations = properties["validations"] || {}
+
+      next unless validations["required"]
+
+      error_regex = /#{facet['key'].humanize} can't be blank|#{facet['name']} can't be blank/
+      expect(page).to have_css(".gem-c-error-summary__list-item", text: error_regex)
+      expect(page).to have_css(".govuk-error-message", text: error_regex)
+    end
+  end
+
+  scenario "saving a new document with valid data", skip: "Skipped pending migration of the multiple select to the design system" do
+    visit new_document_path
+
+    fill_in "Title", with: "Example #{document_type.to_s.humanize}"
+    fill_in "Summary", with: "Example Summary"
+    fill_in "Body", with: "Example Body"
+
+    # TODO: fill in author - odd multiple select type, because it does not have allowed values; we do not currently have a component for this
+
+    # Custom fields
+    select "Unreviewed", from: "Review status"
+
+    schema.facets.each do |facet|
+      key = facet["key"]
+      properties = facet["specialist_publisher_properties"] || {}
+
+      if facet["type"] == "date"
+        fill_in "#{document_type}[#{key}(1i)]", with: "2014"
+        fill_in "#{document_type}[#{key}(2i)]", with: "01"
+        fill_in "#{document_type}[#{key}(3i)]", with: "01"
+      elsif properties["select"] == "one"
+        select facet["allowed_values"].first["label"], from: facet["name"], match: :first
+      elsif properties["select"] == "multiple"
+        select facet["allowed_values"].first["label"], from: "#{key}_0"
+      else
+        fill_in facet["name"], with: "Example #{facet['name']}"
+      end
+    end
+    expect(page).to have_css("div.govspeak-help")
+    expect(page).to have_content("To add an attachment, please save the draft first.")
+
+    click_button "Save as draft"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Created Example #{document_type.to_s.humanize}")
+  end
+end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -414,6 +414,7 @@ FactoryBot.define do
           "theme" => %w[infrastructure],
           "first_published_at" => "2016-04-28",
           "bulk_published" => true,
+          "review_status" => "unreviewed",
         }
       end
     end

--- a/spec/models/research_for_development_output_spec.rb
+++ b/spec/models/research_for_development_output_spec.rb
@@ -3,7 +3,6 @@ require "models/valid_against_schema"
 
 RSpec.describe ResearchForDevelopmentOutput do
   let(:payload) { FactoryBot.create(:research_for_development_output) }
-  include_examples "it saves payloads that are valid against the 'specialist_document' schema"
 
   it "is always bulk published to hide the publishing-api published date" do
     expect(subject.bulk_published).to be true


### PR DESCRIPTION
Testing:
- Custom model fields and validations are covered in `research_for_development_output_spec.rb`.
- Remove "valid against schema" checks from custom spec as is covered in `document_type_spec`.
- Feature test coverage: added custom test. Skipped tests waiting on multiple select migration to help figure out the "authors" field.

View:
- "Authors" is a weird facet type; we'll probably be better suited to migrate when we have the multiple select pulled in/better understood.
- "Review status" - opted to have it preselected ("unreviewed") by adding a default parameter to the single select component.
- Removed the helper in favour of adding the "Review status" options straight into the view.

Model:
- Added validation for "Review status" to match the view's behaviour

Note for future: it is a bit odd we're sending this "Review status" to Publishing API (it's in the schema there too), when it's only needed for SP internals.

[Trello](https://trello.com/c/Bl6vFuT4/3656-design-system-add-new-document-non-conforming-pages)
