### PR TITLE
Add integration target stack override

### DIFF
--- a/app/models/finder_schema.rb
+++ b/app/models/finder_schema.rb
@@ -38,6 +38,7 @@ class FinderSchema
   attribute :email_filter_options
   attribute :facets, default: []
   attribute :filter
+  attribute :integration_target_stack, :boolean
   attribute :label_text
   attribute :name
   attribute :organisations, default: []

--- a/lib/documents/schemas/ukhsa_chemical_hazards.json
+++ b/lib/documents/schemas/ukhsa_chemical_hazards.json
@@ -129,6 +129,7 @@
   "filter": {
     "format": "ukhsa_chemical_hazard"
   },
+  "integration_target_stack": "live",
   "name": "Chemical risks to human health",
   "organisations": [
     "80091cd8-7a8f-41ef-8faf-8af91fce4fdb"


### PR DESCRIPTION
In order to facilitate testing, we introduce a target stack override which only takes effect in integration.

This is helpful to:
- Developers who typically want to deploy the config and test it end to end, with all the functionality present. This typically requires setting the "target_stack" to "live" for testing, then back to "draft" to merge the PR, which is prone to error.
- Developers who want to test the finders locally following instructions in https://docs.publishing.service.gov.uk/repos/govuk-docker/how-tos/finder-setup.html#content
- Departments who want to test the search functionality which is not quite working at the minute in prod (i.e. draft documents do not appear on the draft finder; published documents will, but that's typically undesirable; it is also quite confusing to have to explain users this rather intricate flow to users).

An alternative approach trying to use a flipflop toggle was attempted here https://github.com/alphagov/specialist-publisher/pull/3335, but that wasn't very successful as we still operate with rake task for publishing finders. Since SP does not have its own DB, it cannot store the value of the flipflop with the active_record strategy, so the rake task cannot tap into the value of the flag set in the dashboard. Current implementation is probably simpler than using the toggle, but the flag approach could be revived if we build finder publishing into the UI, as part of future work to make SP more self-serve. Also tried using the `redis` strategy, but not successful (out of the box). Could explore other gems, but the schema based will do for now.