### PR TITLE
[WHIT-2297] [Design System] Design changes for DS release

### DIFF
--- a/app/assets/stylesheets/_summary.scss
+++ b/app/assets/stylesheets/_summary.scss
@@ -1,5 +1,11 @@
 .app-view-summary__section {
   padding: govuk-spacing(3) 0;
+
+  .govspeak-help__pre {
+    padding: govuk-spacing(4);
+    @include govuk-font($size: 19);
+  }
+
 }
 
 .app-view-summary__table-link {

--- a/app/assets/stylesheets/admin/_overrides.scss
+++ b/app/assets/stylesheets/admin/_overrides.scss
@@ -1,0 +1,7 @@
+.govuk-tag--s {
+  @include govuk-font(16, $weight: bold, $line-height: 1);
+}
+
+.govuk-summary-list__value .govuk-tag {
+  max-width: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,8 @@ $govuk-page-width: 1140px;
 @import "./govspeak-help";
 @import "./summary";
 
+@import "./admin/overrides";
+
 .bg-light-grey {
   background-color: govuk-colour("light-grey");
 }

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -24,7 +24,7 @@
 }
 
 .app-c-govspeak-editor__preview {
-  border: 1px solid $govuk-border-colour;
+  border: $govuk-border-width-form-element solid $govuk-border-colour;
   padding: govuk-spacing(4);
 }
 

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -6,9 +6,9 @@ module StateHelper
   end
 
   def design_system_classes_for_frontend(document)
-    return "govuk-tag govuk-tag--blue" if state_for_frontend(document) =~ /draft/
+    return "govuk-tag govuk-tag--s govuk-tag--blue" if state_for_frontend(document) =~ /draft/
 
-    "govuk-tag govuk-tag--green"
+    "govuk-tag govuk-tag--s govuk-tag--green"
   end
 
   def state_for_frontend(document)

--- a/app/views/passthrough/error.html.erb
+++ b/app/views/passthrough/error.html.erb
@@ -1,2 +1,9 @@
-<h1>Sorry, you don't have permission to access this application</h1>
-<p>Please contact your main GDS contact if you need access.</p>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Permission required",
+  heading_level: 1,
+	font_size: "xl",
+	margin_bottom: 6,
+} %>
+
+<p class="govuk-body">Sorry, you don't have permission to access this application.</p>
+<p class="govuk-body">Please contact your main GDS contact if you need access.</p>


### PR DESCRIPTION
On the back of testing for the design system release:

- Add classes to error page to match DS
- Documents index page: make status bold (700) + also update it on the summary page
- Summary page: Change the body font size / line height - it is unreadable at the moment
- Summary page: Publication state - badge - should be longer + ensure it works ok on the document index page after the change
- Update preview border to match border of other elements (both add new and edit pages)


## Screenshots

| Before | After |
| --- | --- |
| Error page | |
| <img width="734" height="178" alt="Screenshot 2025-07-15 at 13 54 12" src="https://github.com/user-attachments/assets/48578bfe-3ff5-40fe-aa99-de5387219f67" /> | <img width="796" height="258" alt="Screenshot 2025-07-15 at 13 54 23" src="https://github.com/user-attachments/assets/4d7c3965-bcee-46a8-93a9-9aed54db28db" /> |
| Index page status badge | |
| <img width="363" height="377" alt="Screenshot 2025-07-15 at 13 53 09" src="https://github.com/user-attachments/assets/2fa50e60-8026-43c5-82c9-d63d74fc56f4" /> | <img width="363" height="377" alt="Screenshot 2025-07-15 at 13 53 14" src="https://github.com/user-attachments/assets/1480c05b-3ccb-48b2-b875-b9d6967e6ae0" /> |
| Summary page status badge | |
| <img width="668" height="90" alt="Screenshot 2025-07-15 at 13 53 40" src="https://github.com/user-attachments/assets/12e2626a-b98b-431f-8e4c-d61306603527" /> | <img width="734" height="90" alt="Screenshot 2025-07-15 at 13 53 48" src="https://github.com/user-attachments/assets/b97e7723-f033-4d0c-9a23-fae6aa1e234c" /> |
| Summary page body - font size and padding | |
| <img width="796" height="289" alt="Screenshot 2025-07-15 at 13 54 39" src="https://github.com/user-attachments/assets/52f6fb75-37b2-4441-a4cd-252b629ce385" /> | <img width="796" height="412" alt="Screenshot 2025-07-15 at 14 09 08" src="https://github.com/user-attachments/assets/738f8f9d-e537-4fca-8a61-f0e69df38ff3" /> |
| Body preview border - should be a (one) pixel difference 🕵🏻‍♀️|
| <img width="618" height="493" alt="Screenshot 2025-07-15 at 14 19 05" src="https://github.com/user-attachments/assets/ef726922-38af-4104-9696-d272bc5d0477" /> | <img width="618" height="334" alt="Screenshot 2025-07-15 at 14 19 42" src="https://github.com/user-attachments/assets/592a5fc6-7aa8-4441-b2c6-126a667b469d" /> |

