### PR TITLE
Add Newcastle city council to ATR finder's Organisation filter [WHIT-3891]

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -160,6 +160,10 @@
         {
           "label": "West Midlands Police",
           "value": "west-midlands-police"
+        },
+        {
+          "label": "Newcastle City Council",
+          "value": "newcastle-city-council"
         }
       ],
       "display_as_result_metadata": true,


### PR DESCRIPTION
Updates the finder's organisation filter to include `Newcastle City Council` option.

Support Request: [WHIT-3891](https://gov-uk.atlassian.net/browse/WHIT-3891)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[WHIT-3891]: https://gov-uk.atlassian.net/browse/WHIT-3891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ