### PR TITLE
[WHIT-2027] Bump govuk-publishing-components to 59.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.3)
-    erb (5.0.1)
+    erb (5.0.2)
     erubi (1.13.1)
     execjs (2.10.0)
     factory_bot (6.5.4)
@@ -228,7 +228,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (58.2.0)
+    govuk_publishing_components (59.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -259,7 +259,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)


### PR DESCRIPTION
This is a manual upgrade to pull in the latest changes - specifically a change fixing the background colour of the select with search, as it was rendering transparent on top of the grey left-hand-side section. We wanted it white.

Background colour change for the select (from grey - well, transparent - to white):

<img width="1886" height="670" alt="org background colour" src="https://github.com/user-attachments/assets/48079c9c-6498-44ae-903b-12c980b0e265" />

Co-authored-by @matthillco 

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2027)
