### PR TITLE
Refactor views

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -107,6 +107,15 @@ class DocumentsController < ApplicationController
     redirect_to documents_path(current_format.admin_slug)
   end
 
+  helper_method :computed_partial
+  def computed_partial
+    if lookup_context.exists?(@document.document_type.pluralize.to_s, %w[metadata_fields], true)
+      "metadata_fields/#{@document.document_type.pluralize}"
+    else
+      "shared/specialist_document_form"
+    end
+  end
+
 private
 
   def merge_nested_facet_fields

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -116,6 +116,15 @@ class DocumentsController < ApplicationController
     end
   end
 
+  helper_method :computed_partial_legacy
+  def computed_partial_legacy
+    if lookup_context.exists?(@document.document_type.pluralize.to_s, %w[metadata_fields_legacy], true)
+      "metadata_fields_legacy/#{@document.document_type.pluralize}"
+    else
+      "shared/legacy/specialist_document_form_legacy"
+    end
+  end
+
 private
 
   def merge_nested_facet_fields

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -23,7 +23,7 @@
 
         <%= render partial: "shared/legacy/preview_govspeak_legacy", locals: {attachments: @document.attachments} %>
 
-        <%= render partial: "metadata_fields_legacy/#{@document.document_type.pluralize}", locals: {f: f} %>
+        <%= render partial: computed_partial_legacy, locals: { f: f } %>
 
         <%= render partial: "shared/minor_major_update_fields", locals: {f: f, document: @document} %>
 

--- a/app/views/documents/legacy/new_legacy.html.erb
+++ b/app/views/documents/legacy/new_legacy.html.erb
@@ -19,7 +19,7 @@
 
       <%= render partial: "shared/legacy/preview_govspeak_legacy", locals: {attachments: @document.attachments} %>
 
-      <%= render partial: "metadata_fields_legacy/#{@document.document_type.pluralize}", locals: { f: f } %>
+      <%= render partial: computed_partial_legacy, locals: { f: f } %>
 
       <div class="actions">
         <button name="save" class="btn btn-success" data-disable-with="Saving...">Save as draft</button>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -30,7 +30,7 @@
                  html: { class: "new_document" } do |f| %>
       <%= render partial: "shared/form_fields", locals: { f: f } %>
 
-      <%= render partial: "metadata_fields/#{@document.document_type.pluralize}", locals: { f: f } %>
+      <%= render partial: computed_partial, locals: { f: f } %>
 
       <div class="actions">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/metadata_fields/_aaib_reports.html.erb
+++ b/app/views/metadata_fields/_aaib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_ai_assurance_portfolio_techniques.html.erb
+++ b/app/views/metadata_fields/_ai_assurance_portfolio_techniques.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
+++ b/app/views/metadata_fields/_algorithmic_transparency_records.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_animal_disease_cases.html.erb
+++ b/app/views/metadata_fields/_animal_disease_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields/_asylum_support_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_cma_cases.html.erb
+++ b/app/views/metadata_fields/_cma_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
+++ b/app/views/metadata_fields/_countryside_stewardship_grants.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_data_ethics_guidance_documents.html.erb
+++ b/app/views/metadata_fields/_data_ethics_guidance_documents.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_design_decisions.html.erb
+++ b/app/views/metadata_fields/_design_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
+++ b/app/views/metadata_fields/_drcf_digital_markets_researches.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_drug_safety_updates.html.erb
+++ b/app/views/metadata_fields/_drug_safety_updates.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_appeal_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_employment_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_esi_funds.html.erb
+++ b/app/views/metadata_fields/_esi_funds.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_export_health_certificates.html.erb
+++ b/app/views/metadata_fields/_export_health_certificates.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_farming_grants.html.erb
+++ b/app/views/metadata_fields/_farming_grants.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_hmrc_contacts.html.erb
+++ b/app/views/metadata_fields/_hmrc_contacts.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_international_development_funds.html.erb
+++ b/app/views/metadata_fields/_international_development_funds.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_life_saving_maritime_appliance_service_stations.erb
+++ b/app/views/metadata_fields/_life_saving_maritime_appliance_service_stations.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_maib_reports.html.erb
+++ b/app/views/metadata_fields/_maib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_marine_equipment_approved_recommendations.html.erb
+++ b/app/views/metadata_fields/_marine_equipment_approved_recommendations.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_marine_notices.html.erb
+++ b/app/views/metadata_fields/_marine_notices.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_medical_safety_alerts.html.erb
+++ b/app/views/metadata_fields/_medical_safety_alerts.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_product_safety_alert_report_recalls.html.erb
+++ b/app/views/metadata_fields/_product_safety_alert_report_recalls.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields/_protected_food_drink_names.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_raib_reports.html.erb
+++ b/app/views/metadata_fields/_raib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_residential_property_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_service_standard_reports.html.erb
+++ b/app/views/metadata_fields/_service_standard_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_sfo_cases.html.erb
+++ b/app/views/metadata_fields/_sfo_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields/_tax_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_trademark_decisions.html.erb
+++ b/app/views/metadata_fields/_trademark_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_traffic_commissioner_regulatory_decisions.html.erb
+++ b/app/views/metadata_fields/_traffic_commissioner_regulatory_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_ukhsa_data_access_approvals.html.erb
+++ b/app/views/metadata_fields/_ukhsa_data_access_approvals.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_utaac_decisions.html.erb
+++ b/app/views/metadata_fields/_utaac_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields/_veterans_support_organisations.html.erb
+++ b/app/views/metadata_fields/_veterans_support_organisations.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/specialist_document_form", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_aaib_reports.html.erb
+++ b/app/views/metadata_fields_legacy/_aaib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_ai_assurance_portfolio_techniques.html.erb
+++ b/app/views/metadata_fields_legacy/_ai_assurance_portfolio_techniques.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_algorithmic_transparency_records.html.erb
+++ b/app/views/metadata_fields_legacy/_algorithmic_transparency_records.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_animal_disease_cases.html.erb
+++ b/app/views/metadata_fields_legacy/_animal_disease_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_asylum_support_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_asylum_support_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_cma_cases.html.erb
+++ b/app/views/metadata_fields_legacy/_cma_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_countryside_stewardship_grants.html.erb
+++ b/app/views/metadata_fields_legacy/_countryside_stewardship_grants.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_data_ethics_guidance_documents.html.erb
+++ b/app/views/metadata_fields_legacy/_data_ethics_guidance_documents.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_design_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_design_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_drcf_digital_markets_researches.html.erb
+++ b/app/views/metadata_fields_legacy/_drcf_digital_markets_researches.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_drug_safety_updates.html.erb
+++ b/app/views/metadata_fields_legacy/_drug_safety_updates.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_employment_appeal_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_employment_appeal_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_employment_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_employment_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_esi_funds.html.erb
+++ b/app/views/metadata_fields_legacy/_esi_funds.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_export_health_certificates.html.erb
+++ b/app/views/metadata_fields_legacy/_export_health_certificates.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_farming_grants.html.erb
+++ b/app/views/metadata_fields_legacy/_farming_grants.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_hmrc_contacts.html.erb
+++ b/app/views/metadata_fields_legacy/_hmrc_contacts.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_international_development_funds.html.erb
+++ b/app/views/metadata_fields_legacy/_international_development_funds.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_life_saving_maritime_appliance_service_stations.erb
+++ b/app/views/metadata_fields_legacy/_life_saving_maritime_appliance_service_stations.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_maib_reports.html.erb
+++ b/app/views/metadata_fields_legacy/_maib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_marine_equipment_approved_recommendations.html.erb
+++ b/app/views/metadata_fields_legacy/_marine_equipment_approved_recommendations.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_marine_notices.html.erb
+++ b/app/views/metadata_fields_legacy/_marine_notices.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_medical_safety_alerts.html.erb
+++ b/app/views/metadata_fields_legacy/_medical_safety_alerts.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_product_safety_alert_report_recalls.html.erb
+++ b/app/views/metadata_fields_legacy/_product_safety_alert_report_recalls.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_protected_food_drink_names.html.erb
+++ b/app/views/metadata_fields_legacy/_protected_food_drink_names.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_raib_reports.html.erb
+++ b/app/views/metadata_fields_legacy/_raib_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_residential_property_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_residential_property_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_service_standard_reports.html.erb
+++ b/app/views/metadata_fields_legacy/_service_standard_reports.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_sfo_cases.html.erb
+++ b/app/views/metadata_fields_legacy/_sfo_cases.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_tax_tribunal_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_tax_tribunal_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_trademark_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_trademark_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_traffic_commissioner_regulatory_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_traffic_commissioner_regulatory_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_ukhsa_data_access_approvals.html.erb
+++ b/app/views/metadata_fields_legacy/_ukhsa_data_access_approvals.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_utaac_decisions.html.erb
+++ b/app/views/metadata_fields_legacy/_utaac_decisions.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>

--- a/app/views/metadata_fields_legacy/_veterans_support_organisations.html.erb
+++ b/app/views/metadata_fields_legacy/_veterans_support_organisations.html.erb
@@ -1,2 +1,0 @@
-<%= render layout: "shared/legacy/specialist_document_form_legacy", locals: { f: f } do %>
-<% end %>


### PR DESCRIPTION
## What

Refactor views so we don't have to maintain different view files of identical contents for conforming types. 

Previously, we maintained a view file for each document type. Most pages are what we call "conforming pages", in that their views are directly populated from the schema fields. These standard pages just render the `specialist_document_form` partial. The rest of the pages, non-conforming ones, must, for whatever reasons, implement a custom view with their own fields and sometimes custom logic.

These changes implement two controller helper methods to be used in the views, both DS and legacy variants, to help with computing which view to render. Using a `lookup_context` implementation, the methods look up a defined partial, and fall back on `specialist_document_form` if they cannot find the partial. 

The legacy method was added as to distinguish it from the DS helper method. This method should be deleted alongside the rest of the code when the DS is released.

The edit view has not yet been migrated to the Design System so it's still using the legacy partials.

## Why

We want to only ever have to define the custom views for non-conforming pages. This makes it more obvious which documents have custom views. It should help us better track how "generalised" the document types are and thus aid in our efforts to unify them so that everything is schema based.

## Technical considerations

This refactor was suggested by @patrickpatrickpatrick in a review comment [here](https://github.com/alphagov/specialist-publisher/pull/3165#issuecomment-2912176466).

I originally implemented the `rescue` suggestion, but I did not quite like the semantics of `rescue` in a code that was basically behaving as expected, so ended up going for `lookup_context`. 

These changes are a refactor as no behaviour has been changed.

## Testing

Tested locally with and without`preview_design_system` permissions.
