### PR TITLE
[WHIT-1480 ] Add missed plural for finder title

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,7 +14,7 @@
   } %>
 <% end %>
 <% content_for :page_title, "Edit #{current_format.title} finder" %>
-<% content_for :title, "#{current_format.title} finder" %>
+<% content_for :title, "#{current_format.title.pluralize} finder" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/spec/features/design_system/viewing_the_admin_summary_for_cma_cases_design_system_spec.rb
+++ b/spec/features/design_system/viewing_the_admin_summary_for_cma_cases_design_system_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Viewing the admin summary for CMA cases", type: :feature do
 
   scenario "viewing finders/cma-cases should display details of the CMA Case finder" do
     visit "finders/cma-cases"
-    expect(page).to have_selector("h1", text: "CMA Case finder")
+    expect(page).to have_selector("h1", text: "CMA Cases finder")
     expect(page).to have_selector("dt", text: "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)")
     expect(page).to have_selector(".govspeak", text: "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)")
     expect(page.find(".govuk-summary-list__row", text: "Should summary of each content show under the title in the finder list page?")).to have_selector("dt", text: "No")

--- a/spec/features/legacy/viewing_the_admin_summary_for_cma_cases_spec.rb
+++ b/spec/features/legacy/viewing_the_admin_summary_for_cma_cases_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Viewing the admin summary for CMA cases", type: :feature do
 
   scenario "viewing finders/cma-cases should display details of the CMA Case finder" do
     visit "finders/cma-cases"
-    expect(page).to have_selector("h1", text: "CMA Case finder")
+    expect(page).to have_selector("h1", text: "CMA Cases finder")
     expect(page).to have_selector("dt", text: "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)")
     expect(page).to have_selector(".govspeak", text: "This case finder includes cases and projects from the Competition and Markets Authority (CMA), Office for the Internal Market (OIM) and Subsidy Advice Unit (SAU)")
     expect(page.find(".govuk-summary-list__row", text: "Should summary of each content show under the title in the finder list page?")).to have_selector("dt", text: "No")


### PR DESCRIPTION
Missed this when merging https://github.com/alphagov/specialist-publisher/pull/3232. The title of the finder on the show page should match the breadcrumb.

![Screenshot 2025-07-02 at 12 52 21](https://github.com/user-attachments/assets/b3936d4f-9a39-46e9-bb71-6809e93bf472)


 [Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-1480)
