### PR TITLE
Display permission notices for actions

### DIFF
--- a/app/components/sidebar_actions_component.rb
+++ b/app/components/sidebar_actions_component.rb
@@ -19,11 +19,17 @@ class SidebarActionsComponent < ViewComponent::Base
   end
 
   def notices
-    return if @presenter.unpublish_text.blank?
+    notices = []
+
+    notices << notice("Publishing", @presenter.publish_notice) if @presenter.publish_notice.present?
+    notices << notice("Unpublishing", @presenter.unpublish_notice) if @presenter.unpublish_notice.present?
+    notices << notice("Delete draft", @presenter.discard_draft_notice) if @presenter.discard_draft_notice.present?
+
+    return if notices.empty?
 
     tag.div(
       render("govuk_publishing_components/components/inset_text", {
-        text: notice("Unpublishing", @presenter.unpublish_text).html_safe,
+        text: notices.join("<br>").html_safe,
       }), class: "app-view-summary__sidebar-notices"
     )
   end

--- a/app/presenters/actions_presenter.rb
+++ b/app/presenters/actions_presenter.rb
@@ -77,12 +77,24 @@ class ActionsPresenter
     policy.unpublish? && state == "published"
   end
 
-  def unpublish_text
+  def publish_notice
+    if !policy.publish? && document.draft?
+      "You don't have permission to publish this document."
+    end
+  end
+
+  def discard_draft_notice
+    if !policy.discard? && document.draft?
+      "You don't have permission to delete this draft."
+    end
+  end
+
+  def unpublish_notice
     return if document.first_draft?
 
     if state == "draft"
       "The document cannot be unpublished because it has a draft. You need to publish the draft first."
-    elsif !policy.unpublish?
+    elsif !policy.unpublish? && state == "published"
       "You don't have permission to unpublish this document."
     end
   end

--- a/spec/components/sidebar_actions_component_spec.rb
+++ b/spec/components/sidebar_actions_component_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should show on published document" do
@@ -104,7 +103,6 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to have_link("Unpublish document")
-      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should not show on published with draft document" do
@@ -114,7 +112,6 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to have_text("The document cannot be unpublished because it has a draft. You need to publish the draft first.")
     end
 
     it "should not show on unpublished document" do
@@ -124,7 +121,6 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
     end
 
     it "should not show when user not allowed to unpublish" do
@@ -134,7 +130,6 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Unpublish document")
-      expect(page).to have_text("You don't have permission to unpublish this document.")
     end
   end
 
@@ -182,6 +177,98 @@ RSpec.describe SidebarActionsComponent, type: :component do
       render_inline(described_class.new(document, user))
 
       expect(page).to_not have_link("Delete draft")
+    end
+  end
+
+  describe "notices" do
+    it "should not show on draft document" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
+    end
+
+    it "should not show on published document" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
+    end
+
+    it "should show unpublishing notice on published with draft document" do
+      content_item = FactoryBot.create(:cma_case, :redrafted, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_text("The document cannot be unpublished because it has a draft. You need to publish the draft first.")
+    end
+
+    it "should not show on unpublished document" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_editor)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_selector(".app-view-summary__sidebar-notices")
+    end
+
+    it "should show permissions notice when publish button should show but user not allowed to publish" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_text("You don't have permission to publish this document.")
+    end
+
+    it "should show permissions notice when unpublish button should show but user not allowed to unpublish" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_text("You don't have permission to unpublish this document.")
+    end
+
+    it "should show permissions notice when delete draft button should show but user not allowed to delete draft" do
+      content_item = FactoryBot.create(:cma_case, :draft, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to have_text("You don't have permission to delete this draft.")
+    end
+
+    it "should not show publish permissions notice when publish button doesn't show" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_text("You don't have permission to publish this document.")
+    end
+
+    it "should not show unpublish permissions notice when unpublish button doesn't show" do
+      content_item = FactoryBot.create(:cma_case, :unpublished, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_text("You don't have permission to unpublish this document.")
+    end
+
+    it "should not show delete draft permissions notice when delete draft button doesn't show" do
+      content_item = FactoryBot.create(:cma_case, :published, title: "Example CMA Case")
+      user = FactoryBot.create(:cma_writer)
+      document = DocumentBuilder.build(CmaCase, content_item)
+      render_inline(described_class.new(document, user))
+
+      expect(page).to_not have_text("You don't have permission to delete this draft.")
     end
   end
 end


### PR DESCRIPTION
If actions are actionable but users are not permitted to action them, we now display a notice about this scenario in the notice box under the actions buttons in the sidebar. 

This is a direct follow-on from discussions on previous PRs. We don't want to lose the messaging should the user need to see them to explain why buttons are not there when they should be: 
- https://github.com/alphagov/specialist-publisher/pull/3197
- https://github.com/alphagov/specialist-publisher/pull/3199
- https://github.com/alphagov/specialist-publisher/pull/3202

Renamed the methods in actions_presenter that relate to this notice box to *_notice. This is to differentiate them from things like publishing_text where it is actually displayed on the interstitial page.

https://trello.com/c/5jxeMAlM/3815-design-system-edit-document-new-draft-published-unpublished-with-new-draft

<img width="430" alt="Screenshot 2025-06-16 at 13 41 21" src="https://github.com/user-attachments/assets/c8fc29f9-9f30-419d-afeb-39e78f77c426" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
