### PR TITLE
Ensure changenote timestamp is updated on document publish (WHIT-2263)

### DIFF
--- a/spec/services/document_publisher_spec.rb
+++ b/spec/services/document_publisher_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe DocumentPublisher do
+  it "updates the timestamp of the changenote prior to publishing" do
+    payload = FactoryBot.create(:cma_case)
+    stub_publishing_api_has_item(payload)
+    document = DocumentBuilder.build(CmaCase, payload)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_patch_links
+    stub_publishing_api_publish(payload["content_id"], {})
+    stub_email_alert_api_accepts_content_change
+
+    current_time = "2016-12-03T16:59:13+00:00"
+    Timecop.freeze(Time.zone.parse(current_time)) do
+      expect(document.public_updated_at).to eq("2015-11-16T11:53:30+00:00")
+      DocumentPublisher.publish(document)
+      expect(document.public_updated_at).to eq(current_time)
+    end
+  end
+end


### PR DESCRIPTION
We used to rely on Publishing API to set this value for us, but there were two problems with that:

1. This weird email hack where we need to fetch the published document from Publishing API in order to fetch the 'public updated at' timestamp before manually calling Email Alert API.
2. More recently - and more pressing - we've been made aware of a bug whereby the latest changenote for a document takes its timestamp from the last time the document was edited _prior to publishing_. This means that if a document is drafted on 1st April and then published on 2nd April, the public changenote says 1st April, which can be misleading to users (it might suggest that the changes are effective from 1st April, rather than from 2nd April when the content was actually visible).

Setting the `public_updated_at` means:

1. No need to fetch the content item from Publishing API - we can proceed to our Email Alert API call immediately.
2. We explicitly tell Publishing API to use the `public_updated_at` in our payload, for its corresponding ChangeNote:  https://github.com/alphagov/publishing-api/blob/6143731ffad5db48476d7647a75413c42a5224fd/app/models/change_note.rb#L31

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2263

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
