### PR TITLE
[WHIT-2320] Revert stack to draft

### DIFF
--- a/lib/documents/schemas/ukhsa_chemical_hazards.json
+++ b/lib/documents/schemas/ukhsa_chemical_hazards.json
@@ -139,5 +139,5 @@
   "signup_content_id": "1f4b54fb-cbc4-43c4-9255-1dd0ab2ff421",
   "subscription_list_title_prefix": "UKHSA Chemical Hazards",
   "summary": "Find information on chemicals and chemical products - where they’re found, how they may affect your health and what steps to take if you are exposed.",
-  "target_stack": "live"
+  "target_stack": "draft"
 }


### PR DESCRIPTION
[This finder](https://specialist-publisher.integration.publishing.service.gov.uk/ukhsa-chemical-risks) was accidentally published earlier than it should have. A redirect was applied to the live finder, so that it redirects to the org home page.

Nonetheless, the draft setting does not match the current status. Reverting this until we get go-live confirmation.

Another reason for change was that the preview draft feature (both documents and finder) was not working anymore. Since this finder is still WIP, we want the publishers to be able to preview. Tested in integration and this change fixes the preview. The live page still [redirects to the org page](https://draft-origin.integration.publishing.service.gov.uk/government/organisations/uk-health-security-agency), as intended.



[Jira](https://gov-uk.atlassian.net/browse/WHIT-2320)