### PR TITLE
Rename `Nauru` to `Naoero` [WHIT-3918]

### DIFF
--- a/lib/documents/schemas/export_health_certificates.json
+++ b/lib/documents/schemas/export_health_certificates.json
@@ -586,6 +586,10 @@
           "value": "nauru"
         },
         {
+          "label": "Naoero",
+          "value": "naoero"
+        },        
+        {
           "label": "Nepal",
           "value": "nepal"
         },

--- a/lib/documents/schemas/international_development_funds.json
+++ b/lib/documents/schemas/international_development_funds.json
@@ -521,6 +521,10 @@
           "value": "nauru"
         },
         {
+          "label": "Naoero",
+          "value": "naoero"
+        },
+        {
           "label": "Nepal",
           "value": "nepal"
         },

--- a/lib/documents/schemas/research_for_development_outputs.json
+++ b/lib/documents/schemas/research_for_development_outputs.json
@@ -500,6 +500,10 @@
           "value": "NR"
         },
         {
+          "label": "Naoero",
+          "value": "NR"
+        },        
+        {
           "label": "Nepal",
           "value": "NP"
         },


### PR DESCRIPTION
## What 

Rename Nauru to Naoero. 

Following the process outline in these [docs](https://docs.publishing.service.gov.uk/manual/rename-a-country.html#7-update-specialist-publisher)

## Why

We need to support both the old countries temporarily (during the data migration). So that is why Micronesia remains, once the transition is complete there will be a subsequent PR to remove the old values.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
