### PR TITLE
Add rake task to override first_published_at

### DIFF
--- a/app/lib/ops_tasks.rb
+++ b/app/lib/ops_tasks.rb
@@ -34,6 +34,26 @@ module_function
     Services.publishing_api.publish(content_id, "republish")
   end
 
+  def override_first_published_at(content_id, locale, timestamp)
+    timestamp = if timestamp == "now"
+                  Time.zone.now
+                else
+                  Time.zone.parse(timestamp)
+                end
+
+    document = Document.find(content_id, locale)
+    document.update_type = "republish"
+
+    state = document.publication_state
+    raise_helpful_error(state) unless state == "published"
+
+    payload = DocumentPresenter.new(document).to_json
+    payload["first_published_at"] = timestamp
+
+    Services.publishing_api.put_content(content_id, payload)
+    Services.publishing_api.publish(content_id, "republish")
+  end
+
   def raise_helpful_error(state)
     message = "That document has a '#{state}' state"
     message += " and cannot be updated. You can either:"

--- a/lib/tasks/ops.rake
+++ b/lib/tasks/ops.rake
@@ -8,4 +8,12 @@ namespace :ops do
   task :set_public_updated_at, %i[content_id locale timestamp] => :environment do |_, args|
     OpsTasks.set_public_updated_at(args.content_id, args.locale, args.timestamp)
   end
+
+  desc "Override the first_published_at for a published document"
+  # Call with bundle exec rake ops:override_first_published_at[content_id,locale,timestamp], e.g. ops:override_first_published_at['1234-5678-9012-3456','en','2024-01-01T12:00:00Z']
+  # This change will not send an email to users subscribed to the finder, nor to user subscribed to the finder organisation.
+  # Be mindful that this change should be consistent with any further change note history, i.e. the first_published_at should not be after any change note timestamp.
+  task :override_first_published_at, %i[content_id locale timestamp] => :environment do |_, args|
+    OpsTasks.override_first_published_at(args.content_id, args.locale, args.timestamp)
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
