### PR TITLE
[WHIT-2025 ] [Design system] Fix authors

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -185,6 +185,7 @@ private
 
   def fetch_document
     @document = current_format.find(content_id_param, locale_param)
+    set_design_system_flag
     if params[:content_id_and_locale].split(":")[1] != @document.locale
       redirect_to(
         document_path(
@@ -232,6 +233,12 @@ private
       else
         e.full_message
       end
+    end
+  end
+
+  def set_design_system_flag
+    if @document && current_format.document_type == "research_for_development_output"
+      @document.is_using_design_system_view = current_user.permissions.include?("preview_design_system")
     end
   end
 end

--- a/app/models/research_for_development_output.rb
+++ b/app/models/research_for_development_output.rb
@@ -3,10 +3,11 @@ class ResearchForDevelopmentOutput < Document
 
   FORMAT_SPECIFIC_FIELDS = format_specific_fields + [:review_status]
 
-  attr_accessor(*FORMAT_SPECIFIC_FIELDS)
+  attr_accessor(*FORMAT_SPECIFIC_FIELDS, :is_using_design_system_view)
 
   def initialize(params = {})
     super(params, FORMAT_SPECIFIC_FIELDS)
+    self.is_using_design_system_view = params[:is_using_design_system_view] || false
     self.author_tags = params[:author_tags]
   end
 
@@ -19,11 +20,15 @@ class ResearchForDevelopmentOutput < Document
     true
   end
 
+  def split_string
+    is_using_design_system_view ? "\r\n" : "::"
+  end
+
   def author_tags
-    (authors || []).join("::")
+    (authors || []).join(split_string)
   end
 
   def author_tags=(tags)
-    self.authors = (tags || "").split("::")
+    self.authors = (tags || "").split(split_string).reject(&:blank?)
   end
 end

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -1,9 +1,10 @@
 <% finder_schema = f.object.class.finder_schema %>
+<% format_name = f.object.class.document_type.to_sym %>
+
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:research_document_type), params) %>
 
-<%= render layout: 'shared/legacy/form_group_legacy', locals: { f: f, field: :authors, label: 'Authors' } do %>
-  <%= f.text_field :author_tags, class: 'form-control free-form-list', data: { placeholder: 'Add authors' } %>
-<% end %>
+<%= f.hidden_field :is_using_design_system_view, value: true%>
+<%= render FacetInputComponent::TextAreaComponent.new(@document, format_name, :author_tags, "Authors") %>
 
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:country), params) %>
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:theme), params) %>

--- a/app/views/metadata_fields/_research_for_development_outputs.html.erb
+++ b/app/views/metadata_fields/_research_for_development_outputs.html.erb
@@ -21,5 +21,5 @@
     "value" => "peer-reviewed",
   },
 ] %>
-<%= render FacetInputComponent::SingleSelectComponent.new(@document, @document_type, :review_status, "Review status", review_status_options) %>
+<%= render FacetInputComponent::SingleSelectComponent.new(@document, format_name, :review_status, "Review status", review_status_options) %>
 

--- a/spec/features/design_system/creating_a_research_for_development_output_spec.rb
+++ b/spec/features/design_system/creating_a_research_for_development_output_spec.rb
@@ -72,8 +72,7 @@ RSpec.feature "Creating a Research for Development Output ", type: :feature do
       elsif properties["select"] == "multiple"
         select facet["allowed_values"].first["label"], from: "#{document_type}[#{facet['key']}][]"
       elsif facet["key"] == "authors"
-        # TODO: fill in author - odd multiple select type, because it does not have allowed values; we do not currently have a component for this
-        fill_in "research_for_development_output[author_tags]", with: "A. Author"
+        fill_in "research_for_development_output[author_tags]", with: "Mr. Potato Head\r\nMrs. Potato Head"
       else
         fill_in facet["name"], with: "Example #{facet['name']}"
       end
@@ -85,5 +84,6 @@ RSpec.feature "Creating a Research for Development Output ", type: :feature do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Created Example #{document_type.to_s.humanize}")
+    expect(page.body).to include("Mr. Potato Head<br>Mrs. Potato Head")
   end
 end

--- a/spec/models/research_for_development_output_spec.rb
+++ b/spec/models/research_for_development_output_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ResearchForDevelopmentOutput do
     expect(subject.bulk_published).to be true
   end
 
-  it "has a author_tags virtual attribute" do
+  it "has a legacy author_tags virtual attribute" do
     subject.author_tags = "a, b::c"
     expect(subject.authors).to eq ["a, b", "c"]
 
@@ -17,5 +17,18 @@ RSpec.describe ResearchForDevelopmentOutput do
 
     subject = described_class.new(author_tags: "foo, bar::baz")
     expect(subject.authors).to eq ["foo, bar", "baz"]
+  end
+
+  it "has an author_tags virtual attribute" do
+    allow_any_instance_of(described_class).to receive(:is_using_design_system_view).and_return(true)
+
+    subject.author_tags = "a b\r\nc, d\r\n\r\n\   \r\nd. e, f"
+    expect(subject.authors).to eq ["a b", "c, d", "d. e, f"]
+
+    subject.authors = ["foo, bar", "bar. baz", "baz"]
+    expect(subject.author_tags).to eq "foo, bar\r\nbar. baz\r\nbaz"
+
+    subject = described_class.new(author_tags: "foo bar\r\nbar, baz\r\nbaz. qux\r\nqux")
+    expect(subject.authors).to eq ["foo bar", "bar, baz", "baz. qux", "qux"]
   end
 end


### PR DESCRIPTION
## Implement the authors field as a textarea

The authors facet is implemented as a filterable text facet, but it does not have allowed values. In the legacy view it was rendered as a `<ul>` with the last `<li>` having an input.

The facet itself is registered as a type array of strings in publishing-api, so we need to map it from a string to an array, and vice versa, for writing and reading respectively. On the form we use the `author_tags` name and then do the conversion with the `author_tags` getters and setters in the model.

We implemented it as a textarea, using a hidden field to represent whether we're on a DS or legacy view. The field value is used to toggle the split string value on the model ("::" for legacy, newline - \r\n - for the textarea). For the edit pages to work, I also had to pass the virtual attribute from the controller.

Also fixed the review status field, which was not saving.

## Testing

- Still saves field correctly for legacy
![Screenshot 2025-07-04 at 18 34 49](https://github.com/user-attachments/assets/cea9b240-f2f2-4ffc-8693-b3eb2a294fe0)
- Authors text area on a new page
![Screenshot 2025-07-04 at 18 29 06](https://github.com/user-attachments/assets/c98947d7-7268-4c65-8e14-2d1a43f48b3d)
- Authors persists on validation
![Screenshot 2025-07-04 at 18 29 24](https://github.com/user-attachments/assets/ce87df12-e865-43b8-b5cb-269f80e0edc9)
- Authors on summary page (renders as an array, each value on new line + any blank lines are dropped)
![Screenshot 2025-07-04 at 18 29 42](https://github.com/user-attachments/assets/50cef9ed-4df4-4642-ac34-3f6f4d200b4b)
- Authors on edit page
![Screenshot 2025-07-04 at 18 29 52](https://github.com/user-attachments/assets/e0a034c2-dac3-4a9c-8561-799ece4b1a5a)
- Renders pre-existing authors field correctly
Legacy:
![Screenshot 2025-07-04 at 18 34 49](https://github.com/user-attachments/assets/cea9b240-f2f2-4ffc-8693-b3eb2a294fe0)
DS:
![Screenshot 2025-07-04 at 18 35 13](https://github.com/user-attachments/assets/66c325cb-d038-4bc3-8a90-2d71de5dae3d)
- Before review status not saved
![Screenshot 2025-07-04 at 16 56 22](https://github.com/user-attachments/assets/2d2f7b35-0cbd-4729-a1fb-b5a2be054e2f)
- After review status saved
![Screenshot 2025-07-04 at 16 57 27](https://github.com/user-attachments/assets/2a3223dc-7d9b-4e96-afc1-8995bef263e2)



[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2025)