### PR TITLE
[Design System] Publishing Flow

### DIFF
--- a/app/components/sidebar_actions_component.rb
+++ b/app/components/sidebar_actions_component.rb
@@ -19,16 +19,8 @@ class SidebarActionsComponent < ViewComponent::Base
   end
 
   def notices
-    notices = []
-
-    notices << notice("Publishing", @presenter.publish_text) if @presenter.publish_button_visible?
-
-    notices << notice("Unpublishing", @presenter.unpublish_text)
-
-    return unless notices
-
     render("govuk_publishing_components/components/inset_text", {
-      text: notices.join("<br>").html_safe,
+      text: notice("Unpublishing", @presenter.unpublish_text).html_safe,
     })
   end
 
@@ -52,7 +44,7 @@ private
     render("govuk_publishing_components/components/button", {
       text: "Publish document",
       title: "Publish #{@document.title}",
-      href: "#",
+      href: @presenter.confirm_publish_path,
     })
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,7 +7,7 @@ class DocumentsController < ApplicationController
   include OrganisationsHelper
 
   layout :get_layout
-  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show].freeze
+  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show confirm_publish].freeze
   include DesignSystemHelper
 
   before_action :fetch_document, except: %i[index new create]
@@ -67,6 +67,8 @@ class DocumentsController < ApplicationController
       re_render :edit, flash_key: :errors, flash_message: document_error_messages, status: :unprocessable_entity
     end
   end
+
+  def confirm_publish; end
 
   def publish
     if @document.publish

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -26,6 +26,7 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   alias_method :unpublish?, :publish?
+  alias_method :confirm_publish?, :publish?
   alias_method :discard?, :publish?
 
 private

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -18,6 +18,25 @@ class ActionsPresenter
   end
 
   def publish_text
+    if update_type == "minor"
+      safe_join([
+        tag.p("You are about to publish a minor edit."),
+        tag.p("Are you sure you want to publish this document?"),
+      ])
+    elsif update_type == "major" && !document.first_draft?
+      safe_join([
+        tag.p("You are about to publish a major edit with a public change note. Publishing will email subscribers to #{klass_name}."),
+        tag.p("Are you sure you want to publish this document?"),
+      ])
+    else
+      safe_join([
+        tag.p("Publishing will email subscribers to #{klass_name}."),
+        tag.p("Are you sure you want to publish this document?"),
+      ])
+    end
+  end
+
+  def publish_text_legacy
     if state == "published"
       "There are no changes to publish."
     elsif state == "unpublished"
@@ -45,6 +64,10 @@ class ActionsPresenter
     else
       "Publishing will email subscribers to #{document.class.title.pluralize}. Continue?"
     end
+  end
+
+  def confirm_publish_path
+    confirm_publish_document_path(slug, document.content_id_and_locale)
   end
 
   def publish_path

--- a/app/views/documents/confirm_publish.html.erb
+++ b/app/views/documents/confirm_publish.html.erb
@@ -1,0 +1,54 @@
+<% page_title = "Publish #{current_format.title}" %>
+<% presenter = ActionsPresenter.new(@document, policy(@document.class)) %>
+
+<%= content_for :page_title, page_title %>
+<% content_for :title, page_title %>
+<% content_for :context, @document.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: current_format.title.pluralize,
+        url: documents_path(current_format.admin_slug)
+      },
+      {
+        title: @document.title,
+        url: document_path(current_format.admin_slug, @document.content_id_and_locale)
+      },
+      {
+        title: "Publish"
+      }
+    ]
+  } %>
+<% end %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-body govuk-!-margin-bottom-8">
+      <%= presenter.publish_text %>
+    </div>
+
+    <%= form_tag(presenter.publish_path,
+                 method: :post,
+                 data: { gtm: "confirm-publish" }) do %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Publish"
+        } %>
+        <%= link_to "Cancel",
+                    document_path(current_format.admin_slug, @document.content_id_and_locale),
+                    class: "govuk-link govuk-link--no-visited-state app-link--inline",
+                    data: { gtm: "cancel-publish" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/legacy/_actions_legacy.html.erb
+++ b/app/views/documents/legacy/_actions_legacy.html.erb
@@ -11,7 +11,7 @@
     <%= form_tag(presenter.publish_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Publish document</h3></div>
       <div class="panel-body">
-        <%= content_tag(:p, presenter.publish_text) %>
+        <%= content_tag(:p, presenter.publish_text_legacy) %>
 
         <% if presenter.publish_button_visible? %>
           <button name="submit" class="btn btn-danger"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,10 @@ Rails.application.routes.draw do
     resources :attachments, param: :attachment_content_id, except: %i[index show]
 
     post :unpublish, on: :member
+
+    get :confirm_publish, on: :member
     post :publish, on: :member
+
     post :discard, on: :member
   end
 

--- a/spec/components/sidebar_actions_component_spec.rb
+++ b/spec/components/sidebar_actions_component_spec.rb
@@ -1,0 +1,187 @@
+require "rails_helper"
+
+RSpec.describe SidebarActionsComponent, type: :component do
+  describe "edit button" do
+    it "should show on draft document" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Edit document")
+    end
+
+    it "should show on published document" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Edit document")
+    end
+
+    it "should show on published with draft document" do
+      content_item = FactoryBot.create(:cma_case, :redrafted, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Edit document")
+    end
+
+    it "should show on unpublished document" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Edit document")
+    end
+  end
+
+  describe "publish button" do
+    it "should show on draft document" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Publish document")
+    end
+
+    it "should not show on published document" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Publish document")
+    end
+
+    it "should show on published with draft document" do
+      content_item = FactoryBot.create(:cma_case, :redrafted, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Publish document")
+    end
+
+    it "should not show on unpublished document" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Publish document")
+    end
+
+    it "should not show when user not allowed to publish" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Publish document")
+    end
+  end
+
+  describe "unpublish button and text" do
+    it "should not show on draft document" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Unpublish document")
+      expect(page).to have_text("The document has never been published.")
+    end
+
+    it "should show on published document" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Unpublish document")
+      expect(page).to have_text("The document will be removed from the site. It will still be possible to edit and publish a new version.")
+    end
+
+    it "should not show on published with draft document" do
+      content_item = FactoryBot.create(:cma_case, :redrafted, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Unpublish document")
+      expect(page).to have_text("The document cannot be unpublished because it has a draft. You need to publish the draft first.")
+    end
+
+    it "should not show on unpublished document" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Unpublish document")
+      expect(page).to have_text("The document is already unpublished.")
+    end
+
+    it "should not show when user not allowed to unpublish" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Unpublish document")
+      expect(page).to have_text("You don't have permission to unpublish this document.")
+    end
+  end
+
+  describe "discard draft link" do
+    it "should show on draft document" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Delete draft")
+    end
+
+    it "should not show on published document" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Delete draft")
+    end
+
+    it "should show on published with draft document" do
+      content_item = FactoryBot.create(:cma_case, :redrafted, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_link("Delete draft")
+    end
+
+    it "should not show on unpublished document" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Delete draft")
+    end
+
+    it "should not show when user not allowed to discard draft" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_link("Delete draft")
+    end
+  end
+end

--- a/spec/features/design_system/publishing_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/publishing_a_cma_case_design_system_spec.rb
@@ -1,0 +1,223 @@
+require "spec_helper"
+
+RSpec.feature "Publishing a CMA case", type: :feature do
+  let(:content_id) { item["content_id"] }
+  let(:publish_alert_message) { page.find_button("Publish")["data-message"] }
+  let(:publish_disable_with_message) { page.find_button("Publish")["data-disable-with"] }
+
+  before do
+    Timecop.freeze(Time.zone.parse("2015-12-03T16:59:13+00:00"))
+    log_in_as_design_system_editor(:cma_editor)
+
+    stub_publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
+    stub_publishing_api_has_item(item)
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+    stub_publishing_api_publish(content_id, {})
+    stub_email_alert_api_accepts_content_change
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context "when the document is a new draft" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        title: "Example CMA Case",
+        base_path: "/cma-cases/example-cma-case",
+        public_updated_at: "2015-11-16T11:53:30+00:00",
+        publication_state: "draft",
+      )
+    end
+
+    let(:published_item) do
+      FactoryBot.create(
+        :cma_case,
+        :published,
+        content_id:,
+        title: "Example CMA Case",
+        base_path: "/cma-cases/example-cma-case",
+        public_updated_at: "2015-11-16T11:53:30+00:00",
+      )
+    end
+
+    scenario "from the index" do
+      visit "/cma-cases"
+      expect(page.status_code).to eq(200)
+
+      click_link "Example CMA Case"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Example CMA Case")
+
+      stub_publishing_api_has_item_in_sequence(content_id, [item, published_item])
+
+      expect(AttachmentRestoreWorker).not_to receive(:perform_async)
+
+      click_link "Publish document"
+      expect(page.status_code).to eq(200)
+      click_button "Publish"
+      expect(page).to have_content("Published Example CMA Case")
+
+      changed_json = { "change_note" => "First published." }
+
+      assert_publishing_api_put_content(content_id, request_json_includes(changed_json))
+
+      assert_publishing_api_publish(content_id)
+      assert_email_alert_api_content_change_created
+    end
+  end
+
+  context "when there is a redrafted document with a major update" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        :redrafted,
+        title: "Major Update Case",
+      )
+    end
+
+    scenario "adds a change note" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+
+      click_link "Major Update Case"
+      expect(page.status_code).to eq(200)
+
+      click_link "Edit document"
+
+      fill_in "Title", with: "Changed title"
+      choose "Major"
+      fill_in "Change note", with: "Updated change note"
+
+      click_button "Save as draft"
+
+      assert_publishing_api_put_content(
+        content_id,
+        lambda { |request|
+          payload = JSON.parse(request.body)
+
+          expect(payload["title"]).to eq("Changed title")
+          expect(payload["update_type"]).to eq("major")
+          expect(payload["change_note"]).to eq("Updated change note")
+        },
+      )
+    end
+  end
+
+  context "when there is a redrafted document with a minor update" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        :redrafted,
+        title: "Minor Update Case",
+        update_type: "minor",
+      )
+    end
+
+    scenario "alerts should not be sent when the item is published" do
+      visit "/cma-cases"
+
+      expect(page.status_code).to eq(200)
+
+      click_link "Minor Update Case"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Minor Update Case")
+
+      click_link "Publish document"
+      expect(page.status_code).to eq(200)
+      click_button "Publish"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Published Minor Update Case")
+
+      assert_publishing_api_publish(content_id)
+
+      assert_not_requested(:post, "#{Plek.find('email-alert-api')}/notifications")
+    end
+  end
+
+  context "when the document is unpublished with new draft" do
+    let(:content_id) { item["content_id"] }
+
+    let(:existing_attachments) { [] }
+
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        :unpublished,
+        title: "Example CMA Case",
+        publication_state: "draft",
+        state_history: { "1" => "unpublished", "2" => "draft" },
+        details: { attachments: existing_attachments },
+      )
+    end
+
+    before do
+      log_in_as_design_system_editor(:cma_editor)
+
+      stub_publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
+      stub_publishing_api_has_item(item)
+
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+      stub_publishing_api_publish(content_id, {})
+      stub_email_alert_api_accepts_content_change
+
+      visit "/cma-cases/#{content_id}"
+    end
+
+    context "a new draft of a previously unpublished document with attachments" do
+      let(:existing_attachments) do
+        [
+          {
+            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+            "content_type" => "application/jpeg",
+            "title" => "asylum report image title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00",
+          },
+          {
+            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+            "content_type" => "application/pdf",
+            "title" => "asylum report pdf title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00",
+          },
+        ]
+      end
+
+      describe "#publish" do
+        it "restores the assets via the asset api" do
+          expect(Services.asset_api).to receive(:restore_asset).once.ordered
+                                                               .with("513a0efbed915d425e000002")
+          expect(Services.asset_api).to receive(:restore_asset).once.ordered
+                                                               .with("513a0efbed915d425e000004")
+
+          Sidekiq::Testing.inline! do
+            click_on "Publish document"
+            click_on "Publish"
+          end
+        end
+      end
+    end
+
+    context "a new draft of a previously unpublished document without attachments" do
+      describe "#publish" do
+        it "doesn't call the asset api" do
+          expect(Services.asset_api).not_to receive(:restore_asset)
+
+          Sidekiq::Testing.inline! do
+            click_on "Publish document"
+            click_on "Publish"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -42,39 +42,56 @@ RSpec.describe ActionsPresenter do
   end
 
   describe "publish_text" do
-    specify { expect(subject.publish_text).to include("will email subscribers") }
-    specify { expect(subject.publish_text).not_to include("major edit") }
+    context "when the document is a new draft" do
+      let(:payload) { FactoryBot.create(:cma_case, :draft) }
+      specify { expect(subject.publish_text).to eq("<p>Publishing will email subscribers to CMA Cases.</p><p>Are you sure you want to publish this document?</p>") }
+    end
+
+    context "when the document is redrafted" do
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
+      specify { expect(subject.publish_text).to eq("<p>You are about to publish a major edit with a public change note. Publishing will email subscribers to CMA Cases.</p><p>Are you sure you want to publish this document?</p>") }
+    end
+
+    context "when the document is redrafted and the update_type is minor" do
+      let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
+      specify { expect(subject.publish_text).to eq("<p>You are about to publish a minor edit.</p><p>Are you sure you want to publish this document?</p>") }
+    end
+  end
+
+  describe "publish_text_legacy" do
+    specify { expect(subject.publish_text_legacy).to include("will email subscribers") }
+    specify { expect(subject.publish_text_legacy).not_to include("major edit") }
 
     context "when the user does not have editor permissions" do
       let(:user) { FactoryBot.create(:cma_writer) }
-      specify { expect(subject.publish_text).to include("don't have permission to publish") }
+      specify { expect(subject.publish_text_legacy).to include("don't have permission to publish") }
     end
 
     context "when the document is already published" do
       let(:payload) { FactoryBot.create(:cma_case, :published) }
-      specify { expect(subject.publish_text).to include("no changes") }
+      specify { expect(subject.publish_text_legacy).to include("no changes") }
 
       context "and the update_type is republish" do
         let(:payload) { FactoryBot.create(:cma_case, :published, update_type: "republish") }
-        specify { expect(subject.publish_text).to include("no changes") }
+        specify { expect(subject.publish_text_legacy).to include("no changes") }
       end
     end
 
     context "when the document is unpublished" do
       let(:payload) { FactoryBot.create(:cma_case, :unpublished) }
-      specify { expect(subject.publish_text).to include("create a new draft") }
+      specify { expect(subject.publish_text_legacy).to include("create a new draft") }
     end
 
     context "when the document is redrafted" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
-      specify { expect(subject.publish_text).to include("major edit") }
-      specify { expect(subject.publish_text).to include("will email subscribers") }
+      specify { expect(subject.publish_text_legacy).to include("major edit") }
+      specify { expect(subject.publish_text_legacy).to include("will email subscribers") }
     end
 
     context "when the document is redrafted and the update_type is minor" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
-      specify { expect(subject.publish_text).to include("minor edit") }
-      specify { expect(subject.publish_text).not_to include("will email subscribers") }
+      specify { expect(subject.publish_text_legacy).to include("minor edit") }
+      specify { expect(subject.publish_text_legacy).not_to include("will email subscribers") }
     end
   end
 


### PR DESCRIPTION
Added interstitial page for publishing a document. 

- Publishing page contains text depending on the state of the document
- This text has been moved from the sidebar into the interstitial page as discussed in [previous PR](https://github.com/alphagov/specialist-publisher/pull/3180).
- Figma Design has all the text on the same line, but I've added a break to separate the confirmation question from the explanation of the impact. 

Publishing confirmation for new draft: 
![Screenshot 2025-06-11 at 10 26 47](https://github.com/user-attachments/assets/37ce23ec-82cd-4da2-9716-d94ded66aeb0)

Publishing confirmation for published with new draft (major update):
![Screenshot 2025-06-11 at 10 20 00](https://github.com/user-attachments/assets/e51476c2-9ef9-4694-a724-66c0dc7b9bc4)

Publishing confirmation for published with new draft (minor update):
![Screenshot 2025-06-11 at 10 22 38](https://github.com/user-attachments/assets/8f55264f-e9bd-4a82-a8d0-f4288e4eb26e)

Sidebar: 
![Screenshot 2025-06-11 at 10 27 03](https://github.com/user-attachments/assets/cebc014b-8dd9-4c67-8e38-dd608ff0360d)


QA Note 

- Even if the publishing button doesn't show (e.g. unpublished document, published document), there's nothing stopping the user from navigating to the `/confirm_publish` part of the document link and clicking publish. This is currently returning the following error so there's no broken flow, but is not super user friendly. As it's not a valid user flow, only happens if users force going to the URL, and it does not introduce any bugs, feel like we can descope handling of this case from this PR/ticket. There may be a wider discussion to have about how to handle more granular authorisation and status checks for controller methods in Specialist Publisher.

![Screenshot 2025-06-11 at 11 03 46](https://github.com/user-attachments/assets/d291fc12-6af7-40a4-8843-c5aec839249c)


https://trello.com/c/TnRzQDr5/3796-design-system-publishing-flow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
