### PR TITLE
[WHIT-2027] [Design system] Release final tweaks

### DIFF
--- a/app/assets/stylesheets/_summary.scss
+++ b/app/assets/stylesheets/_summary.scss
@@ -3,7 +3,7 @@
 
   .govspeak-help__pre {
     padding: govuk-spacing(4);
-    @include govuk-font($size: 19);
+    @include govuk-font-size($size: 19);
   }
 
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/layout-footer';
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/previous-and-next-navigation';
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/select-with-search';

--- a/app/views/documents/_show_summary.html.erb
+++ b/app/views/documents/_show_summary.html.erb
@@ -62,16 +62,25 @@
     <%= render "govuk_publishing_components/components/table", {
       head: [
         { text: "Title" },
+        { text: "Filename" },
         { text: "Created" },
         { text: "Last updated" }
       ],
       rows: attachments.map { |attachment|
-        [{ text: attachment.title },
+        [
+          {
+            text: attachment.title,
+          },
+          {
+            text: link_to(attachment.filename, attachment.url, class: "govuk-link"),
+          },
          {
            text: attachment.created_at.to_date.to_fs(:govuk_date)
-         }, {
+         },
+          {
            text: attachment.updated_at.to_date.to_fs(:govuk_date)
-         }]
+         }
+        ]
         }
     } %>
   <% else %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,4 +1,4 @@
-<% title = "Editing #{@document.title}" %>
+<% title = "Editing #{current_format.title}" %>
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 <% content_for :error_summary, render(ErrorSummaryComponent.new(object: @document)) %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -124,7 +124,7 @@
         previous_page: ({
           url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page - 1),
           title: "Previous page",
-          label: "1 of #{@paged_documents.total_pages}",
+          label: "#{@paged_documents.current_page - 1}  of #{@paged_documents.total_pages}",
         } if @paged_documents.current_page > 1),
         next_page: ({
           url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page + 1),

--- a/spec/features/design_system/attachments_on_a_cma_case_design_system_spec.rb
+++ b/spec/features/design_system/attachments_on_a_cma_case_design_system_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
     click_button "Save attachment"
 
-    expect(page).to have_content("Editing Example CMA Case")
+    expect(page).to have_content("Editing CMA Case")
     expect(page).to have_content("Attached New cma case image")
 
     assert_requested(stub_request)
@@ -115,7 +115,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
     click_button "Save attachment"
 
-    expect(page).to have_content("Editing Example CMA Case")
+    expect(page).to have_content("Editing CMA Case")
     expect(page).to have_content("Updated New cma case image")
 
     assert_requested(stub_request)
@@ -130,7 +130,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
     click_link "Delete attachment", match: :first
     click_button "Delete"
 
-    expect(page).to have_content("Editing Example CMA Case")
+    expect(page).to have_content("Editing CMA Case")
     expect(page).to have_content("Attachment successfully removed")
 
     assert_requested(stub_request)
@@ -156,7 +156,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
       page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
       click_button "Save attachment"
 
-      expect(page).to have_content("Editing Example CMA Case")
+      expect(page).to have_content("Editing CMA Case")
       expect(page).to have_content("Attached New cma case image")
       expect(page.find_field("Body")).to have_content("")
 
@@ -165,7 +165,7 @@ RSpec.feature "Attachments on a CMA case", type: :feature do
       page.attach_file("attachment_file", "spec/support/images/cma_case_image.jpg")
       click_button "Save attachment"
 
-      expect(page).to have_content("Editing Example CMA Case")
+      expect(page).to have_content("Editing CMA Case")
       expect(page).to have_content("Updated New cma case image 2")
       expect(page.find_field("Body")).to have_content("")
     end


### PR DESCRIPTION
Wrapping up testing for the design system release.


### Screenshots - Before/After

Pagination fix (was broken):
<img width="1892" height="262" alt="pagination" src="https://github.com/user-attachments/assets/0f5c1b5c-5b96-4bcf-a39b-3eae1f47fa8a" />

Body font change (revert to monospace):
<img width="1886" height="944" alt="body font" src="https://github.com/user-attachments/assets/d76c21a3-cb0b-48e1-a5fb-21c84a96db92" />

Edit page title changed to use document format rather than actual title:
<img width="1892" height="223" alt="Edit page title" src="https://github.com/user-attachments/assets/1a9d08f0-0c94-40df-8c7f-9eabac0d049f" />

Attachment links added:
<img width="1886" height="226" alt="Atatchment links" src="https://github.com/user-attachments/assets/9c3154e7-c4ef-4c4b-8142-27dfdf4964ee" />


Co-authored-by @matthillco 

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2027)