### PR TITLE
Fix single select for organisations

### DIFF
--- a/app/components/facet_input_component/organisation_single_select_component.rb
+++ b/app/components/facet_input_component/organisation_single_select_component.rb
@@ -2,12 +2,12 @@ class FacetInputComponent::OrganisationSingleSelectComponent < ViewComponent::Ba
   include ErrorsHelper
   include OrganisationsHelper
 
-  def initialize(document, document_type, facet_key, facet_name, _selected_organisation_content_id)
+  def initialize(document, document_type, facet_key, facet_name, selected_organisation_content_id)
     @document = document
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
     @error_message = errors_for_input(document.errors, facet_key)
-    @options = organisation_select_options(selected_organisation: nil)
+    @options = organisation_select_options(selected_organisation_content_id)
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,17 +1,17 @@
 module OrganisationsHelper
   def organisation_select_options_with_all(selected_organisation: nil)
-    organisation_select_options(selected_organisation:)
+    organisation_select_options(selected_organisation)
       .prepend({ text: "All organisations", value: "all", selected: false })
   end
 
-  def organisation_select_options(selected_organisation: nil)
+  def organisation_select_options(selected_organisation_content_id)
     all_organisations
       .sort_by { |org| org.title.downcase.strip }
       .map do |organisation|
         {
           text: organisation.title,
           value: organisation.content_id,
-          selected: organisation.content_id == selected_organisation,
+          selected: organisation.content_id == selected_organisation_content_id,
         }
       end
   end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OrganisationsHelper, type: :helper do
       expect(Organisation).to receive(:all).and_return(organisations.shuffle)
       selected_organisation = organisations.first
 
-      result = organisation_select_options(selected_organisation: selected_organisation.content_id)
+      result = organisation_select_options(selected_organisation.content_id)
       expected_result = organisations.map do |organisation|
         {
           text: organisation.title,


### PR DESCRIPTION
The `organisation_select_options` method should have always received the value of the selected organisation passed in the `OrganisationSingleSelectComponent`.

Also changed the signature of the `organisation_select_options` so that the selected organisation is not optional - it should always be passed in. 

Saving the organisation
> ![Screenshot 2025-06-09 at 09 33 02](https://github.com/user-attachments/assets/96c0453c-a3a1-4771-b38f-9e56995e0902)

Before - on validation error (it defaults to first option in the list)
> ![Screenshot 2025-06-09 at 09 34 06](https://github.com/user-attachments/assets/2fd156c9-9549-455d-9a9e-ac145b4012f8)

> After - on validation error (persists selection)
![Screenshot 2025-06-09 at 09 34 28](https://github.com/user-attachments/assets/7eeb64ee-e078-4b90-9021-fe69049115b0)

[Trello](https://trello.com/c/pTuNpxzZ/3742-design-system-add-new-document-replace-add-another-component-with-select-with-search-multiple-variant)