### PR TITLE
[WHIT-2023] [Design System] Transition Export to CSV page

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,6 +1,10 @@
 class ExportsController < ApplicationController
   before_action :check_authorisation, if: :document_type_slug
 
+  layout :get_layout
+  DESIGN_SYSTEM_MIGRATED_ACTIONS = %w[show].freeze
+  include DesignSystemHelper
+
   def check_authorisation
     if current_format
       authorize current_format
@@ -12,6 +16,7 @@ class ExportsController < ApplicationController
 
   def show
     @query = params[:query]
+    render design_system_view(:show, "exports/legacy/show_legacy")
   end
 
   def create

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -44,7 +44,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "govuk-!-padding-3 bg-light-grey") do %>
+    <%= form_tag(documents_path(current_format.admin_slug), method: :get, class: "govuk-!-padding-3 bg-light-grey govuk-!-margin-bottom-4") do %>
       <%= render "govuk_publishing_components/components/heading", {
         text: "Filter by",
         margin_bottom: 6,
@@ -78,6 +78,7 @@
         <%= link_to "Clear all filters", documents_path(current_format.admin_slug), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
+
     <% if current_format.exportable? %>
       <%= link_to "Export document list to CSV", export_documents_path(current_format.admin_slug, query: @query), class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>

--- a/app/views/exports/legacy/show_legacy.html.erb
+++ b/app/views/exports/legacy/show_legacy.html.erb
@@ -1,0 +1,22 @@
+<%= content_for :page_title, "Export as CSV" %>
+
+<% content_for :breadcrumbs do %>
+  <li><%= current_format.title.pluralize %></li>
+  <li class="active">Export as CSV</li>
+<% end %>
+
+<h1 class="page-header">Export as CSV</h1>
+
+<p>Please confirm you want to export the documents list. The following will be emailed to <strong><%= current_user.email %></strong>:</p>
+<ul>
+  <li>All <%= current_format.title.pluralize %></li>
+  <% if @query.present? %>
+    <li>Matching query: “<%= @query %>”</li>
+  <% end %>
+</ul>
+<%= form_tag export_documents_path(current_format.admin_slug), method: 'post' do %>
+  <%= hidden_field_tag :query, @query %>
+  <%= submit_tag "Export as CSV", class: 'btn btn-primary' %>
+
+  <%= link_to "Cancel and return to list", documents_path(current_format.admin_slug, query: params[:query]), class: 'btn btn-default' %>
+<% end %>

--- a/app/views/exports/show.html.erb
+++ b/app/views/exports/show.html.erb
@@ -1,22 +1,51 @@
-<%= content_for :page_title, "Export as CSV" %>
+<% page_title = "Export as CSV" %>
+
+<% content_for :page_title, page_title %>
+<% content_for :title, page_title %>
 
 <% content_for :breadcrumbs do %>
-  <li><%= current_format.title.pluralize %></li>
-  <li class="active">Export as CSV</li>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "All finders",
+        url: finders_path
+      },
+      {
+        title: current_format.title.pluralize,
+        url: documents_path(current_format.admin_slug)
+      },
+      {
+        title: page_title
+      }
+    ]
+  } %>
 <% end %>
 
-<h1 class="page-header">Export as CSV</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(export_documents_path(current_format.admin_slug),
+                 method: :post,
+                 data: { gtm: "export-csv" }) do %>
 
-<p>Please confirm you want to export the documents list. The following will be emailed to <strong><%= current_user.email %></strong>:</p>
-<ul>
-  <li>All <%= current_format.title.pluralize %></li>
-  <% if @query.present? %>
-    <li>Matching query: “<%= @query %>”</li>
-  <% end %>
-</ul>
-<%= form_tag export_documents_path(current_format.admin_slug), method: 'post' do %>
-  <%= hidden_field_tag :query, @query %>
-  <%= submit_tag "Export as CSV", class: 'btn btn-primary' %>
+      <p class="govuk-body">Please confirm you want to export the documents list. The following will be emailed to <%= current_user.email %>:</p>
 
-  <%= link_to "Cancel and return to list", documents_path(current_format.admin_slug, query: params[:query]), class: 'btn btn-default' %>
-<% end %>
+      <% items = [ sanitize("All #{current_format.title.pluralize}") ] %>
+      <% items << sanitize("Matching query: \"#{@query}\"") if @query.present? %>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items:
+      } %>
+
+      <%= hidden_field_tag :query, @query %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", text: "Export as CSV" %>
+        <%= link_to "Cancel",
+                    documents_path(current_format.admin_slug, query: params[:query]),
+                    class: "govuk-link govuk-link--no-visited-state app-link--inline",
+                    data: { gtm: "cancel-export-csv" } %>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
The Export to CSV page exists for any finder that is exportable. An example is Business Finance Support Schemes. This is hard coded on the document model. This page is now transitioned to the new Design System.

| Before | After |
| --- | --- |
| ![Screenshot 2025-07-02 at 12 55 18](https://github.com/user-attachments/assets/6ef165c3-97f5-4103-b161-dcc2e36cbc59) | ![Screenshot 2025-07-02 at 13 06 49](https://github.com/user-attachments/assets/b0c94653-233b-4637-bb1c-112aabe13bc0) |
| ![Screenshot 2025-07-02 at 12 57 39](https://github.com/user-attachments/assets/90a0bd73-1883-41e0-99e3-406af7ef78db) | ![Screenshot 2025-07-02 at 12 57 50](https://github.com/user-attachments/assets/ed2cbfbb-12b0-4006-a28c-9591a42ae5eb) |
| ![Screenshot 2025-07-02 at 13 46 45](https://github.com/user-attachments/assets/4ed60bff-24da-4b20-a631-0828603a8d33) | ![Screenshot 2025-07-02 at 13 48 15](https://github.com/user-attachments/assets/d627ebe3-5332-434c-9d91-e574bd0350d2) |

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2023)
