### PR TITLE
Selects with a multiple attribute should show several options (no JS)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,3 +41,7 @@ $govuk-page-width: 1140px;
 .bg-light-grey {
   background-color: govuk-colour("light-grey");
 }
+
+.govuk-select[multiple] {
+  height: auto;
+}


### PR DESCRIPTION
## What

When JS is unavailable, `select` elements with a `multiple` attribute should have their height increased to show more options than are currently displayed. [Trello](https://trello.com/c/6mkl64lT/3744-design-system-add-new-document-replace-single-drop-down-with-select-with-search)

## Why

Select elements are set to 2.5rem high, which is defined in the CSS of `govuk-frontend`. This has a detrimental affect on selects using the `multiple` attribute as they only display one option. It's even worse if the first option is blank as the select appears to be empty, and it's easy to miss the tiny scroll bar that reveals more options.

Setting the height of these variant selects to `auto` will ensure that they display several options within the scrolling area and therefore will provide an improved UX.

Note that in practice this only applies to the non-JS experience: selects with a `multiple` attribute are entirely replaced in the JS experience with markup generated by the third party plugin [choices.js](https://github.com/Choices-js/Choices).

## Before / After

| Before | After |
| --- | ----------- |
| <img width="765" alt="image" src="https://github.com/user-attachments/assets/c08997a9-97df-4ce8-8ce8-330a73180393" /> | <img width="765" alt="image" src="https://github.com/user-attachments/assets/9a45cd32-95c1-48a5-9b5f-8b29153ce677" /> |

## Future consideration

This fix should eventually apply to all apps that might use `select_with_search` with multiple variants. Therefore it should be made available in a higher root dependency, for example the publishing gem or the design system.

-------------------------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
