### PR TITLE
Add new option for data set in UKHSA Data approvals finder 

### DIFF
--- a/lib/documents/schemas/ukhsa_data_access_approvals.json
+++ b/lib/documents/schemas/ukhsa_data_access_approvals.json
@@ -503,7 +503,11 @@
           "value": "linked-hospital-episode-statistics-admitted-care-ip"
         },
         {
-          "label": "linked Hospital Episode Statistics (OP)",
+          "label": "Linked Hospital Episode Statistics Critical Care (CC)",
+          "value": "linked-hospital-episode-statistics-critical-care-cc"
+        },
+        {
+          "label": "Linked Hospital Episode Statistics (OP)",
           "value": "linked-hospital-episode-statistics-op"
         },
         {


### PR DESCRIPTION
Adds a new option to the `Data set` field in the UKHSA data access approvals finder, for a support request.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
