### PR TITLE
Fix error summary link to multiselect

### DIFF
--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,6 +1,7 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/skip-link

--- a/app/components/facet_input_component/multi_select_component.html.erb
+++ b/app/components/facet_input_component/multi_select_component.html.erb
@@ -9,4 +9,5 @@
   options: @options,
   error_items: @error_items,
   include_blank: true,
+  full_width: true,
 } %>


### PR DESCRIPTION
Due to a missing import for error summary, the links to a multiselect error were not working.

[Trello](https://trello.com/c/pTuNpxzZ/3742-design-system-add-new-document-replace-add-another-component-with-select-with-search-multiple-variant)