### PR TITLE
[WHIT-2298] [Design System] Release QA - fix breadcrumbs

### DIFF
--- a/app/components/error_summary_component.rb
+++ b/app/components/error_summary_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ErrorSummaryComponent < ViewComponent::Base
+  include ErrorsHelper
+
   attr_reader :object, :errors
 
   def initialize(object:, parent_class: nil)
@@ -26,7 +28,7 @@ private
   def error_items
     errors.map do |error|
       error_item = {
-        text: get_text(error),
+        text: get_text(object_type, error),
         data_attributes: {
           module: "ga4-auto-tracker",
           "ga4-auto": {
@@ -48,8 +50,8 @@ private
     @parent_class ||= object.class.to_s.underscore
   end
 
-  def get_text(error)
-    object.try(:custom_error_message_fields) && object.custom_error_message_fields.include?(error.attribute) ? error.message : error.full_message
+  def object_type
+    object.class.try(:document_type)
   end
 
   def ga4_title

--- a/app/components/facet_input_component/date_component.rb
+++ b/app/components/facet_input_component/date_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::DateComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @params = params
   end
 

--- a/app/components/facet_input_component/input_component.rb
+++ b/app/components/facet_input_component/input_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::InputComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @type = input_type || "text"
   end
 end

--- a/app/components/facet_input_component/multi_select_with_search_component.rb
+++ b/app/components/facet_input_component/multi_select_with_search_component.rb
@@ -8,7 +8,7 @@ class FacetInputComponent::MultiSelectWithSearchComponent < ViewComponent::Base
     @facet_key = facet_key
     @facet_name = facet_name
     @allowed_values = allowed_values
-    @error_items = errors_for(@document.errors, @facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @options = select_options
   end
 

--- a/app/components/facet_input_component/organisation_multi_select_with_search_component.rb
+++ b/app/components/facet_input_component/organisation_multi_select_with_search_component.rb
@@ -7,9 +7,9 @@ class FacetInputComponent::OrganisationMultiSelectWithSearchComponent < ViewComp
     @document_type = document_type
     @facet_key = facet_key
     @label = facet_name
-    @id = document_type ? "#{@document_type}_#{@facet_key}" : @facet_key.to_s
-    @name = document_type ? "#{@document_type}[#{@facet_key}][]" : "#{@facet_key}[]"
-    @error_items = errors_for(@document.errors, @facet_key)
+    @id = document_type ? "#{document_type}_#{facet_key}" : facet_key.to_s
+    @name = document_type ? "#{document_type}[#{facet_key}][]" : "#{facet_key}[]"
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @options = select_options
   end
 

--- a/app/components/facet_input_component/organisation_single_select_with_search_component.rb
+++ b/app/components/facet_input_component/organisation_single_select_with_search_component.rb
@@ -8,9 +8,9 @@ class FacetInputComponent::OrganisationSingleSelectWithSearchComponent < ViewCom
     @facet_key = facet_key
     @label = facet_name
     @heading_size = heading_size
-    @id = document_type ? "#{@document_type}_#{@facet_key}" : @facet_key.to_s
-    @name = document_type ? "#{@document_type}[#{@facet_key}]" : @facet_key
-    @error_items = @document ? errors_for(document.errors, facet_key) : nil
+    @id = document_type ? "#{document_type}_#{facet_key}" : facet_key.to_s
+    @name = document_type ? "#{document_type}[#{facet_key}]" : facet_key
+    @error_items = @document ? errors_for(document_type, document.errors, facet_key) : nil
     @options = organisation_single_select_options(selected_organisation_content_id, has_all_option: has_all_option)
   end
 end

--- a/app/components/facet_input_component/single_select_component.rb
+++ b/app/components/facet_input_component/single_select_component.rb
@@ -9,7 +9,7 @@ class FacetInputComponent::SingleSelectComponent < ViewComponent::Base
     @facet_name = facet_name
     @allowed_values = allowed_values
     @options = select_options
-    @error_message = errors_for_input(document.errors, facet_key)
+    @error_message = errors_for_input(document_type, document.errors, facet_key)
   end
 
   def select_options

--- a/app/components/facet_input_component/single_select_with_search_component.rb
+++ b/app/components/facet_input_component/single_select_with_search_component.rb
@@ -9,7 +9,7 @@ class FacetInputComponent::SingleSelectWithSearchComponent < ViewComponent::Base
     @facet_name = facet_name
     @allowed_values = allowed_values
     @options = select_options
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
   end
 
   def select_options

--- a/app/components/facet_input_component/text_area_component.rb
+++ b/app/components/facet_input_component/text_area_component.rb
@@ -6,7 +6,7 @@ class FacetInputComponent::TextAreaComponent < ViewComponent::Base
     @document_type = document_type
     @facet_key = facet_key
     @facet_name = facet_name
-    @error_items = errors_for(document.errors, facet_key)
+    @error_items = errors_for(document_type, document.errors, facet_key)
     @hint = hint
   end
 end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -31,16 +31,4 @@ module ErrorsHelper
     custom_error = I18n.exists?("activemodel.errors.models.#{object_type}.attributes.#{error.attribute}", :en)
     custom_error ? error.message : error.full_message
   end
-
-  def field_has_errors(document, field)
-    field_errors(document, field).any?
-  end
-
-  def field_errors(document, field)
-    if document.custom_error_message_fields.include?(field)
-      document.errors.messages_for(field)
-    else
-      document.errors.full_messages_for(field)
-    end
-  end
 end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,10 +1,10 @@
 module ErrorsHelper
-  def errors_for_input(errors, attribute)
+  def errors_for_input(object_type, errors, attribute)
     return nil if errors.blank?
 
     errors.filter_map { |error|
       if error.attribute == attribute
-        error.full_message
+        get_text(object_type, error)
       end
     }
     .join(tag.br)
@@ -12,17 +12,24 @@ module ErrorsHelper
     .presence
   end
 
-  def errors_for(errors, attribute)
+  def errors_for(object_type, errors, attribute)
     return nil if errors.blank?
 
     errors.filter_map { |error|
       if error.attribute == attribute
         {
-          text: error.full_message,
+          text: get_text(object_type, error),
         }
       end
     }
     .presence
+  end
+
+  def get_text(object_type, error)
+    return error.full_message unless object_type
+
+    custom_error = I18n.exists?("activemodel.errors.models.#{object_type}.attributes.#{error.attribute}", :en)
+    custom_error ? error.message : error.full_message
   end
 
   def field_has_errors(document, field)

--- a/app/helpers/legacy/errors_helper.rb
+++ b/app/helpers/legacy/errors_helper.rb
@@ -1,0 +1,13 @@
+module Legacy::ErrorsHelper
+  def field_has_errors(document, field)
+    field_errors(document, field).any?
+  end
+
+  def field_errors(document, field)
+    if document.custom_error_message_fields.include?(field)
+      document.errors.messages_for(field)
+    else
+      document.errors.full_messages_for(field)
+    end
+  end
+end

--- a/app/views/attachments/confirm_delete.html.erb
+++ b/app/views/attachments/confirm_delete.html.erb
@@ -18,9 +18,6 @@
       {
         title: @document.title,
         url: edit_document_path(params[:document_type_slug], @document.content_id)
-      },
-      {
-        title: page_title
       }
     ]
   } %>

--- a/app/views/attachments/edit.html.erb
+++ b/app/views/attachments/edit.html.erb
@@ -19,9 +19,6 @@
       {
         title: @document.title,
         url: edit_document_path(params[:document_type_slug], @document.content_id)
-      },
-      {
-        title: page_title
       }
     ]
   } %>

--- a/app/views/attachments/new.html.erb
+++ b/app/views/attachments/new.html.erb
@@ -19,9 +19,6 @@
       {
         title: @document.title,
         url: edit_document_path(params[:document_type_slug], @document.content_id)
-      },
-      {
-        title: page_title
       }
     ]
   } %>

--- a/app/views/documents/confirm_discard.html.erb
+++ b/app/views/documents/confirm_discard.html.erb
@@ -20,9 +20,6 @@
       {
         title: @document.title,
         url: document_path(current_format.admin_slug, @document.content_id_and_locale)
-      },
-      {
-        title: "Delete draft"
       }
     ]
   } %>

--- a/app/views/documents/confirm_publish.html.erb
+++ b/app/views/documents/confirm_publish.html.erb
@@ -20,9 +20,6 @@
       {
         title: @document.title,
         url: document_path(current_format.admin_slug, @document.content_id_and_locale)
-      },
-      {
-        title: "Publish"
       }
     ]
   } %>

--- a/app/views/documents/confirm_unpublish.html.erb
+++ b/app/views/documents/confirm_unpublish.html.erb
@@ -20,9 +20,6 @@
       {
         title: @document.title,
         url: document_path(current_format.admin_slug, @document.content_id_and_locale)
-      },
-      {
-        title: "Unpublish"
       }
     ]
   } %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -19,9 +19,6 @@
       {
         title: @document.title,
         url: document_path(current_format.admin_slug, @document.content_id_and_locale)
-      },
-      {
-        title: "Edit document"
       }
     ]
   } %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,4 +1,4 @@
-<% title = "Editing #{current_format.title}" %>
+<% title = "Editing #{@document.title}" %>
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 <% content_for :error_summary, render(ErrorSummaryComponent.new(object: @document)) %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -7,10 +7,7 @@
       {
         title: "All finders",
         url: finders_path
-      },
-      {
-        title: current_format.title.pluralize
-      },
+      }
     ]
   } %>
 <% end %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -14,9 +14,6 @@
       {
         title: current_format.title.pluralize,
         url: documents_path(current_format.admin_slug)
-      },
-      {
-        title: "New document"
       }
     ]
   } %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -14,9 +14,6 @@
       {
         title: current_format.title.pluralize,
         url: documents_path(current_format.admin_slug)
-      },
-      {
-        title: @document.title
       }
     ]
   } %>

--- a/app/views/exports/show.html.erb
+++ b/app/views/exports/show.html.erb
@@ -1,5 +1,4 @@
 <% page_title = "Export as CSV" %>
-
 <% content_for :page_title, page_title %>
 <% content_for :title, page_title %>
 
@@ -14,9 +13,6 @@
       {
         title: current_format.title.pluralize,
         url: documents_path(current_format.admin_slug)
-      },
-      {
-        title: page_title
       }
     ]
   } %>

--- a/app/views/finders/edit_facets.html.erb
+++ b/app/views/finders/edit_facets.html.erb
@@ -9,10 +9,6 @@
       {
         title: "#{current_format.title.pluralize} finder",
         url: finder_path(current_format.admin_slug)
-      },
-      {
-        title: "Request change",
-        url: request.original_url
       }
     ]
   } %>

--- a/app/views/finders/edit_metadata.html.erb
+++ b/app/views/finders/edit_metadata.html.erb
@@ -9,10 +9,6 @@
       {
         title: "#{current_format.title.pluralize} finder",
         url: finder_path(current_format.admin_slug)
-      },
-      {
-        title: "Request change",
-        url: request.original_url
       }
     ]
   } %>

--- a/app/views/finders/index.html.erb
+++ b/app/views/finders/index.html.erb
@@ -1,14 +1,3 @@
-<% content_for :breadcrumbs do %>
-  <%= render "govuk_publishing_components/components/breadcrumbs", {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: "All finders",
-        url: finders_path
-      },
-    ]
-  } %>
-<% end %>
 <% content_for :page_title, "All finders" %>
 <% content_for :title, "All finders" %>
 

--- a/app/views/finders/new.html.erb
+++ b/app/views/finders/new.html.erb
@@ -5,10 +5,6 @@
       {
         title: "All finders",
         url: finders_path
-      },
-      {
-        title: "Request for a new finder",
-        url: new_finder_path
       }
     ]
   } %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -5,10 +5,6 @@
       {
         title: "All finders",
         url: finders_path
-      },
-      {
-        title: "#{current_format.title.pluralize} finder",
-        url: finder_path(current_format.admin_slug)
       }
     ]
   } %>

--- a/app/views/finders/update_facets.html.erb
+++ b/app/views/finders/update_facets.html.erb
@@ -13,10 +13,6 @@
       {
         title: "Request change",
         url: facets_finder_path(current_format.admin_slug)
-      },
-      {
-        title: "Check changes",
-        url: request.original_url
       }
     ]
   } %>

--- a/app/views/finders/update_metadata.html.erb
+++ b/app/views/finders/update_metadata.html.erb
@@ -13,10 +13,6 @@
       {
         title: "Request change",
         url: metadata_finder_path(current_format.admin_slug)
-      },
-      {
-        title: "Check changes",
-        url: request.original_url
       }
     ]
   } %>

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -15,7 +15,7 @@
   id: "#{format_name}_link_and_identifier_exists",
   error_message: errors_for_input(format_name, @document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(format_name, @document.errors, :base) : nil,
 } do %>
-  <% unless field_has_errors(@document, :base) %>
+  <% unless errors_for_input(format_name, @document.errors, :base) %>
     <p class="govuk-body govuk-!-margin-bottom-6">Enter either the website where users can apply for the licence, or the licence identifier.</p>
   <% end %>
 

--- a/app/views/metadata_fields/_licence_transactions.html.erb
+++ b/app/views/metadata_fields/_licence_transactions.html.erb
@@ -13,7 +13,7 @@
   heading_level: 2,
   heading_size: "l",
   id: "#{format_name}_link_and_identifier_exists",
-  error_message: errors_for_input(@document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(@document.errors, :base) : nil,
+  error_message: errors_for_input(format_name, @document.errors, :base)&.include?(t("activemodel.errors.models.licence_transaction.attributes.base.link_and_identifier_exists")) ? errors_for_input(format_name, @document.errors, :base) : nil,
 } do %>
   <% unless field_has_errors(@document, :base) %>
     <p class="govuk-body govuk-!-margin-bottom-6">Enter either the website where users can apply for the licence, or the licence identifier.</p>

--- a/app/views/shared/_attachments_form.html.erb
+++ b/app/views/shared/_attachments_form.html.erb
@@ -9,7 +9,7 @@
       heading_level: 2,
       heading_size: "l",
       value: f.object.title,
-      error_items: errors_for(@attachment.errors, :title)
+      error_items: errors_for(@attachment.document_type, @attachment.errors, :title)
     } %>
   </div>
 
@@ -31,7 +31,7 @@
     heading_size: "l",
     name: "attachment[file]",
     id: "attachment_file",
-    error_items: errors_for(@attachment.errors, :file)
+    error_items: errors_for(@attachment.document_type, @attachment.errors, :file)
   } %>
 
   <div class="govuk-button-group">

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -7,7 +7,7 @@
   id: "#{format_name}_title",
   name: "#{format_name}[title]",
   value: @document.title,
-  error_items: errors_for(@document.errors, :title)
+  error_items: errors_for(format_name, @document.errors, :title)
 } %>
 
 <%= render "govuk_publishing_components/components/character_count", {
@@ -19,7 +19,7 @@
     name: "#{format_name}[summary]",
     value: @document.summary,
     margin_bottom: 8,
-    error_items: errors_for(@document.errors, :summary),
+    error_items: errors_for(format_name, @document.errors, :summary),
   },
   id: "#{format_name}_summary",
   maxlength: 280,
@@ -34,7 +34,7 @@
   name: "#{format_name}[body]",
   rows: 20,
   value: @document.body || @document.finder_schema.body_template,
-  error_items: errors_for(@document.errors, :body),
+  error_items: errors_for(format_name, @document.errors, :body),
   attachments: @document.attachments
 } %>
 

--- a/app/views/shared/_minor_major_update_fields.html.erb
+++ b/app/views/shared/_minor_major_update_fields.html.erb
@@ -17,7 +17,7 @@
           },
           name: "#{document.document_type}[change_note]",
           textarea_id: "#{document.document_type}_change_note",
-          error_message: errors_for_input(document.errors, :change_note),
+          error_message: errors_for_input(document.document_type, document.errors, :change_note),
           value: document.change_note,
           hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
             link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,

--- a/spec/features/design_system/attachments_on_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/attachments_on_a_cma_case_design_system_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
     click_button "Save attachment"
 
-    expect(page).to have_content("Editing CMA Case")
+    expect(page).to have_content("Editing Example CMA Case")
     expect(page).to have_content("Attached New cma case image")
 
     assert_requested(stub_request)
@@ -115,7 +115,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
     click_button "Save attachment"
 
-    expect(page).to have_content("Editing CMA Case")
+    expect(page).to have_content("Editing Example CMA Case")
     expect(page).to have_content("Updated New cma case image")
 
     assert_requested(stub_request)
@@ -130,7 +130,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     click_link "Delete attachment", match: :first
     click_button "Delete"
 
-    expect(page).to have_content("Editing CMA Case")
+    expect(page).to have_content("Editing Example CMA Case")
     expect(page).to have_content("Attachment successfully removed")
 
     assert_requested(stub_request)
@@ -138,7 +138,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
 
   context "when the document is in an invalid state" do
     let(:cma_case) do
-      FactoryBot.create(:cma_case, :draft, title: "Title", details: {
+      FactoryBot.create(:cma_case, :draft, title: "Example CMA Case", details: {
         "body" => "",
         "attachments" => existing_attachments,
       })
@@ -156,7 +156,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
       page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
       click_button "Save attachment"
 
-      expect(page).to have_content("Editing CMA Case")
+      expect(page).to have_content("Editing Example CMA Case")
       expect(page).to have_content("Attached New cma case image")
       expect(page.find_field("Body")).to have_content("")
 
@@ -165,7 +165,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
       page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
       click_button "Save attachment"
 
-      expect(page).to have_content("Editing CMA Case")
+      expect(page).to have_content("Editing Example CMA Case")
       expect(page).to have_content("Updated New cma case image 2")
       expect(page.find_field("Body")).to have_content("")
     end


### PR DESCRIPTION
Change how we compose breadcrumbs

--- 

We decided to follow conventions for GOV.UK rather than previous Specialist Publisher way of doing breadcrumbs. The last element in the breadcrumbs is now the parent of the current page, and it should always have a link.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2298)