### PR TITLE
Add GA4 `pageview` tracking [WHIT-2373]

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../builds
 //= link application.js
+//= link domain-config.js
 //= link es6-components.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,3 +7,7 @@
 //= require components/govspeak-editor
 //= require components/paste-html-to-govspeak
 //= require components/sifting-status
+
+'use strict'
+window.GOVUK.approveAllCookieTypes()
+window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })

--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -1,0 +1,25 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.extraDomains = [
+  {
+    name: 'production',
+    domains: ['specialist-publisher.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    gaProperty: 'UA-26179049-6'
+  },
+  {
+    name: 'staging',
+    domains: ['specialist-publisher.staging.publishing.service.gov.uk'],
+    initialiseGA4: false
+  },
+  {
+    name: 'integration',
+    domains: ['specialist-publisher.integration.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    auth: '8jHx-VNEguw67iX9TBC6_g',
+    preview: 'env-50'
+  }
+]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,18 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def get_content_id
+    content = case controller_name
+              when "attachments"
+                @attachment
+              when "documents"
+                @document
+              end
+
+    content && content.content_id
+  end
+  helper_method :get_content_id
+
 private
 
   def user_not_authorized

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -3,6 +3,16 @@
 <% if user_signed_in? %>
   <% content_for :head do %>
     <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
+    <% unless Rails.env.test? %>
+      <meta name="govuk:user-created-at" content="<%= current_user&._id&.generation_time&.to_date %>">
+      <meta name="govuk:user-organisation-name" content="<%= organisation_name(current_user&.organisation_content_id) %>">
+    <% end %>
+    <% if get_content_id %>
+      <meta name="govuk:content-id" content="<%= get_content_id %>">
+    <% end %>    
+    <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
+    <meta name="govuk:user-id" content="">
+    <%= javascript_include_tag "domain-config" %>
     <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
     <%= javascript_include_tag "es6-components", type: "module" %>
   <% end %>


### PR DESCRIPTION
## What

Add GA4 and `pageview` tracking

## Why

Requested from publishing PA team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
