### PR TITLE
Add new organisation to algorithmic_transparency_records [WHIT-2775] 

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -102,6 +102,10 @@
           "value": "home-office"
         },
         {
+          "label": "Housing Ombudsman Service",
+          "value": "housing-ombudsman-service"
+        },
+        {
           "label": "Information Commissioner’s Office",
           "value": "information-commissioners-office"
         },


### PR DESCRIPTION
Specialist Finder Edit Request: Algorithmic transparency records.
- Added  "Housing Ombudsman Service" to the list of organisation options

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2775

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
