### PR TITLE
[Design system] Unpublishing flow

### DIFF
--- a/app/components/sidebar_actions_component.html.erb
+++ b/app/components/sidebar_actions_component.html.erb
@@ -7,6 +7,4 @@
   </div>
 </aside>
 
-<div class="app-view-summary__sidebar-notices">
-  <%= notices %>
-</div>
+<%= notices %>

--- a/app/components/sidebar_actions_component.rb
+++ b/app/components/sidebar_actions_component.rb
@@ -53,7 +53,7 @@ private
 
     render("govuk_publishing_components/components/button", {
       text: "Unpublish document",
-      href: "#",
+      href: @presenter.confirm_unpublish_path,
       destructive: true,
     })
   end

--- a/app/components/sidebar_actions_component.rb
+++ b/app/components/sidebar_actions_component.rb
@@ -19,9 +19,13 @@ class SidebarActionsComponent < ViewComponent::Base
   end
 
   def notices
-    render("govuk_publishing_components/components/inset_text", {
-      text: notice("Unpublishing", @presenter.unpublish_text).html_safe,
-    })
+    return if @presenter.unpublish_text.blank?
+
+    tag.div(
+      render("govuk_publishing_components/components/inset_text", {
+        text: notice("Unpublishing", @presenter.unpublish_text).html_safe,
+      }), class: "app-view-summary__sidebar-notices"
+    )
   end
 
 private

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,7 +7,7 @@ class DocumentsController < ApplicationController
   include OrganisationsHelper
 
   layout :get_layout
-  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show confirm_publish].freeze
+  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show confirm_publish confirm_unpublish].freeze
   include DesignSystemHelper
 
   before_action :fetch_document, except: %i[index new create]
@@ -78,6 +78,8 @@ class DocumentsController < ApplicationController
     end
     redirect_to document_path(current_format.admin_slug, params[:content_id_and_locale])
   end
+
+  def confirm_unpublish; end
 
   def unpublish
     if @document.unpublish(params[:alternative_path])

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -25,6 +25,7 @@ class DocumentPolicy < ApplicationPolicy
     document_type_editor? || gds_editor? || departmental_editor?
   end
 
+  alias_method :confirm_unpublish?, :publish?
   alias_method :unpublish?, :publish?
   alias_method :confirm_publish?, :publish?
   alias_method :discard?, :publish?

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -83,6 +83,16 @@ class ActionsPresenter
   end
 
   def unpublish_text
+    return if document.first_draft?
+
+    if state == "draft"
+      "The document cannot be unpublished because it has a draft. You need to publish the draft first."
+    elsif !policy.unpublish?
+      "You don't have permission to unpublish this document."
+    end
+  end
+
+  def unpublish_text_legacy
     if document.first_draft?
       text = "The document has never been published."
     elsif state == "draft"

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -70,6 +70,10 @@ class ActionsPresenter
     confirm_publish_document_path(slug, document.content_id_and_locale)
   end
 
+  def confirm_unpublish_path
+    confirm_unpublish_document_path(slug, document.content_id_and_locale)
+  end
+
   def publish_path
     publish_document_path(slug, document.content_id_and_locale)
   end

--- a/app/views/documents/confirm_unpublish.html.erb
+++ b/app/views/documents/confirm_unpublish.html.erb
@@ -1,0 +1,68 @@
+<% page_title = "Unpublish #{current_format.title}" %>
+<% presenter = ActionsPresenter.new(@document, policy(@document.class)) %>
+
+<% content_for :page_title, page_title %>
+<% content_for :title, page_title %>
+<% content_for :context, @document.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: current_format.title.pluralize,
+        url: documents_path(current_format.admin_slug)
+      },
+      {
+        title: @document.title,
+        url: document_path(current_format.admin_slug, @document.content_id_and_locale)
+      },
+      {
+        title: "Unpublish"
+      }
+    ]
+  } %>
+<% end %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-body govuk-!-margin-bottom-8">
+      The document will be removed from the site. It will still be possible to edit and publish a new version.
+    </div>
+
+    <%= form_tag(presenter.unpublish_path,
+                 method: :post,
+                 data: { gtm: "confirm-unpublish" }) do %>
+      <%= render("govuk_publishing_components/components/input", {
+        label: {
+          text: "Redirect to alternative GOV.UK content path (optional)",
+        },
+        heading_level: 3,
+        heading_size: "m",
+        name: "alternative_path",
+        hint: "For example: /the-replacement-page",
+      }) %>
+
+      <div class="govuk-body govuk-!-margin-top-8">
+        Are you sure you want to unpublish this document?
+      </div>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Unpublish",
+          destructive: true,
+        } %>
+        <%= link_to "Cancel",
+                    document_path(current_format.admin_slug, @document.content_id_and_locale),
+                    class: "govuk-link govuk-link--no-visited-state app-link--inline",
+                    data: { gtm: "cancel-unpublish" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/legacy/_actions_legacy.html.erb
+++ b/app/views/documents/legacy/_actions_legacy.html.erb
@@ -25,7 +25,7 @@
     <%= form_tag(presenter.unpublish_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Unpublish document</h3></div>
       <div class="panel-body">
-        <%= content_tag(:p, presenter.unpublish_text) %>
+        <%= content_tag(:p, presenter.unpublish_text_legacy) %>
 
         <% if presenter.unpublish_button_visible? %>
           <div class="form-group">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     end
     resources :attachments, param: :attachment_content_id, except: %i[index show]
 
+    get :confirm_unpublish, on: :member
     post :unpublish, on: :member
 
     get :confirm_publish, on: :member

--- a/spec/components/sidebar_actions_component_spec.rb
+++ b/spec/components/sidebar_actions_component_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to have_text("The document has never been published.")
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should show on published document" do
@@ -104,7 +104,7 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to have_link("Unpublish document")
-      expect(page).to have_text("The document will be removed from the site. It will still be possible to edit and publish a new version.")
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should not show on published with draft document" do
@@ -124,7 +124,7 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to have_text("The document is already unpublished.")
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should not show when user not allowed to unpublish" do

--- a/spec/features/design_system/unpublishing_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/unpublishing_a_cma_case_design_system_spec.rb
@@ -1,0 +1,128 @@
+require "spec_helper"
+
+RSpec.feature "Unpublishing a CMA Case", type: :feature do
+  let(:content_id) { item["content_id"] }
+  let(:locale) { item["locale"] }
+
+  before do
+    log_in_as_design_system_editor(:cma_editor)
+    stub_publishing_api_has_item(item)
+  end
+
+  context "a published document" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        title: "Example CMA Case",
+        publication_state: "published",
+      )
+    end
+
+    scenario "clicking the unpublish button redirects back to the show page" do
+      stub_publishing_api_unpublish(content_id, body: { type: "gone", locale: })
+
+      visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+      click_link "Unpublish document"
+      expect(page.status_code).to eq(200)
+      click_button "Unpublish"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Unpublished Example CMA Case")
+
+      assert_publishing_api_unpublish(content_id)
+    end
+
+    scenario "specifying a redirect to an alternative GOV.UK content path" do
+      stub_publishing_api_unpublish(content_id, body: { type: "redirect", alternative_path: "/government/organisations/competition-and-markets-authority", locale: })
+
+      stub_publishing_api_has_lookups("/government/organisations/competition-and-markets-authority" => SecureRandom.uuid)
+
+      visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+
+      click_link "Unpublish document"
+      expect(page.status_code).to eq(200)
+      fill_in "alternative_path", with: "/government/organisations/competition-and-markets-authority"
+      click_button "Unpublish"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Unpublished Example CMA Case")
+
+      assert_publishing_api_unpublish(content_id, type: "redirect", alternative_path: "/government/organisations/competition-and-markets-authority", locale:)
+    end
+
+    context "with attachments" do
+      let(:existing_attachments) do
+        [
+          {
+            "content_id" => "77f2d40e-3853-451f-9ca3-a747e8402e34",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
+            "content_type" => "application/jpeg",
+            "title" => "asylum report image title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00",
+          },
+          {
+            "content_id" => "ec3f6901-4156-4720-b4e5-f04c0b152141",
+            "url" => "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000004/asylum-support-pdf.pdf",
+            "content_type" => "application/pdf",
+            "title" => "asylum report pdf title",
+            "created_at" => "2015-12-03T16:59:13+00:00",
+            "updated_at" => "2015-12-03T16:59:13+00:00",
+          },
+        ]
+      end
+
+      let(:item) do
+        FactoryBot.create(
+          :cma_case,
+          :published,
+          title: "Example CMA Case",
+          details: { "attachments" => existing_attachments },
+        )
+      end
+
+      scenario "clicking the unpublish button deletes document attachments" do
+        Sidekiq::Testing.inline! do
+          stub_publishing_api_unpublish(content_id, body: { type: "gone", locale: })
+
+          visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+
+          expect(Services.asset_api).to receive(:delete_asset).once.ordered
+            .with("513a0efbed915d425e000002")
+          expect(Services.asset_api).to receive(:delete_asset).once.ordered
+            .with("513a0efbed915d425e000004")
+
+          click_link "Unpublish document"
+          expect(page.status_code).to eq(200)
+          click_button "Unpublish"
+
+          expect(page.status_code).to eq(200)
+          expect(page).to have_content("Unpublished Example CMA Case")
+        end
+      end
+    end
+  end
+
+  context "publishing-api returns error" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        title: "Example CMA Case",
+        publication_state: "published",
+      )
+    end
+
+    scenario "clicking the unpublish button shows an error message" do
+      stub_publishing_api_unpublish(content_id, { body: { type: "gone", locale: } }, status: 409)
+
+      visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+      click_link "Unpublish document"
+      expect(page.status_code).to eq(200)
+      click_button "Unpublish"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Something has gone wrong. Please try again and see if it works.")
+    end
+  end
+end

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -129,29 +129,29 @@ RSpec.describe ActionsPresenter do
     end
   end
 
-  describe "unpublish_text" do
+  describe "unpublish_text_legacy" do
     let(:payload) { FactoryBot.create(:cma_case, :published) }
 
-    specify { expect(subject.unpublish_text).to include("removed from the site") }
+    specify { expect(subject.unpublish_text_legacy).to include("removed from the site") }
 
     context "when the document is a draft" do
       let(:payload) { FactoryBot.create(:cma_case) }
-      specify { expect(subject.unpublish_text).to include("never been published") }
+      specify { expect(subject.unpublish_text_legacy).to include("never been published") }
     end
 
     context "when the document is redrafted" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
-      specify { expect(subject.unpublish_text).to include("publish the draft first") }
+      specify { expect(subject.unpublish_text_legacy).to include("publish the draft first") }
     end
 
     context "when the document is already unpublished" do
       let(:payload) { FactoryBot.create(:cma_case, publication_state: "unpublished") }
-      specify { expect(subject.unpublish_text).to include("already unpublished") }
+      specify { expect(subject.unpublish_text_legacy).to include("already unpublished") }
     end
 
     context "when the user does not have editor permissions" do
       let(:user) { FactoryBot.create(:cma_writer) }
-      specify { expect(subject.unpublish_text).to include("don't have permission to unpublish") }
+      specify { expect(subject.unpublish_text_legacy).to include("don't have permission to unpublish") }
     end
   end
 


### PR DESCRIPTION
Transitioning Unpublishing flow to the design system. 
Added interstitial page for unpublishing a document.

- In the old world, there used to be a permanent "Unpublishing" section which used to show a message of why the unpublish button wasn't showing or what the impact would be of unpublishing.
- Now that we have an interstital page, we are duplicating the information when the button is visible. Text from unpublishing notice relating to Unpublishing on the document summary sidebar has been moved to the confirmation page.
- Also removing some other scenarios and instances of the notice messages appearing such as: 
  - when document is already unpublished or when it is first draft. These can be seen on the publish status of the document. 
  - The only relevant useful message we should show users is when they expect to see an unpublishing button but it's not there. This is the case where they have a publish with draft, or they don't have permission. these messages will still be showing.

<img width="400" alt="Screenshot 2025-06-11 at 16 19 16" src="https://github.com/user-attachments/assets/df44466a-2ce9-45ba-a5c8-9b2a055c6e19" />

<img width="1183" alt="Screenshot 2025-06-11 at 16 19 24" src="https://github.com/user-attachments/assets/4ba37b44-d2a1-41d3-9fd5-53c6fbfc44c8" />


No unpublishing notice on Unpublished document:
<img width="1164" alt="Screenshot 2025-06-11 at 16 19 36" src="https://github.com/user-attachments/assets/09f0bf0a-8344-4cfa-b4fd-8857198db6ac" />

Unpublishing notice: existing draft
<img width="1161" alt="Screenshot 2025-06-11 at 16 20 59" src="https://github.com/user-attachments/assets/a4abcf1a-0e75-4422-9389-be6eb5de4a3c" />
<img width="1206" alt="Screenshot 2025-06-11 at 16 20 05" src="https://github.com/user-attachments/assets/c7c361b6-a361-4b7f-84c2-9bb8fbe1b3b3" />

Unpublishing notice: no permission
<img width="1191" alt="Screenshot 2025-06-11 at 16 27 56" src="https://github.com/user-attachments/assets/a0559f7a-f193-4e55-8325-ad0a483cde9d" />


QA Note:

Even if the unpublishing button doesn't show (e.g. unpublished with draft), there's nothing stopping the user from navigating to the /confirm_unpublish part of the document link and clicking unpublish. This is currently returning the following error so there's no broken flow, but is not super user friendly. As it's not a valid user flow, only happens if users force going to the URL, and it does not introduce any bugs, feel like we can descope handling of this case from this PR/ticket. There may be a wider discussion to have about how to handle more granular authorisation and status checks for controller methods in Specialist Publisher. Similar case in https://github.com/alphagov/specialist-publisher/pull/3197 

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/e470f068-89cc-4b82-9d68-bc902078a108" />


https://trello.com/c/KHABJSW9/3801-design-system-unpublishing-flow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
