### PR TITLE
Remove version parameter from document find request

### DIFF
--- a/app/services/republish_service.rb
+++ b/app/services/republish_service.rb
@@ -20,7 +20,6 @@ class RepublishService
         published_document = Document.find(
           content_id,
           locale,
-          version: published_edition_version_number,
         )
         published_document.update_type = "republish"
 


### PR DESCRIPTION
The presence of the version parameter was causing a 422 HTTP response from Publishing API with the message "version parameter no longer supported in get_content"

JIRA: https://gov-uk.atlassian.net/browse/WHIT-3005
