### PR TITLE
[WHIT-3667] Change veterans finder base_path and title

### DIFF
--- a/lib/documents/schemas/veterans_support_organisations.json
+++ b/lib/documents/schemas/veterans_support_organisations.json
@@ -1,5 +1,5 @@
 {
-  "base_path": "/support-for-veterans",
+  "base_path": "/veteran-support-organisations",
   "content_id": "0bf7f581-a547-4dd1-aef0-754e0924281d",
   "default_order": "title",
   "description": "Find support organisations for veterans of the UK armed forces and their families.",
@@ -369,7 +369,7 @@
     "format": "veterans_support_organisation"
   },
   "index_documents_in_search_engines": true,
-  "name": "Find support for veterans and their families",
+  "name": "Find organisations that support veterans and their families",
   "organisations": [
     "516357f6-92f3-4292-8449-b958e1c63c5f"
   ],

--- a/lib/tasks/base_path.rake
+++ b/lib/tasks/base_path.rake
@@ -2,16 +2,22 @@ namespace :base_path do
   # This is equivalent to other Publishing applications' "reslugging" tasks.
   # Once run, it will create a new draft document with the new `base_path`. The published document remains at the old base_path at this point. Your edition is now in a "published with new draft" state.
   # To finish the reslug, you will need to publish the new draft document. This will cause the old document to redirect to the new base_path.
+  # Pass `true` as the final argument to publish the new draft automatically and complete the reslug in one step.
 
   desc "Edits the base_path of a document, given its content_id and the new base_path"
-  task :edit, %i[content_id locale new_base_path] => %i[environment] do |_t, args|
+  task :edit, %i[content_id locale new_base_path publish] => %i[environment] do |_t, args|
     document = Document.find(args[:content_id], args[:locale])
     old_base_path = document.base_path
 
     document.base_path = args[:new_base_path]
     document.update_type = "minor"
-    document.save
+    abort "Failed to save: #{document.errors.full_messages.join(', ')}" unless document.save
 
     puts "#{old_base_path} -> #{document.base_path}"
+
+    if args[:publish] == "true"
+      abort "Failed to publish: #{document.errors.full_messages.join(', ')}" unless document.publish
+      puts "Published #{document.base_path}"
+    end
   end
 end

--- a/spec/fixtures/factories.rb
+++ b/spec/fixtures/factories.rb
@@ -262,7 +262,7 @@ FactoryBot.define do
   end
 
   factory :veterans_support_organisation, parent: :document do
-    base_path { "/support-for-veterans/example-document" }
+    base_path { "/veteran-support-organisations/example-document" }
     document_type { "veterans_support_organisation" }
     transient do
       default_metadata do

--- a/spec/lib/tasks/base_path_spec.rb
+++ b/spec/lib/tasks/base_path_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe "base_path rake tasks", type: :task do
+  describe "base_path:edit" do
+    let(:output) { StringIO.new }
+    let(:task) { Rake::Task["base_path:edit"] }
+    let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
+    let(:new_base_path) { "/new-finder/example-document" }
+
+    let(:document) do
+      instance_double(
+        Document,
+        base_path: "/old-finder/example-document",
+        :base_path= => nil,
+        :update_type= => nil,
+        save: true,
+        publish: true,
+      )
+    end
+
+    before do
+      $stdout = output
+      task.reenable
+    end
+
+    after { $stdout = STDOUT }
+
+    it "creates a draft at the new base_path" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+
+      task.invoke(content_id, locale, new_base_path)
+
+      expect(document).to have_received(:base_path=).with(new_base_path)
+      expect(document).to have_received(:update_type=).with("minor")
+      expect(document).to have_received(:save)
+    end
+
+    it "does not publish when no publish argument is given" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+
+      task.invoke(content_id, locale, new_base_path)
+
+      expect(document).not_to have_received(:publish)
+    end
+
+    it "publishes the new draft when publish is 'true'" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+
+      task.invoke(content_id, locale, new_base_path, "true")
+
+      expect(document).to have_received(:update_type=).with("minor")
+      expect(document).to have_received(:publish)
+    end
+
+    it "does not publish when publish is not 'true'" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+
+      task.invoke(content_id, locale, new_base_path, "false")
+
+      expect(document).not_to have_received(:publish)
+    end
+
+    it "aborts without publishing when the save fails" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+      allow(document).to receive(:save).and_return(false)
+      allow(document).to receive(:errors).and_return(
+        instance_double(ActiveModel::Errors, full_messages: ["Base path is invalid"]),
+      )
+
+      expect { task.invoke(content_id, locale, new_base_path, "true") }.to raise_error(SystemExit)
+      expect(document).not_to have_received(:publish)
+    end
+
+    it "aborts when the publish fails" do
+      allow(Document).to receive(:find).with(content_id, locale).and_return(document)
+      allow(document).to receive(:publish).and_return(false)
+      allow(document).to receive(:errors).and_return(
+        instance_double(ActiveModel::Errors, full_messages: ["conflicts with content_id"]),
+      )
+
+      expect { task.invoke(content_id, locale, new_base_path, "true") }.to raise_error(SystemExit)
+    end
+  end
+end


### PR DESCRIPTION
## What

- Move the veterans support finder from `/support-for-veterans` to `/veteran-support-organisations`.
- Change the finder title from "Find support for veterans and their families" to "Find organisations that support veterans and their families".
- Add an optional `publish` argument to the `base_path:edit` rake task so a reslug can be completed (draft + publish) in one step.

## Why

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3667)

## Deploy / post-merge steps

```
publishing_api:publish_finder[veterans_support_organisations]
```

republish/represent each finder document

```
require "rake"
Rails.application.load_tasks
task = Rake::Task["base_path:edit"]

OLD = "/support-for-veterans"
NEW = "/veteran-support-organisations"

published = []; drafted = []; skipped = []

VeteransSupportOrganisation.find_each do |summary|
  content_id = summary.content_id
  locale     = summary.locale

  item      = Services.publishing_api.get_content(content_id, locale:).to_h
  base_path = item["base_path"]
  ordered   = item["state_history"].sort_by { |k, _| Integer(k) }.map(&:last)
  latest    = ordered.last
  previous  = ordered[-2]
  label     = (previous && latest == "draft") ? "#{previous} with new draft" : latest

  unless base_path&.start_with?("#{OLD}/")
    skipped << "#{base_path} (#{label})"
    next
  end

  new_base_path = base_path.sub(OLD, NEW)
  task.reenable

  if latest == "published"
    task.invoke(content_id, locale, new_base_path, "true")
    published << new_base_path
  elsif latest == "draft" && previous != "unpublished"
    task.invoke(content_id, locale, new_base_path)
    drafted << new_base_path
  else
    skipped << "#{base_path} (#{label})"
  end
end

puts "Published #{published.size}:"; puts published
puts "Drafted #{drafted.size}:";     puts drafted
puts "Skipped #{skipped.size}:";     puts skipped
```