### PR TITLE
Add a confirmation step to publishing_api rake tasks [WHIT-1876]

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,9 +1,19 @@
 require "services"
+require "thor"
+
+def shell
+  @shell ||= Thor::Shell::Basic.new
+end
 
 namespace :publishing_api do
   desc "Publish all Finders to the Publishing API"
   task publish_finders: :environment do
     finder_loader = FinderLoader.new
+
+    unless shell.yes?("You're about to publish all finders to the Publishing API, proceed? (yes/no)")
+      shell.say_error "Aborted"
+      next
+    end
 
     begin
       PublishingApiFinderPublisher.new(finder_loader.finders).call
@@ -19,6 +29,12 @@ namespace :publishing_api do
       finder = finder_loader.finder(args.name)
     rescue StandardError => e
       puts "Error: #{e.inspect}"
+    end
+
+    puts "You're about to publish #{finder} to the Publishing API"
+    unless shell.yes?("Would you like to proceed with publishing this? (yes/no)")
+      shell.say_error "Aborted"
+      next
     end
 
     if finder

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "thor"
 
 RSpec.describe "publishing_api rake tasks", type: :task do
   describe "publishing_api:publish_finders" do
@@ -7,6 +8,7 @@ RSpec.describe "publishing_api rake tasks", type: :task do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
       stub_any_publishing_api_publish
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:yes?).and_return(true)
     end
 
     it "publishes all finders to the Publishing API" do
@@ -40,6 +42,7 @@ RSpec.describe "publishing_api rake tasks", type: :task do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
       stub_any_publishing_api_publish
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:yes?).and_return(true)
     end
 
     context "incorrect file name is given" do


### PR DESCRIPTION
I have added a confirmation step to the following rake tasks:
- publish_finders
- publish_finder

This is to ensure that the person running these rake tasks explicitly opts in to making these changes. I have also added a stub in the before block of each task in the publishing_api_spec file to prevent the rake task from waiting for actual user input during the test.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
