### PR TITLE
[WHIT-2320] Add option to override target_stack for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "dartsass-rails"
 gem "diffy"
+gem "flipflop"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govspeak"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,9 @@ GEM
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    flipflop (2.8.0)
+      activesupport (>= 4.0)
+      terminal-table (>= 1.8)
     gds-api-adapters (101.0.0)
       addressable
       link_header
@@ -769,6 +772,8 @@ GEM
     statsd-ruby (1.5.0)
     stringex (2.8.6)
     stringio (3.1.7)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.4.0)
@@ -818,6 +823,7 @@ DEPENDENCIES
   database_cleaner-mongoid
   diffy
   factory_bot
+  flipflop
   gds-api-adapters
   gds-sso
   govspeak

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_authenticated_user_header
   after_action :verify_authorized
+  skip_after_action :verify_authorized, if: -> { self.class.name.include?("Flipflop") }
 
   helper_method :current_format
   helper_method :formats_user_can_access

--- a/app/lib/publishing_api_finder_publisher.rb
+++ b/app/lib/publishing_api_finder_publisher.rb
@@ -18,7 +18,11 @@ private
   attr_reader :finders, :logger
 
   def should_deploy_to_live?(finder)
-    finder[:file]["target_stack"] == "live"
+    finder[:file]["target_stack"] == "live" || has_a_target_stack_override_for_testing?
+  end
+
+  def has_a_target_stack_override_for_testing?
+    %w[integration staging].include?(GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment) && Flipflop.enabled?(:live_target_stack_override)
   end
 
   def export_finder(finder)

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,14 @@ Bundler.require(*Rails.groups)
 
 module SpecialistPublisher
   class Application < Rails::Application
+    # Before filter for Flipflop dashboard. Replace with a lambda or method name
+    # defined in ApplicationController to implement access control.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden unless Rails.env.development? || %w[integration staging].any? { |environment| ENV.fetch("GOVUK_WEBSITE_ROOT", "").include?(environment) } }
+
+    # By default, when set to `nil`, strategy loading errors are suppressed in test
+    # mode. Set to `true` to always raise errors, or `false` to always warn.
+    config.flipflop.raise_strategy_errors = nil
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,21 @@
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :cookie
+  strategy :default
+
+  # Other strategies:
+  #
+  # strategy :sequel
+  # strategy :redis
+  #
+  # strategy :query_string
+  # strategy :session
+  #
+  # strategy :my_strategy do |feature|
+  #   # ... your custom code here; return true/false/nil.
+  # end
+
+  feature :live_target_stack_override,
+          default: false,
+          description: "Sets the target_stack to live. This is restricted to the integration and staging environments only, and is used to override the target stack for testing purposes."
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ require "healthcheck/s3"
 
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
+  mount Flipflop::Engine => "/flipflop"
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(


### PR DESCRIPTION
Introduce a feature toggle option that overrides the schema value for `target_stack`. This is only available in integration and staging.

This is to facilitate "live" testing and to avoid accidental publishing of finders after testing.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2320)
