### PR TITLE
Add Curaçao to destination country options for export health certificates [WHIT-3473]

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -218,6 +218,10 @@
           "value": "cuba"
         },
         {
+          "label": "Curaçao",
+          "value": "curacao"
+        },
+        {
           "label": "Cyprus",
           "value": "cyprus"
         },


### PR DESCRIPTION
Request from Support.

Rake task to be run: `bundle exec rake publishing_api:publish_finder[export_health_certificates]`

### Screenshots

Finder filters:

> <img width="1151" height="548" alt="image" src="https://github.com/user-attachments/assets/cae1be7b-a9c3-449c-ac7f-8069c1850778" />

Finder document page:
> <img width="956" height="642" alt="image" src="https://github.com/user-attachments/assets/86af018d-0de6-4536-8eb7-e2104bd58e82" />

Finder document edit:
> <img width="818" height="200" alt="image" src="https://github.com/user-attachments/assets/028bda60-aaef-48ed-b24b-2849f7cb95e7" />





[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3473)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
