### PR TITLE
[WHIT-2899] Update date validation to match Publishing API

### DIFF
--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -2,8 +2,10 @@ class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    Date.parse(value)
-    Date.strptime(value, "%Y-%m-%d")
+    date = Date.strptime(value, "%Y-%m-%d")
+    unless date.year.between?(1000, 9999)
+      record.errors.add(attribute, "must be between year 1000 and 9999")
+    end
   rescue ArgumentError, RangeError
     record.errors.add(attribute, "is not a valid date")
   end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DateValidator do
     end
 
     it "adds an error to the record if the date value is unparseable" do
-      subject.validate_each(record, :dob, "31-02-2013")
+      subject.validate_each(record, :dob, "2013-02-31")
       expect(record.errors[:dob]).to eq(["is not a valid date"])
     end
 
@@ -23,8 +23,18 @@ RSpec.describe DateValidator do
       expect(record.errors[:dob]).to eq(["is not a valid date"])
     end
 
+    it "adds an error to the record if the date value is before 1000" do
+      subject.validate_each(record, :dob, "999-12-31")
+      expect(record.errors[:dob]).to eq(["must be between year 1000 and 9999"])
+    end
+
+    it "adds an error to the record if the date value is after 9999" do
+      subject.validate_each(record, :dob, "10000-01-01")
+      expect(record.errors[:dob]).to eq(["must be between year 1000 and 9999"])
+    end
+
     it "doesn't add an error if the date value can be parsed" do
-      subject.validate_each(record, :dob, "25-02-2013")
+      subject.validate_each(record, :dob, "2013-02-25")
       expect(record.errors).to be_empty
     end
   end


### PR DESCRIPTION
This fixes an issue where a user had input a year (20206) that was outside the range specified by Publishing API (^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$ === 1000-01-01 to 9999-12-31). The validator has been updated to check the range for the year. Also the parse operation has been removed because the `strptime` function we use already performs stricter validation.

The unit tests were also passing in the dates in the wrong format. The tests still passed by coincidence rather than intention, so these have also been fixed.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-2899)
