### PR TITLE
Improve thor message for publishing finder

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -31,14 +31,13 @@ namespace :publishing_api do
       puts "Error: #{e.inspect}"
     end
 
-    puts "You're about to publish #{finder} to the Publishing API"
-    unless shell.yes?("Would you like to proceed with publishing this? (yes/no)")
-      shell.say_error "Aborted"
-      next
-    end
-
     if finder
       begin
+        unless shell.yes?("You're about to publish '#{finder[0][:file]['name']}' to the Publishing API. Proceed? (yes/no)")
+          shell.say_error "Aborted"
+          next
+        end
+
         PublishingApiFinderPublisher.new(finder).call
       rescue GdsApi::HTTPServerError => e
         puts "Error publishing finder: #{e.inspect}"


### PR DESCRIPTION
Previously we logged the entire finder object, which was not very readable. Now printing out the name of the finder.

Before:
<img width="949" height="893" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/6031aca9-34a5-4dc6-96d0-0753c7be6177" />

After:
<img width="948" height="72" alt="Screenshot 2025-10-14 at 15 57 07" src="https://github.com/user-attachments/assets/ed07166d-aa58-4889-97fd-3458bbdaa7d6" />
