### PR TITLE
[WHIT-1460] Create Rake Task to Bulk Import Design Decisions From Whitehall 

### DIFF
--- a/lib/tasks/bulk_import_documents_from_csv.rake
+++ b/lib/tasks/bulk_import_documents_from_csv.rake
@@ -69,7 +69,7 @@ task :bulk_import_documents_from_csv, %i[csv_file_path mapping_file_path dry_run
     raise StandardError, "CSV import failed: #{invalid_rows.count} row(s) have missing required fields."
   end
 
-  documents_to_import.each do |document_data|
+  documents_to_import.reverse.each do |document_data|
     design_decision = DesignDecision.new(**document_data[:attributes].deep_symbolize_keys)
 
     if design_decision_has_attachment?(document_data[:row])

--- a/lib/tasks/bulk_import_documents_from_csv.rake
+++ b/lib/tasks/bulk_import_documents_from_csv.rake
@@ -83,7 +83,12 @@ task :bulk_import_documents_from_csv, %i[csv_file_path mapping_file_path dry_run
       )
     end
 
-    design_decision.save unless dry_run
+    unless dry_run
+      design_decision.save
+      # We want the documents to be saved in order, but there are small delays on the publishing-api side, which result in some records being out of sequence.
+      Kernel.sleep 1
+    end
+
     imported_count += 1
   end
 

--- a/lib/tasks/bulk_import_documents_from_csv.rake
+++ b/lib/tasks/bulk_import_documents_from_csv.rake
@@ -1,0 +1,89 @@
+desc "Import design decisions from a CSV file and save them with optional attachments"
+
+task :bulk_import_documents_from_csv, %i[csv_file_path] => :environment do |_, args|
+  csv_file_path = args[:csv_file_path]
+
+  unless File.exist?(csv_file_path)
+    puts "CSV file not found"
+    exit
+  end
+
+  hearing_officer_allowed_values = get_hearing_officer_allowed_values
+
+  CSV.foreach(csv_file_path, headers: true) do |row|
+    title = row["title"]
+    summary = row["summary"]&.delete('"')
+    body = row["body"]&.delete('"')
+    design_decision_litigants = get_design_decision_litigants(body)
+    design_decision_hearing_officer = get_design_decision_hearing_officer(body, hearing_officer_allowed_values)
+    design_decision_british_library_number = get_design_decision_british_library_number(title)
+    design_decision_date = get_design_decision_date(summary)
+    note_body = get_note_body(body)
+
+    design_decision = DesignDecision.new(title: title,
+                                         summary: summary,
+                                         design_decision_litigants: design_decision_litigants,
+                                         design_decision_hearing_officer: design_decision_hearing_officer,
+                                         design_decision_british_library_number: design_decision_british_library_number,
+                                         design_decision_date: design_decision_date,
+                                         body: note_body)
+
+    if design_decision_has_attachment?(row)
+      design_decision.attachments.build(
+        title: row["attachment_title"],
+        filename: row["attachment_filename"],
+        url: row["attachment_url"],
+        content_type: "application/pdf",
+        created_at: row["attachment_created_at"].present? ? Time.zone.parse(row["attachment_created_at"]) : nil,
+        updated_at: row["attachment_updated_at"].present? ? Time.zone.parse(row["attachment_updated_at"]) : nil,
+      )
+    end
+
+    design_decision.save
+  end
+end
+
+def get_hearing_officer_allowed_values
+  FinderSchema.load_from_schema("design_decisions")
+              .allowed_values_for("design_decision_hearing_officer")
+              .to_h { |val| [val.fetch("label"), val.fetch("value")] }
+end
+
+def get_humanised_hearing_officer(body)
+  if body
+    hearing_officer_line = body.lines.find { |line| line.match?(/Hearing Officer|Appointed Person/i) }
+
+    if hearing_officer_line
+      cleaned_line = hearing_officer_line.gsub(/<[^>]+>|\*\*/, "")
+      match = cleaned_line.match(/\|?\s*(?:Hearing Officer|Appointed Person)\s*\|\s*(.+?)(?:\||$)/i)
+      match[1].strip if match
+    end
+  end
+end
+
+def get_design_decision_hearing_officer(body, hearing_officers)
+  humanised_hearing_officer = get_humanised_hearing_officer(body)&.strip
+  hearing_officers.fetch(humanised_hearing_officer, nil)
+end
+
+def design_decision_has_attachment?(row)
+  row["attachment_title"].present? && row["attachment_filename"].present? && row["attachment_url"].present?
+end
+
+def get_design_decision_british_library_number(title)
+  title[/([O0]\/\d+\/\d+)/i, 1] if title
+end
+
+def get_design_decision_litigants(body)
+  body[/\|\s*.*?litigants.*?\s*\|\s*(.+?)\s*\|/i, 1] if body
+end
+
+def get_note_body(body)
+  start_index = body&.lines&.find_index { |line| line.match?(/^.*Every effort.*$/i) }
+  start_index ? body.lines[start_index..].join.strip : nil
+end
+
+def get_design_decision_date(summary)
+  raw_date = summary[/\b\d{1,2} \w+ \d{4}\b/] if summary
+  raw_date ? Date.parse(raw_date).strftime("%Y-%m-%d") : nil
+end

--- a/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
+++ b/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+RSpec.describe "bulk_import_documents_from_csv", type: :task do
+  let(:task) { Rake::Task["bulk_import_documents_from_csv"] }
+  let(:csv_path) { "dummy_path.csv" }
+
+  before(:each) do
+    # stub stdout to reduce noise
+    allow($stdout).to receive(:write)
+    allow(File).to receive(:exist?).with(csv_path).and_return(true)
+  end
+
+  after(:each) do
+    task.reenable
+  end
+
+  it "imports documents from a CSV file" do
+    csv_data = [{
+      "title" => "Design hearing decision: O/0567/25",
+      "summary" => '"Outcome of request to invalidate, hearing held on 24 June 2025."',
+      "body" => '"| **Litigants** | Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited |
+| **Hearing Officer** | Arran Cooper |
+
+## Note
+
+Every effort is made to ensure design hearing decisions have been accurately recorded, but some errors may have been introduced during conversion for the web.
+
+Copies of any documents annexed to a decision are available from:
+
+$A
+Tribunal Section,
+Intellectual Property Office,
+Concept House,
+Cardiff Road,
+Newport,
+South Wales
+NP10 8QQ
+$A"',
+      "attachment_title" => "Design Decision O/0567/25",
+      "attachment_filename" => "o056725.pdf",
+      "attachment_url" => "http://asset-manager.dev.gov.uk/media/685d5038f85b4b993fd752dd/o056725.pdf",
+      "attachment_created_at" => "2025-06-26 14:50:48 +0100",
+      "attachment_updated_at" => "2025-06-26 14:50:48 +0100",
+    }]
+    allow(CSV).to receive(:foreach).with(csv_path, headers: true).and_yield(csv_data.first)
+    attachments_double = double("attachments")
+    design_decision_double = instance_double(
+      DesignDecision,
+      attachments: attachments_double,
+      save: true,
+    )
+    expect(attachments_double).to receive(:build).with(
+      title: "Design Decision O/0567/25",
+      filename: "o056725.pdf",
+      url: "http://asset-manager.dev.gov.uk/media/685d5038f85b4b993fd752dd/o056725.pdf",
+      content_type: "application/pdf",
+      created_at: Time.zone.parse("2025-06-26 14:50:48 +0100"),
+      updated_at: Time.zone.parse("2025-06-26 14:50:48 +0100"),
+    )
+    expect(DesignDecision).to receive(:new).with(
+      title: "Design hearing decision: O/0567/25",
+      summary: "Outcome of request to invalidate, hearing held on 24 June 2025.",
+      design_decision_litigants: "Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited",
+      design_decision_hearing_officer: "arran-cooper",
+      design_decision_british_library_number: "O/0567/25",
+      design_decision_date: "2025-06-24",
+      body: 'Every effort is made to ensure design hearing decisions have been accurately recorded, but some errors may have been introduced during conversion for the web.
+
+Copies of any documents annexed to a decision are available from:
+
+$A
+Tribunal Section,
+Intellectual Property Office,
+Concept House,
+Cardiff Road,
+Newport,
+South Wales
+NP10 8QQ
+$A',
+    ).and_return(design_decision_double)
+
+    task.execute(csv_file_path: csv_path.to_s)
+  end
+
+  it "extracts design_decision_hearing_officer from Appointed Person when Hearing Officer is absent" do
+    csv_data = [
+      {
+        "title" => "Design hearing decision: O/1234/56",
+        "summary" => "Outcome of hearing held on 15 July 2025.",
+        "body" => '| **Litigants** | Some Company Ltd v Other Company Ltd |
+| **Appointed Person** | Martin Howe |
+Every effort is made to ensure...',
+        "attachment_title" => nil,
+        "attachment_filename" => nil,
+        "attachment_url" => nil,
+        "attachment_created_at" => nil,
+        "attachment_updated_at" => nil,
+      },
+    ]
+    allow(CSV).to receive(:foreach).with(csv_path, headers: true).and_yield(csv_data.first)
+    attachments_double = double("attachments")
+    allow(attachments_double).to receive(:build)
+    design_decision_double = double("DesignDecision", attachments: attachments_double, save: true)
+    expect(DesignDecision).to receive(:new).with(
+      a_hash_including(design_decision_hearing_officer: "martin-howe"),
+    ).and_return(design_decision_double)
+
+    task.execute(csv_file_path: csv_path.to_s)
+  end
+
+  it "imports a design decision without creating attachments when no attachment data present" do
+    csv_data = [
+      {
+        "title" => "Design hearing decision: O/9999/88",
+        "summary" => "Outcome of hearing held on 10 August 2025.",
+        "body" => '| **Litigants** | Example Ltd v Sample Ltd |
+| **Hearing Officer** | Martin Howe |
+
+## Note
+
+Every effort is made to ensure design hearing decisions have been accurately recorded.',
+        "attachment_title" => nil,
+        "attachment_filename" => nil,
+        "attachment_url" => nil,
+        "attachment_created_at" => nil,
+        "attachment_updated_at" => nil,
+      },
+    ]
+    allow(CSV).to receive(:foreach).with(csv_path, headers: true).and_yield(csv_data.first)
+    design_decision_double = instance_double("DesignDecision", attachments: [], save: true)
+    expect(DesignDecision).to receive(:new).with(
+      hash_including(
+        title: "Design hearing decision: O/9999/88",
+        design_decision_litigants: "Example Ltd v Sample Ltd",
+        design_decision_hearing_officer: "martin-howe",
+        design_decision_british_library_number: "O/9999/88",
+        design_decision_date: "2025-08-10",
+      ),
+    ).and_return(design_decision_double)
+    expect(design_decision_double.attachments).not_to receive(:build)
+    expect(design_decision_double).to receive(:save)
+
+    task.execute(csv_file_path: csv_path.to_s)
+  end
+end

--- a/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
+++ b/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "bulk_import_documents_from_csv", type: :task do
     # stub stdout to reduce noise
     allow($stdout).to receive(:write)
     allow(File).to receive(:exist?).with(csv_path).and_return(true)
+    allow(Kernel).to receive(:sleep)
   end
 
   after(:each) do

--- a/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
+++ b/spec/lib/tasks/bulk_import_documents_from_csv_spec.rb
@@ -124,6 +124,49 @@ $A',
     task.execute(csv_file_path: csv_path.to_s)
   end
 
+  it "imports documents in reverse order" do
+    csv_data = [
+      {
+        "title" => "Design hearing decision: O/0567/25",
+        "summary" => '"Outcome of request to invalidate, hearing held on 24 June 2025."',
+        "body" => '"| **Litigants** | Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited |
+| **Hearing Officer** | Arran Cooper |',
+      },
+      {
+        "title" => "Design hearing decision: O/0567/26",
+        "summary" => '"Outcome of request to invalidate, hearing held on 24 June 2025."',
+        "body" => '"| **Litigants** | Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited |
+| **Hearing Officer** | Arran Cooper |',
+      },
+    ]
+    allow(CSV).to receive(:foreach).with(csv_path, headers: true).and_return(csv_data.each)
+    attachments_double = double("attachments")
+    design_decision_double = instance_double(
+      DesignDecision,
+      attachments: attachments_double,
+      save: true,
+    )
+    expect(DesignDecision).to receive(:new).with(
+      title: "Design hearing decision: O/0567/26",
+      summary: "Outcome of request to invalidate, hearing held on 24 June 2025.",
+      design_decision_litigants: "Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited",
+      design_decision_hearing_officer: "arran-cooper",
+      design_decision_british_library_number: "O/0567/26",
+      design_decision_date: "2025-06-24",
+      body: "Missing note body",
+    ).and_return(design_decision_double).ordered
+    expect(DesignDecision).to receive(:new).with(
+      title: "Design hearing decision: O/0567/25",
+      summary: "Outcome of request to invalidate, hearing held on 24 June 2025.",
+      design_decision_litigants: "Caesar Commerce Ltd v Huizhou New Road Cosmetics Company Limited",
+      design_decision_hearing_officer: "arran-cooper",
+      design_decision_british_library_number: "O/0567/25",
+      design_decision_date: "2025-06-24",
+      body: "Missing note body",
+    ).and_return(design_decision_double).ordered
+    task.execute(csv_file_path: csv_path.to_s)
+  end
+
   it "extracts design_decision_hearing_officer from Appointed Person when Hearing Officer is absent" do
     csv_data = [
       {


### PR DESCRIPTION
## What

A rake task that reads from a CSV of exported Design Decisions (including attachments) from Whitehall and creates corresponding records for Specialist Publisher. It uses the `design_decisions.json` schema to map the Hearing Officers against the allowed values. Any rows that fail to import due to missing/unmapped values are outputted so that the csv can be checked.

## Why

[[WHIT-1460] IPO Design decisions Finder](https://gov-uk.atlassian.net/browse/WHIT-1460) Involved the creation of a new finder for Design Decisions. IPO asked if the existing records could be bulk imported rather than manually created, due to the amount of existing decisions. The script could be extended to support imports for other types in future.

[WHIT-1460]: https://gov-uk.atlassian.net/browse/WHIT-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Testing in integration 
- Ran the rake task in `dry-run` mode to identify any data anomalies that would prevent a row being imported - using the [csv](https://docs.google.com/spreadsheets/d/1P9Ycu9IYRI1Lio-lVNakIddnVdXSjy0VD7b1J7bGpv0/edit?gid=108004737#gid=108004737) extracted by [the export rake task](https://github.com/alphagov/whitehall/pull/10453)
- We identified some missing notes, missing dates (just missing from summary), some missing litigants and officers (due to bad table formatting), hearing officers that were not previously in the schema, hearing officers that do not match to existing officers (but are very likely them), BL numbers that do not conform to the format (o/O), and incorrectly named attachments. There was one document that did not get imported due to missing associations in WH.
```
[DRY RUN] Imported: 163 document(s)
Skipped: 4 row(s)
Fix up: 1 row(s)
Skipped row details:
- Line 3: Missing design_decision_litigants, design_decision_hearing_officer (Title: Design hearing decision: O/0636/25)
- Line 75: Missing design_decision_date (Title: Designs hearing decision: O/652/21)
- Line 89: Missing design_decision_hearing_officer (Title: Designs hearing decision: O/409/20)
- Line 161: Missing design_decision_date (Title: Designs hearing decision: O/288/14)

Fix up row details:
- Line 2: Fix up note (Title: Design hearing decision: O/0646/25)
```

- We manually fixed some litigants, dates and hearing officers in the csv - see [corrected csv](https://docs.google.com/spreadsheets/d/17EH3L5IWLXqrJZRbfnbe_k72GDE87te6H0hvTsUQy2c/edit?gid=108004737#gid=108004737)
- Added missing hearing officers to the schema
- Compose the mapping file from the output of the dry run
- Run the rake task with the  provisory hearing officer mappings, csv corrections and schema changes
```
[DRY RUN] Imported: 167 document(s)
Skipped: 0 row(s)
Fix up: 1 row(s)

Fix up row details:
- Line 2: Fix up note (Title: Design hearing decision: O/0646/25)
```
- Identified that the order in which decisions save needs to be reverted so that oldest ones are created first
- Added a sleep instruction to ensure the order is correct
- Final test run gave no missing fields, no skipped rows, just one remaining fix up note that can be manually fixed by user. One document needs to be created manually. All documents were created in the order of the csv:
<img width="644" height="394" alt="image" src="https://github.com/user-attachments/assets/579ad428-c2ff-49c7-8a91-33cafce01d3a" />



## Prod run 
This is pending on https://github.com/alphagov/specialist-publisher/pull/3320. The user needs to confirm the hearing officers mapping file, as well as the schema changes in #3320.

The process for running the rake task:
- add csv file to pod `kubectl cp -n <namespace> <source> <pod-name>:<path>` - in the /tmp folder that we have write access to.
- add mappings file to pod `kubectl cp -n <namespace> <source> <pod-name>:<path>` - in the /tmp folder that we have write access to.
- run rake task -  dry-run, then actual run.
```
bundle exec rake bulk_import_documents_from_csv["/tmp/corrected_publications_export.csv","/tmp/mapping_file.csv",true]
bundle exec rake bulk_import_documents_from_csv["/tmp/corrected_publications_export.csv","/tmp/mapping_file.csv",false]
```