### PR TITLE
[WHIT-3667] Add task to reslug all documents of a type

### DIFF
--- a/app/services/document_reslugger.rb
+++ b/app/services/document_reslugger.rb
@@ -1,0 +1,95 @@
+class DocumentReslugger
+  Report = Struct.new(:published, :drafted, :skipped, :failed) do
+    def to_s
+      {
+        "Published" => published,
+        "Drafted" => drafted,
+        "Skipped" => skipped,
+        "Failed" => failed,
+      }.map { |label, paths| ["#{label} #{paths.size}:", *paths].join("\n") }.join("\n")
+    end
+  end
+
+  def initialize(document_type, finder_base_path)
+    @document_type = document_type
+    @finder_base_path = finder_base_path
+    @published = []
+    @drafted = []
+    @skipped = []
+    @failed = []
+  end
+
+  def reslug_all
+    klass.find_each do |document|
+      reslug(document)
+    end
+
+    Report.new(@published, @drafted, @skipped, @failed)
+  end
+
+private
+
+  def klass
+    @klass ||= begin
+      Rails.application.eager_load!
+      Document.subclasses.find { |subclass| subclass.document_type == @document_type } ||
+        raise(ArgumentError, "Unknown document_type: #{@document_type}")
+    end
+  end
+
+  # Reslugs a single document according to its state:
+  #   - already under the finder's base_path -> skipped
+  #   - unpublished -> skipped
+  #   - published -> moved and re-published, so the old path redirects
+  #   - draft (incl. published-with-new-draft) -> moved, kept in draft
+  #   - a failed save/publish or unexpected error -> recorded as a failure
+  def reslug(document)
+    if should_reslug?(document)
+      new_base_path = target_base_path(document)
+      was_reslugged = move_to_new_base_path(document, new_base_path)
+
+      if was_reslugged
+        outcome_for(document) << new_base_path
+      else
+        record_failure(document)
+      end
+    else
+      skip(document)
+    end
+  rescue StandardError => e
+    @failed << "#{document.content_id} (#{document.locale}) - #{e.message}"
+  end
+
+  def should_reslug?(document)
+    !already_reslugged?(document) && (document.published? || document.draft?)
+  end
+
+  def already_reslugged?(document)
+    target = target_base_path(document)
+    target.nil? || target == document.base_path
+  end
+
+  def move_to_new_base_path(document, new_base_path)
+    document.base_path = new_base_path
+    document.update_type = "minor"
+    document.save && (document.draft? || document.publish)
+  end
+
+  def outcome_for(document)
+    document.published? ? @published : @drafted
+  end
+
+  def target_base_path(document)
+    return unless document.base_path
+
+    "#{@finder_base_path}/#{File.basename(document.base_path)}"
+  end
+
+  def skip(document)
+    @skipped << "#{document.base_path} (#{document.publication_state})"
+  end
+
+  def record_failure(document)
+    @failed << "#{document.content_id} (#{document.locale}) - #{document.errors.full_messages.join(', ')}"
+  end
+end

--- a/lib/tasks/base_path.rake
+++ b/lib/tasks/base_path.rake
@@ -20,4 +20,55 @@ namespace :base_path do
       puts "Published #{document.base_path}"
     end
   end
+
+  # Reslugs every document of a type so it sits under its finder's live base_path:
+  # published documents are moved and re-published (the old path then redirects),
+  # drafts are moved but kept in draft, and unpublished documents or ones already
+  # under the finder's base_path are skipped. It prints a report of each outcome.
+  #
+  # Only runs when the finder is published to the live stack at the base_path in
+  # its schema, so deploy the schema change and run publishing_api:publish_finder
+  # first.
+  desc "Reslugs a type's documents under its finder's live base_path (published redirect, drafts stay draft)"
+  task :edit_all, %i[document_type] => %i[environment] do |_t, args|
+    document_type = args[:document_type]
+    shell = Thor::Shell::Basic.new
+    finder_schema = FinderSchema.load_from_schema(document_type.pluralize)
+    schema_base_path = finder_schema.base_path
+
+    begin
+      finder = Services.publishing_api.get_content(finder_schema.content_id).to_h
+    rescue GdsApi::HTTPNotFound
+      shell.say_error "The #{document_type} finder does not exist."
+      next
+    end
+
+    unless finder["publication_state"] == "published"
+      shell.say_error "The #{document_type} finder is not published to the live stack " \
+                      "(currently #{finder['publication_state']}); this task only reslugs " \
+                      "documents for finders on the live stack."
+      next
+    end
+
+    unless finder["base_path"] == schema_base_path
+      shell.say_error "The #{document_type} finder must be published at #{schema_base_path} " \
+                      "before reslugging its documents (currently published at #{finder['base_path']})."
+      next
+    end
+
+    message = <<~CONFIRMATION
+      This will reslug every #{document_type} document to sit under #{schema_base_path}.
+      Published documents are moved and re-published (redirecting the old path);
+      documents with a draft are moved but kept in draft.
+    CONFIRMATION
+
+    unless shell.yes?("#{message}Proceed? (yes/no)")
+      shell.say_error "Aborted"
+      next
+    end
+
+    report = DocumentReslugger.new(document_type, schema_base_path).reslug_all
+
+    puts report
+  end
 end

--- a/spec/lib/tasks/base_path_spec.rb
+++ b/spec/lib/tasks/base_path_spec.rb
@@ -82,4 +82,92 @@ RSpec.describe "base_path rake tasks", type: :task do
       expect { task.invoke(content_id, locale, new_base_path, "true") }.to raise_error(SystemExit)
     end
   end
+
+  describe "base_path:edit_all" do
+    let(:output) { StringIO.new }
+    let(:task) { Rake::Task["base_path:edit_all"] }
+    let(:document_type) { "veterans_support_organisation" }
+    let(:schema_base_path) { "/veteran-support-organisations" }
+    let(:finder_content_id) { "finder-content-id" }
+    let(:shell) { instance_double(Thor::Shell::Basic, yes?: true, say_error: nil) }
+    let(:publishing_api) { double("publishing_api") }
+    let(:report) do
+      DocumentReslugger::Report.new(["/veteran-support-organisations/foo"], [], [], [])
+    end
+    let(:reslugger) { instance_double(DocumentReslugger, reslug_all: report) }
+
+    before do
+      $stdout = output
+      task.reenable
+      allow(Thor::Shell::Basic).to receive(:new).and_return(shell)
+      allow(DocumentReslugger).to receive(:new).with(document_type, schema_base_path).and_return(reslugger)
+      allow(FinderSchema).to receive(:load_from_schema)
+        .with("veterans_support_organisations")
+        .and_return(double(base_path: schema_base_path, content_id: finder_content_id))
+      allow(Services).to receive(:publishing_api).and_return(publishing_api)
+      stub_finder(publication_state: "published", base_path: schema_base_path)
+    end
+
+    after { $stdout = STDOUT }
+
+    def stub_finder(publication_state:, base_path:)
+      allow(publishing_api).to receive(:get_content).with(finder_content_id).and_return(
+        double(to_h: { "publication_state" => publication_state, "base_path" => base_path }),
+      )
+    end
+
+    it "reslugs every document of the type after confirmation" do
+      task.invoke(document_type)
+
+      expect(DocumentReslugger).to have_received(:new).with(document_type, schema_base_path)
+      expect(reslugger).to have_received(:reslug_all)
+    end
+
+    it "prints a report of the results" do
+      task.invoke(document_type)
+
+      expect(output.string).to include("Published 1:")
+      expect(output.string).to include("/veteran-support-organisations/foo")
+    end
+
+    it "does not reslug when the user does not confirm" do
+      allow(shell).to receive(:yes?).and_return(false)
+
+      task.invoke(document_type)
+
+      expect(reslugger).not_to have_received(:reslug_all)
+      expect(shell).to have_received(:say_error).with("Aborted")
+    end
+
+    it "does not reslug when the finder does not exist" do
+      allow(publishing_api).to receive(:get_content).with(finder_content_id)
+        .and_raise(GdsApi::HTTPNotFound.new(404))
+
+      task.invoke(document_type)
+
+      expect(shell).not_to have_received(:yes?)
+      expect(reslugger).not_to have_received(:reslug_all)
+      expect(shell).to have_received(:say_error).with(/does not exist/)
+    end
+
+    it "does not reslug when the finder is only on the draft stack" do
+      stub_finder(publication_state: "draft", base_path: schema_base_path)
+
+      task.invoke(document_type)
+
+      expect(shell).not_to have_received(:yes?)
+      expect(reslugger).not_to have_received(:reslug_all)
+      expect(shell).to have_received(:say_error).with(/not published to the live stack/)
+    end
+
+    it "does not reslug when the published finder does not match the schema" do
+      stub_finder(publication_state: "published", base_path: "/support-for-veterans")
+
+      task.invoke(document_type)
+
+      expect(shell).not_to have_received(:yes?)
+      expect(reslugger).not_to have_received(:reslug_all)
+      expect(shell).to have_received(:say_error).with(/must be published at/)
+    end
+  end
 end

--- a/spec/services/document_reslugger_spec.rb
+++ b/spec/services/document_reslugger_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe DocumentReslugger do
+  subject(:reslugger) { described_class.new(document_type, finder_base_path) }
+
+  let(:document_type) { "veterans_support_organisation" }
+  let(:finder_base_path) { "/veteran-support-organisations" }
+  let(:old_base_path) { "/support-for-veterans" }
+  let(:klass) { class_double(Document, document_type:) }
+
+  before do
+    allow(Rails.application).to receive(:eager_load!)
+    allow(Document).to receive(:subclasses).and_return([klass])
+    allow(klass).to receive(:find_each)
+  end
+
+  def stub_document(base_path:, publication_state:, content_id: "content-id")
+    instance_double(
+      Document,
+      content_id:,
+      locale: "en",
+      base_path:,
+      publication_state:,
+      published?: publication_state == "published",
+      draft?: publication_state == "draft",
+      :base_path= => nil,
+      :update_type= => nil,
+      save: true,
+      publish: true,
+    )
+  end
+
+  describe "#reslug_all" do
+    it "raises for an unknown document type" do
+      expect { described_class.new("not_a_real_type", finder_base_path).reslug_all }
+        .to raise_error(ArgumentError, /not_a_real_type/)
+    end
+
+    it "reslugs and publishes a published document" do
+      document = stub_document(base_path: "#{old_base_path}/foo", publication_state: "published")
+      allow(klass).to receive(:find_each).and_yield(document)
+
+      report = reslugger.reslug_all
+
+      expect(document).to have_received(:base_path=).with("#{finder_base_path}/foo")
+      expect(document).to have_received(:update_type=).with("minor")
+      expect(document).to have_received(:save)
+      expect(document).to have_received(:publish)
+      expect(report.published).to eq(["#{finder_base_path}/foo"])
+    end
+
+    it "reslugs but keeps a draft document in draft" do
+      document = stub_document(base_path: "#{old_base_path}/bar", publication_state: "draft")
+      allow(klass).to receive(:find_each).and_yield(document)
+
+      report = reslugger.reslug_all
+
+      expect(document).to have_received(:base_path=).with("#{finder_base_path}/bar")
+      expect(document).to have_received(:save)
+      expect(document).not_to have_received(:publish)
+      expect(report.drafted).to eq(["#{finder_base_path}/bar"])
+    end
+
+    it "skips an unpublished document" do
+      document = stub_document(base_path: "#{old_base_path}/baz", publication_state: "unpublished")
+      allow(klass).to receive(:find_each).and_yield(document)
+
+      report = reslugger.reslug_all
+
+      expect(document).not_to have_received(:save)
+      expect(document).not_to have_received(:publish)
+      expect(report.skipped).to eq(["#{old_base_path}/baz (unpublished)"])
+    end
+
+    it "skips a document already at the finder base_path" do
+      document = stub_document(base_path: "#{finder_base_path}/thing", publication_state: "published")
+      allow(klass).to receive(:find_each).and_yield(document)
+
+      report = reslugger.reslug_all
+
+      expect(document).not_to have_received(:save)
+      expect(report.skipped).to eq(["#{finder_base_path}/thing (published)"])
+    end
+
+    it "records a failure and continues with the next document" do
+      failing = stub_document(content_id: "doc-5", base_path: "#{old_base_path}/fail", publication_state: "published")
+      allow(failing).to receive(:save).and_return(false)
+      allow(failing).to receive(:errors).and_return(
+        instance_double(ActiveModel::Errors, full_messages: ["conflicts with content_id"]),
+      )
+      ok = stub_document(base_path: "#{old_base_path}/ok", publication_state: "published")
+      allow(klass).to receive(:find_each).and_yield(failing).and_yield(ok)
+
+      report = reslugger.reslug_all
+
+      expect(ok).to have_received(:publish)
+      expect(report.published).to eq(["#{finder_base_path}/ok"])
+      expect(report.failed).to eq(["doc-5 (en) - conflicts with content_id"])
+    end
+
+    it "records a failure and continues when a document raises unexpectedly" do
+      document = instance_double(Document, content_id: "doc-7", locale: "en")
+      allow(document).to receive(:base_path).and_raise(StandardError, "boom")
+      allow(klass).to receive(:find_each).and_yield(document)
+
+      report = reslugger.reslug_all
+
+      expect(report.failed).to eq(["doc-7 (en) - boom"])
+    end
+
+    it "returns a report of the results" do
+      expect(reslugger.reslug_all).to be_a(DocumentReslugger::Report)
+    end
+  end
+
+  describe DocumentReslugger::Report do
+    it "formats each category with its count and paths" do
+      report = described_class.new(["/a", "/b"], ["/c"], [], ["doc-1 (en) - boom"])
+
+      expect(report.to_s).to eq(<<~REPORT.chomp)
+        Published 2:
+        /a
+        /b
+        Drafted 1:
+        /c
+        Skipped 0:
+        Failed 1:
+        doc-1 (en) - boom
+      REPORT
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a `base_path:edit_all[document_type]` rake task that reslugs every document of a given type so it sits under its finder's live `base_path` — for example after a finder's `base_path` changes.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3667)

## How it works

- Extracted into a `DocumentReslugger` service; the rake task owns the preconditions, the confirmation prompt, and printing the report.
- **Precondition:** the task reads the live finder and only proceeds when it's published **to the live stack** at the `base_path` in its schema. Otherwise it stops with a specific message (finder missing, only on the draft stack, or published at the wrong path). So deploy the schema change and publish the finder first.
- Prompts for `y/n` confirmation before running.
- Each document's slug is preserved: new path = `<finder base_path>/<basename of current path>`.
- Documents are handled by state:
  - **published** → reslugged and re-published (completing the redirect from the old path)
  - **draft / published-with-new-draft** → reslugged but kept in draft, so an in-progress edit isn't pushed live but will publish to the correct path later
  - **unpublished**, **brand-new first drafts**, or anything already under the finder's base_path → left untouched
- Failures don't halt the run: each is recorded as `content_id (locale) - error` and printed in the end-of-run summary alongside the published/drafted/skipped tallies.

Safe to re-run — already-moved documents are skipped.

## Usage

```
rake 'base_path:edit_all[veterans_support_organisation]'
```
