### PR TITLE
Update EAT finder intro copy

### DIFF
--- a/lib/documents/schemas/employment_appeal_tribunal_decisions.json
+++ b/lib/documents/schemas/employment_appeal_tribunal_decisions.json
@@ -1067,7 +1067,7 @@
   "show_summaries": true,
   "signup_content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",
   "subscription_list_title_prefix": "Employment Appeal Tribunal decisions",
-  "summary": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.\r\n\r\nIncludes decisions after December 2015. Find details of [older cases](http://www.employmentappeals.gov.uk/Public/Search.aspx).",
+  "summary": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.\r\n\r\nIncludes decisions after December 2017. Find details of [older cases](https://employmentappeals.decisions.tribunals.gov.uk/Public/Search.aspx).",
   "target_stack": "live",
   "taxons": [
     "357110bb-cbc5-4708-9711-1b26e6c63e86"


### PR DESCRIPTION
The link to older cases finder returns 403 error and the cut off date is incorrect.  This change fixes both issues by updating the link and text, as per the support ticket.

Zendesk: https://govuk.zendesk.com/agent/tickets/6782888

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
