### PR TITLE
[WHIT-2298] [Design System] Release QA - Change how we surface custom error messages

### DIFF
--- a/app/components/error_summary_component.rb
+++ b/app/components/error_summary_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ErrorSummaryComponent < ViewComponent::Base
+  include ErrorsHelper
+
   attr_reader :object, :errors
 
   def initialize(object:, parent_class: nil)
@@ -26,7 +28,7 @@ private
   def error_items
     errors.map do |error|
       error_item = {
-        text: get_text(error),
+        text: get_text(object_type, error),
         data_attributes: {
           module: "ga4-auto-tracker",
           "ga4-auto": {
@@ -48,8 +50,8 @@ private
     @parent_class ||= object.class.to_s.underscore
   end
 
-  def get_text(error)
-    object.try(:custom_error_message_fields) && object.custom_error_message_fields.include?(error.attribute) ? error.message : error.full_message
+  def object_type
+    object.class.try(:document_type)
   end
 
   def ga4_title

--- a/app/components/error_summary_component.rb
+++ b/app/components/error_summary_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class ErrorSummaryComponent < ViewComponent::Base
-  attr_reader :object
+  attr_reader :object, :errors
 
   def initialize(object:, parent_class: nil)
     @object = object
     @parent_class = parent_class
+    @errors = object.errors
   end
 
   def render?
@@ -47,21 +48,11 @@ private
     @parent_class ||= object.class.to_s.underscore
   end
 
-  def errors
-    @errors ||= if [ActiveModel::Errors, Array].include?(object.class)
-                  object
-                else
-                  object.errors
-                end
-  end
-
   def get_text(error)
-    @object.try(:custom_error_message_fields) && @object.custom_error_message_fields.include?(error.attribute) ? error.message : error.full_message
+    object.try(:custom_error_message_fields) && object.custom_error_message_fields.include?(error.attribute) ? error.message : error.full_message
   end
 
   def ga4_title
-    return object.class.name.humanize if [ActiveModel::Errors, Array].include?(object.class)
-
     "#{object.try(:new_record?) ? 'New' : 'Editing'} #{object.model_name.human.downcase.titleize}"
   end
 end

--- a/app/components/facet_input_component/date_component.rb
+++ b/app/components/facet_input_component/date_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::DateComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @params = params
   end
 

--- a/app/components/facet_input_component/input_component.rb
+++ b/app/components/facet_input_component/input_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::InputComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @type = input_type || "text"
   end
 end

--- a/app/components/facet_input_component/multi_select_with_search_component.rb
+++ b/app/components/facet_input_component/multi_select_with_search_component.rb
@@ -8,7 +8,7 @@ class FacetInputComponent::MultiSelectWithSearchComponent < ViewComponent::Base
     @facet_key = facet_key
     @facet_name = facet_name
     @allowed_values = allowed_values
-    @error_items = errors_for(@document.errors, @facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @options = select_options
   end
 

--- a/app/components/facet_input_component/organisation_multi_select_with_search_component.rb
+++ b/app/components/facet_input_component/organisation_multi_select_with_search_component.rb
@@ -7,9 +7,9 @@ class FacetInputComponent::OrganisationMultiSelectWithSearchComponent < ViewComp
     @document_type = document_type
     @facet_key = facet_key
     @label = facet_name
-    @id = document_type ? "#{@document_type}_#{@facet_key}" : @facet_key.to_s
-    @name = document_type ? "#{@document_type}[#{@facet_key}][]" : "#{@facet_key}[]"
-    @error_items = errors_for(@document.errors, @facet_key)
+    @id = document_type ? "#{document_type}_#{facet_key}" : facet_key.to_s
+    @name = document_type ? "#{document_type}[#{facet_key}][]" : "#{facet_key}[]"
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @options = select_options
   end
 

--- a/app/components/facet_input_component/organisation_single_select_with_search_component.rb
+++ b/app/components/facet_input_component/organisation_single_select_with_search_component.rb
@@ -8,9 +8,9 @@ class FacetInputComponent::OrganisationSingleSelectWithSearchComponent < ViewCom
     @facet_key = facet_key
     @label = facet_name
     @heading_size = heading_size
-    @id = document_type ? "#{@document_type}_#{@facet_key}" : @facet_key.to_s
-    @name = document_type ? "#{@document_type}[#{@facet_key}]" : @facet_key
-    @error_items = @document ? errors_for(document.errors, facet_key) : nil
+    @id = document_type ? "#{document_type}_#{facet_key}" : facet_key.to_s
+    @name = document_type ? "#{document_type}[#{facet_key}]" : facet_key
+    @error_items = @document ? errors_for(document_type, document.errors, facet_key) : nil
     @options = organisation_single_select_options(selected_organisation_content_id, has_all_option: has_all_option)
   end
 end

--- a/app/components/facet_input_component/single_select_component.rb
+++ b/app/components/facet_input_component/single_select_component.rb
@@ -9,7 +9,7 @@ class FacetInputComponent::SingleSelectComponent < ViewComponent::Base
     @facet_name = facet_name
     @allowed_values = allowed_values
     @options = select_options
-    @error_message = errors_for_input(document.errors, facet_key)
+    @error_message = errors_for_input(document_type, document.errors, facet_key)
   end
 
   def select_options

--- a/app/components/facet_input_component/single_select_with_search_component.rb
+++ b/app/components/facet_input_component/single_select_with_search_component.rb
@@ -9,7 +9,7 @@ class FacetInputComponent::SingleSelectWithSearchComponent < ViewComponent::Base
     @facet_name = facet_name
     @allowed_values = allowed_values
     @options = select_options
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
   end
 
   def select_options

--- a/app/components/facet_input_component/text_area_component.rb
+++ b/app/components/facet_input_component/text_area_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::TextAreaComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @hint = hint
   end
 end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -31,16 +31,4 @@ module ErrorsHelper
     custom_error = I18n.exists?("activemodel.errors.models.#{object_type}.attributes.#{error.attribute}", :en)
     custom_error ? error.message : error.full_message
   end
-
-  def field_has_errors(document, field)
-    field_errors(document, field).any?
-  end
-
-  def field_errors(document, field)
-    if document.custom_error_message_fields.include?(field)
-      document.errors.messages_for(field)
-    else
-      document.errors.full_messages_for(field)
-    end
-  end
 end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,10 +1,10 @@
 module ErrorsHelper
-  def errors_for_input(errors, attribute)
+  def errors_for_input(object_type, errors, attribute)
     return nil if errors.blank?
 
     errors.filter_map { |error|
       if error.attribute == attribute
-        error.full_message
+        get_text(object_type, error)
       end
     }
     .join(tag.br)
@@ -12,17 +12,24 @@ module ErrorsHelper
     .presence
   end
 
-  def errors_for(errors, attribute)
+  def errors_for(object_type, errors, attribute)
     return nil if errors.blank?
 
     errors.filter_map { |error|
       if error.attribute == attribute
         {
-          text: error.full_message,
+          text: get_text(object_type, error),
         }
       end
     }
     .presence
+  end
+
+  def get_text(object_type, error)
+    return error.full_message unless object_type
+
+    custom_error = I18n.exists?("activemodel.errors.models.#{object_type}.attributes.#{error.attribute}", :en)
+    custom_error ? error.message : error.full_message
   end
 
   def field_has_errors(document, field)

--- a/app/helpers/legacy/errors_helper.rb
+++ b/app/helpers/legacy/errors_helper.rb
@@ -1,0 +1,13 @@
+module Legacy::ErrorsHelper
+  def field_has_errors(document, field)
+    field_errors(document, field).any?
+  end
+
+  def field_errors(document, field)
+    if document.custom_error_message_fields.include?(field)
+      document.errors.messages_for(field)
+    else
+      document.errors.full_messages_for(field)
+    end
+  end
+end

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -15,7 +15,7 @@
   id: "#{format_name}_link_and_identifier_exists",
   error_message: errors_for_input(format_name, @document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(format_name, @document.errors, :base) : nil,
 } do %>
-  <% unless field_has_errors(@document, :base) %>
+  <% unless errors_for_input(format_name, @document.errors, :base) %>
     <p class="govuk-body govuk-!-margin-bottom-6">Enter either the website where users can apply for the licence, or the licence identifier.</p>
   <% end %>
 

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -4,7 +4,7 @@
 <%= render FacetInputComponent.new(@document, schema.get_facet(:licence_transaction_industry), params, "Industry") %>
 
 <% # TODO: find a way of making organisation management schema-driven %>
-<% format_name = f.object.class.finder_schema.filter["format"].to_sym %>
+<% format_name = f.object.class.document_type.to_sym %>
 <%= render FacetInputComponent::OrganisationSingleSelectWithSearchComponent.new(@document, format_name, :primary_publishing_organisation, "Publishing organisation", selected_organisation_or_current(@document.primary_publishing_organisation)) %>
 <%= render FacetInputComponent::OrganisationMultiSelectWithSearchComponent.new(@document, format_name, :organisations, "Other associated organisations") %>
 

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -13,7 +13,7 @@
   heading_level: 2,
   heading_size: "l",
   id: "#{format_name}_link_and_identifier_exists",
-  error_message: errors_for_input(@document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(@document.errors, :base) : nil,
+  error_message: errors_for_input(format_name, @document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(format_name, @document.errors, :base) : nil,
 } do %>
   <% unless field_has_errors(@document, :base) %>
     <p class="govuk-body govuk-!-margin-bottom-6">Enter either the website where users can apply for the licence, or the licence identifier.</p>

--- a/app/views/shared/_attachments_form.html.erb
+++ b/app/views/shared/_attachments_form.html.erb
@@ -9,7 +9,7 @@
       heading_level: 2,
       heading_size: "l",
       value: f.object.title,
-      error_items: errors_for(@attachment.errors, :title)
+      error_items: errors_for(@attachment.document_type, @attachment.errors, :title)
     } %>
   </div>
 
@@ -31,7 +31,7 @@
     heading_size: "l",
     name: "attachment[file]",
     id: "attachment_file",
-    error_items: errors_for(@attachment.errors, :file)
+    error_items: errors_for(@attachment.document_type, @attachment.errors, :file)
   } %>
 
   <div class="govuk-button-group">

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -7,7 +7,7 @@
   id: "#{format_name}_title",
   name: "#{format_name}[title]",
   value: @document.title,
-  error_items: errors_for(@document.errors, :title)
+  error_items: errors_for(format_name, @document.errors, :title)
 } %>
 
 <%= render "govuk_publishing_components/components/character_count", {
@@ -19,7 +19,7 @@
     name: "#{format_name}[summary]",
     value: @document.summary,
     margin_bottom: 8,
-    error_items: errors_for(@document.errors, :summary),
+    error_items: errors_for(format_name, @document.errors, :summary),
   },
   id: "#{format_name}_summary",
   maxlength: 280,
@@ -34,7 +34,7 @@
   name: "#{format_name}[body]",
   rows: 20,
   value: @document.body || @document.finder_schema.body_template,
-  error_items: errors_for(@document.errors, :body),
+  error_items: errors_for(format_name, @document.errors, :body),
   attachments: @document.attachments
 } %>
 

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -17,7 +17,7 @@
           },
           name: "#{document.document_type}[change_note]",
           textarea_id: "#{document.document_type}_change_note",
-          error_message: errors_for_input(document.errors, :change_note),
+          error_message: errors_for_input(document.document_type, document.errors, :change_note),
           value: document.change_note,
           hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
             link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,

--- a/spec/components/error_summary_component_spec.rb
+++ b/spec/components/error_summary_component_spec.rb
@@ -89,40 +89,6 @@ RSpec.describe ErrorSummaryComponent, type: :component do
     expect(page).to have_css(".gem-c-error-summary__list-item span", text: "This is a top level error that is agnostic of model level validations. It has probably been added by an updater service or a controller and does not link to an input.")
   end
 
-  it "renders errors when 'ActiveModel::Errors' are passed in" do
-    render_inline(ErrorSummaryComponent.new(object: @object_with_errors.errors, parent_class: "error_summary_test_object"))
-
-    first_link = page.all(".gem-c-error-summary__list-item")[0].find("a")
-    second_link = page.all(".gem-c-error-summary__list-item")[1].find("a")
-    third_link = page.all(".gem-c-error-summary__list-item")[2].find("a")
-
-    expect(page.all(".gem-c-error-summary__list-item").count).to eq 3
-    expect(page.all(".gem-c-error-summary__list-item a").count).to eq 3
-    expect(first_link.text).to eq "Title can't be blank"
-    expect(first_link[:href]).to eq "#error_summary_test_object_title"
-    expect(second_link.text).to eq "Date can't be blank"
-    expect(second_link[:href]).to eq "#error_summary_test_object_date"
-    expect(third_link.text).to eq "Date is invalid"
-    expect(third_link[:href]).to eq "#error_summary_test_object_date"
-  end
-
-  it "renders errors when an array of 'ActiveModel::Error' objects are passed in" do
-    render_inline(ErrorSummaryComponent.new(object: @object_with_errors.errors.errors, parent_class: "error_summary_test_object"))
-
-    first_link = page.all(".gem-c-error-summary__list-item")[0].find("a")
-    second_link = page.all(".gem-c-error-summary__list-item")[1].find("a")
-    third_link = page.all(".gem-c-error-summary__list-item")[2].find("a")
-
-    expect(page.all(".gem-c-error-summary__list-item").count).to eq 3
-    expect(page.all(".gem-c-error-summary__list-item a").count).to eq 3
-    expect(first_link.text).to eq "Title can't be blank"
-    expect(first_link[:href]).to eq "#error_summary_test_object_title"
-    expect(second_link.text).to eq "Date can't be blank"
-    expect(second_link[:href]).to eq "#error_summary_test_object_date"
-    expect(third_link.text).to eq "Date is invalid"
-    expect(third_link[:href]).to eq "#error_summary_test_object_date"
-  end
-
   it "renders messages, rather than full messages, for objects with custom error message fields" do
     licence_transaction = LicenceTransaction.new(body: "body")
     licence_transaction.errors.add(:title, "Custom error message for title")


### PR DESCRIPTION
## Context

The issue we're trying to fix here is the rendering of custom error messages/fields. These are currently only defined for licence transactions in the `en.yml` I18n file. The `LicenceTransaction model` is marked as having custom fields through the `custom_error_message_fields` method. This is again consumed in the `DocumentsController` - `document_error_messages` method, to figure out the errors - either custom or full messages. All this controller logic is bypassed if we are on the design system.

In the previous implementation, we tapped into this logic in the `ErrorSummaryComponent` to render the correct errors for Licences. But we missed the fact that the validation messages on the fields themselves were not being done properly (they're full message mixed with custom, giving the rather unsightly `Licence transaction industry Select an industry`).


## Implementation


This PR fixes both the `ErrorSummary` and the field errors, as well as opening up the possibility of adding custom errors for subsequent models without having to go through the model or controller. The licence model and controller code will stay in place for legacy, but once we remove the DS toggle code, we will be able to remove that complexity (tested this locally ✨).

Alternatively, this also means we can remove the "customization of error messages" from licences/codebase by simply removing their definition from the yml file, if that's a preferable course of action. For now, we've decided to maintain content as is whilst going live with the Design System.

This is done by:
- moving the `get_text` method in the `ErrorsHelper` and reuse it for both fields and summary.
- make the `get_text` method tap into the yml file directly.
- we need to know what to search for in the yml file so we pass into `get_text`, the model "format" or document_type - which is how adding things to yml happens by convention.
- this has caused many changes where the `errors_for` or `errors_for_input` were used, but it's simply passing that param through.
- `errors_for` or `errors_for_input` - are mainly distinguished by the fact that they map to either an array, or an object with the `text` key in it, depending on what consumes them; for now we have to keep both.
- `errors_for` is used practically across all the components under `FacetInputComponent` so we could extract it at the top in the `FacetInputComponent` initializer - but I think we can live with the repetition.


### Screenshots
- licences before (weird inline error messages)
<img width="407" height="677" alt="Screenshot 2025-07-10 at 13 30 59" src="https://github.com/user-attachments/assets/db3477ad-270f-4a71-82bc-88d8241f63b6" />

- licences after 
> <img width="412" height="667" alt="Screenshot 2025-07-10 at 13 32 21" src="https://github.com/user-attachments/assets/bca7dede-9942-428e-972c-abfff122d087" />

- licences before (change note broken)
> <img width="732" height="336" alt="Screenshot 2025-07-10 at 13 52 42" src="https://github.com/user-attachments/assets/8f72a503-1d39-4d7f-809b-85337140cf69" />

- licences after (change note ok)
> <img width="732" height="425" alt="Screenshot 2025-07-10 at 13 52 56" src="https://github.com/user-attachments/assets/ed9c692e-d699-4606-b329-de62e8aa1cab" />

- DS other finders' error showing correctly (no change) before (left) / after (right)
> <img width="1892" height="935" alt="Screenshot 2025-07-10 at 13 33 34" src="https://github.com/user-attachments/assets/f2f166e9-017c-468e-8ca0-0be2830f9e03" />
- DS this one has custom fields in the en.yml - still rendering as expected (no change) - before (left) / after (right)
<img width="1892" height="961" alt="Screenshot 2025-07-10 at 13 35 10" src="https://github.com/user-attachments/assets/f56ad2c5-d102-4fdf-9b9b-04fab403ca4c" />

- Legacy - still displaying correctly (needs to still work)
> <img width="1058" height="979" alt="Screenshot 2025-07-10 at 13 47 21" src="https://github.com/user-attachments/assets/2e4b5501-8e15-4e5d-b91d-0783a1bfcacd" />
> <img width="1058" height="979" alt="Screenshot 2025-07-10 at 13 48 00" src="https://github.com/user-attachments/assets/6c41576f-0918-47ca-8bd0-3ce98aa8b976" />

- Attachments are not changed; they're actually not affected although we've changed their `errors_for` methods (the error is shown through flash not error summary)
> <img width="1877" height="509" alt="Screenshot 2025-07-10 at 13 56 44" src="https://github.com/user-attachments/assets/7555d80c-939d-4e68-aa3e-1a8c0627b614" />


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2298)
