### PR TITLE
Add `govuk:user-id` meta tag [WHIT-2514]

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -6,6 +6,7 @@
     <% unless Rails.env.test? %>
       <meta name="govuk:user-created-at" content="<%= current_user&._id&.generation_time&.to_date %>">
       <meta name="govuk:user-organisation-name" content="<%= organisation_name(current_user&.organisation_content_id) %>">
+      <meta name="govuk:user-id" content="<%= current_user&.anonymous_user_id %>">
     <% end %>
     <% if get_content_id %>
       <meta name="govuk:content-id" content="<%= get_content_id %>">


### PR DESCRIPTION
## What

Add `govuk:user-id` meta tag 

## Why

To add tracking for `user_id` to analytics as requested by Publishing PA team. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
