### PR TITLE
[WHIT-3667] Realign unpublished documents to finder base_path

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -102,6 +102,15 @@ class Document
     truncate(@base_path, length: 250, omission: "")
   end
 
+  # A redraft of an unpublished document must land under the finder's current
+  # base_path, which may have moved since the document was unpublished. The
+  # existing slug is preserved so the document keeps its URL identity.
+  def realign_base_path_to_finder
+    return unless @base_path
+
+    self.base_path = "#{finder_schema.base_path}/#{File.basename(@base_path)}"
+  end
+
   def rendering_app
     "frontend"
   end

--- a/app/services/document_saver.rb
+++ b/app/services/document_saver.rb
@@ -4,6 +4,7 @@ require "services"
 class DocumentSaver
   def self.save(document)
     document.update_type = "major" if document.first_draft?
+    document.realign_base_path_to_finder if document.unpublished?
 
     presented_document = DocumentPresenter.new(document)
     presented_links = DocumentLinksPresenter.new(document)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -780,6 +780,108 @@ RSpec.describe Document do
     end
   end
 
+  describe "#base_path" do
+    context "when the document is a first draft" do
+      it "derives the base_path from the finder base_path and the title" do
+        first_draft = MyDocumentType.new(title: "A brand new document")
+        expect(first_draft.base_path).to eq("/my-document-types/a-brand-new-document")
+      end
+    end
+
+    context "when the document is unpublished" do
+      subject(:unpublished_document) do
+        MyDocumentType.from_publishing_api(
+          FactoryBot.create(:document, :unpublished, payload_attributes.merge(base_path: "/old-finder/example-document")),
+        )
+      end
+
+      it "reports the stored base_path, even if the finder has since moved" do
+        expect(unpublished_document.base_path).to eq("/old-finder/example-document")
+      end
+    end
+
+    context "when the document is published" do
+      subject(:published_document) do
+        MyDocumentType.from_publishing_api(
+          FactoryBot.create(:document, :published, payload_attributes.merge(base_path: "/old-finder/example-document")),
+        )
+      end
+
+      it "returns the stored base_path" do
+        expect(published_document.base_path).to eq("/old-finder/example-document")
+      end
+    end
+
+    context "when the base_path is not set" do
+      it "returns nil rather than raising" do
+        document = MyDocumentType.new(publication_state: "unpublished")
+        expect(document.base_path).to be_nil
+      end
+    end
+
+    context "when the derived base_path exceeds 250 characters" do
+      it "truncates it to 250 characters" do
+        first_draft = MyDocumentType.new(title: "a" * 300)
+        expect(first_draft.base_path.length).to eq(250)
+      end
+    end
+  end
+
+  describe "#realign_base_path_to_finder" do
+    it "moves the base_path under the finder's live base_path, keeping the slug" do
+      document = MyDocumentType.from_publishing_api(
+        FactoryBot.create(:document, :unpublished, payload_attributes.merge(base_path: "/old-finder/example-document")),
+      )
+      document.realign_base_path_to_finder
+      expect(document.base_path).to eq("/my-document-types/example-document")
+    end
+
+    it "keeps the existing slug rather than deriving one from the title" do
+      document = MyDocumentType.from_publishing_api(
+        FactoryBot.create(:document, :unpublished, payload_attributes.merge(base_path: "/old-finder/example-document")),
+      )
+      document.title = "A completely different title"
+      document.realign_base_path_to_finder
+      expect(document.base_path).to eq("/my-document-types/example-document")
+    end
+
+    it "leaves a base_path that already sits under the finder unchanged" do
+      document = MyDocumentType.from_publishing_api(
+        FactoryBot.create(:document, :unpublished, payload_attributes),
+      )
+      document.realign_base_path_to_finder
+      expect(document.base_path).to eq("/my-document-types/example-document")
+    end
+
+    it "does nothing when the base_path is not set" do
+      document = MyDocumentType.new(publication_state: "unpublished")
+      document.realign_base_path_to_finder
+      expect(document.base_path).to be_nil
+    end
+  end
+
+  context "saving a new draft from an unpublished document" do
+    subject(:unpublished_document) do
+      MyDocumentType.from_publishing_api(
+        FactoryBot.create(:document, :unpublished, payload_attributes.merge(base_path: "/old-finder/example-document")),
+      )
+    end
+
+    before do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+    end
+
+    it "realigns the draft to the finder's live base_path" do
+      unpublished_document.update_type = "minor"
+      expect(unpublished_document.save).to be true
+      assert_publishing_api_put_content(
+        unpublished_document.content_id,
+        request_json_includes(base_path: "/my-document-types/example-document"),
+      )
+    end
+  end
+
   context "saving a draft where another draft has the same base_path" do
     before do
       stub_any_publishing_api_put_content


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/browse/WHIT-3667)

Follow-up to #3742 (the `base_path:edit_all` reslug task), closing the loop on unpublished documents.

## Why

When a finder's `base_path` changes, the reslug task moves published and draft documents but deliberately **skips unpublished ones**. A document that was unpublished before the finder moved therefore keeps its old `base_path`. The next time someone creates a new draft from it, that draft would be saved at the stale path instead of under the finder's current location.

## What

`Document#base_path` now derives the path for an **unpublished** document from the finder's live `base_path`, preserving the document's existing slug (`File.basename`). So redrafting an unpublished document saves it at the correct URL. This mirrors the transform the reslug task applies to published/draft documents.

- Published and draft documents are unaffected (they keep their stored `base_path`).
- Idempotent: an unpublished document already under the finder's `base_path` is unchanged.
