### PR TITLE
[Design System] Delete Attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -2,7 +2,7 @@ class AttachmentsController < ApplicationController
   before_action :check_authorisation, if: :document_type_slug
 
   layout :get_layout
-  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new edit].freeze
+  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[new edit confirm_delete].freeze
   include DesignSystemHelper
 
   def check_authorisation
@@ -46,6 +46,11 @@ class AttachmentsController < ApplicationController
     else
       failed_to_attach(document)
     end
+  end
+
+  def confirm_delete
+    @document = fetch_document
+    @attachment = @document.attachments.find(attachment_content_id)
   end
 
   def destroy

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -9,6 +9,7 @@ class DocumentPolicy < ApplicationPolicy
   alias_method :update?, :index?
   alias_method :show?, :index?
   alias_method :destroy?, :index? # used only by AttachmentsController
+  alias_method :confirm_delete?, :index? # used only by AttachmentsController
 
   # TODO: move these into the FinderSchemaPolicy and add associated tests
   def can_request_edits_to_finder?

--- a/app/views/attachments/_attachment_links.html.erb
+++ b/app/views/attachments/_attachment_links.html.erb
@@ -29,12 +29,17 @@
             </p>
 
             <div class="govuk-button-group">
-              <%= link_to "Edit attachment", edit_document_attachment_path(params[:document_type_slug],
-                                                                @document.content_id_and_locale,
-                                                                attachment.content_id),
+              <%= link_to "Edit attachment",
+                          edit_document_attachment_path(params[:document_type_slug],
+                                                        @document.content_id_and_locale,
+                                                        attachment.content_id),
                           class: "govuk-link govuk-link--no-visited-state"
               %>
-              <%= link_to "Delete attachment", "#", class: "govuk-link gem-link--destructive" %>
+              <%= link_to "Delete attachment",
+                          confirm_delete_document_attachment_path(params[:document_type_slug],
+                                                                    @document.content_id_and_locale,
+                                                                    attachment.content_id),
+                          class: "govuk-link gem-link--destructive" %>
             </div>
             <hr>
           </div>

--- a/app/views/attachments/confirm_delete.html.erb
+++ b/app/views/attachments/confirm_delete.html.erb
@@ -1,0 +1,63 @@
+<% page_title = "Delete attachment" %>
+<% content_for :page_title, page_title %>
+<% content_for :title, page_title %>
+<% content_for :context, @attachment.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: current_format.title.pluralize,
+        url: documents_path(current_format.admin_slug)
+      },
+      {
+        title: @document.title,
+        url: edit_document_path(params[:document_type_slug], @document.content_id)
+      },
+      {
+        title: page_title
+      }
+    ]
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(document_attachment_path(params[:document_type_slug],
+                                          @document.content_id_and_locale,
+                                          @attachment.content_id),
+                 method: :delete,
+                 data: { gtm: "confirm-delete-attachment" }) do %>
+
+      <div class="govuk-body govuk-!-margin-bottom-8">
+        <p class="govuk-body">
+          <strong>Title: </strong>
+          <span><%= @attachment.title %></span>
+        </p>
+
+        <p class="govuk-body">
+          <strong>Attachment: </strong>
+          <span> <%= @attachment.filename %> </span>
+        </p>
+
+        <p>Are you sure you want to delete this attachment?</p>
+      </div>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to "Cancel",
+                    edit_document_path(current_format.admin_slug, @document.content_id_and_locale),
+                    class: "govuk-link govuk-link--no-visited-state app-link--inline",
+                    data: { gtm: "cancel-delete-attachment" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/confirm_discard.html.erb
+++ b/app/views/documents/confirm_discard.html.erb
@@ -46,7 +46,7 @@
         <%= link_to "Cancel",
                     document_path(current_format.admin_slug, @document.content_id_and_locale),
                     class: "govuk-link govuk-link--no-visited-state app-link--inline",
-                    data: { gtm: "cancel-unpublish" } %>
+                    data: { gtm: "cancel-discard-draft" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -48,7 +48,7 @@
         <%= link_to "Cancel",
                     document_path(current_format.admin_slug, @document.content_id_and_locale),
                     class: "govuk-link govuk-link--no-visited-state app-link--inline",
-                    data: { gtm: "cancel-publish" } %>
+                    data: { gtm: "cancel-edit" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -39,7 +39,7 @@
         <%= link_to "Cancel",
                     document_path(current_format.admin_slug, @document.content_id_and_locale),
                     class: "govuk-link govuk-link--no-visited-state app-link--inline",
-                    data: { gtm: "cancel-publish" } %>
+                    data: { gtm: "cancel-create" } %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,10 @@ Rails.application.routes.draw do
     collection do
       resource :export, only: %i[show create], as: :export_documents
     end
-    resources :attachments, param: :attachment_content_id, except: %i[index show]
+
+    resources :attachments, param: :attachment_content_id, except: %i[index show] do
+      get :confirm_delete, on: :member
+    end
 
     get :confirm_unpublish, on: :member
     post :unpublish, on: :member

--- a/spec/features/design_system/editing_attachments_on_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/editing_attachments_on_a_cma_case_design_system_spec.rb
@@ -179,6 +179,8 @@ RSpec.feature "Editing attachments on a CMA case", type: :feature do
         .to_return(body: asset_manager_response.to_json, status: 200)
       find(".attachments").first(:link, "Delete attachment").click
       expect(page.status_code).to eq(200)
+      click_button "Delete"
+      expect(page.status_code).to eq(200)
 
       # TODO: fix tests so that asset manager is updated appropriately
       # expect(page).not_to have_content('asylum-support-image.jpg')


### PR DESCRIPTION
Added a new Confirm Delete Attachment page. Users get to this page by clicking Delete Attachment on the edit document page. 

![image](https://github.com/user-attachments/assets/a25d068e-1347-4966-a008-519e3b388f9e)

![image](https://github.com/user-attachments/assets/cbd65a7a-06fd-4cf8-9ce1-230741e052b8)


https://trello.com/c/aC8wMxHy/3831-design-system-edit-document-attachment-links-and-buttons

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
