### PR TITLE
[WHIT-2297] [Design System] Fix the broken JS for the sifting status toggle

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,4 @@
 
 //= require components/govspeak-editor
 //= require components/paste-html-to-govspeak
+//= require components/sifting-status

--- a/app/assets/javascripts/components/sifting-status.js
+++ b/app/assets/javascripts/components/sifting-status.js
@@ -1,0 +1,35 @@
+'use strict'
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+
+;(function (Modules) {
+  function SiftingStatus (module) {
+    this.module = module
+  }
+
+  SiftingStatus.prototype.init = function () {
+    this.siftingStatusSelect = this.module.querySelector('#statutory_instrument_sifting_status')
+    this.withdrawnDateWrapper = this.module.querySelector('.withdrawn-date-wrapper')
+    this.withdrawnDateFields = this.module.querySelectorAll('input[id^="statutory_instrument_withdrawn_date"]')
+    this.siftEndDateFields = this.module.querySelectorAll('input[id^="statutory_instrument_sift_end_date"]')
+
+    this.siftingStatusSelect.addEventListener('change', this.handleChange.bind(this))
+  }
+
+  SiftingStatus.prototype.handleChange = function (event) {
+    if (event.target.value === 'withdrawn') {
+      this.withdrawnDateWrapper.style.display = 'block'
+      for (var i = 0; i < this.siftEndDateFields.length; i++) {
+        this.siftEndDateFields[i].value = ''
+      }
+    } else {
+      this.withdrawnDateWrapper.style.display = 'none'
+      for (i = 0; i < this.withdrawnDateFields.length; i++) {
+        this.withdrawnDateFields[i].value = ''
+      }
+    }
+  }
+
+  Modules.SiftingStatus = SiftingStatus
+})(window.GOVUK.Modules)

--- a/app/views/metadata_fields/_statutory_instruments.html.erb
+++ b/app/views/metadata_fields/_statutory_instruments.html.erb
@@ -1,33 +1,20 @@
 <% finder_schema = f.object.class.finder_schema %>
 <% format_name = f.object.class.document_type.to_sym %>
+
 <!-- TODO: to be standardized - added manually to maintain custom labels -->
+<div data-module="sifting-status" data-sifting-status-init>
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:sift_end_date), params) %>
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:laid_date), params, "Laid date") %>
 <%= render FacetInputComponent::SingleSelectComponent.new(@document, format_name, :sifting_status, "Sifting status", finder_schema.get_facet(:sifting_status)["allowed_values"]) %>
 
 <% # TODO: this bit of logic prevents us moving to the shared view; this field also renders between other schema fields %>
 <% withdrawn_date_display = f.object.withdrawn_sifting_status? ? "block" : "none" %>
-<div class="withdrawn-date-wrapper" style="display:<%= withdrawn_date_display %>">
-  <%= render FacetInputComponent::DateComponent.new(@document, format_name, :withdrawn_date, "Withdrawn date (required)", params) %>
+  <div class="withdrawn-date-wrapper" style="display:<%= withdrawn_date_display %>">
+    <%= render FacetInputComponent::DateComponent.new(@document, format_name, :withdrawn_date, "Withdrawn date (required)", params) %>
+  </div>
 </div>
 
 <%= render FacetInputComponent.new(@document, finder_schema.get_facet(:subject), params) %>
 
 <%= render FacetInputComponent::OrganisationSingleSelectWithSearchComponent.new(@document, format_name, :primary_publishing_organisation, "Publishing organisation", selected_organisation_or_current(@document.primary_publishing_organisation)) %>
 <%= render FacetInputComponent::OrganisationMultiSelectWithSearchComponent.new(@document, format_name, :organisations, "Other associated organisations") %>
-
-<% # TODO: this bit of JS prevents us moving to the shared view %>
-<% content_for :document_ready do %>
-  var $withdrawnDateEl = $(".withdrawn-date-wrapper");
-  var $withdrawnDateFields = $("input[id^='statutory_instrument_withdrawn_date']");
-  var $siftEndDateFields = $("input[id^='statutory_instrument_sift_end_date']");
-  $("#statutory_instrument_sifting_status").change(function(e) {
-    if (e.target.value === "withdrawn") {
-      $withdrawnDateEl.show();
-      $siftEndDateFields.val("");
-    } else {
-      $withdrawnDateEl.hide();
-      $withdrawnDateFields.val("");
-    }
-  });
-<% end %>


### PR DESCRIPTION
## What
Update the broken JS for the _Sifting Status_ field. This field can be found within the document type _EU Withdrawal Act 2018 statutory instrument_.

## Why
The JS broke after porting this document over to the design system, due to the legacy JS using jQuery and being generally incompatible with our current standards.