### PR TITLE
[Design system] Discard Draft flow

### DIFF
--- a/app/components/sidebar_actions_component.rb
+++ b/app/components/sidebar_actions_component.rb
@@ -67,7 +67,7 @@ private
 
     link_to(
       "Delete draft",
-      "#",
+      @presenter.confirm_discard_path,
       class: "govuk-link gem-link--destructive",
     )
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,7 +7,7 @@ class DocumentsController < ApplicationController
   include OrganisationsHelper
 
   layout :get_layout
-  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show confirm_publish confirm_unpublish].freeze
+  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new create index show confirm_publish confirm_unpublish confirm_discard discard].freeze
   include DesignSystemHelper
 
   before_action :fetch_document, except: %i[index new create]
@@ -91,9 +91,16 @@ class DocumentsController < ApplicationController
     redirect_to document_path(current_format.admin_slug, params[:content_id_and_locale])
   end
 
+  def confirm_discard; end
+
   def discard
     if @document.discard
-      flash[:success] = "Discarded draft of #{@document.title}"
+      message = if get_layout == "design_system"
+                  "The draft of '#{@document.title}' has been deleted"
+                else
+                  "Discarded draft of #{@document.title}"
+                end
+      flash[:success] = message
     else
       flash[:danger] = unknown_error_message
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -247,7 +247,7 @@ class Document
 
   def discard
     handle_remote_error(self) do
-      Services.publishing_api.discard_draft(content_id, previous_version:)
+      Services.publishing_api.discard_draft(content_id, previous_version:, locale:)
     end
   end
 

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -28,6 +28,7 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :confirm_unpublish?, :publish?
   alias_method :unpublish?, :publish?
   alias_method :confirm_publish?, :publish?
+  alias_method :confirm_discard?, :publish?
   alias_method :discard?, :publish?
 
 private

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -74,6 +74,10 @@ class ActionsPresenter
     confirm_unpublish_document_path(slug, document.content_id_and_locale)
   end
 
+  def confirm_discard_path
+    confirm_discard_document_path(slug, document.content_id_and_locale)
+  end
+
   def publish_path
     publish_document_path(slug, document.content_id_and_locale)
   end

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -19,20 +19,11 @@ class ActionsPresenter
 
   def publish_text
     if update_type == "minor"
-      safe_join([
-        tag.p("You are about to publish a minor edit."),
-        tag.p("Are you sure you want to publish this document?"),
-      ])
+      "You are about to publish a minor edit."
     elsif update_type == "major" && !document.first_draft?
-      safe_join([
-        tag.p("You are about to publish a major edit with a public change note. Publishing will email subscribers to #{klass_name}."),
-        tag.p("Are you sure you want to publish this document?"),
-      ])
+      "You are about to publish a major edit with a public change note. Publishing will email subscribers to #{klass_name}."
     else
-      safe_join([
-        tag.p("Publishing will email subscribers to #{klass_name}."),
-        tag.p("Are you sure you want to publish this document?"),
-      ])
+      "Publishing will email subscribers to #{klass_name}."
     end
   end
 

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -58,7 +58,7 @@ class ActionsPresenter
     end
   end
 
-  def publish_alert
+  def publish_alert_legacy
     if update_type == "minor"
       "You are about to publish a minor edit. Continue?"
     else
@@ -114,7 +114,7 @@ class ActionsPresenter
     text
   end
 
-  def unpublish_alert
+  def unpublish_alert_legacy
     "Are you sure you want to unpublish this document?"
   end
 
@@ -126,7 +126,7 @@ class ActionsPresenter
     policy.discard? && document.draft?
   end
 
-  def discard_text
+  def discard_text_legacy
     if state != "draft"
       "There is no draft to discard."
     elsif !policy.discard?
@@ -136,7 +136,7 @@ class ActionsPresenter
     end
   end
 
-  def discard_alert
+  def discard_alert_legacy
     "Are you sure you want to discard this draft?"
   end
 

--- a/app/views/documents/confirm_discard.html.erb
+++ b/app/views/documents/confirm_discard.html.erb
@@ -1,0 +1,53 @@
+<% page_title = "Delete draft" %>
+<% presenter = ActionsPresenter.new(@document, policy(@document.class)) %>
+
+<% content_for :page_title, page_title %>
+<% content_for :title, page_title %>
+<% content_for :context, @document.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: current_format.title.pluralize,
+        url: documents_path(current_format.admin_slug)
+      },
+      {
+        title: @document.title,
+        url: document_path(current_format.admin_slug, @document.content_id_and_locale)
+      },
+      {
+        title: "Delete draft"
+      }
+    ]
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(presenter.discard_path,
+                 method: :post,
+                 data: { gtm: "confirm-discard" }) do %>
+
+      <div class="govuk-body govuk-!-margin-bottom-8">
+        Are you sure you want to delete this draft?
+      </div>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to "Cancel",
+                    document_path(current_format.admin_slug, @document.content_id_and_locale),
+                    class: "govuk-link govuk-link--no-visited-state app-link--inline",
+                    data: { gtm: "cancel-unpublish" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/confirm_publish.html.erb
+++ b/app/views/documents/confirm_publish.html.erb
@@ -32,13 +32,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <div class="govuk-body govuk-!-margin-bottom-8">
-      <%= presenter.publish_text %>
-    </div>
+    <p class="govuk-body"><%= presenter.publish_text %></p>
 
     <%= form_tag(presenter.publish_path,
                  method: :post,
                  data: { gtm: "confirm-publish" }) do %>
+
+      <div class="govuk-body govuk-!-margin-bottom-8">
+        Are you sure you want to publish this document?
+      </div>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/documents/legacy/_actions_legacy.html.erb
+++ b/app/views/documents/legacy/_actions_legacy.html.erb
@@ -16,7 +16,7 @@
         <% if presenter.publish_button_visible? %>
           <button name="submit" class="btn btn-danger"
                   data-module="confirm"
-                  data-message="<%= presenter.publish_alert %>"
+                  data-message="<%= presenter.publish_alert_legacy %>"
                   data-disable-with="Publishing..." >Publish</button>
         <% end %>
       </div>
@@ -36,7 +36,7 @@
           <div class="form-group">
             <button name="submit" class="btn btn-warning"
                     data-module="confirm"
-                    data-message="<%= presenter.unpublish_alert %>"
+                    data-message="<%= presenter.unpublish_alert_legacy %>"
                     data-disable-with="Unpublishing..." >Unpublish document</button>
           </div>
         <% end %>
@@ -46,12 +46,12 @@
     <%= form_tag(presenter.discard_path, method: :post, class: 'panel panel-default') do %>
       <div class="panel-heading"><h3 class="panel-title">Discard draft</h3></div>
       <div class="panel-body">
-        <%= content_tag(:p, presenter.discard_text) %>
+        <%= content_tag(:p, presenter.discard_text_legacy) %>
 
         <% if presenter.discard_button_visible? %>
           <button name="submit" class="btn btn-warning"
                   data-module="confirm"
-                  data-message="<%= presenter.discard_alert %>"
+                  data-message="<%= presenter.discard_alert_legacy %>"
                   data-disable-with="Discarding draft..." >Discard draft</button>
         <% end %>
       </div>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -50,7 +50,7 @@
         message: flash[:notice] || flash[:success]
       } if flash[:notice] || flash[:success] %>
       <%= render "govuk_publishing_components/components/error_alert", {
-        message: flash[:danger]
+        message: flash[:danger].html_safe
       } if flash[:danger] %>
 
       <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     get :confirm_publish, on: :member
     post :publish, on: :member
 
+    get :confirm_discard, on: :member
     post :discard, on: :member
   end
 

--- a/spec/features/design_system/discarding_a_draft_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/discarding_a_draft_cma_case_design_system_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.feature "Discarding a draft CMA Case", type: :feature do
+  let(:content_id) { item["content_id"] }
+  let(:locale) { item["locale"] }
+
+  before do
+    stub_publishing_api_has_item(item)
+    stub_publishing_api_discard_draft(content_id)
+    stub_publishing_api_has_content([item], hash_including(document_type: CmaCase.document_type))
+  end
+
+  context "a draft document" do
+    let(:item) do
+      FactoryBot.create(
+        :cma_case,
+        title: "Example CMA Case",
+        publication_state: "draft",
+      )
+    end
+
+    context "as a CMA editor" do
+      scenario "clicking the discard button discards the draft" do
+        log_in_as_design_system_editor(:cma_editor)
+        visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+        expect(page).to have_content("Example CMA Case")
+
+        click_link "Delete draft"
+        expect(page.status_code).to eq(200)
+        click_button "Delete"
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("The draft of 'Example CMA Case' has been deleted")
+
+        assert_publishing_api_discard_draft(content_id)
+        expect(current_path).to eq(documents_path(document_type_slug: "cma-cases"))
+      end
+    end
+  end
+end

--- a/spec/features/design_system/publishing_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/publishing_a_cma_case_design_system_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 RSpec.feature "Publishing a CMA case", type: :feature do
   let(:content_id) { item["content_id"] }
-  let(:publish_alert_message) { page.find_button("Publish")["data-message"] }
   let(:publish_disable_with_message) { page.find_button("Publish")["data-disable-with"] }
 
   before do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe Document do
     it "sends a discard draft request to the publishing api" do
       stub_publishing_api_discard_draft(content_id)
       document.discard
-      assert_publishing_api_discard_draft(content_id)
+      assert_publishing_api_discard_draft(content_id, locale: "en")
     end
 
     it "returns true if the draft was discarded successfully" do

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe ActionsPresenter do
     end
   end
 
-  describe "publish_alert" do
-    specify { expect(subject.publish_alert).to include("will email subscribers to CMA Cases") }
+  describe "publish_alert_legacy" do
+    specify { expect(subject.publish_alert_legacy).to include("will email subscribers to CMA Cases") }
 
     context "when the update_type is minor" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
-      specify { expect(subject.publish_alert).to include("minor edit") }
+      specify { expect(subject.publish_alert_legacy).to include("minor edit") }
     end
   end
 
@@ -155,8 +155,8 @@ RSpec.describe ActionsPresenter do
     end
   end
 
-  describe "unpublish_alert" do
-    specify { expect(subject.unpublish_alert).to include("Are you sure") }
+  describe "unpublish_alert_legacy" do
+    specify { expect(subject.unpublish_alert_legacy).to include("Are you sure") }
   end
 
   describe "unpublish_path" do

--- a/spec/presenters/actions_presenter_spec.rb
+++ b/spec/presenters/actions_presenter_spec.rb
@@ -44,17 +44,17 @@ RSpec.describe ActionsPresenter do
   describe "publish_text" do
     context "when the document is a new draft" do
       let(:payload) { FactoryBot.create(:cma_case, :draft) }
-      specify { expect(subject.publish_text).to eq("<p>Publishing will email subscribers to CMA Cases.</p><p>Are you sure you want to publish this document?</p>") }
+      specify { expect(subject.publish_text).to eq("Publishing will email subscribers to CMA Cases.") }
     end
 
     context "when the document is redrafted" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted) }
-      specify { expect(subject.publish_text).to eq("<p>You are about to publish a major edit with a public change note. Publishing will email subscribers to CMA Cases.</p><p>Are you sure you want to publish this document?</p>") }
+      specify { expect(subject.publish_text).to eq("You are about to publish a major edit with a public change note. Publishing will email subscribers to CMA Cases.") }
     end
 
     context "when the document is redrafted and the update_type is minor" do
       let(:payload) { FactoryBot.create(:cma_case, :redrafted, update_type: "minor") }
-      specify { expect(subject.publish_text).to eq("<p>You are about to publish a minor edit.</p><p>Are you sure you want to publish this document?</p>") }
+      specify { expect(subject.publish_text).to eq("You are about to publish a minor edit.") }
     end
   end
 


### PR DESCRIPTION
Added an interstitial page to confirm draft deletion. 

This PR also includes: 
- Bug fixing discard draft for editions that are not EN. Currently on integration we are not able to discard non-EN drafts. 
- Bug fixing the rendering of an error message. Currently on integration, the message renders with the a href html

The error message appears when you get a publishing API error. Reproduceable by: 
- navigating to `/confirm_discard` when there are no drafts
- navigating to `/confirm_unpublish` when there is a draft
- navigateing to `confirm_publish` when document is not publishable
This behaviour is already discussed in previous PRs https://github.com/alphagov/specialist-publisher/pull/3199 and https://github.com/alphagov/specialist-publisher/pull/3197

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/85af03cd-2148-4dbb-bbf0-79e5d57db8ec" />

Error message Before:
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/e04d28eb-ca6d-4173-bae2-0912ef7416d8" />

Error message After: 
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/9da91241-699f-44c6-b371-9bbabf43e665" />



https://trello.com/c/uX6Wsh6Z/3802-design-system-delete-draft-flow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
