### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -33,7 +33,7 @@ class DocumentsController < ApplicationController
       flash[:success] = "Created #{@document.title}"
       redirect_to document_path(current_format.admin_slug, @document.content_id_and_locale)
     elsif @document.errors.any?
-      re_render :new, status: :unprocessable_entity
+      re_render :new, status: :unprocessable_content
     else
       re_render :new, flash_key: :danger, flash_message: unknown_error_message
     end
@@ -58,7 +58,7 @@ class DocumentsController < ApplicationController
         re_render :edit, flash_key: :danger, flash_message: unknown_error_message
       end
     else
-      re_render :edit, status: :unprocessable_entity
+      re_render :edit, status: :unprocessable_content
     end
   end
 


### PR DESCRIPTION
Addresses:
> .*/root/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/rendering.rb:235: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
