### PR TITLE
[WHIT-3299] Change document type for CMA finder

### DIFF
--- a/app/models/digital_markets_measure.rb
+++ b/app/models/digital_markets_measure.rb
@@ -1,4 +1,4 @@
-class DigitalMarketsIntervention < Document
+class DigitalMarketsMeasure < Document
   apply_validations
 
   FORMAT_SPECIFIC_FIELDS = format_specific_fields

--- a/lib/documents/schemas/digital_markets_measures.json
+++ b/lib/documents/schemas/digital_markets_measures.json
@@ -3,7 +3,7 @@
   "content_id": "10c9af21-e300-4e3f-8397-5881541b6c8d",
   "description": "Find measures by the Competition and Markets Authority under the digital markets competition regime.",
   "document_noun": "item",
-  "document_title": "Digital markets intervention",
+  "document_title": "Digital markets measure",
   "facets": [
     {
       "allowed_values": [
@@ -18,7 +18,7 @@
       ],
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_firm",
+      "key": "digital_markets_measure_firm",
       "name": "Firm",
       "preposition": "Firm",
       "short_name": "Firm",
@@ -43,7 +43,7 @@
       ],
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_activity",
+      "key": "digital_markets_measure_activity",
       "name": "Activity",
       "preposition": "Activity",
       "short_name": "Activity",
@@ -68,7 +68,7 @@
       ],
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_type",
+      "key": "digital_markets_measure_type",
       "name": "Type",
       "preposition": "Type",
       "short_name": "Type",
@@ -93,7 +93,7 @@
       ],
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_state",
+      "key": "digital_markets_measure_state",
       "name": "State",
       "preposition": "State",
       "short_name": "State",
@@ -108,7 +108,7 @@
     {
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_opened",
+      "key": "digital_markets_measure_opened",
       "name": "Opened",
       "preposition": "Opened",
       "short_name": "Opened",
@@ -117,7 +117,7 @@
     {
       "display_as_result_metadata": true,
       "filterable": true,
-      "key": "digital_markets_interventions_closed",
+      "key": "digital_markets_measure_closed",
       "name": "Closed",
       "preposition": "Closed",
       "short_name": "Closed",
@@ -125,7 +125,7 @@
     }
   ],
   "filter": {
-    "format": "digital_markets_intervention"
+    "format": "digital_markets_measure"
   },
   "integration_target_stack": "live",
   "name": "Find digital markets measures",
@@ -138,7 +138,7 @@
   "show_metadata_block": true,
   "show_table_of_contents": true,
   "signup_content_id": "ba8de13f-8dc7-4238-a71e-849b00eb4bdd",
-  "subscription_list_title_prefix": "Digital markets interventions",
+  "subscription_list_title_prefix": "Digital markets measures",
   "summary": "Find measures by the Competition and Markets Authority under the digital markets competition regime.",
   "target_stack": "draft"
 }

--- a/spec/features/publishing_workflow/viewing_the_finders_index_page_spec.rb
+++ b/spec/features/publishing_workflow/viewing_the_finders_index_page_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Viewing the finders index page", type: :feature do
 
       expect(page).to have_text("CMA Cases")
       expect(page).to have_text("DRCF digital markets research")
-      expect(page).to have_text("Digital markets interventions")
+      expect(page).to have_text("Digital markets measures")
 
       expect(page).to have_css(".gem-c-document-list li", count: 3)
     end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -950,18 +950,18 @@ FactoryBot.define do
     end
   end
 
-  factory :digital_markets_intervention, parent: :document do
+  factory :digital_markets_measure, parent: :document do
     base_path { "/find-digital-markets-measures/example-document" }
-    document_type { "digital_markets_intervention" }
+    document_type { "digital_markets_measure" }
     transient do
       default_metadata do
         {
-          "digital_markets_interventions_firm" => %w[google],
-          "digital_markets_interventions_activity" => %w[mobile],
-          "digital_markets_interventions_type" => "commitment",
-          "digital_markets_interventions_state" => "open",
-          "digital_markets_interventions_opened" => "2015-11-14",
-          "digital_markets_interventions_closed" => "2015-11-16",
+          "digital_markets_measure_firm" => %w[google],
+          "digital_markets_measure_activity" => %w[mobile],
+          "digital_markets_measure_type" => "commitment",
+          "digital_markets_measure_state" => "open",
+          "digital_markets_measure_opened" => "2015-11-14",
+          "digital_markets_measure_closed" => "2015-11-16",
         }
       end
     end


### PR DESCRIPTION
This is to ensure that the document "name" displayed in the publisher matches the new finder name which is Digital markets **measures** rather than **interventions**.

Related PRs:
https://github.com/alphagov/publishing-api/pull/3988
https://github.com/alphagov/search-api/pull/3557

The tests in this PR will pass once publishing API is merged.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3299)


