### PR TITLE
Fix "Unhelpful error message when removing a document in specialist finder" [WHIT-1932]

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -78,6 +78,8 @@ class DocumentsController < ApplicationController
   def unpublish
     if @document.unpublish(params[:alternative_path])
       flash[:success] = "Unpublished #{@document.title}"
+    elsif params[:alternative_path].present? && params[:alternative_path].match(/^\/[\/.a-zA-Z0-9-]+$/).blank?
+      flash[:danger] = "Failed to unpublish. The provided URL \"#{params[:alternative_path]}\" is not in a valid format. Please try again with a URL in the correct format."
     else
       flash[:danger] = unknown_error_message
     end

--- a/spec/features/publishing_workflow/unpublishing_a_document_spec.rb
+++ b/spec/features/publishing_workflow/unpublishing_a_document_spec.rb
@@ -124,5 +124,20 @@ RSpec.feature "Unpublishing a document", type: :feature do
       expect(page.status_code).to eq(200)
       expect(page).to have_content("Something has gone wrong. Please try again and see if it works.")
     end
+
+    scenario "clicking the unpublish button shows an error message if invalid URL specified" do
+      alternative_path = "https://www.invalid.com"
+
+      stub_publishing_api_unpublish(content_id, { body: { type: "redirect", locale:, alternative_path: } }, status: 409)
+
+      visit document_path(content_id_and_locale: "#{content_id}:#{locale}", document_type_slug: "cma-cases")
+      expect(page).to have_content("Example CMA Case")
+      click_link "Unpublish document"
+      expect(page.status_code).to eq(200)
+      fill_in "alternative_path", with: alternative_path
+      click_button "Unpublish"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("Failed to unpublish. The provided URL \"https://www.invalid.com\" is not in a valid format. Please try again with a URL in the correct format.")
+    end
   end
 end


### PR DESCRIPTION
## What

Add more helpful error message if the user provides a URL in an incorrect format for the redirect of an unpublished document.

### Visual Differences

<img width="1203" height="418" alt="Screenshot 2026-02-05 at 16 14 50" src="https://github.com/user-attachments/assets/813ebad0-6c21-452a-a164-9b35b4f78e2a" />


## Why

Requested in a support ticket.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
