### PR TITLE
Add Leasehold disputes option to tribunal decision sub category in RPTD finder [WHIT-3895]

### DIFF
--- a/lib/documents/schemas/residential_property_tribunal_decisions.json
+++ b/lib/documents/schemas/residential_property_tribunal_decisions.json
@@ -210,6 +210,10 @@
           "value": "leasehold-disputes-management---service-charges"
         },
         {
+          "label": "Leasehold disputes (management) - 20ZA",
+          "value": "leasehold-disputes-management---dispensation"
+        },
+        {
           "label": "Leasehold disputes (management) - Variation of leases",
           "value": "leasehold-disputes-management---variation-of-leases"
         },


### PR DESCRIPTION
Adds Leasehold disputes option to tribunal decision sub category in Residential Property Tribunal Decision finder. 
This came from a support request.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3895)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
