### PR TITLE
[WHIT-3108] Add 'Markets - phase 1 recommendations to government' CMA outcome type

### DIFF
--- a/lib/documents/schemas/cma_cases.json
+++ b/lib/documents/schemas/cma_cases.json
@@ -304,6 +304,10 @@
           "value": "firm-not-designated"
         },
         {
+          "label": "Markets - phase 1 recommendations to government",
+          "value": "markets-phase-1-recommendations-to-government"
+        },
+        {
           "label": "Markets - phase 1 referral",
           "value": "markets-phase-1-referral"
         },


### PR DESCRIPTION
## Summary
- Adds a new `outcome_type` allowed value to the CMA cases schema: "Markets - phase 1 recommendations to government" (`markets-phase-1-recommendations-to-government`)
- This allows CMA to correctly tag markets case pages where recommendations were published to government without proceeding to a full phase 2 market investigation (e.g. the road fuel market study)

## Jira
https://gov-uk.atlassian.net/browse/WHIT-3108

## Post-deployment
After deployment, republish the finder:
```
rake publishing_api:publish_finder[cma_cases]
```