### PR TITLE
Change all_stylesheets to component_guide_stylesheet [WHIT-2839]

### DIFF
--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -2,6 +2,6 @@ APP_STYLESHEETS = {
   "application.scss" => "application.css",
 }.freeze
 
-all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)
+all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.component_guide_stylesheet)
 Rails.application.config.dartsass.builds = all_stylesheets
 Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
The frontend team have been making some changes to the way CSS asset files are built. As a result, we need to change the following line in all of our Rails apps' initializers/dartsass.rb files from

`all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)`

to 

`all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.component_guide_stylesheet)`

This will fix issues such as https://gov-uk.atlassian.net/browse/WHIT-2838 which are caused by a duplicate SASS import of some of the publishing component styles.
