### PR TITLE
[WHIT-2319] [Design System] Preserve organisation query parameters when navigating

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -122,12 +122,12 @@
 
       <%= render "govuk_publishing_components/components/previous_and_next_navigation", {
         previous_page: ({
-          url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page - 1),
+          url: documents_path(current_format.admin_slug, organisation: @organisation, query: @query, page: @paged_documents.current_page - 1),
           title: "Previous page",
           label: "#{@paged_documents.current_page - 1}  of #{@paged_documents.total_pages}",
         } if @paged_documents.current_page > 1),
         next_page: ({
-          url: documents_path(current_format.admin_slug, query: @query, page: @paged_documents.current_page + 1),
+          url: documents_path(current_format.admin_slug, organisation: @organisation, query: @query, page: @paged_documents.current_page + 1),
           title: "Next page",
           label: "#{@paged_documents.current_page + 1} of #{@paged_documents.total_pages}",
         } if @paged_documents.current_page < @paged_documents.total_pages)

--- a/spec/services/all_documents_finder_spec.rb
+++ b/spec/services/all_documents_finder_spec.rb
@@ -171,34 +171,6 @@ RSpec.describe AllDocumentsFinder do
     end
   end
 
-  # NOTE: we do this manually because the stub_publishing_api_has_content test helper
-  # is too restrictive and we can't properly control pagination
-  def publishing_api_paginates_content(content_items, per_page, document_klass, search_query: nil)
-    total_pages = content_items.length / per_page
-    total_pages += 1 unless content_items.length.remainder(per_page).zero?
-    if total_pages.zero?
-      publishing_api_has_no_content(document_klass, search_query)
-    else
-      content_items.each_slice(per_page).with_index.map do |page_items, index|
-        body = {
-          results: page_items,
-          total: content_items.length,
-          pages: total_pages,
-          current_page: index + 1,
-        }
-        query_params = {
-          page: (index + 1).to_s,
-          document_type: document_klass.document_type,
-        }
-        query_params[:q] = search_query if search_query.present?
-
-        stub_request(:get, "#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}/content")
-          .with(query: hash_including(query_params))
-          .to_return(status: 200, body: body.to_json, headers: {})
-      end
-    end
-  end
-
   def publishing_api_has_no_content(document_klass, search_query: nil)
     body = {
       results: [],

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -24,6 +24,34 @@ module PublishingApiHelpers
     updated_body_content = GovspeakBodyPresenter.present(doc)
     document["details"]["body"][0]["content"] = updated_body_content
   end
+
+  # NOTE: we do this manually because the stub_publishing_api_has_content test helper
+  # is too restrictive and we can't properly control pagination
+  def publishing_api_paginates_content(content_items, per_page, document_klass, search_query: nil)
+    total_pages = content_items.length / per_page
+    total_pages += 1 unless content_items.length.remainder(per_page).zero?
+    if total_pages.zero?
+      publishing_api_has_no_content(document_klass, search_query)
+    else
+      content_items.each_slice(per_page).with_index.map do |page_items, index|
+        body = {
+          results: page_items,
+          total: content_items.length,
+          pages: total_pages,
+          current_page: index + 1,
+        }
+        query_params = {
+          page: (index + 1).to_s,
+          document_type: document_klass.document_type,
+        }
+        query_params[:q] = search_query if search_query.present?
+
+        stub_request(:get, "#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}/content")
+          .with(query: hash_including(query_params))
+          .to_return(status: 200, body: body.to_json, headers: {})
+      end
+    end
+  end
 end
 
 RSpec.configuration.include PublishingApiHelpers


### PR DESCRIPTION
Identified an issue with the organisation filter on some non-conforming document types such as Licences, whereby navigating to the next search results page does not carry over the organisation query param.

This fixes the pagination links and adds test coverage for organisation filtering and pagination, as well as title filtering and pagination.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2319)