### PR TITLE
[WHIT-2950] Add MOD as an editing organisation to covenants finder

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -175,16 +175,12 @@ class Document
     organisations.first
   end
 
-  def schema_editing_organisations
+  def self.schema_editing_organisations
     finder_schema.editing_organisations
   end
 
   def self.schema_organisations
     finder_schema.organisations
-  end
-
-  def self.schema_editing_organisations
-    new.schema_editing_organisations
   end
 
   def format_specific_metadata

--- a/docs/creating-editing-and-removing-specialist-document-types-and-finders.md
+++ b/docs/creating-editing-and-removing-specialist-document-types-and-finders.md
@@ -166,9 +166,9 @@ To release the finder to the live stack:
 
 Specialist Publisher grants access to the publishing interface for a document type to the following Signon users:
 
-1. Users that belong to the owner organisation - have default "write" permissions, allowing them to view and draft new documents.
-2. Users that belong to the owner organisation AND have `editor` permission in Signon - are considered "departmental editors" and can publish, unpublish and discard documents.
-3. Users that have the permission `<your_new_document_type>_editor` in Signon are granted "departmental editor" access regardless of their organisation. This is sometimes required for cross-departmental documents. These special permissions need to be [created manually](https://docs.publishing.service.gov.uk/repos/signon/usage.html#creating-editing-and-deleting-permissions) in Signon. You do not need to create this permission unless cross-departmental access has been explicitly requested.
+1. Users that belong to the owner organisation or an editing organisation - have default "write" permissions, allowing them to view and draft new documents.
+2. Users that belong to the owner organisation or an editing organisation, AND have `editor` permission in Signon - are considered "departmental editors" and can publish, unpublish and discard documents.
+3. Users that have the permission `<your_new_document_type>_editor` in Signon are granted "document_type_editor" access regardless of their organisation. This is sometimes required for cross-departmental documents. These special permissions need to be [created manually](https://docs.publishing.service.gov.uk/repos/signon/usage.html#creating-editing-and-deleting-permissions) in Signon. You do not need to create this permission unless cross-departmental access has been explicitly requested for individual users outside the owning organisation. If you need access for an entire non-owning organisation, add it to `editing_organisations` in the schema file instead.
 
 You'll need to manually grant users access to the Specialist Publisher app in Signon, and the `editor` permission (or custom cross-organisation permissions from step 3 above) if appropriate.
 

--- a/lib/documents/schemas/armed_forces_covenant_businesses.json
+++ b/lib/documents/schemas/armed_forces_covenant_businesses.json
@@ -9,6 +9,9 @@
   "email_filter_options": {
     "email_filter_by": "all_selected_facets"
   },
+  "editing_organisations": [
+    "d994e55c-48c9-4795-b872-58d8ec98af12"
+  ],
   "facets": [
     {
       "allowed_values": [


### PR DESCRIPTION
MOD has been removed as an owning organisation due to too many updates about covenant signatories appearing on the organisation page. That inadvertently caused the publishers in MOD to lose access to their finder.

Adding MOD as an editing organisation should restore their access.

Also added documentation about `editing_organisations` as that was not at all mentioned as an option.

Removed redundant instance method that calls the `schema_editing_organisations`. We only ever call this from the `DocumentPolicy`, on the record class.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2950)
