### PR TITLE
[WHIT-2298] [Design system] Handle missing `last_edited_at` date

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -107,7 +107,7 @@
               text: document.title,
             },
             {
-              text: "Updated #{time_ago_in_words(document.last_edited_at)} ago",
+              text: document.last_edited_at ? "Updated #{time_ago_in_words(document.last_edited_at)} ago" : "",
             },
             {
               text: tag.span(state_for_frontend(document).humanize, class: design_system_classes_for_frontend(document)),


### PR DESCRIPTION
We found around 30k editions from various document types that are missing the `last_edited_at` date.

Previously [there was a check for presence](https://github.com/alphagov/specialist-publisher/blob/3f2544fdec98e2031e628a0f98b61b11fd9ec4c6/app/views/documents/legacy/_document_legacy.html.erb#L4) that we're missing in the DS code. This brings it back in.

The current rendering being in a table, it makes the view look quite broken if we display nothing, so [a data migration will be run to populate the missing dates](https://github.com/alphagov/publishing-api/pull/3443). Nonetheless, we want to keep this defensive presence check.

Stats:
```
#   specialist_publisher_document_types = %w[aaib_report ai_assurance_portfolio_technique algorithmic_transparency_record animal_disease_case asylum_support_decision business_finance_support_scheme cma_case countryside_stewardship_grant data_ethics_guidance_document design_decision drcf_digital_markets_researche drug_safety_update employment_appeal_tribunal_decision employment_tribunal_decision esi_fund export_health_certificate farming_grant flood_and_coastal_erosion_risk_management_research_report hmrc_contact international_development_fund licence_transaction life_saving_maritime_appliance_service_station maib_report marine_equipment_approved_recommendation marine_notice medical_safety_alert product_safety_alert_report_recall protected_food_drink_name raib_report research_for_development_output residential_property_tribunal_decision service_standard_report sfo_case statutory_instrument tax_tribunal_decision trademark_decision traffic_commissioner_regulatory_decision ukhsa_data_access_approval utaac_decision veterans_support_organisation]
#   specialist_publisher_document_types.map { |type| editions = Edition.where(document_type: type, last_edited_at: nil); /
#       [type, editions.count] if editions.count > 0}.compact
#   [["aaib_report", 19689],
#    ["asylum_support_decision", 81],
#    ["business_finance_support_scheme", 655],
#    ["cma_case", 3611],
#    ["countryside_stewardship_grant", 486],
#    ["drug_safety_update", 792],
#    ["esi_fund", 856],
#    ["international_development_fund", 106],
#    ["maib_report", 2603],
#    ["medical_safety_alert", 717],
#    ["raib_report", 664],
#    ["service_standard_report", 36]]
#
#  => Adds up to 30.296 (out of 667,461) editions that need to be updated, for a total of 12 (out of 40) document types
```

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2298)
