### PR TITLE
Change finder organisation form control from multiselect with search to select with search plus add another [WHIT-1975]

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -87,7 +87,7 @@ private
       :show_table_of_contents,
       :document_title,
       :document_noun,
-      organisations: [],
+      organisations: %i[id _destroy],
       related: [],
     )
   end
@@ -128,6 +128,14 @@ private
   def overwrite_with_metadata_params(proposed_schema)
     email_alert = EmailAlert.from_finder_admin_form_params(email_alert_params)
     params_to_overwrite = metadata_params.merge!(email_alert.to_finder_schema_attributes)
+
+    if metadata_params[:organisations]
+      params_to_overwrite[:organisations] = metadata_params[:organisations]
+        .reject { |index| metadata_params[:organisations][index.to_s][:_destroy] == "1" }
+        .transform_values { |organisation_params| organisation_params[:id] }
+        .values
+    end
+
     proposed_schema.update(params_to_overwrite.to_unsafe_h)
 
     if params[:document_title] && proposed_schema.filter.blank?

--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -71,7 +71,7 @@ class FinderSchema
   end
 
   def remove_empty_organisations
-    organisations.reject!(&:blank?)
+    organisations&.reject!(&:blank?)
   end
 
   def remove_empty_related_links

--- a/app/views/finders/_metadata_form_fields.html.erb
+++ b/app/views/finders/_metadata_form_fields.html.erb
@@ -22,8 +22,37 @@
   hint: "Example: /animal-disease-cases-england"
 } %>
 
-<%= render FacetInputComponent::OrganisationMultiSelectWithSearchComponent.new(schema, nil, :organisations, "Organisations the finder should be attached to") %>
-
+<%= render "govuk_publishing_components/components/fieldset", {
+  legend_text: "Organisations the finder should be attached to",
+  heading_level: 2,
+  heading_size: "m",
+  margin_bottom: 6,
+} do %>
+  <%= render "govuk_publishing_components/components/add_another", {
+    fieldset_legend: "Organisation",
+    add_button_text: "Add another organisation",
+    items: schema.organisations.each_with_index.map do |organisation_content_id, index|
+      {
+        fields: render("govuk_publishing_components/components/select_with_search", {
+          label: "Select an organisation",
+          heading_size: "m",
+          id: "organisations_#{index + 1}",
+          name: "organisations[#{index}][id]",
+          options: organisation_single_select_options(organisation_content_id),
+        }),
+        destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "organisations[#{index}][_destroy]", items: [{label: "Delete", value: "1" }]})
+      }
+    end,
+    empty: render("govuk_publishing_components/components/select_with_search", {
+      label: "Select an organisation",
+      heading_size: "m",
+      id: "organisations_#{schema.organisations.length + 1}",
+      name: "organisations[#{schema.organisations.length}][id]",
+      options: organisation_single_select_options(nil),
+      include_blank: true,
+    }),
+  } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/textarea", {
   label: {


### PR DESCRIPTION
We require the order of the user's selection to be respected in the schema changes sent to Zendesk, as the order controls the order in which the organisations are listed on the finder content item when it is rendered on GOV.UK.

The select with search component in multiselect mode does not respect the order because it uses the native browser select element to store the selected values. Most browsers simply submit the selections in the order they appear in the select options list.

By using the add another component, we can allow the user to control the order in which the organisations will appear on GOV.UK.

## Screenshots

### Before

<img width="860" height="245" alt="Screenshot 2025-08-04 at 11 26 50" src="https://github.com/user-attachments/assets/86a67805-77b8-41d4-8176-478811bb917b" />

###  After

Note that there is a defect in the "add another" button positioning, which is too close to the "delete" button. I will look at fixing this in govuk publishing components

<img width="1003" height="570" alt="Screenshot 2025-08-04 at 11 42 43" src="https://github.com/user-attachments/assets/3b6a6e0e-b8c5-48e7-b81b-187ba9c5178f" />


JIRA: https://gov-uk.atlassian.net/browse/WHIT-1975
