### PR TITLE
Correctly capitalise the topic facet [WHIT-3451]

### DIFF
--- a/lib/documents/schemas/hmrc_contacts.json
+++ b/lib/documents/schemas/hmrc_contacts.json
@@ -93,7 +93,7 @@
           "value": "pension-schemes"
         },
         {
-          "label": "Property Taxes",
+          "label": "Property taxes",
           "value": "stamp-taxes"
         },
         {


### PR DESCRIPTION
As per a user support request, `taxes` in `Property taxes` should not be capitalised.

see https://govuk.zendesk.com/agent/tickets/6608589

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
