### PR TITLE
Bump js-yaml from 4.1.1 to 4.2.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,13 +2031,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 86bd35548a0c19cd1f5861147c09aa1f52eb0fc9464f34023524d22bbe079c62c30fd00750e63f632e8d12c12ad36ea0dd1e6bec5171c492ecad433d8db295eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves Dependabot alert [GHSA-h67p-54hq-rp68](https://github.com/alphagov/specialist-publisher/security/dependabot/202) (CVE-2026-53550), a medium-severity quadratic-complexity DoS in `js-yaml`'s merge-key (`<<`) handling.