### PR TITLE
[WHIT-3849] - Strip whitespace from date field values

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -10,7 +10,7 @@ module DateHelper
         attrs.fetch(:"#{k}(1i)"),
         attrs.fetch(:"#{k}(2i)"),
         attrs.fetch(:"#{k}(3i)"),
-      ]
+      ].map { |d| d.to_s.remove(/[[:space:]]/) }
       format_date.delete_if(&:empty?)
       format_date.map { |d| zero_pad(d) }.join("-")
     end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe DateHelper, type: :helper do
       expect(date_param_value(params, "my_date")).to eq("2016-02-01")
     end
 
+    it "strips leading whitespace from date values" do
+      params = { "my_date(1i)" => "2016", "my_date(2i)" => "02", "my_date(3i)" => " 1" }
+      expect(date_param_value(params, "my_date")).to eq("2016-02-01")
+    end
+
+    it "strips trailing whitespace from date values" do
+      params = { "my_date(1i)" => "2016", "my_date(2i)" => "02", "my_date(3i)" => "01\t" }
+      expect(date_param_value(params, "my_date")).to eq("2016-02-01")
+    end
+
+    it "strips non-breaking spaces from date values" do
+      params = { "my_date(1i)" => "2016", "my_date(2i)" => "\u00A02", "my_date(3i)" => "01\u00A0" }
+      expect(date_param_value(params, "my_date")).to eq("2016-02-01")
+    end
+
+    it "strips whitespace within date values" do
+      params = { "my_date(1i)" => "2016", "my_date(2i)" => "02", "my_date(3i)" => "0 1" }
+      expect(date_param_value(params, "my_date")).to eq("2016-02-01")
+    end
+
+    it "treats a whitespace only value as empty" do
+      params = { "my_date(1i)" => "2016", "my_date(2i)" => "02", "my_date(3i)" => " " }
+      expect(date_param_value(params, "my_date")).to eq("2016-02")
+    end
+
     it "doesn't alter non-numerical values" do
       params = { "my_date(1i)" => "some", "my_date(2i)" => "bad", "my_date(3i)" => "data" }
       expect(date_param_value(params, "my_date")).to eq("some-bad-data")


### PR DESCRIPTION
Whitespace typed or pasted into a date input survived into the joined YYYY-MM-DD string, which publishing-api rejected against its date schema:

  The property '#/details/metadata/tribunal_decision_decision_date'
  value "2026-07-31 " did not match the regex

Only the day field got that far. DateValidator parses with Date.strptime(value, "%Y-%m-%d") and %d is the last directive, so trailing characters are ignored and " 1" or "31 " parse cleanly. Whitespace in the month or year fails strptime and is caught as "is not a valid date" before sending to publishing-api.

Matching [[:space:]] rather than stripping catches a non-breaking space pasted from Excel or Word, and whitespace inside a value: "3 1" parses as day 3, giving a silently wrong date rather than an error.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3849)
