### PR TITLE
Resync yarn.lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,15 +2392,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 38699257447dc59e21e73e0510d0dfb16b7a610d9ca80633d5c3a68f9b4298c990513d30404ca8f163c2d03225ee01695ff8898bea6179183f38f0477b7635ac
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.16":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"


### PR DESCRIPTION
The `yarn.lock` file has fallen out of sync with `package.json`, which means that `yarn install --frozen-lockfile` in the CI pipeline is failing for any new PR since that commit.

I think it's this depndabot PR merged bythe auto-merger https://github.com/alphagov/specialist-publisher/pull/3773

Removing `node_modules` locally and re-running `yarn install` recreates the lock file with the errant dependency removed.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
