### PR TITLE
Add Newcastle city council to ATR finder's Organisation filter [WHIT-3891]

### DIFF
--- a/lib/documents/schemas/algorithmic_transparency_records.json
+++ b/lib/documents/schemas/algorithmic_transparency_records.json
@@ -130,6 +130,10 @@
           "value": "ministry-of-justice"
         },
         {
+          "label": "Newcastle City Council",
+          "value": "newcastle-city-council"
+        },
+        {
           "label": "NHS England",
           "value": "nhs-england"
         },


### PR DESCRIPTION
Update to #3815 - made the new option maintain the correct alphabetical order.

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
