### PR TITLE
Replace add another with multiple select

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "rails", "~> 8.0.2"
 
@@ -26,6 +27,7 @@ gem "multi_json"
 gem "plek"
 gem "pundit"
 gem "select2-rails", "< 4" # v4 changes the generated HTML and breaks the e2e tests
+gem "select_with_search_component", github: "alphagov/select-with-search-component"
 gem "sentry-sidekiq"
 gem "stringex"
 gem "terser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/alphagov/select-with-search-component.git
+  revision: 3fb9f71dc1d23cfaae0c21068c7c1a5a77451409
+  specs:
+    select_with_search_component (0.1.0)
+      govuk_publishing_components
+      rails (>= 8.0.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -885,6 +893,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   select2-rails (< 4)
+  select_with_search_component!
   sentry-sidekiq
   simplecov
   stringex

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,4 @@
 //= require components/autocomplete
 //= require components/govspeak-editor
 //= require components/paste-html-to-govspeak
+//= require select_with_search_component/application

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@ $govuk-page-width: 1140px;
 @import "./components/govspeak-editor";
 @import "./components/autocomplete";
 @import "./components/diff";
+@import "select_with_search_component/application";
 
 @import "./govspeak-help";
 @import "./summary";

--- a/app/components/facet_input_component/multi_select_component.html.erb
+++ b/app/components/facet_input_component/multi_select_component.html.erb
@@ -1,15 +1,12 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: @facet_name,
-  heading_level: 3,
-  font_size: "m",
-  margin_bottom: 4,
-} %>
-<%= render "govuk_publishing_components/components/add_another", {
-  fieldset_legend: @facet_name,
-  name: @facet_name.downcase,
+<%= render "components/select_with_search", {
+  label: @facet_name,
+  heading_size: "m",
   id: "#{@document_type}_#{@facet_key}",
-  add_button_text: "Add another #{@facet_name.downcase}",
-  margin_bottom: 6,
-  items: pre_selected_items,
-  empty: template_add_another(pre_selected_items.count),
+  name: "#{@document_type}[#{@facet_key}][]",
+  select: {
+    multiple: true
+  },
+  options: @options,
+  error_items: @error_items,
+  include_blank: true,
 } %>

--- a/app/components/facet_input_component/multi_select_component.rb
+++ b/app/components/facet_input_component/multi_select_component.rb
@@ -7,35 +7,19 @@ class FacetInputComponent::MultiSelectComponent < ViewComponent::Base
     @facet_key = facet_key
     @facet_name = facet_name
     @allowed_values = allowed_values
+    @error_items = errors_for(@document.errors, @facet_key)
+    @options = select_options
   end
 
-  def pre_selected_items
-    return [{ fields: template_add_another }] if @document.send(@facet_key).blank?
+  def select_options
+    selected_values = @document.send(@facet_key)
 
-    items = []
-    @document.send(@facet_key).each_with_index do |facet_value, index|
-      items << {
-        fields: template_add_another(index, facet_value),
+    @allowed_values.map do |item|
+      {
+        text: item["label"],
+        value: item["value"],
+        selected: selected_values&.include?(item["value"]),
       }
     end
-    items
-  end
-
-  def template_add_another(index = 0, value = nil)
-    render("govuk_publishing_components/components/select", {
-      id: "#{@facet_key}_#{index}",
-      name: "#{@document_type}[#{@facet_key}][]",
-      label: "Select a #{@facet_name.downcase}",
-      heading_size: "s",
-      full_width: true,
-      error_message: errors_for_input(@document.errors, @facet_key),
-      options: @allowed_values.inject([{}]) do |options, item|
-        options << {
-          text: item["label"],
-          value: item["value"],
-          selected: item["value"] == value,
-        }
-      end,
-    })
   end
 end

--- a/app/components/facet_input_component/organisation_multi_select_component.html.erb
+++ b/app/components/facet_input_component/organisation_multi_select_component.html.erb
@@ -1,0 +1,12 @@
+<%= render "components/select_with_search", {
+  label: @facet_name,
+  heading_size: "m",
+  id: "#{@document_type}_#{@facet_key}",
+  name: "#{@document_type}[#{@facet_key}][]",
+  select: {
+    multiple: true
+  },
+  options: @options,
+  error_items: @error_items,
+  include_blank: true,
+} %>

--- a/app/components/facet_input_component/organisation_multi_select_component.rb
+++ b/app/components/facet_input_component/organisation_multi_select_component.rb
@@ -1,0 +1,27 @@
+class FacetInputComponent::OrganisationMultiSelectComponent < ViewComponent::Base
+  include ErrorsHelper
+  include OrganisationsHelper
+
+  def initialize(document, document_type, facet_key, facet_name)
+    @document = document
+    @document_type = document_type
+    @facet_key = facet_key
+    @facet_name = facet_name
+    @error_items = errors_for(@document.errors, @facet_key)
+    @options = select_options
+  end
+
+  def select_options
+    selected_values = @document.send(@facet_key)
+
+    all_organisations
+      .sort_by { |org| org.title.downcase.strip }
+      .map do |organisation|
+      {
+        text: organisation.title,
+        value: organisation.content_id,
+        selected: selected_values&.include?(organisation.content_id),
+      }
+    end
+  end
+end

--- a/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
+++ b/app/views/metadata_fields/_flood_and_coastal_erosion_risk_management_research_reports.html.erb
@@ -3,5 +3,4 @@
 
 <% format_name = f.object.class.document_type.to_sym %>
 <%= render FacetInputComponent::OrganisationSingleSelectComponent.new(@document, format_name, :primary_publishing_organisation, "Publishing organisation", selected_organisation_or_current(@document.primary_publishing_organisation)) %>
-<!-- TODO to be migrated over -->
-<%= render FacetInputComponent::MultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations", organisation_select_options) %>
+<%= render FacetInputComponent::OrganisationMultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations") %>

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -6,8 +6,7 @@
 <% # TODO: find a way of making organisation management schema-driven %>
 <% format_name = f.object.class.finder_schema.filter["format"].to_sym %>
 <%= render FacetInputComponent::OrganisationSingleSelectComponent.new(@document, format_name, :primary_publishing_organisation, "Publishing organisation", selected_organisation_or_current(@document.primary_publishing_organisation)) %>
-<!-- TODO: to be migrated over -->
-<%= render FacetInputComponent::MultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations", organisation_select_options) %>
+<%= render FacetInputComponent::OrganisationMultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations") %>
 
 <%= render "govuk_publishing_components/components/fieldset", {
   legend_text: "How users apply",

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -14,8 +14,7 @@
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:subject)) %>
 
 <%= render FacetInputComponent::OrganisationSingleSelectComponent.new(@document, format_name, :primary_publishing_organisation, "Publishing organisation", selected_organisation_or_current(@document.primary_publishing_organisation)) %>
-<!-- TODO to be migrated over -->
-<%= render FacetInputComponent::MultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations", organisation_select_options) %>
+<%= render FacetInputComponent::OrganisationMultiSelectComponent.new(@document, format_name, :organisations, "Other associated organisations") %>
 
 <% # TODO: this bit of JS prevents us moving to the shared view %>
 <% content_for :document_ready do %>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "accessible-autocomplete-multiselect": "alphagov/accessible-autocomplete-multiselect",
+    "choices.js": "^11.1.0",
     "paste-html-to-govspeak": "^0.5.0"
   },
   "devDependencies": {

--- a/spec/features/design_system/creating_a_business_finance_support_scheme_spec.rb
+++ b/spec/features/design_system/creating_a_business_finance_support_scheme_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Creating a Business Finance Support Scheme", type: :feature do
       elsif properties["select"] == "one"
         select facet["allowed_values"].first["label"], from: facet["name"], match: :first
       elsif properties["select"] == "multiple"
-        select facet["allowed_values"].first["label"], from: "#{key}_0"
+        select facet["allowed_values"].first["label"], from: "#{document_type}[#{key}][]"
       else
         fill_in facet["name"], with: "Example #{facet['name']}"
       end

--- a/spec/features/design_system/creating_a_flood_and_coastal_erosion_risk_management_research_report_spec.rb
+++ b/spec/features/design_system/creating_a_flood_and_coastal_erosion_risk_management_research_report_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Creating a Flood and Coastal Erosion Risk Management Research Rep
       elsif properties["select"] == "one"
         select facet["allowed_values"].first["label"], from: facet["name"], match: :first
       elsif properties["select"] == "multiple"
-        select facet["allowed_values"].first["label"], from: "#{key}_0"
+        select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
       else
         fill_in facet["name"], with: "Example #{facet['name']}"
       end

--- a/spec/features/design_system/creating_a_flood_and_coastal_erosion_risk_management_research_report_spec.rb
+++ b/spec/features/design_system/creating_a_flood_and_coastal_erosion_risk_management_research_report_spec.rb
@@ -86,8 +86,8 @@ RSpec.feature "Creating a Flood and Coastal Erosion Risk Management Research Rep
 
     # Expect page to have preselected organisation if it's registered on the model
     expect(page).to have_content(organisation_name_for_authorized_user) if document["links"]["primary_publishing_organisation"]
-
-    # TODO: add the multiselect for :organisations field
+    # Select value for custom 'organisations' field
+    select organisation_name_for_authorized_user, from: "#{document_type}[organisations][]"
 
     click_button "Save as draft"
 

--- a/spec/features/design_system/creating_a_licence_spec.rb
+++ b/spec/features/design_system/creating_a_licence_spec.rb
@@ -99,8 +99,8 @@ RSpec.feature "Creating a Licence", type: :feature do
 
     # Expect page to have preselected organisation if it's registered on the model
     expect(page).to have_content(organisation_name_for_authorized_user) if document["links"]["primary_publishing_organisation"]
-
-    # TODO: add the multiselect for :organisations field
+    # Select value for custom 'organisations' field
+    select organisation_name_for_authorized_user, from: "#{document_type}[organisations][]"
 
     click_button "Save as draft"
 

--- a/spec/features/design_system/creating_a_licence_spec.rb
+++ b/spec/features/design_system/creating_a_licence_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Creating a Licence", type: :feature do
       elsif properties["select"] == "one"
         select facet["allowed_values"].first["label"], from: facet["name"], match: :first
       elsif properties["select"] == "multiple"
-        select facet["allowed_values"].first["label"], from: "#{key}_0"
+        select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
       else
         fill_in facet["name"], with: "Example #{facet['name']}"
       end

--- a/spec/features/design_system/creating_a_new_document_design_system_spec.rb
+++ b/spec/features/design_system/creating_a_new_document_design_system_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Creating a document", type: :feature do
         elsif properties["select"] == "one"
           select facet["allowed_values"].first["label"], from: facet["name"], match: :first
         elsif properties["select"] == "multiple"
-          select facet["allowed_values"].first["label"], from: "#{facet['key']}_0"
+          select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
         else
           fill_in facet["name"], with: "Example #{facet['name']}"
         end
@@ -131,7 +131,7 @@ RSpec.feature "Creating a document", type: :feature do
         elsif properties["select"] == "one"
           select facet["allowed_values"].first["label"], from: facet["name"], match: :first
         elsif properties["select"] == "multiple"
-          select facet["allowed_values"].first["label"], from: "#{facet['key']}_0"
+          select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
         else
           fill_in facet["name"], with: "Example #{facet['name']}"
         end
@@ -156,7 +156,7 @@ RSpec.feature "Creating a document", type: :feature do
         elsif properties["select"] == "one"
           expect(page).to have_select("#{document_type}[#{key}]", with_selected: facet["allowed_values"].first["label"])
         elsif properties["select"] == "multiple"
-          expect(page).to have_select("#{facet['key']}_0", with_selected: facet["allowed_values"].first["label"])
+          expect(page).to have_select("#{document_type}[#{facet['key']}][]", with_selected: facet["allowed_values"].first["label"])
         else
           expect(page).to have_field("#{document_type}[#{key}]", with: "Example #{facet['name']}")
         end

--- a/spec/features/design_system/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/design_system/creating_a_statutory_instrument_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
       elsif properties["select"] == "one"
         select facet["allowed_values"].first["label"], from: facet["name"], match: :first
       elsif properties["select"] == "multiple"
-        select facet["allowed_values"].first["label"], from: "#{key}_0"
+        select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
       else
         fill_in facet["name"], with: "Example #{facet['name']}"
       end

--- a/spec/features/design_system/creating_a_statutory_instrument_spec.rb
+++ b/spec/features/design_system/creating_a_statutory_instrument_spec.rb
@@ -84,8 +84,8 @@ RSpec.feature "Creating a Statutory Instrument", type: :feature do
 
     # Expect page to have preselected organisation if it's registered on the model
     expect(page).to have_content(organisation_name_for_authorized_user) if document["links"]["primary_publishing_organisation"]
-
-    # TODO: add the multiselect for :organisations field
+    # Select value for custom 'organisations' field
+    select organisation_name_for_authorized_user, from: "#{document_type}[organisations][]"
 
     click_button "Save as draft"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,15 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   languageName: node
   linkType: hard
 
+"choices.js@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "choices.js@npm:11.1.0"
+  dependencies:
+    fuse.js: ^7.0.0
+  checksum: 8e6438568ef6b5a280a10952650a76c0bdf587ac3b0ec1c036fcaef4431a295922fa2da4deabad61020616e1101ec533b055a5ecb200c5c86c64d8bfeb9a79ae
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
@@ -1418,6 +1427,13 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   version: 1.0.1
   resolution: "functional-red-black-tree@npm:1.0.1"
   checksum: ca6c170f37640e2d94297da8bb4bf27a1d12bea3e00e6a3e007fd7aa32e37e000f5772acf941b4e4f3cf1c95c3752033d0c509af157ad8f526e7f00723b9eb9f
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: e0c7d6833d336f9facd9359a888170b90c418b2f46c6cb389fd7dbc708712a2d1c5f30b5fea13b634a090a21f69d746eb0ceaff545b11ca088d3e5058c2a8e15
   languageName: node
   linkType: hard
 
@@ -3294,6 +3310,7 @@ accessible-autocomplete-multiselect@alphagov/accessible-autocomplete-multiselect
   resolution: "specialist-publisher@workspace:."
   dependencies:
     accessible-autocomplete-multiselect: alphagov/accessible-autocomplete-multiselect
+    choices.js: ^11.1.0
     jasmine-browser-runner: ^3.0.0
     jasmine-core: ^5.4.0
     paste-html-to-govspeak: ^0.5.0


### PR DESCRIPTION
Replace add another usage with select with search (multiple), in:
- Facets
- Custom/non-conforming `:organisations` field.

![Screenshot 2025-06-06 at 13 27 56](https://github.com/user-attachments/assets/683dc60e-c440-4ac8-ae43-7de647676b3f)

<img width="615" alt="Screenshot 2025-06-06 at 17 17 54" src="https://github.com/user-attachments/assets/a46793e1-6605-4c7c-84b8-4aeb3ad02f3e" />



[Trello](https://trello.com/c/pTuNpxzZ/3742-design-system-add-new-document-replace-add-another-component-with-select-with-search-multiple-variant)